### PR TITLE
docs: add Termux setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ cd server && npm install && npm start
 # Listening on http://0.0.0.0:8081
 ```
 
+### Termux (Android)
+
+Run MobiSSH directly on your phone with [Termux](https://termux.dev):
+
+```bash
+pkg install nodejs-lts git
+git clone https://github.com/flavordrake/mobissh.git
+cd mobissh/server && npm install && npm start
+```
+
+Open `http://localhost:8081` in your device browser. To keep the server running when the screen is off:
+
+```bash
+termux-wake-lock
+npm start
+```
+
+Use `termux-open http://localhost:8081` to launch the browser from Termux. To connect to other machines on your network, use their Tailscale IP as the SSH host.
+
 ### Other options
 
 **Tailscale Serve (no Docker):** `cd server && npm start` then `tailscale serve https / http://localhost:8081`


### PR DESCRIPTION
## Summary
- Adds a "Termux (Android)" setup section to README.md between the Local and Other options sections
- Covers Node.js installation, cloning, running, `termux-wake-lock`, and browser access tips
- Closes #17

## Test plan
- [ ] Verify README renders correctly on GitHub

Generated with [Claude Code](https://claude.com/claude-code)