### PR TITLE
feat: auto-populate profile name from hostname

### DIFF
--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -318,6 +318,21 @@ export function initConnectForm(): void {
   _initPasswordFieldCloaking(document.getElementById('remote_c') as HTMLInputElement);
   _initPasswordFieldCloaking(document.getElementById('remote_pp') as HTMLInputElement);
 
+  // Auto-populate profile name from hostname (#16)
+  const hostInput = document.getElementById('host') as HTMLInputElement;
+  const nameInput = document.getElementById('profileName') as HTMLInputElement;
+  let nameManuallySet = false;
+
+  nameInput.addEventListener('input', () => { nameManuallySet = true; });
+  nameInput.addEventListener('focus', () => {
+    if (!nameInput.value) nameManuallySet = false;
+  });
+  hostInput.addEventListener('input', () => {
+    if (!nameManuallySet) {
+      nameInput.value = hostInput.value.trim();
+    }
+  });
+
   form.addEventListener('submit', (e) => {
     e.preventDefault();
 


### PR DESCRIPTION
## Summary
- Auto-populates the profile name field from the hostname as the user types, when creating a new connection profile
- Respects manual edits: once the user types in the name field, auto-fill stops
- Resets the manual-edit flag when the name field is empty (covers new-connection form reset)

Closes #16

## Test plan
- [ ] Create a new connection, type a hostname — profile name should mirror it
- [ ] Clear the name field, type a custom name, then change hostname — name should not change
- [ ] Click "New Connection" to reset form, type a hostname — auto-fill should resume

Generated with Claude Code