### PR TITLE
fix: detect clipboard images for paste button visibility

### DIFF
--- a/src/modules/selection.ts
+++ b/src/modules/selection.ts
@@ -210,9 +210,32 @@ export function initSelection(): void {
   // Show paste button when long-press activates selection (clipboard likely has content)
   // and when selection is dismissed (user may want to paste after copying).
   function _showPasteIfClipboard(): void {
-    void navigator.clipboard.readText()
-      .then((text) => { pasteBtn.classList.toggle('hidden', !text); })
-      .catch(() => { pasteBtn.classList.add('hidden'); });
+    // Try clipboard.read() first to detect images; fall back to readText()
+    void (async () => {
+      try {
+        const items = await navigator.clipboard.read();
+        let hasContent = false;
+        let hasImage = false;
+        for (const item of items) {
+          if (item.types.includes('text/plain')) { hasContent = true; break; }
+          for (const type of item.types) {
+            if (type.startsWith('image/')) { hasContent = true; hasImage = true; break; }
+          }
+          if (hasContent) break;
+        }
+        pasteBtn.classList.toggle('hidden', !hasContent);
+        pasteBtn.textContent = hasImage ? 'Paste (image)' : 'Paste';
+      } catch {
+        // clipboard.read() not available — fall back to readText
+        try {
+          const text = await navigator.clipboard.readText();
+          pasteBtn.classList.toggle('hidden', !text);
+          pasteBtn.textContent = 'Paste';
+        } catch {
+          pasteBtn.classList.add('hidden');
+        }
+      }
+    })();
   }
 
   // ── Back gesture / hardware back → dismiss chip ───────────────────────────


### PR DESCRIPTION
## Summary
- `_showPasteIfClipboard()` now uses `clipboard.read()` to detect image-only clipboard content, falling back to `readText()` when unavailable
- Updates `#handlePasteBtn` label to "Paste (image)" when clipboard contains an image
- Fixes paste button not appearing when clipboard has only image content

Closes #22

## Test plan
- [ ] Copy an image to clipboard on Android, long-press terminal — paste button should appear with "Paste (image)" label
- [ ] Copy text to clipboard, long-press — paste button shows "Paste" as before
- [ ] Clear clipboard, long-press — paste button stays hidden
- [ ] Test on iOS Safari (clipboard.read() may not be available) — should fall back to readText() gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)