### PR TITLE
feat: bell/OSC notification indicator next to compose button

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -384,8 +384,22 @@ body.debug-ime #imePreview {
 .handle-menu-btn:active { color: var(--accent); }
 
 /* Compose/IME toggle in handle bar — always visible, compact icon */
+.handle-compose-btn { position: relative; }
 .handle-compose-btn.compose-active { color: var(--accent); }
 .handle-compose-btn:active { opacity: 0.7; }
+
+/* Bell indicator — small dot on compose button, shown on BEL / OSC 9 / OSC 777 */
+.bell-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  pointer-events: none;
+}
+.bell-indicator.hidden { display: none; }
 
 /* Copy and paste buttons in handle bar — shared layout (#55, #197) */
 .handle-copy-btn,

--- a/public/index.html
+++ b/public/index.html
@@ -180,7 +180,7 @@
         <button id="handlePasteBtn" class="handle-paste-btn hidden" title="Paste clipboard" aria-label="Paste clipboard">Paste</button>
         <button id="sessionMenuBtn" title="Session menu" aria-label="Session menu">MobiSSH</button>
         <button id="handleCopyBtn" class="handle-copy-btn hidden" title="Copy selection" aria-label="Copy selection">Copy</button>
-        <button id="composeModeBtn" class="handle-btn handle-compose-btn" title="Compose mode: swipe typing, voice, autocorrect"><svg viewBox="0 0 12 20" width="9" height="15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8.5 1.5l2 2L4 10l-2.5.5.5-2.5Z"/><line x1="1" y1="14" x2="11" y2="14"/><line x1="1" y1="18" x2="11" y2="18"/></svg></button>
+        <button id="composeModeBtn" class="handle-btn handle-compose-btn" title="Compose mode: swipe typing, voice, autocorrect"><svg viewBox="0 0 12 20" width="9" height="15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8.5 1.5l2 2L4 10l-2.5.5.5-2.5Z"/><line x1="1" y1="14" x2="11" y2="14"/><line x1="1" y1="18" x2="11" y2="18"/></svg><span id="bellIndicator" class="bell-indicator hidden"></span></button>
         <!-- Session menu anchored inside the positioned parent so absolute positioning works -->
         <div id="sessionMenu" class="hidden" role="menu">
           <div class="session-menu-item font-size-row" role="menuitem">
@@ -530,6 +530,14 @@
             <input type="checkbox" id="enablePinchZoom" />
             <span class="toggle-slider"></span>
           </label>
+        </div>
+
+        <div class="danger-zone-item">
+          <div class="danger-zone-item-info">
+            <span class="danger-zone-item-label">Test bell indicator</span>
+            <p class="hint">Flashes the bell dot next to the compose button for 5 seconds.</p>
+          </div>
+          <button id="testBellBtn" class="secondary-btn">Test</button>
         </div>
       </div>
 

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -8,6 +8,7 @@
 import type { SettingsDeps } from './types.js';
 import { getDefaultWsUrl, THEMES } from './constants.js';
 import type { ThemeName } from './types.js';
+import { showBellIndicator } from './terminal.js';
 
 let _toast = (_msg: string): void => {};
 let _applyFontSize = (_size: number): void => {};
@@ -198,6 +199,10 @@ export function initSettingsPanel(): void {
   document.getElementById('resetAppBtn')!.addEventListener('click', () => {
     if (!confirm('Clear all stored keys, profiles, settings, and caches, then reload?')) return;
     void clearCacheAndReload();
+  });
+
+  document.getElementById('testBellBtn')?.addEventListener('click', () => {
+    showBellIndicator();
   });
 
   const versionEl = document.getElementById('versionInfo');

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -43,6 +43,16 @@ function fireNotification(title: string, body: string): void {
   } catch { /* permission may have been revoked */ }
 }
 
+let _bellTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function showBellIndicator(): void {
+  const el = document.getElementById('bellIndicator');
+  if (!el) return;
+  el.classList.remove('hidden');
+  if (_bellTimer !== null) clearTimeout(_bellTimer);
+  _bellTimer = setTimeout(() => { el.classList.add('hidden'); _bellTimer = null; }, 5000);
+}
+
 export function initTerminal(): void {
   const fontSize = parseInt(localStorage.getItem('fontSize') ?? '14') || 14;
   const savedTheme = localStorage.getItem('termTheme') ?? 'dark';
@@ -68,6 +78,7 @@ export function initTerminal(): void {
   applyTheme(appState.activeThemeName);
 
   appState.terminal.onBell(() => {
+    showBellIndicator();
     if (!shouldNotify()) return;
     const buffer = appState.terminal!.buffer.active;
     let body = 'Terminal bell';
@@ -79,16 +90,25 @@ export function initTerminal(): void {
   });
 
   appState.terminal.parser.registerOscHandler(9, (data: string) => {
+    showBellIndicator();
     if (shouldNotify()) fireNotification('MobiSSH', data);
     return true;
   });
 
   appState.terminal.parser.registerOscHandler(777, (data: string) => {
     const parts = data.split(';');
+    showBellIndicator();
     if (parts[0] === 'notify' && shouldNotify()) {
       fireNotification(parts[1] ?? 'MobiSSH', parts[2] ?? '');
     }
     return true;
+  });
+
+  // Dismiss bell indicator on tap
+  document.getElementById('bellIndicator')?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    (e.target as HTMLElement).classList.add('hidden');
+    if (_bellTimer !== null) { clearTimeout(_bellTimer); _bellTimer = null; }
   });
 
   // Re-measure character cells after web fonts finish loading (#71)


### PR DESCRIPTION
## Summary
- Adds a green dot indicator on the compose button that flashes for 5s on BEL (`\x07`), OSC 9, or OSC 777
- Fires unconditionally — not gated by browser notification permission or settings
- Tap indicator to dismiss early; auto-clears after 5 seconds
- Adds "Test bell indicator" button in Advanced debug settings

Closes #24

## Test plan
- [ ] Connect to SSH session, run `echo -e '\a'` — verify green dot appears on compose button
- [ ] Dot auto-clears after 5 seconds
- [ ] Tap dot to dismiss immediately
- [ ] Go to Settings > Advanced > Test bell indicator — verify dot appears
- [ ] Verify existing browser notification flow is unchanged (enable notifications toggle, check BEL still sends browser notification)

Generated with [Claude Code](https://claude.com/claude-code)