### PR TITLE
docs: research iOS Simulator testing setup

### DIFF
--- a/docs/research-ios-simulator.md
+++ b/docs/research-ios-simulator.md
@@ -1,0 +1,228 @@
+# iOS Simulator Testing Setup Research
+
+Research spike for issue #9: iOS Simulator testing parallel to the Android emulator approach.
+
+## 1. Tools Needed
+
+| Tool | Purpose | Install method |
+|------|---------|----------------|
+| Xcode | Full IDE, includes Simulator.app and CLI tools | Mac App Store or `xcode-select --install` (CLI tools only) |
+| `xcrun simctl` | CLI for creating, booting, managing simulators | Bundled with Xcode |
+| `safaridriver` | WebDriver for Safari (desktop and Simulator) | Bundled with macOS (`/usr/bin/safaridriver`) |
+| Appium + XCUITest driver | WebDriver automation for iOS Simulator Safari | `npm install -g appium && appium driver install xcuitest` |
+
+## 2. Can iOS Simulator Run Without Full Xcode?
+
+**No.** The iOS Simulator requires the full Xcode installation, not just Xcode Command Line Tools.
+
+- `xcode-select --install` gives you compilers, `git`, `make`, etc., but NOT Simulator.app.
+- Simulator.app lives inside `Xcode.app/Contents/Developer/Applications/Simulator.app`.
+- Xcode is ~12-15 GB on disk. There is no lightweight alternative.
+- Starting with Xcode 14, you can download additional simulator runtimes separately (`xcodebuild -downloadPlatform iOS`), but Xcode itself is still required.
+
+**Android comparison:** Android SDK cmdline-tools can be installed standalone (~500 MB for emulator + system image). iOS has no equivalent lightweight path.
+
+## 3. Creating, Booting, and Managing Simulators via CLI
+
+All management is done through `xcrun simctl`:
+
+```bash
+# List available runtimes and device types
+xcrun simctl list runtimes
+xcrun simctl list devicetypes
+
+# Create a simulator (returns UUID)
+xcrun simctl create "MobiSSH_iPhone15" \
+  "com.apple.CoreSimulator.SimDeviceType.iPhone-15" \
+  "com.apple.CoreSimulator.SimRuntime.iOS-17-4"
+
+# Boot the simulator
+xcrun simctl boot "MobiSSH_iPhone15"
+
+# Check status
+xcrun simctl list devices | grep "MobiSSH_iPhone15"
+
+# Shutdown
+xcrun simctl shutdown "MobiSSH_iPhone15"
+
+# Delete
+xcrun simctl delete "MobiSSH_iPhone15"
+
+# Erase all content and settings (reset to clean state)
+xcrun simctl erase "MobiSSH_iPhone15"
+```
+
+**Headless mode:** Starting with Xcode 15, simulators can run headless (no Simulator.app window):
+```bash
+# Boot headless — no GUI window opens
+xcrun simctl boot "MobiSSH_iPhone15"
+# vs. opening the GUI
+open -a Simulator --args -CurrentDeviceUDID <UUID>
+```
+
+**Android comparison:** `avdmanager create avd` + `emulator -avd` maps to `xcrun simctl create` + `xcrun simctl boot`. The iOS CLI is simpler (single tool vs. sdkmanager + avdmanager + emulator).
+
+## 4. Opening a URL in Simulator Safari
+
+```bash
+# Open URL in the booted simulator's Safari
+xcrun simctl openurl booted "http://localhost:8081"
+
+# Target a specific simulator by name or UUID
+xcrun simctl openurl "MobiSSH_iPhone15" "http://localhost:8081"
+```
+
+**Network access:** The iOS Simulator shares the host's network stack. No port forwarding needed (unlike Android which requires `adb reverse`). `localhost:8081` on the host is directly accessible from Simulator Safari.
+
+**Android comparison:** Android emulator requires `adb reverse tcp:8081 tcp:8081` for localhost access. iOS Simulator needs nothing, which simplifies the test setup.
+
+## 5. WebDriver Options for Safari on Simulator
+
+### Option A: safaridriver (built-in, limited)
+
+`safaridriver` is bundled with macOS and supports Safari on Simulator.
+
+```bash
+# Enable safaridriver (one-time, requires admin)
+safaridriver --enable
+
+# Enable remote automation in Safari's Develop menu
+# (Settings > Safari > Advanced > "Web Inspector" must be on in Simulator)
+
+# Start safaridriver
+safaridriver --port 4444
+```
+
+Limitations:
+- Only supports Safari (not WKWebView in other apps)
+- Limited gesture/touch simulation compared to Appium
+- No access to native UI elements outside the browser
+- Does support W3C WebDriver protocol
+
+### Option B: Appium + XCUITest driver (recommended)
+
+Appium's XCUITest driver provides full device automation including Safari.
+
+```bash
+# Install
+npm install -g appium
+appium driver install xcuitest
+
+# Run Appium
+appium --port 4723
+
+# Capabilities for Safari on Simulator
+# {
+#   "platformName": "iOS",
+#   "appium:automationName": "XCUITest",
+#   "appium:deviceName": "MobiSSH_iPhone15",
+#   "appium:platformVersion": "17.4",
+#   "appium:browserName": "Safari",
+#   "appium:noReset": true
+# }
+```
+
+Advantages over safaridriver:
+- Touch gesture support (swipe, pinch, long press)
+- Access to native UI elements (keyboard, alerts)
+- Screen recording via `mobile: startRecordingScreen`
+- Consistent API with our Android Appium tests
+
+**Android comparison:** Our Android setup uses Appium + UiAutomator2. The iOS equivalent is Appium + XCUITest. The Appium server is shared; only the driver changes. This means `scripts/start-appium.sh` could serve both platforms.
+
+## 6. Playwright and Safari on iOS Simulator
+
+### Playwright's WebKit vs. Real Mobile Safari
+
+Playwright's WebKit browser is a desktop build of WebKit, NOT Safari on iOS. Key differences:
+
+- **Playwright WebKit:** Desktop WebKit engine, runs on Linux/macOS/Windows. No iOS-specific behaviors (address bar, safe area insets, virtual keyboard, PWA install prompt).
+- **Real Mobile Safari:** iOS WebKit with mobile viewport, touch events, virtual keyboard, `PasswordCredential` restrictions, PWA manifest handling.
+
+For MobiSSH, the gap matters for:
+- Virtual keyboard detection (`visualViewport.height`)
+- IME input behavior (swipe typing, autocorrect)
+- PWA install and home screen behavior
+- `PasswordCredential` API absence (issue #14)
+- Touch event handling and gesture recognition
+
+### Can Playwright Connect to Safari on Simulator?
+
+**Not directly.** Playwright does not support connecting to Safari on iOS Simulator via CDP or any other protocol. Options:
+
+1. **Playwright WebKit (what we have today):** Tests run against desktop WebKit. Good for basic functional testing, misses iOS-specific behavior. Already runs in our `scripts/test-headless.sh`.
+
+2. **Playwright as test runner + Appium for device control:** Use Playwright's test runner (assertions, fixtures, parallelism) while delegating browser interaction to Appium/WebDriverIO. This is exactly what our `playwright.appium.config.js` does for Android.
+
+3. **WebDriverIO standalone:** Skip Playwright entirely, use WebDriverIO's test runner. Adds another test framework dependency.
+
+**Recommendation:** Mirror the Android approach. Use Playwright as the test runner with Appium+XCUITest for device interaction. The `playwright.appium.config.js` pattern already proves this works.
+
+## 7. Parallel with Android Approach
+
+| Aspect | Android | iOS (proposed) |
+|--------|---------|----------------|
+| Setup script | `scripts/setup-avd.sh` | `scripts/setup-ios-sim.sh` |
+| Emulator tool | `emulator` (Android SDK) | `xcrun simctl` (Xcode) |
+| Device profile | Pixel 7, API 35 | iPhone 15, iOS 17.4 |
+| Browser | Chrome (Play Store) | Safari (built-in) |
+| Port forwarding | `adb reverse tcp:8081 tcp:8081` | Not needed (shared network) |
+| Automation | Appium + UiAutomator2 | Appium + XCUITest |
+| CDP/DevTools | `adb forward` + Chrome CDP | Safari Web Inspector (via `safaridriver` or Appium) |
+| Run script | `scripts/run-appium-tests.sh` | `scripts/run-ios-tests.sh` (future) |
+| Test config | `playwright.appium.config.js` | `playwright.ios.config.js` (future) |
+| Screen recording | `adb emu screenrecord` | `xcrun simctl io booted recordVideo` |
+| Debug overlays | `adb shell settings put system show_touches 1` | Not available natively; Appium logs touch events |
+| Host platform | Linux (KVM), macOS | **macOS only** |
+
+### Shared infrastructure
+- Appium server (`scripts/start-appium.sh`) could serve both platforms
+- Test fixtures could share base logic with platform-specific overrides
+- `scripts/server-ctl.sh` and Docker test-sshd work identically
+
+## 8. CI/CD Constraints
+
+### macOS Runners Required
+
+iOS Simulator requires macOS. This affects CI significantly:
+
+| Provider | macOS runner | Cost | Notes |
+|----------|-------------|------|-------|
+| GitHub Actions | `macos-13`, `macos-14` (M1) | 10x Linux minutes | M1 runners are faster but more expensive |
+| Self-hosted Mac | Mac Mini / Mac Studio | One-time hardware | Apple SLA requires macOS on Apple hardware |
+| MacStadium / AWS EC2 Mac | Cloud Mac instances | $1-2/hr | Dedicated hardware, not shared |
+
+**Cost comparison:** A typical Appium test run takes 3-5 minutes. On GitHub Actions:
+- Linux (Android): 3-5 minutes = 3-5 minutes billed
+- macOS (iOS): 3-5 minutes = 30-50 minutes billed (10x multiplier)
+
+### Recommendations for CI
+1. **Local-first:** Run iOS Simulator tests locally on macOS dev machines, not in CI initially.
+2. **Gate selectively:** Only run iOS tests on PRs that touch iOS-specific code paths.
+3. **Self-hosted runner:** If regular iOS CI is needed, a Mac Mini self-hosted runner is most cost-effective.
+4. **BrowserStack/Sauce Labs:** Cloud device farms can run iOS Safari tests without local macOS. See `browserstack.yml` for existing config.
+
+## 9. Can iOS Simulator Run on Linux?
+
+**No. iOS Simulator cannot run on Linux.**
+
+This is a hard constraint with no workarounds:
+- iOS Simulator requires macOS and the Xcode toolchain
+- Apple does not provide any Linux-compatible iOS simulation
+- There are no open-source iOS simulators for Linux
+- Running macOS in a VM on Linux violates Apple's EULA (and is unreliable for Simulator)
+
+**Alternatives for Linux-based CI:**
+- **Playwright WebKit:** Desktop WebKit on Linux covers basic functional testing (already in our CI)
+- **BrowserStack/Sauce Labs:** Cloud-based real iOS devices, accessible from any CI platform
+- **Corellium:** ARM-based iOS device virtualization (cloud service, expensive)
+
+**This means:** Our current Linux development/CI environment cannot run iOS Simulator tests. iOS Simulator testing is macOS-only and supplements (not replaces) our existing Playwright WebKit tests.
+
+## Summary and Next Steps
+
+1. iOS Simulator testing is feasible but macOS-only, making it a complement to our Linux-based CI.
+2. The Appium + XCUITest approach mirrors our Android setup closely, minimizing new code.
+3. `scripts/setup-ios-sim.sh` (draft) captures the key CLI commands for macOS setup.
+4. Priority: set up local macOS testing first, defer CI integration until test volume justifies the cost.
+5. BrowserStack (already partially configured in `browserstack.yml`) is the pragmatic path for cross-platform CI.

--- a/scripts/setup-ios-sim.sh
+++ b/scripts/setup-ios-sim.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# scripts/setup-ios-sim.sh -- Set up iOS Simulator for MobiSSH testing
+#
+# DRAFT: Key commands and TODOs for iOS Simulator testing on macOS.
+# This script is the iOS parallel to scripts/setup-avd.sh (Android).
+#
+# Prerequisites: macOS, Xcode installed (full, not just CLI tools)
+# Usage: ./scripts/setup-ios-sim.sh
+# Log: $MOBISSH_LOGDIR/setup-ios-sim.log
+#
+# NOTE: iOS Simulator CANNOT run on Linux. This script is macOS-only.
+
+set -euo pipefail
+
+MOBISSH_TMPDIR="${MOBISSH_TMPDIR:-/tmp/mobissh}"
+MOBISSH_LOGDIR="${MOBISSH_LOGDIR:-/tmp/mobissh/logs}"
+mkdir -p "$MOBISSH_TMPDIR" "$MOBISSH_LOGDIR"
+SETUP_LOG="${MOBISSH_LOGDIR}/setup-ios-sim.log"
+exec > >(tee -a "$SETUP_LOG") 2>&1
+echo "$(date '+%Y-%m-%d %H:%M:%S') setup-ios-sim.sh started"
+
+SIM_NAME="MobiSSH_iPhone15"
+# TODO: Update these when targeting newer iOS versions
+IOS_RUNTIME="com.apple.CoreSimulator.SimRuntime.iOS-17-4"
+DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-15"
+MOBISSH_PORT="${MOBISSH_PORT:-8081}"
+APPIUM_PORT="${APPIUM_PORT:-4723}"
+
+log() { echo "> $*"; }
+ok()  { echo "+ $*"; }
+err() { echo "! $*" >&2; exit 1; }
+
+# Step 0: Platform check
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  err "iOS Simulator requires macOS. This script cannot run on $(uname -s)."
+fi
+
+# Step 1: Verify Xcode installation
+log "Step 1: Verify Xcode"
+if ! xcode-select -p &>/dev/null; then
+  err "Xcode not installed. Install from the Mac App Store, then run: sudo xcode-select -s /Applications/Xcode.app"
+fi
+
+XCODE_PATH=$(xcode-select -p)
+log "Xcode developer path: $XCODE_PATH"
+
+# Verify xcrun simctl is available
+if ! xcrun simctl help &>/dev/null; then
+  err "xcrun simctl not available. Ensure Xcode (not just CLI tools) is installed."
+fi
+ok "xcrun simctl available"
+
+# Step 2: Check for iOS runtime
+log "Step 2: Check iOS runtime"
+if ! xcrun simctl list runtimes | grep -q "iOS 17"; then
+  log "iOS 17 runtime not found. Attempting to download..."
+  # TODO: This requires Xcode 15+. Adjust runtime version as needed.
+  xcodebuild -downloadPlatform iOS
+  log "Download complete. Verify with: xcrun simctl list runtimes"
+fi
+
+# List available runtimes for reference
+xcrun simctl list runtimes
+
+# Step 3: Create simulator if it doesn't exist
+log "Step 3: Create simulator"
+if xcrun simctl list devices | grep -q "$SIM_NAME"; then
+  ok "Simulator '$SIM_NAME' already exists"
+else
+  log "Creating simulator: $SIM_NAME ($DEVICE_TYPE, $IOS_RUNTIME)..."
+  SIM_UUID=$(xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE" "$IOS_RUNTIME")
+  ok "Simulator created: $SIM_NAME (UUID: $SIM_UUID)"
+fi
+
+# Step 4: Boot simulator (headless, no Simulator.app window)
+log "Step 4: Boot simulator"
+SIM_STATE=$(xcrun simctl list devices | grep "$SIM_NAME" | head -1)
+if echo "$SIM_STATE" | grep -q "Booted"; then
+  ok "Simulator already booted"
+else
+  xcrun simctl boot "$SIM_NAME"
+  ok "Simulator booted (headless)"
+fi
+
+# Step 5: Verify network access
+# iOS Simulator shares the host network. No port forwarding needed.
+log "Step 5: Verify network (no port forwarding needed)"
+log "iOS Simulator shares host network stack."
+log "localhost:$MOBISSH_PORT on host is directly accessible from Simulator Safari."
+# TODO: Add a curl check here once MobiSSH server is running
+
+# Step 6: Open MobiSSH in Safari
+log "Step 6: Open URL in Simulator Safari"
+xcrun simctl openurl booted "http://localhost:$MOBISSH_PORT"
+ok "Opened http://localhost:$MOBISSH_PORT in Simulator Safari"
+
+# Step 7: Enable Safari Web Inspector
+log "Step 7: Safari Web Inspector setup"
+log "To enable remote debugging:"
+log "  1. On Simulator: Settings > Safari > Advanced > Web Inspector = ON"
+log "  2. On host Mac: Safari > Settings > Advanced > 'Show features for web developers'"
+log "  3. On host Mac: Safari > Develop menu > Simulator device > page"
+# TODO: Automate this with defaults(1) if possible:
+#   xcrun simctl spawn booted defaults write com.apple.Safari WebKitDeveloperExtrasEnabledPreferenceKey -bool true
+#   xcrun simctl spawn booted defaults write com.apple.Safari IncludeInternalDebugMenu -bool true
+
+# Step 8: Install Appium + XCUITest driver
+log "Step 8: Appium + XCUITest"
+if command -v appium &>/dev/null; then
+  ok "Appium already installed: $(appium --version)"
+else
+  log "Installing Appium..."
+  npm install -g appium
+  ok "Appium installed: $(appium --version)"
+fi
+
+if appium driver list --installed 2>&1 | grep -q xcuitest; then
+  ok "XCUITest driver already installed"
+else
+  log "Installing XCUITest driver..."
+  appium driver install xcuitest
+  ok "XCUITest driver installed"
+fi
+
+# TODO: Run appium driver doctor xcuitest to validate setup
+
+# Step 9: Enable safaridriver (alternative to Appium for simple tests)
+log "Step 9: safaridriver"
+if [[ -x /usr/bin/safaridriver ]]; then
+  log "safaridriver found at /usr/bin/safaridriver"
+  log "Enable with: safaridriver --enable (requires admin password)"
+  # TODO: Check if already enabled; safaridriver --enable is idempotent but prompts for password
+else
+  log "safaridriver not found (expected on macOS)"
+fi
+
+# Step 10: Screen recording setup
+log "Step 10: Screen recording"
+log "Record Simulator screen with:"
+log "  xcrun simctl io booted recordVideo output.mp4"
+log "  # Press Ctrl+C to stop recording"
+log ""
+log "Take screenshot with:"
+log "  xcrun simctl io booted screenshot screenshot.png"
+
+# Summary
+echo ""
+echo "$(date '+%Y-%m-%d %H:%M:%S') setup-ios-sim.sh finished"
+echo "Log saved to: $SETUP_LOG"
+echo ""
+echo "Simulator: $SIM_NAME"
+echo ""
+echo "Useful commands:"
+echo "  xcrun simctl boot '$SIM_NAME'              # Boot (headless)"
+echo "  open -a Simulator                           # Open Simulator GUI"
+echo "  xcrun simctl openurl booted 'http://localhost:$MOBISSH_PORT'  # Open in Safari"
+echo "  xcrun simctl io booted recordVideo out.mp4  # Record screen"
+echo "  xcrun simctl io booted screenshot shot.png  # Screenshot"
+echo "  xcrun simctl shutdown '$SIM_NAME'           # Shutdown"
+echo "  xcrun simctl erase '$SIM_NAME'              # Reset to clean state"
+echo "  xcrun simctl delete '$SIM_NAME'             # Delete simulator"
+echo ""
+echo "Appium capabilities for Safari on this Simulator:"
+echo '  {'
+echo '    "platformName": "iOS",'
+echo '    "appium:automationName": "XCUITest",'
+echo "    \"appium:deviceName\": \"$SIM_NAME\","
+echo '    "appium:platformVersion": "17.4",'
+echo '    "appium:browserName": "Safari",'
+echo '    "appium:noReset": true'
+echo '  }'
+echo ""
+echo "TODO: Create scripts/run-ios-tests.sh (parallel to scripts/run-appium-tests.sh)"
+echo "TODO: Create playwright.ios.config.js (parallel to playwright.appium.config.js)"


### PR DESCRIPTION
Research spike: iOS Simulator CLI setup, Xcode requirements, Safari WebDriver options, CI constraints. Closes #9