### PR TITLE
feat: parameterize emulator scripts for parallel instances

### DIFF
--- a/docs/parallel-emulators.md
+++ b/docs/parallel-emulators.md
@@ -1,0 +1,44 @@
+# Parallel Android Emulators
+
+Run multiple AVD instances side by side for parallel Appium testing.
+
+## Port allocation
+
+Each emulator needs a unique console port (even number) and a unique Appium port.
+
+| Instance | AVD name         | Emulator port | Appium port |
+|----------|------------------|---------------|-------------|
+| 1        | MobiSSH_Pixel7   | 5554          | 4723        |
+| 2        | MobiSSH_Pixel7_2 | 5556          | 4725        |
+
+ADB derives its serial from the console port: `emulator-5554`, `emulator-5556`.
+
+## Setup
+
+Create two AVDs (one-time):
+
+```bash
+scripts/setup-avd.sh
+scripts/setup-avd.sh --name MobiSSH_Pixel7_2 --port 5556
+```
+
+## Running tests in parallel
+
+Terminal 1:
+
+```bash
+scripts/run-appium-tests.sh --avd MobiSSH_Pixel7 --port 5554 --appium-port 4723
+```
+
+Terminal 2:
+
+```bash
+scripts/run-appium-tests.sh --avd MobiSSH_Pixel7_2 --port 5556 --appium-port 4725
+```
+
+## Notes
+
+- Emulator console ports must be even numbers in the range 5554-5682.
+- Each instance gets its own ADB serial (`emulator-PORT`), so `adb` commands are isolated.
+- The MobiSSH server port (`MOBISSH_PORT`) is separate and shared by default (8081). Override with `MOBISSH_PORT=8082` if needed.
+- Default behavior (no arguments) is unchanged: AVD `MobiSSH_Pixel7`, port 5554, Appium 4723.

--- a/scripts/run-appium-tests.sh
+++ b/scripts/run-appium-tests.sh
@@ -10,6 +10,7 @@
 #   scripts/run-appium-tests.sh gesture-scroll-baseline    # specific test file
 #   scripts/run-appium-tests.sh --suite baseline-pre       # all tests, suite-tagged archive
 #   scripts/run-appium-tests.sh integrate-117 --suite integrate-117-before
+#   scripts/run-appium-tests.sh --avd MyAVD --port 5556 --appium-port 4725
 # Log: /tmp/run-appium-tests.log
 
 set -euo pipefail
@@ -27,14 +28,23 @@ export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
 AVD_NAME="MobiSSH_Pixel7"
 MOBISSH_PORT="${MOBISSH_PORT:-8081}"
 APPIUM_PORT="${APPIUM_PORT:-4723}"
+EMU_PORT=""
 SPEC=""
 SUITE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --avd) AVD_NAME="$2"; shift 2 ;;
+    --port) EMU_PORT="$2"; shift 2 ;;
+    --appium-port) APPIUM_PORT="$2"; shift 2 ;;
     --suite) SUITE="$2"; shift 2 ;;
     *) SPEC="$1"; shift ;;
   esac
 done
+# Derive ADB serial from emulator port (if specified)
+ADB_SERIAL=""
+if [[ -n "$EMU_PORT" ]]; then
+  ADB_SERIAL="emulator-$EMU_PORT"
+fi
 RESULTS_DIR="test-results-appium"
 # Record to /tmp first — Playwright cleans RESULTS_DIR at startup, which would
 # delete a recording in progress. Move the finalized file in afterward.
@@ -47,11 +57,21 @@ log() { echo "> $*"; }
 ok()  { echo "+ $*"; }
 err() { echo "! $*" >&2; exit 1; }
 
+# Build ADB command with optional serial targeting.
+# When ADB_SERIAL is set, all adb commands target that specific emulator.
+adb_cmd() {
+  if [[ -n "$ADB_SERIAL" ]]; then
+    adb -s "$ADB_SERIAL" "$@"
+  else
+    adb "$@"
+  fi
+}
+
 # Run an ADB command, log failures but don't abort the script.
 # ADB setup commands are best-effort — the emulator may not have Chrome yet,
 # permissions may already be granted, etc.
 adb_try() {
-  if ! adb "$@" 2>&1; then
+  if ! adb_cmd "$@" 2>&1; then
     log "adb $1 $2 ... failed (non-fatal)"
   fi
 }
@@ -79,13 +99,17 @@ log "Phase 2: Android emulator"
 command -v emulator &>/dev/null || err "emulator not found. Run scripts/setup-avd.sh"
 command -v adb &>/dev/null || err "adb not found. Run scripts/setup-avd.sh"
 
-if ! adb devices 2>/dev/null | grep -q 'emulator\|device$'; then
+if ! adb_cmd devices 2>/dev/null | grep -q 'emulator\|device$'; then
+  EMU_PORT_ARGS=""
+  if [[ -n "$EMU_PORT" ]]; then
+    EMU_PORT_ARGS="-port $EMU_PORT"
+  fi
   log "Booting emulator ($AVD_NAME)..."
-  sg kvm -c "emulator -avd \"$AVD_NAME\" -no-snapshot-save -gpu auto -no-audio -no-qt" &
+  sg kvm -c "emulator -avd \"$AVD_NAME\" $EMU_PORT_ARGS -no-snapshot-save -gpu auto -no-audio -no-qt" &
   EMU_PID=$!
-  adb wait-for-device
+  adb_cmd wait-for-device
   for i in $(seq 1 120); do
-    if adb shell getprop sys.boot_completed 2>/dev/null | grep -q '^1$'; then break; fi
+    if adb_cmd shell getprop sys.boot_completed 2>/dev/null | grep -q '^1$'; then break; fi
     if (( i == 120 )); then err "Emulator failed to boot within 120s"; fi
     sleep 1
   done
@@ -101,9 +125,9 @@ adb_try reverse tcp:"$MOBISSH_PORT" tcp:"$MOBISSH_PORT"
 # Dismiss any lingering ANR (Application Not Responding) dialogs.
 # System UI crashes are common on emulators; the dialog blocks the screen
 # and corrupts recordings even if JS-based tests pass underneath.
-if adb shell uiautomator dump /sdcard/window_dump.xml 2>/dev/null &&
-   adb shell cat /sdcard/window_dump.xml 2>/dev/null | grep -q 'aerr_wait'; then
-  adb shell input tap 540 1367   # "Wait" button coordinates (standard ANR dialog)
+if adb_cmd shell uiautomator dump /sdcard/window_dump.xml 2>/dev/null &&
+   adb_cmd shell cat /sdcard/window_dump.xml 2>/dev/null | grep -q 'aerr_wait'; then
+  adb_cmd shell input tap 540 1367   # "Wait" button coordinates (standard ANR dialog)
   log "Dismissed ANR dialog"
   sleep 1
 fi
@@ -149,6 +173,7 @@ EXTRA_ARGS=()
 set +e
 BASE_URL="http://localhost:$MOBISSH_PORT" \
   APPIUM_PORT="$APPIUM_PORT" \
+  ADB_SERIAL="${ADB_SERIAL}" \
   APPIUM_RECORDING_DIR="$RECORDING_DIR" \
   npx playwright test \
     --config=playwright.appium.config.js \
@@ -157,7 +182,7 @@ EXIT=$?
 set -e
 
 # Safety stop in case a test crashed before stopping its recording.
-if ! adb emu screenrecord stop 2>/dev/null; then
+if ! adb_cmd emu screenrecord stop 2>/dev/null; then
   log "OK: recording is already stopped."
 fi
 sleep 1

--- a/scripts/setup-avd.sh
+++ b/scripts/setup-avd.sh
@@ -5,7 +5,9 @@
 # a Pixel 7 AVD with Google Play (for real Chrome + WebAuthn testing).
 #
 # Prerequisites: android-studio snap, KVM enabled
-# Usage: ./scripts/setup-avd.sh
+# Usage: ./scripts/setup-avd.sh [--name AVD_NAME] [--port PORT]
+#   --name NAME   AVD name (default: MobiSSH_Pixel7)
+#   --port PORT   Emulator console port (default: 5554)
 # Log: /tmp/setup-avd.log
 
 set -euo pipefail
@@ -21,8 +23,18 @@ ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"
 CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
 JAVA_HOME="/snap/android-studio/current/jbr"
 AVD_NAME="MobiSSH_Pixel7"
+EMU_PORT="5554"
 SYSTEM_IMAGE="system-images;android-35;google_apis_playstore;x86_64"
 DEVICE_PROFILE="pixel_7"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name) AVD_NAME="$2"; shift 2 ;;
+    --port) EMU_PORT="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
 
 export ANDROID_HOME JAVA_HOME
 export PATH="$JAVA_HOME/bin:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
@@ -97,42 +109,43 @@ if [[ -f "$AVD_INI" ]]; then
 fi
 
 # 6. Write helper scripts
-LAUNCH_SCRIPT="$ANDROID_HOME/launch-mobissh-avd.sh"
-cat > "$LAUNCH_SCRIPT" <<'LAUNCH'
+LAUNCH_SCRIPT="$ANDROID_HOME/launch-${AVD_NAME}.sh"
+cat > "$LAUNCH_SCRIPT" <<LAUNCH
 #!/usr/bin/env bash
 # Launch the MobiSSH test emulator and set up port forwarding.
-# Usage: bash ~/Android/Sdk/launch-mobissh-avd.sh
+# Usage: bash $LAUNCH_SCRIPT
 
 set -euo pipefail
 
-ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"
-export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
+ANDROID_HOME="\${ANDROID_HOME:-\$HOME/Android/Sdk}"
+export PATH="\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/emulator:\$PATH"
 
-AVD_NAME="MobiSSH_Pixel7"
-MOBISSH_PORT="${MOBISSH_PORT:-8080}"
+AVD_NAME="${AVD_NAME}"
+EMU_PORT="${EMU_PORT}"
+MOBISSH_PORT="\${MOBISSH_PORT:-8080}"
 
-echo "> Starting emulator ($AVD_NAME)..."
-emulator -avd "$AVD_NAME" -no-snapshot-save -gpu auto -no-audio -no-qt &
-EMU_PID=$!
+echo "> Starting emulator (\$AVD_NAME) on port \$EMU_PORT..."
+emulator -avd "\$AVD_NAME" -port "\$EMU_PORT" -no-snapshot-save -gpu auto -no-audio -no-qt &
+EMU_PID=\$!
 
 echo "> Waiting for device to boot..."
-adb wait-for-device
-adb shell 'while [[ "$(getprop sys.boot_completed)" != "1" ]]; do sleep 1; done'
+adb -s emulator-\$EMU_PORT wait-for-device
+adb -s emulator-\$EMU_PORT shell 'while [[ "\$(getprop sys.boot_completed)" != "1" ]]; do sleep 1; done'
 echo "> Device booted."
 
 # Port-forward so emulator's localhost:8080 -> host's localhost:8080
-adb reverse tcp:$MOBISSH_PORT tcp:$MOBISSH_PORT
-echo "> Port forwarded: emulator localhost:$MOBISSH_PORT -> host localhost:$MOBISSH_PORT"
-echo "> Open Chrome on emulator and navigate to http://localhost:$MOBISSH_PORT"
+adb -s emulator-\$EMU_PORT reverse tcp:\$MOBISSH_PORT tcp:\$MOBISSH_PORT
+echo "> Port forwarded: emulator localhost:\$MOBISSH_PORT -> host localhost:\$MOBISSH_PORT"
+echo "> Open Chrome on emulator and navigate to http://localhost:\$MOBISSH_PORT"
 echo ""
 echo "Useful commands:"
-echo "  adb emu finger touch 1     # simulate fingerprint (for WebAuthn biometric)"
-echo "  adb shell input text 'url' # type text"
-echo "  adb logcat -s chromium     # Chrome logs"
-echo "  kill $EMU_PID              # stop emulator"
+echo "  adb -s emulator-\$EMU_PORT emu finger touch 1     # simulate fingerprint"
+echo "  adb -s emulator-\$EMU_PORT shell input text 'url' # type text"
+echo "  adb -s emulator-\$EMU_PORT logcat -s chromium     # Chrome logs"
+echo "  kill \$EMU_PID              # stop emulator"
 echo ""
 
-wait $EMU_PID
+wait \$EMU_PID
 LAUNCH
 chmod +x "$LAUNCH_SCRIPT"
 
@@ -157,6 +170,6 @@ echo "  bash $LAUNCH_SCRIPT"
 echo ""
 echo "Or manually:"
 echo "  source ~/.bashrc"
-echo "  emulator -avd $AVD_NAME &"
-echo "  adb reverse tcp:8080 tcp:8080"
+echo "  emulator -avd $AVD_NAME -port $EMU_PORT &"
+echo "  adb -s emulator-$EMU_PORT reverse tcp:8080 tcp:8080"
 echo "  # Then open http://localhost:8080 in Chrome on emulator"


### PR DESCRIPTION
Adds --name and --port params to setup-avd.sh and --avd/--port/--appium-port to run-appium-tests.sh for running multiple emulators. Docs in docs/parallel-emulators.md. Closes #13