### PR TITLE
fix: add test notification button in settings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -485,6 +485,14 @@
         </select>
       </div>
 
+      <div class="setting-row">
+        <div class="setting-row-info">
+          <span class="setting-row-label">Test</span>
+          <p class="hint">Fire a test notification to verify your device settings.</p>
+        </div>
+        <button id="testNotifBtn" class="secondary-btn">Test notification</button>
+      </div>
+
       <hr />
 
       <div class="vault-settings">

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -157,6 +157,20 @@ export function initSettingsPanel(): void {
     });
   }
 
+  const testNotifBtn = document.getElementById('testNotifBtn');
+  if (testNotifBtn) {
+    testNotifBtn.addEventListener('click', () => {
+      void Notification.requestPermission().then((perm) => {
+        if (perm === 'granted') {
+          new Notification('MobiSSH', { body: 'Test notification' });
+          _toast('Notification sent.');
+        } else {
+          _toast('Notification permission denied.');
+        }
+      });
+    });
+  }
+
   const dockEl = document.getElementById('keyControlsDockLeft') as HTMLInputElement | null;
   if (dockEl) {
     dockEl.checked = localStorage.getItem('keyControlsDock') === 'left';


### PR DESCRIPTION
Adds a button to fire a real PWA notification for testing the mobile notification pipeline. Closes #32