### PR TITLE
feat: bell notification icon with badge in handle bar

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -387,6 +387,28 @@ body.debug-ime #imePreview {
 .handle-compose-btn.compose-active { color: var(--accent); }
 .handle-compose-btn:active { opacity: 0.7; }
 
+/* Bell notification indicator in handle bar (#33) */
+.handle-bell-btn {
+  position: relative;
+  padding: 4px 6px;
+}
+
+.bell-badge {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  background: var(--accent);
+  color: var(--bg-deep);
+  font-size: 10px;
+  font-weight: bold;
+  min-width: 14px;
+  height: 14px;
+  line-height: 14px;
+  border-radius: 7px;
+  text-align: center;
+  padding: 0 3px;
+}
+
 /* Copy and paste buttons in handle bar — shared layout (#55, #197) */
 .handle-copy-btn,
 .handle-paste-btn {

--- a/public/index.html
+++ b/public/index.html
@@ -179,6 +179,7 @@
         <button id="handleMenuBtn" class="handle-btn handle-menu-btn" title="Show tabs" aria-label="Show tabs">≡</button>
         <button id="handlePasteBtn" class="handle-paste-btn hidden" title="Paste clipboard" aria-label="Paste clipboard">Paste</button>
         <button id="sessionMenuBtn" title="Session menu" aria-label="Session menu">MobiSSH</button>
+        <button id="bellIndicatorBtn" class="handle-btn handle-bell-btn hidden" title="Notifications" aria-label="Notifications"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg><span class="bell-badge hidden">0</span></button>
         <button id="handleCopyBtn" class="handle-copy-btn hidden" title="Copy selection" aria-label="Copy selection">Copy</button>
         <button id="composeModeBtn" class="handle-btn handle-compose-btn" title="Compose mode: swipe typing, voice, autocorrect"><svg viewBox="0 0 12 20" width="9" height="15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8.5 1.5l2 2L4 10l-2.5.5.5-2.5Z"/><line x1="1" y1="14" x2="11" y2="14"/><line x1="1" y1="18" x2="11" y2="18"/></svg></button>
         <!-- Session menu anchored inside the positioned parent so absolute positioning works -->

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -6,6 +6,37 @@ import type { ThemeName, RootCSS } from './types.js';
 import { THEMES, ANSI, FONT_SIZE } from './constants.js';
 import { appState } from './state.js';
 
+interface NotifEntry {
+  time: number;
+  message: string;
+}
+
+const _notifications: NotifEntry[] = [];
+
+export function getNotifications(): readonly NotifEntry[] {
+  return _notifications;
+}
+
+export function clearNotifications(): void {
+  _notifications.length = 0;
+  _updateBellBadge();
+}
+
+function _addNotification(message: string): void {
+  _notifications.push({ time: Date.now(), message });
+  _updateBellBadge();
+}
+
+function _updateBellBadge(): void {
+  const btn = document.getElementById('bellIndicatorBtn');
+  const badge = btn?.querySelector('.bell-badge');
+  if (!btn || !badge) return;
+  const count = _notifications.length;
+  btn.classList.toggle('hidden', count === 0);
+  badge.classList.toggle('hidden', count === 0);
+  badge.textContent = String(count);
+}
+
 // ── CSS layout constants (read from :root once; JS never hardcodes px values) ─
 
 export const ROOT_CSS: RootCSS = (() => {
@@ -68,25 +99,27 @@ export function initTerminal(): void {
   applyTheme(appState.activeThemeName);
 
   appState.terminal.onBell(() => {
-    if (!shouldNotify()) return;
     const buffer = appState.terminal!.buffer.active;
     let body = 'Terminal bell';
     for (let i = buffer.cursorY; i >= 0; i--) {
       const line = buffer.getLine(i)?.translateToString(true).trim();
       if (line) { body = line; break; }
     }
-    fireNotification('MobiSSH', body);
+    _addNotification(body);
+    if (shouldNotify()) fireNotification('MobiSSH', body);
   });
 
   appState.terminal.parser.registerOscHandler(9, (data: string) => {
+    _addNotification(data);
     if (shouldNotify()) fireNotification('MobiSSH', data);
     return true;
   });
 
   appState.terminal.parser.registerOscHandler(777, (data: string) => {
     const parts = data.split(';');
-    if (parts[0] === 'notify' && shouldNotify()) {
-      fireNotification(parts[1] ?? 'MobiSSH', parts[2] ?? '');
+    if (parts[0] === 'notify') {
+      _addNotification(parts[2] ?? '');
+      if (shouldNotify()) fireNotification(parts[1] ?? 'MobiSSH', parts[2] ?? '');
     }
     return true;
   });


### PR DESCRIPTION
## Summary
- Adds a bell icon (`#bellIndicatorBtn`) to the handle bar between the session menu and copy button
- Badge count increments on every BEL, OSC 9, and OSC 777 notification — independent of browser notification permission
- Exports `getNotifications()` and `clearNotifications()` for the notification drawer (#34)

## Test plan
- [ ] Verify bell icon is hidden by default (no notifications)
- [ ] Send BEL (`printf '\a'`) and confirm badge appears with count
- [ ] Send OSC 9 (`printf '\e]9;hello\e\\'`) and confirm count increments
- [ ] Verify badge styling (accent color, positioned top-right of bell icon)
- [ ] Confirm no click handler (drawer is #34)

Closes #33