### PR TITLE
chore: remove duplicate pinch-to-zoom toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -552,17 +552,6 @@
             <span class="toggle-slider"></span>
           </label>
         </div>
-
-        <div class="danger-zone-item">
-          <div class="danger-zone-item-info">
-            <span class="danger-zone-item-label">Enable pinch-to-zoom</span>
-            <p class="hint">Two-finger pinch changes terminal font size. Disable if it interferes with scrolling.</p>
-          </div>
-          <label class="toggle" aria-label="Enable pinch-to-zoom">
-            <input type="checkbox" id="enablePinchZoom" />
-            <span class="toggle-slider"></span>
-          </label>
-        </div>
       </div>
 
       <div class="danger-zone">


### PR DESCRIPTION
Removes the duplicate Enable pinch-to-zoom checkbox from the Advanced settings section. The toggle in general settings remains. No handler changes needed.

Fixes #44