### PR TITLE
feat: SSH key UX — keys tab CRUD + dropdown

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(scripts/integrate-discover.sh:*)",
+      "Bash(sudo npx:*)",
+      "Bash(do:*)",
+      "Bash(git:*)",
+      "Bash(do gh:*)",
+      "Bash(do echo:*)",
+      "Bash(bash:*)",
+      "Bash(/usr/bin/env bash:*)",
+      "Bash(gh pr:*)",
+      "Bash(/home/dev/workspace/mobissh/scripts/container-ctl.sh restart:*)",
+      "Bash(tmux:*)",
+      "Bash(printf \\\\033]9;local-test\\\\007:*)",
+      "Bash(~/.claude/hooks/notify-bell.sh:*)",
+      "Bash(who:*)",
+      "Bash(scripts/gh-ops.sh comment:*)",
+      "Bash(/tmp/sub-issue-47c.md:*)"
+    ]
+  }
+}

--- a/public/app.css
+++ b/public/app.css
@@ -980,6 +980,23 @@ hr {
   color: var(--text-dim);
 }
 
+.key-dropdown {
+  width: 100%;
+  padding: 8px;
+  background: var(--bg-input);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+#manualKeyGroup {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .item-actions {
   display: flex;
   gap: 8px;

--- a/public/app.js
+++ b/public/app.js
@@ -8,7 +8,7 @@ import { initDebugOverlay } from './modules/debug.js';
 import { initRecording } from './modules/recording.js';
 import { initVault } from './modules/vault.js';
 import { initVaultUI, promptVaultSetupOnStartup } from './modules/vault-ui.js';
-import { initProfiles, getProfiles, loadProfiles, loadProfileIntoForm, deleteProfile, loadKeys, importKey, useKey, deleteKey, } from './modules/profiles.js';
+import { initProfiles, getProfiles, loadProfiles, loadProfileIntoForm, deleteProfile, loadKeys, importKey, useKey, deleteKey, renameKey, populateKeyDropdown, } from './modules/profiles.js';
 import { initSettings, initSettingsPanel, registerServiceWorker } from './modules/settings.js';
 import { initConnection } from './modules/connection.js';
 import { initIME, initIMEInput } from './modules/ime.js';
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
         initSettingsPanel();
         loadProfiles();
         loadKeys();
+        populateKeyDropdown();
         registerServiceWorker();
         initVaultUI({ toast });
         await initVault();
@@ -79,9 +80,15 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
                 return;
             const idx = parseInt(btn.dataset.idx ?? '0');
             if (btn.dataset.action === 'use')
-                void useKey(idx);
+                useKey(idx);
             else if (btn.dataset.action === 'delete')
                 deleteKey(idx);
+            else if (btn.dataset.action === 'rename') {
+                const currentName = btn.closest('.key-item')?.querySelector('.key-name')?.textContent ?? '';
+                const newName = prompt('Rename key to:', currentName);
+                if (newName !== null)
+                    renameKey(idx, newName);
+            }
         });
         // Import key button
         document.getElementById('importKeyBtn').addEventListener('click', () => {

--- a/public/index.html
+++ b/public/index.html
@@ -307,18 +307,24 @@
           </div>
 
           <div id="keyGroup" class="compact-form-span hidden">
-            <label for="privateKey">Private key</label>
-            <textarea id="privateKey" rows="4" placeholder="Paste PEM private key here..." spellcheck="false"></textarea>
-            <label for="remote_pp">Passphrase (if encrypted)</label>
-            <input type="text" id="remote_pp"
-              autocomplete="off"
-              autocorrect="off"
-              autocapitalize="off"
-              spellcheck="false"
-              data-lpignore="true"
-              data-1p-ignore="true"
-              data-form-type="other" />
-            <button type="button" id="useStoredKeyBtn" class="secondary-btn">Use stored key…</button>
+            <label for="selectedKeyId">SSH Key</label>
+            <select id="selectedKeyId" class="key-dropdown">
+              <option value="">Select a stored key...</option>
+              <option value="manual">Paste key manually...</option>
+            </select>
+            <div id="manualKeyGroup" class="hidden">
+              <label for="privateKey">Private key</label>
+              <textarea id="privateKey" rows="4" placeholder="Paste PEM private key here..." spellcheck="false"></textarea>
+              <label for="remote_pp">Passphrase (if encrypted)</label>
+              <input type="text" id="remote_pp"
+                autocomplete="off"
+                autocorrect="off"
+                autocapitalize="off"
+                spellcheck="false"
+                data-lpignore="true"
+                data-1p-ignore="true"
+                data-form-type="other" />
+            </div>
           </div>
 
           <details id="connectAdvanced" class="compact-form-span">

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mobissh-server",
       "version": "0.5.0",
+      "license": "MIT",
       "dependencies": {
         "ssh2": "^1.15.0",
         "ws": "^8.16.0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,7 @@ import { initVaultUI, promptVaultSetupOnStartup } from './modules/vault-ui.js';
 import {
   initProfiles, getProfiles, loadProfiles,
   loadProfileIntoForm, deleteProfile,
-  loadKeys, importKey, useKey, deleteKey,
+  loadKeys, importKey, useKey, deleteKey, renameKey, populateKeyDropdown,
 } from './modules/profiles.js';
 import { initSettings, initSettingsPanel, registerServiceWorker } from './modules/settings.js';
 import { initConnection } from './modules/connection.js';
@@ -61,6 +61,7 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
     initSettingsPanel();
     loadProfiles();
     loadKeys();
+    populateKeyDropdown();
     registerServiceWorker();
     initVaultUI({ toast });
     await initVault();
@@ -99,8 +100,13 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
       const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-action]');
       if (!btn) return;
       const idx = parseInt(btn.dataset.idx ?? '0');
-      if (btn.dataset.action === 'use') void useKey(idx);
+      if (btn.dataset.action === 'use') useKey(idx);
       else if (btn.dataset.action === 'delete') deleteKey(idx);
+      else if (btn.dataset.action === 'rename') {
+        const currentName = btn.closest('.key-item')?.querySelector('.key-name')?.textContent ?? '';
+        const newName = prompt('Rename key to:', currentName);
+        if (newName !== null) renameKey(idx, newName);
+      }
     });
 
     // Import key button

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -34,6 +34,7 @@ interface StoredProfile {
   initialCommand: string;
   vaultId: string;
   hasVaultCreds?: boolean;
+  keyVaultId?: string;
 }
 
 export function getProfiles(): StoredProfile[] {
@@ -57,6 +58,10 @@ export async function saveProfile(profile: SSHProfile): Promise<void> {
     ? (profiles[existingIdx]?.vaultId ?? _generateId())
     : _generateId();
 
+  // Check if the form selected a stored key by its vaultId
+  const selectedKeyId = (document.getElementById('selectedKeyId') as HTMLSelectElement | null)?.value || '';
+  const usingStoredKey = profile.authType === 'key' && selectedKeyId !== '' && selectedKeyId !== 'manual';
+
   const saved: StoredProfile = {
     name: profile.name,
     host: profile.host,
@@ -67,10 +72,15 @@ export async function saveProfile(profile: SSHProfile): Promise<void> {
     vaultId,
   };
 
+  if (usingStoredKey) {
+    saved.keyVaultId = selectedKeyId;
+  }
+
   const creds: Record<string, string> = {};
   if (profile.password) creds.password = profile.password;
-  if (profile.privateKey) creds.privateKey = profile.privateKey;
-  if (profile.passphrase) creds.passphrase = profile.passphrase;
+  // Only store inline key if not using a stored key reference
+  if (profile.privateKey && !usingStoredKey) creds.privateKey = profile.privateKey;
+  if (profile.passphrase && !usingStoredKey) creds.passphrase = profile.passphrase;
 
   const hasVault = await ensureVaultKeyWithUI();
   if (hasVault && Object.keys(creds).length) {
@@ -132,6 +142,9 @@ export function newConnection(): void {
   const form = document.getElementById('connectForm') as HTMLFormElement | null;
   if (form) form.reset();
   (document.getElementById('port') as HTMLInputElement).value = '22';
+  const keySelect = document.getElementById('selectedKeyId') as HTMLSelectElement | null;
+  if (keySelect) keySelect.value = '';
+  document.getElementById('manualKeyGroup')?.classList.add('hidden');
   revealConnectForm();
   (document.getElementById('host') as HTMLInputElement).focus();
 }
@@ -150,9 +163,24 @@ export async function loadProfileIntoForm(idx: number): Promise<void> {
   authTypeEl.dispatchEvent(new Event('change'));
 
   (document.getElementById('remote_c') as HTMLInputElement).value = '';
-  (document.getElementById('privateKey') as HTMLTextAreaElement).value = '';
-  (document.getElementById('remote_pp') as HTMLInputElement).value = '';
+  const privateKeyEl = document.getElementById('privateKey') as HTMLTextAreaElement | null;
+  const remotePpEl = document.getElementById('remote_pp') as HTMLInputElement | null;
+  if (privateKeyEl) privateKeyEl.value = '';
+  if (remotePpEl) remotePpEl.value = '';
   (document.getElementById('initialCommand') as HTMLInputElement).value = profile.initialCommand || '';
+
+  // Select the stored key in the dropdown if profile references one
+  const keySelect = document.getElementById('selectedKeyId') as HTMLSelectElement | null;
+  const manualKeyGroup = document.getElementById('manualKeyGroup');
+  if (keySelect) {
+    if (profile.keyVaultId) {
+      keySelect.value = profile.keyVaultId;
+      manualKeyGroup?.classList.add('hidden');
+    } else {
+      keySelect.value = '';
+      manualKeyGroup?.classList.add('hidden');
+    }
+  }
 
   if (profile.vaultId && profile.hasVaultCreds) {
     if (!appState.vaultKey) {
@@ -166,8 +194,6 @@ export async function loadProfileIntoForm(idx: number): Promise<void> {
     const creds = await vaultLoad(profile.vaultId);
     if (creds) {
       if (creds.password) (document.getElementById('remote_c') as HTMLInputElement).value = creds.password as string;
-      if (creds.privateKey) (document.getElementById('privateKey') as HTMLTextAreaElement).value = creds.privateKey as string;
-      if (creds.passphrase) (document.getElementById('remote_pp') as HTMLInputElement).value = creds.passphrase as string;
       _toast('Credentials unlocked');
     } else {
       _toast('Vault locked — enter credentials manually');
@@ -212,7 +238,29 @@ export async function connectFromProfile(idx: number): Promise<boolean> {
       _navigateToConnect();
       return false;
     }
-  } else if (!profile.hasVaultCreds) {
+  }
+
+  // Load key from stored key reference if profile uses one
+  if (profile.keyVaultId && !sshProfile.privateKey) {
+    if (!appState.vaultKey) {
+      const unlocked = await ensureVaultKeyWithUI();
+      if (!unlocked) {
+        _toast('Vault locked — enter key manually');
+        _navigateToConnect();
+        return false;
+      }
+    }
+    const keyCreds = await vaultLoad(profile.keyVaultId);
+    if (keyCreds?.data) {
+      sshProfile.privateKey = keyCreds.data as string;
+    } else {
+      _toast('Could not load stored key from vault.');
+      _navigateToConnect();
+      return false;
+    }
+  }
+
+  if (!profile.hasVaultCreds && !profile.keyVaultId) {
     _toast('Enter credentials — not saved on this browser.');
     void loadProfileIntoForm(idx);
     return false;
@@ -229,6 +277,21 @@ export function deleteProfile(idx: number): void {
   profiles.splice(idx, 1);
   localStorage.setItem('sshProfiles', JSON.stringify(profiles));
   loadProfiles();
+}
+
+/** Populate the key dropdown in the connect form with current stored keys. */
+export function populateKeyDropdown(): void {
+  const select = document.getElementById('selectedKeyId') as HTMLSelectElement | null;
+  if (!select) return;
+  const currentValue = select.value;
+  const keys = getKeys();
+  select.innerHTML = '<option value="">Select a stored key...</option>'
+    + keys.map(k => `<option value="${escHtml(k.vaultId)}">${escHtml(k.name)}</option>`).join('')
+    + '<option value="manual">Paste key manually...</option>';
+  // Restore previous selection if still valid
+  if (currentValue && Array.from(select.options).some(o => o.value === currentValue)) {
+    select.value = currentValue;
+  }
 }
 
 // Key storage
@@ -258,6 +321,7 @@ export function loadKeys(): void {
       <span class="key-name">${escHtml(k.name)}</span>
       <span class="key-created">Added ${new Date(k.created).toLocaleDateString()}</span>
       <div class="item-actions">
+        <button class="item-btn" data-action="rename" data-idx="${String(i)}">Rename</button>
         <button class="item-btn" data-action="use" data-idx="${String(i)}">Use in form</button>
         <button class="item-btn danger" data-action="delete" data-idx="${String(i)}">Delete</button>
       </div>
@@ -279,23 +343,33 @@ export async function importKey(name: string, data: string): Promise<boolean> {
   keys.push({ name, vaultId, created: new Date().toISOString() });
   localStorage.setItem('sshKeys', JSON.stringify(keys));
   loadKeys();
+  populateKeyDropdown();
   _toast(`Key "${name}" saved.`);
   return true;
 }
 
-export async function useKey(idx: number): Promise<void> {
+export function useKey(idx: number): void {
   const key = getKeys()[idx];
   if (!key) return;
-  if (!appState.vaultKey) {
-    const unlocked = await ensureVaultKeyWithUI();
-    if (!unlocked) { _toast('Vault locked — enter key manually.'); return; }
-  }
-  const creds = key.vaultId ? await vaultLoad(key.vaultId) : null;
-  if (!creds) { _toast('Could not load key from vault.'); return; }
   (document.getElementById('authType') as HTMLSelectElement).value = 'key';
   (document.getElementById('authType') as HTMLSelectElement).dispatchEvent(new Event('change'));
-  (document.getElementById('privateKey') as HTMLTextAreaElement).value = creds.data as string;
-  _toast(`Key "${key.name}" loaded into form.`);
+  const keySelect = document.getElementById('selectedKeyId') as HTMLSelectElement | null;
+  if (keySelect) {
+    keySelect.value = key.vaultId;
+  }
+  _toast(`Key "${key.name}" selected in form.`);
+}
+
+export function renameKey(idx: number, newName: string): void {
+  if (!newName.trim()) { _toast('Key name cannot be empty.'); return; }
+  const keys = getKeys();
+  const key = keys[idx];
+  if (!key) return;
+  key.name = newName.trim();
+  localStorage.setItem('sshKeys', JSON.stringify(keys));
+  loadKeys();
+  populateKeyDropdown();
+  _toast(`Key renamed to "${key.name}".`);
 }
 
 export function deleteKey(idx: number): void {
@@ -305,4 +379,5 @@ export function deleteKey(idx: number): void {
   keys.splice(idx, 1);
   localStorage.setItem('sshKeys', JSON.stringify(keys));
   loadKeys();
+  populateKeyDropdown();
 }

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -10,7 +10,7 @@ import { KEY_REPEAT, THEMES, THEME_ORDER, escHtml } from './constants.js';
 import { appState } from './state.js';
 import { sendSSHInput, disconnect, reconnect, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath } from './connection.js';
 import { startRecording, stopAndDownloadRecording } from './recording.js';
-import { saveProfile, getKeys, connectFromProfile, newConnection } from './profiles.js';
+import { saveProfile, connectFromProfile, newConnection } from './profiles.js';
 
 // ── Hash routing (#137) ─────────────────────────────────────────────────────
 
@@ -330,7 +330,16 @@ export function initConnectForm(): void {
 
   // Cloak password fields: type="text" at rest, type="password" only while focused (#150)
   _initPasswordFieldCloaking(document.getElementById('remote_c') as HTMLInputElement);
-  _initPasswordFieldCloaking(document.getElementById('remote_pp') as HTMLInputElement);
+  const remotePp = document.getElementById('remote_pp') as HTMLInputElement | null;
+  if (remotePp) _initPasswordFieldCloaking(remotePp);
+
+  // Key dropdown: show/hide manual key entry based on selection
+  const keyDropdown = document.getElementById('selectedKeyId') as HTMLSelectElement | null;
+  const manualKeyGroup = document.getElementById('manualKeyGroup');
+  keyDropdown?.addEventListener('change', () => {
+    const showManual = keyDropdown.value === 'manual';
+    manualKeyGroup?.classList.toggle('hidden', !showManual);
+  });
 
   // Auto-populate profile name from hostname (#16)
   const hostInput = document.getElementById('host') as HTMLInputElement;
@@ -350,6 +359,9 @@ export function initConnectForm(): void {
   form.addEventListener('submit', (e) => {
     e.preventDefault();
 
+    const privateKeyEl = document.getElementById('privateKey') as HTMLTextAreaElement | null;
+    const remotePpEl = document.getElementById('remote_pp') as HTMLInputElement | null;
+
     const profile = {
       name: (document.getElementById('profileName') as HTMLInputElement).value.trim() || 'Server',
       host: (document.getElementById('host') as HTMLInputElement).value.trim(),
@@ -357,13 +369,13 @@ export function initConnectForm(): void {
       username: (document.getElementById('remote_a') as HTMLInputElement).value.trim(),
       authType: authType.value as 'password' | 'key',
       password: (document.getElementById('remote_c') as HTMLInputElement).value,
-      privateKey: (document.getElementById('privateKey') as HTMLTextAreaElement).value.trim(),
-      passphrase: (document.getElementById('remote_pp') as HTMLInputElement).value,
+      privateKey: privateKeyEl?.value.trim() ?? '',
+      passphrase: remotePpEl?.value ?? '',
       initialCommand: (document.getElementById('initialCommand') as HTMLInputElement).value.trim(),
     };
 
     (document.getElementById('remote_c') as HTMLInputElement).value = '';
-    (document.getElementById('remote_pp') as HTMLInputElement).value = '';
+    if (remotePpEl) remotePpEl.value = '';
 
     void saveProfile(profile).then(() => {
       // Hide form after save, show profile list
@@ -372,15 +384,6 @@ export function initConnectForm(): void {
       const newBtn = document.getElementById('newConnBtn');
       if (newBtn) newBtn.classList.remove('hidden');
     });
-  });
-
-  document.getElementById('useStoredKeyBtn')!.addEventListener('click', () => {
-    const keys = getKeys();
-    if (!keys.length) { toast('No stored keys. Add one in the Keys tab.'); return; }
-    const key = keys[0];
-    if (!key) return;
-    (document.getElementById('privateKey') as HTMLTextAreaElement).value = key.vaultId;
-    toast(`Using key: ${key.name}`);
   });
 
   document.getElementById('newConnBtn')!.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Replace inline `#privateKey` textarea + `#remote_pp` passphrase field with a `<select id="selectedKeyId">` dropdown populated from stored keys
- Add `keyVaultId?` field to `StoredProfile` so profiles reference stored keys by vault ID instead of embedding them inline
- Add `renameKey(idx, newName)` function and rename button to Keys tab CRUD
- Add `populateKeyDropdown()` to keep dropdown in sync when keys are added/deleted/renamed
- Manual key paste remains available as a dropdown option ("Paste key manually...")
- `connectFromProfile()` loads key from vault using `keyVaultId` reference at connect time

## Files changed
- `src/modules/profiles.ts` — keyVaultId on StoredProfile, renameKey, populateKeyDropdown, updated saveProfile/loadProfileIntoForm/connectFromProfile/useKey
- `src/modules/ui.ts` — key dropdown change handler, removed useStoredKeyBtn handler, null-safe form fields
- `src/app.ts` — wire renameKey delegation, populateKeyDropdown on boot
- `public/index.html` — key dropdown select + hidden manual key group
- `public/app.css` — .key-dropdown and #manualKeyGroup styles

## Test plan
- [x] TypeScript type check passes
- [x] Lint passes (0 errors, warnings are pre-existing)
- [x] Unit tests pass (26/26)
- [x] Headless Playwright tests pass (566/566, 7 skipped)
- [ ] Manual test: create key in Keys tab, verify it appears in profile form dropdown
- [ ] Manual test: save profile with stored key reference, verify connect loads key from vault
- [ ] Manual test: rename key in Keys tab, verify dropdown updates

Generated with [Claude Code](https://claude.com/claude-code)