### PR TITLE
feat: multi-session state model — SessionState map + currentSession()

### DIFF
--- a/src/modules/__tests__/state.test.ts
+++ b/src/modules/__tests__/state.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Stub browser globals before importing modules
+vi.stubGlobal('localStorage', {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+  length: 0,
+  key: () => null,
+});
+vi.stubGlobal('location', { hostname: 'localhost' });
+
+const { appState, currentSession, createSession } = await import('../state.js');
+
+describe('session state management', () => {
+  beforeEach(() => {
+    appState.sessions.clear();
+    appState.activeSessionId = null;
+  });
+
+  it('currentSession returns undefined when no active session', () => {
+    expect(currentSession()).toBeUndefined();
+  });
+
+  it('currentSession returns undefined for non-existent id', () => {
+    appState.activeSessionId = 'does-not-exist';
+    expect(currentSession()).toBeUndefined();
+  });
+
+  it('createSession adds a session to the map', () => {
+    const session = createSession('test-1');
+    expect(session.id).toBe('test-1');
+    expect(appState.sessions.size).toBe(1);
+    expect(appState.sessions.get('test-1')).toBe(session);
+  });
+
+  it('createSession initializes all fields with defaults', () => {
+    const session = createSession('test-2');
+    expect(session.profile).toBeNull();
+    expect(session.terminal).toBeNull();
+    expect(session.fitAddon).toBeNull();
+    expect(session.ws).toBeNull();
+    expect(session.wsConnected).toBe(false);
+    expect(session.sshConnected).toBe(false);
+    expect(session.reconnectTimer).toBeNull();
+    expect(session.reconnectDelay).toBe(2000);
+    expect(session.keepAliveTimer).toBeNull();
+    expect(session.keepAliveWorker).toBeNull();
+    expect(session.activeThemeName).toBe('dark');
+  });
+
+  it('currentSession returns the active session after creation', () => {
+    const session = createSession('test-3');
+    appState.activeSessionId = 'test-3';
+    expect(currentSession()).toBe(session);
+  });
+
+  it('multiple sessions can coexist in the map', () => {
+    createSession('s1');
+    createSession('s2');
+    createSession('s3');
+    expect(appState.sessions.size).toBe(3);
+
+    appState.activeSessionId = 's2';
+    expect(currentSession()?.id).toBe('s2');
+
+    appState.activeSessionId = 's1';
+    expect(currentSession()?.id).toBe('s1');
+  });
+
+  it('createSession inherits current theme from appState', () => {
+    appState.activeThemeName = 'nord';
+    const session = createSession('themed');
+    expect(session.activeThemeName).toBe('nord');
+    // Reset
+    appState.activeThemeName = 'dark';
+  });
+});

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -37,7 +37,7 @@ export function sendSftpRealpath(requestId: string): void {
   appState.ws.send(JSON.stringify({ type: 'sftp_realpath', requestId }));
 }
 import { getDefaultWsUrl, RECONNECT, escHtml } from './constants.js';
-import { appState } from './state.js';
+import { appState, createSession } from './state.js';
 import { stopAndDownloadRecording } from './recording.js';
 
 let _toast = (_msg: string): void => {};
@@ -69,6 +69,15 @@ export function connect(profile: SSHProfile): void {
   appState.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
   _wsConsecFailures = 0;
   cancelReconnect();
+
+  // Create a SessionState entry for multi-session infrastructure (#59)
+  const sessionId = `${profile.host}:${String(profile.port || 22)}:${profile.username}:${String(Date.now())}`;
+  const session = createSession(sessionId);
+  session.profile = profile;
+  session.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
+  session.activeThemeName = appState.activeThemeName;
+  appState.activeSessionId = sessionId;
+
   _openWebSocket();
 }
 

--- a/src/modules/state.ts
+++ b/src/modules/state.ts
@@ -7,10 +7,14 @@
  * without relying on shared global scope.
  */
 
-import type { AppState } from './types.js';
+import type { AppState, SessionState } from './types.js';
 import { RECONNECT } from './constants.js';
 
 export const appState: AppState = {
+  // Multi-session infrastructure
+  sessions: new Map<string, SessionState>(),
+  activeSessionId: null,
+
   // Core terminal and connection
   terminal: null,
   fitAddon: null,
@@ -43,3 +47,27 @@ export const appState: AppState = {
   recordingStartTime: null,
   recordingEvents: [],
 };
+
+export function currentSession(): SessionState | undefined {
+  if (!appState.activeSessionId) return undefined;
+  return appState.sessions.get(appState.activeSessionId);
+}
+
+export function createSession(id: string): SessionState {
+  const session: SessionState = {
+    id,
+    profile: null,
+    terminal: null,
+    fitAddon: null,
+    ws: null,
+    wsConnected: false,
+    sshConnected: false,
+    reconnectTimer: null,
+    reconnectDelay: RECONNECT.INITIAL_DELAY_MS,
+    keepAliveTimer: null,
+    keepAliveWorker: null,
+    activeThemeName: appState.activeThemeName,
+  };
+  appState.sessions.set(id, session);
+  return session;
+}

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -67,9 +67,29 @@ export interface ThemeEntry {
   app: AppColors;
 }
 
+// ── Session state (per-connection) ──────────────────────────────────────────
+
+export interface SessionState {
+  id: string;
+  profile: SSHProfile | null;
+  terminal: Terminal | null;
+  fitAddon: FitAddon.FitAddon | null;
+  ws: WebSocket | null;
+  wsConnected: boolean;
+  sshConnected: boolean;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  reconnectDelay: number;
+  keepAliveTimer: ReturnType<typeof setInterval> | null;
+  keepAliveWorker: Worker | null;
+  activeThemeName: ThemeName;
+}
+
 // ── Application state ───────────────────────────────────────────────────────
 
 export interface AppState {
+  // Multi-session infrastructure
+  sessions: Map<string, SessionState>;
+  activeSessionId: string | null;
   // Core terminal and connection
   terminal: Terminal | null;
   fitAddon: FitAddon.FitAddon | null;


### PR DESCRIPTION
## Summary
- Added `SessionState` interface to `types.ts` with all per-session fields (terminal, ws, reconnect state, theme)
- Added `sessions: Map<string, SessionState>` and `activeSessionId` to `AppState`
- Exported `currentSession()` getter and `createSession()` factory from `state.ts`
- On `connect()`, a `SessionState` entry is created and added to the sessions map

## Test coverage
- Added `src/modules/__tests__/state.test.ts` (7 tests)
- Tests verify: `currentSession()` returns undefined when no session, session creation populates map, all fields initialized with defaults, active session lookup works, multiple sessions coexist, theme inheritance from appState

## Test results
- tsc: PASS
- eslint: PASS (0 errors, pre-existing warnings only)
- vitest: PASS (33/33 tests)

## Diff stats
- Files changed: 4
- Lines: +138 / -2

Closes #59

## Cycles used
1/3