### PR TITLE
feat: SSH key UX — connect-time passphrase prompt + ssh-agent caching

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -146,6 +146,23 @@
     </div>
   </div>
 
+  <!-- Key passphrase prompt — shown at connect time for encrypted keys (#54) -->
+  <div id="keyPassphraseOverlay" class="vault-overlay hidden" role="dialog" aria-label="Key passphrase">
+    <div class="vault-dialog">
+      <h3 class="vault-title">Key passphrase</h3>
+      <p class="vault-desc">This key is passphrase-protected. Enter the passphrase to unlock it.</p>
+      <label for="keyPassphraseInput" class="vault-label">Passphrase</label>
+      <input type="password" id="keyPassphraseInput"
+        autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+        data-lpignore="true" data-1p-ignore="true" data-form-type="other" />
+      <p id="keyPassphraseError" class="vault-error hidden"></p>
+      <div class="vault-buttons">
+        <button id="keyPassphraseCancel" class="vault-btn vault-btn-cancel">Cancel</button>
+        <button id="keyPassphraseOk" class="vault-btn vault-btn-create">Unlock</button>
+      </div>
+    </div>
+  </div>
+
   <div id="menuBackdrop" class="hidden"></div>
   <div id="app">
     <!-- Tab bar -->

--- a/src/modules/__tests__/connection.test.ts
+++ b/src/modules/__tests__/connection.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { webcrypto } from 'node:crypto';
+
+// Stub browser globals before any module imports
+vi.stubGlobal('crypto', webcrypto);
+
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+};
+vi.stubGlobal('localStorage', localStorageMock);
+vi.stubGlobal('location', { hostname: 'localhost' });
+
+// Mock DOM elements for passphrase prompt
+const mockOverlay = {
+  classList: { remove: vi.fn(), add: vi.fn() },
+  id: 'keyPassphraseOverlay',
+};
+const mockInput = { value: '', focus: vi.fn(), addEventListener: vi.fn(), removeEventListener: vi.fn() };
+const mockOkBtn = { addEventListener: vi.fn(), removeEventListener: vi.fn() };
+const mockCancelBtn = { addEventListener: vi.fn(), removeEventListener: vi.fn() };
+const mockErrorEl = { classList: { add: vi.fn() } };
+
+vi.stubGlobal('document', {
+  getElementById: (id: string) => {
+    switch (id) {
+      case 'keyPassphraseOverlay': return mockOverlay;
+      case 'keyPassphraseInput': return mockInput;
+      case 'keyPassphraseOk': return mockOkBtn;
+      case 'keyPassphraseCancel': return mockCancelBtn;
+      case 'keyPassphraseError': return mockErrorEl;
+      default: return null;
+    }
+  },
+  querySelector: () => null,
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  createElement: vi.fn(() => ({
+    className: '',
+    textContent: '',
+    innerHTML: '',
+    id: '',
+    appendChild: vi.fn(),
+    addEventListener: vi.fn(),
+    querySelector: vi.fn(),
+    remove: vi.fn(),
+  })),
+  body: { appendChild: vi.fn() },
+});
+
+vi.stubGlobal('WebSocket', class { onopen = null; onclose = null; onmessage = null; onerror = null; readyState = 0; url = ''; close = vi.fn(); send = vi.fn(); });
+vi.stubGlobal('Worker', class { onmessage = null; postMessage = vi.fn(); terminate = vi.fn(); });
+vi.stubGlobal('navigator', { wakeLock: undefined });
+
+// Mock beforeunload listener registration
+const beforeUnloadHandlers: (() => void)[] = [];
+vi.stubGlobal('window', {
+  addEventListener: (event: string, handler: () => void) => {
+    if (event === 'beforeunload') beforeUnloadHandlers.push(handler);
+  },
+});
+
+const { _getPassphraseCache } = await import('../connection.js');
+
+describe('Key passphrase cache (#54)', () => {
+  beforeEach(() => {
+    _getPassphraseCache().clear();
+  });
+
+  it('cache starts empty', () => {
+    expect(_getPassphraseCache().size).toBe(0);
+  });
+
+  it('stores and retrieves cached passphrases', () => {
+    const cache = _getPassphraseCache();
+    cache.set('key-vault-id-1', 'my-passphrase');
+    expect(cache.get('key-vault-id-1')).toBe('my-passphrase');
+  });
+
+  it('beforeunload clears the cache', () => {
+    const cache = _getPassphraseCache();
+    cache.set('key-vault-id-1', 'my-passphrase');
+    expect(cache.size).toBe(1);
+
+    // Fire beforeunload handlers
+    for (const handler of beforeUnloadHandlers) handler();
+
+    expect(cache.size).toBe(0);
+  });
+
+  it('caches different passphrases for different keys', () => {
+    const cache = _getPassphraseCache();
+    cache.set('key-1', 'pass-1');
+    cache.set('key-2', 'pass-2');
+    expect(cache.get('key-1')).toBe('pass-1');
+    expect(cache.get('key-2')).toBe('pass-2');
+  });
+});

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ConnectionDeps, ConnectionStatus, ServerMessage, ConnectMessage, SSHProfile } from './types.js';
+import { vaultLoad } from './vault.js';
 
 // [SFTP_MSG] -- keep in sync with types.ts SERVER_MESSAGE sftp types and WS router below
 type SftpMsg = Extract<ServerMessage, { type: 'sftp_ls_result' | 'sftp_error' | 'sftp_download_result' | 'sftp_upload_result' | 'sftp_stat_result' | 'sftp_rename_result' | 'sftp_delete_result' | 'sftp_realpath_result' }>;
@@ -52,6 +53,70 @@ export function initConnection({ toast, setStatus, focusIME, applyTabBarVisibili
   _applyTabBarVisibility = applyTabBarVisibility;
 }
 
+// In-memory passphrase cache keyed by keyVaultId. Cleared on page unload.
+const _keyPassphraseCache = new Map<string, string>();
+
+window.addEventListener('beforeunload', () => {
+  _keyPassphraseCache.clear();
+});
+
+/** Exported for testing only. */
+export function _getPassphraseCache(): Map<string, string> {
+  return _keyPassphraseCache;
+}
+
+/** Returns true if the PEM key data appears to be passphrase-encrypted. */
+function _isKeyEncrypted(keyData: string): boolean {
+  return keyData.includes('ENCRYPTED');
+}
+
+/** Show the passphrase prompt dialog and return the entered passphrase, or null on cancel. */
+function _promptPassphrase(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const overlay = document.getElementById('keyPassphraseOverlay');
+    const input = document.getElementById('keyPassphraseInput') as HTMLInputElement | null;
+    const okBtn = document.getElementById('keyPassphraseOk');
+    const cancelBtn = document.getElementById('keyPassphraseCancel');
+    const errorEl = document.getElementById('keyPassphraseError');
+
+    if (!overlay || !input || !okBtn || !cancelBtn) {
+      resolve(null);
+      return;
+    }
+
+    input.value = '';
+    errorEl?.classList.add('hidden');
+    overlay.classList.remove('hidden');
+    input.focus();
+
+    function cleanup(): void {
+      overlay!.classList.add('hidden');
+      okBtn!.removeEventListener('click', onOk);
+      cancelBtn!.removeEventListener('click', onCancel);
+      input!.removeEventListener('keydown', onKeydown);
+    }
+
+    function onOk(): void {
+      cleanup();
+      resolve(input!.value);
+    }
+
+    function onCancel(): void {
+      cleanup();
+      resolve(null);
+    }
+
+    function onKeydown(e: KeyboardEvent): void {
+      if (e.key === 'Enter') { e.preventDefault(); onOk(); }
+      if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+    }
+
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+    input.addEventListener('keydown', onKeydown);
+  });
+}
+
 // ── WebSocket / SSH connection ────────────────────────────────────────────────
 
 // Max consecutive pre-open WS close events before halting the reconnect loop.
@@ -64,7 +129,35 @@ function _getWsToken(): string {
   return document.querySelector<HTMLMetaElement>('meta[name="ws-token"]')?.content ?? '';
 }
 
-export function connect(profile: SSHProfile): void {
+export async function connect(profile: SSHProfile): Promise<void> {
+  // If the profile references a stored key, load the key data from vault
+  if (profile.authType === 'key' && profile.keyVaultId && !profile.privateKey) {
+    const keyCreds = await vaultLoad(profile.keyVaultId);
+    if (keyCreds?.data) {
+      profile.privateKey = keyCreds.data as string;
+    } else {
+      _toast('Could not load stored key from vault.');
+      return;
+    }
+  }
+
+  // If the key is encrypted and no passphrase is set, check cache or prompt
+  if (profile.authType === 'key' && profile.privateKey && _isKeyEncrypted(profile.privateKey) && !profile.passphrase) {
+    const cacheKey = profile.keyVaultId ?? '';
+    const cached = cacheKey ? _keyPassphraseCache.get(cacheKey) : undefined;
+    if (cached !== undefined) {
+      profile.passphrase = cached;
+    } else {
+      const passphrase = await _promptPassphrase();
+      if (passphrase === null) {
+        _toast('Connection cancelled.');
+        return;
+      }
+      profile.passphrase = passphrase;
+      if (cacheKey) _keyPassphraseCache.set(cacheKey, passphrase);
+    }
+  }
+
   appState.currentProfile = profile;
   appState.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
   _wsConsecFailures = 0;

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -266,7 +266,7 @@ export async function connectFromProfile(idx: number): Promise<boolean> {
     return false;
   }
 
-  connect(sshProfile);
+  await connect(sshProfile);
   return true;
 }
 

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -20,6 +20,7 @@ export interface SSHProfile {
   initialCommand?: string;
   vaultId?: string;
   hasVaultCreds?: boolean;
+  keyVaultId?: string;
 }
 
 export type ThemeName = 'dark' | 'light' | 'solarizedDark' | 'solarizedLight' | 'highContrast' | 'dracula' | 'nord' | 'gruvboxDark' | 'monokai' | 'tokyoNight';


### PR DESCRIPTION
## Summary
- Connect-time passphrase prompt for encrypted SSH keys (reuses vault-overlay dialog pattern)
- In-memory ssh-agent-style cache (`Map<keyVaultId, passphrase>`) cleared on `beforeunload`
- `connect()` now async: loads key from vault via `keyVaultId`, prompts if encrypted

## Test coverage
- 4 unit tests: cache lifecycle, beforeunload clearing, multi-key independence

## Test results
- tsc: PASS
- eslint: PASS
- vitest: PASS (30/30)

Closes #54