### PR TITLE
feat: agent hooks — Codex + Gemini CLI hook scripts

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -297,6 +297,17 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
           const hooks = settings.hooks || {};
           hookActive = !!(hooks.PermissionRequest || hooks.Notification);
         } catch (_) {}
+      } else if (installed && a.id === 'codex') {
+        try {
+          const content = fs.readFileSync(a.configPath, 'utf8');
+          hookActive = /^notify\s*=/m.test(content);
+        } catch (_) {}
+      } else if (installed && a.id === 'gemini') {
+        try {
+          const settings = JSON.parse(fs.readFileSync(a.configPath, 'utf8'));
+          const hooks = settings.hooks || [];
+          hookActive = hooks.some(h => h.type === 'BeforeTool' && h.toolName === 'ask_user');
+        } catch (_) {}
       }
       return { name: a.name, id: a.id, installed, hookActive };
     });
@@ -311,30 +322,56 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
     req.on('end', () => {
       try {
         const { agent } = JSON.parse(body);
-        if (agent !== 'claude') {
+        const homeDir = process.env.HOME || os.homedir();
+        const hooksDir = path.join(homeDir, '.claude', 'hooks');
+        const scriptPath = path.join(hooksDir, 'notify-bell.sh');
+
+        // Ensure shared hook script exists
+        fs.mkdirSync(hooksDir, { recursive: true });
+        fs.writeFileSync(scriptPath, NOTIFY_BELL_SCRIPT, { mode: 0o755 });
+
+        if (agent === 'claude') {
+          const settingsPath = path.join(homeDir, '.claude', 'settings.json');
+          let settings = {};
+          try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch (_) {}
+          if (!settings.hooks) settings.hooks = {};
+
+          const hookEntry = [{ matcher: '', command: scriptPath }];
+          settings.hooks.PermissionRequest = hookEntry;
+          settings.hooks.Notification = hookEntry;
+
+          fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+        } else if (agent === 'codex') {
+          const configPath = path.join(homeDir, '.codex', 'config.toml');
+          fs.mkdirSync(path.join(homeDir, '.codex'), { recursive: true });
+          let content = '';
+          try { content = fs.readFileSync(configPath, 'utf8'); } catch (_) {}
+          if (!/^notify\s*=/m.test(content)) {
+            const line = `notify = ["bash", "-c", "${scriptPath}"]\n`;
+            content = content.length > 0 && !content.endsWith('\n') ? content + '\n' + line : content + line;
+            fs.writeFileSync(configPath, content);
+          }
+        } else if (agent === 'gemini') {
+          const configPath = path.join(homeDir, '.gemini', 'settings.json');
+          fs.mkdirSync(path.join(homeDir, '.gemini'), { recursive: true });
+          let settings = {};
+          try { settings = JSON.parse(fs.readFileSync(configPath, 'utf8')); } catch (_) {}
+          if (!Array.isArray(settings.hooks)) settings.hooks = [];
+          const exists = settings.hooks.some(h => h.type === 'BeforeTool' && h.toolName === 'ask_user');
+          if (!exists) {
+            settings.hooks.push({
+              type: 'BeforeTool',
+              toolName: 'ask_user',
+              command: ['bash', '-c', scriptPath],
+            });
+          }
+          fs.writeFileSync(configPath, JSON.stringify(settings, null, 2) + '\n');
+        } else {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unsupported agent' }));
           return;
         }
-        const homeDir = process.env.HOME || os.homedir();
-        const hooksDir = path.join(homeDir, '.claude', 'hooks');
-        const scriptPath = path.join(hooksDir, 'notify-bell.sh');
-        const settingsPath = path.join(homeDir, '.claude', 'settings.json');
 
-        // Create hooks dir and write script
-        fs.mkdirSync(hooksDir, { recursive: true });
-        fs.writeFileSync(scriptPath, NOTIFY_BELL_SCRIPT, { mode: 0o755 });
-
-        // Read or create settings.json
-        let settings = {};
-        try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch (_) {}
-        if (!settings.hooks) settings.hooks = {};
-
-        const hookEntry = [{ matcher: '', command: scriptPath }];
-        settings.hooks.PermissionRequest = hookEntry;
-        settings.hooks.Notification = hookEntry;
-
-        fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
         res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
         res.end(JSON.stringify({ ok: true }));
       } catch (err) {
@@ -351,23 +388,41 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
     req.on('end', () => {
       try {
         const { agent } = JSON.parse(body);
-        if (agent !== 'claude') {
+        const homeDir = process.env.HOME || os.homedir();
+
+        if (agent === 'claude') {
+          const settingsPath = path.join(homeDir, '.claude', 'settings.json');
+          let settings = {};
+          try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch (_) {}
+          if (settings.hooks) {
+            delete settings.hooks.PermissionRequest;
+            delete settings.hooks.Notification;
+            if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+          }
+          fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+        } else if (agent === 'codex') {
+          const configPath = path.join(homeDir, '.codex', 'config.toml');
+          try {
+            let content = fs.readFileSync(configPath, 'utf8');
+            content = content.replace(/^notify\s*=\s*\[.*\]\s*\n?/m, '');
+            fs.writeFileSync(configPath, content);
+          } catch (_) {}
+        } else if (agent === 'gemini') {
+          const configPath = path.join(homeDir, '.gemini', 'settings.json');
+          try {
+            const settings = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+            if (Array.isArray(settings.hooks)) {
+              settings.hooks = settings.hooks.filter(h => !(h.type === 'BeforeTool' && h.toolName === 'ask_user'));
+              if (settings.hooks.length === 0) delete settings.hooks;
+            }
+            fs.writeFileSync(configPath, JSON.stringify(settings, null, 2) + '\n');
+          } catch (_) {}
+        } else {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unsupported agent' }));
           return;
         }
-        const homeDir = process.env.HOME || os.homedir();
-        const settingsPath = path.join(homeDir, '.claude', 'settings.json');
 
-        let settings = {};
-        try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch (_) {}
-        if (settings.hooks) {
-          delete settings.hooks.PermissionRequest;
-          delete settings.hooks.Notification;
-          if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
-        }
-
-        fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
         res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
         res.end(JSON.stringify({ ok: true }));
       } catch (err) {

--- a/src/modules/__tests__/agent-hooks.test.ts
+++ b/src/modules/__tests__/agent-hooks.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+let server: http.Server;
+let baseUrl: string;
+let tmpHome: string;
+
+function post(urlPath: string, body: object): Promise<{ status: number; json: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const req = http.request(`${baseUrl}${urlPath}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) },
+    }, (res) => {
+      let buf = '';
+      res.on('data', (c) => { buf += c; });
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode!, json: JSON.parse(buf) }); }
+        catch { resolve({ status: res.statusCode!, json: {} }); }
+      });
+    });
+    req.on('error', reject);
+    req.end(data);
+  });
+}
+
+function get(urlPath: string): Promise<{ status: number; json: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    http.get(`${baseUrl}${urlPath}`, (res) => {
+      let buf = '';
+      res.on('data', (c) => { buf += c; });
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode!, json: JSON.parse(buf) }); }
+        catch { resolve({ status: res.statusCode!, json: {} }); }
+      });
+    }).on('error', reject);
+  });
+}
+
+beforeAll(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-hooks-test-'));
+  process.env.HOME = tmpHome;
+
+  // Clear require cache so server re-reads HOME
+  const serverPath = path.resolve(__dirname, '../../../server/index.js');
+  delete require.cache[serverPath];
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require(serverPath) as { server: http.Server };
+  server = mod.server;
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => { resolve(); });
+  });
+  const addr = server.address() as { port: number };
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => { server.close(() => { resolve(); }); });
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Clean agent config dirs between tests
+  for (const dir of ['.claude', '.codex', '.gemini']) {
+    const p = path.join(tmpHome, dir);
+    if (fs.existsSync(p)) fs.rmSync(p, { recursive: true, force: true });
+  }
+});
+
+describe('agent hooks API', () => {
+  describe('/api/detect-agents', () => {
+    it('reports agents as not installed when config dirs missing', async () => {
+      const { json } = await get('/api/detect-agents');
+      const agents = json.agents as Array<{ id: string; installed: boolean; hookActive: boolean }>;
+      for (const a of agents) {
+        expect(a.installed).toBe(false);
+        expect(a.hookActive).toBe(false);
+      }
+    });
+
+    it('detects codex as installed with hook active', async () => {
+      const codexDir = path.join(tmpHome, '.codex');
+      fs.mkdirSync(codexDir, { recursive: true });
+      fs.writeFileSync(path.join(codexDir, 'config.toml'), 'notify = ["bash", "-c", "test"]\n');
+      const { json } = await get('/api/detect-agents');
+      const codex = (json.agents as Array<{ id: string; installed: boolean; hookActive: boolean }>).find(a => a.id === 'codex')!;
+      expect(codex.installed).toBe(true);
+      expect(codex.hookActive).toBe(true);
+    });
+
+    it('detects gemini as installed with hook active', async () => {
+      const geminiDir = path.join(tmpHome, '.gemini');
+      fs.mkdirSync(geminiDir, { recursive: true });
+      fs.writeFileSync(path.join(geminiDir, 'settings.json'), JSON.stringify({
+        hooks: [{ type: 'BeforeTool', toolName: 'ask_user', command: ['bash', '-c', 'test'] }],
+      }));
+      const { json } = await get('/api/detect-agents');
+      const gemini = (json.agents as Array<{ id: string; installed: boolean; hookActive: boolean }>).find(a => a.id === 'gemini')!;
+      expect(gemini.installed).toBe(true);
+      expect(gemini.hookActive).toBe(true);
+    });
+  });
+
+  describe('/api/install-hook', () => {
+    it('installs codex hook in config.toml', async () => {
+      fs.mkdirSync(path.join(tmpHome, '.codex'), { recursive: true });
+      fs.writeFileSync(path.join(tmpHome, '.codex', 'config.toml'), '# existing config\n');
+      const { status, json } = await post('/api/install-hook', { agent: 'codex' });
+      expect(status).toBe(200);
+      expect(json.ok).toBe(true);
+      const content = fs.readFileSync(path.join(tmpHome, '.codex', 'config.toml'), 'utf8');
+      expect(content).toContain('notify = ');
+      expect(content).toContain('notify-bell.sh');
+    });
+
+    it('codex install is idempotent', async () => {
+      fs.mkdirSync(path.join(tmpHome, '.codex'), { recursive: true });
+      fs.writeFileSync(path.join(tmpHome, '.codex', 'config.toml'), '');
+      await post('/api/install-hook', { agent: 'codex' });
+      await post('/api/install-hook', { agent: 'codex' });
+      const content = fs.readFileSync(path.join(tmpHome, '.codex', 'config.toml'), 'utf8');
+      const matches = content.match(/^notify\s*=/gm);
+      expect(matches).toHaveLength(1);
+    });
+
+    it('installs gemini hook in settings.json', async () => {
+      fs.mkdirSync(path.join(tmpHome, '.gemini'), { recursive: true });
+      fs.writeFileSync(path.join(tmpHome, '.gemini', 'settings.json'), '{}');
+      const { status, json } = await post('/api/install-hook', { agent: 'gemini' });
+      expect(status).toBe(200);
+      expect(json.ok).toBe(true);
+      const settings = JSON.parse(fs.readFileSync(path.join(tmpHome, '.gemini', 'settings.json'), 'utf8'));
+      expect(settings.hooks).toHaveLength(1);
+      expect(settings.hooks[0].type).toBe('BeforeTool');
+      expect(settings.hooks[0].toolName).toBe('ask_user');
+    });
+
+    it('gemini install is idempotent', async () => {
+      fs.mkdirSync(path.join(tmpHome, '.gemini'), { recursive: true });
+      fs.writeFileSync(path.join(tmpHome, '.gemini', 'settings.json'), '{}');
+      await post('/api/install-hook', { agent: 'gemini' });
+      await post('/api/install-hook', { agent: 'gemini' });
+      const settings = JSON.parse(fs.readFileSync(path.join(tmpHome, '.gemini', 'settings.json'), 'utf8'));
+      expect(settings.hooks).toHaveLength(1);
+    });
+
+    it('rejects unsupported agent', async () => {
+      const { status, json } = await post('/api/install-hook', { agent: 'unknown' });
+      expect(status).toBe(400);
+      expect(json.error).toBe('Unsupported agent');
+    });
+
+    it('writes shared notify-bell.sh script', async () => {
+      await post('/api/install-hook', { agent: 'codex' });
+      const scriptPath = path.join(tmpHome, '.claude', 'hooks', 'notify-bell.sh');
+      expect(fs.existsSync(scriptPath)).toBe(true);
+      const stat = fs.statSync(scriptPath);
+      expect(stat.mode & 0o111).toBeGreaterThan(0); // executable
+    });
+  });
+
+  describe('/api/uninstall-hook', () => {
+    it('removes codex hook from config.toml', async () => {
+      fs.mkdirSync(path.join(tmpHome, '.codex'), { recursive: true });
+      fs.writeFileSync(path.join(tmpHome, '.codex', 'config.toml'), '# header\nnotify = ["bash", "-c", "test"]\nother = true\n');
+      const { status, json } = await post('/api/uninstall-hook', { agent: 'codex' });
+      expect(status).toBe(200);
+      expect(json.ok).toBe(true);
+      const content = fs.readFileSync(path.join(tmpHome, '.codex', 'config.toml'), 'utf8');
+      expect(content).not.toContain('notify');
+      expect(content).toContain('other = true');
+    });
+
+    it('removes gemini hook from settings.json preserving other hooks', async () => {
+      fs.mkdirSync(path.join(tmpHome, '.gemini'), { recursive: true });
+      const existing = {
+        hooks: [
+          { type: 'BeforeTool', toolName: 'ask_user', command: ['test'] },
+          { type: 'AfterTool', toolName: 'other', command: ['keep'] },
+        ],
+        otherSetting: true,
+      };
+      fs.writeFileSync(path.join(tmpHome, '.gemini', 'settings.json'), JSON.stringify(existing));
+      const { status } = await post('/api/uninstall-hook', { agent: 'gemini' });
+      expect(status).toBe(200);
+      const settings = JSON.parse(fs.readFileSync(path.join(tmpHome, '.gemini', 'settings.json'), 'utf8'));
+      expect(settings.hooks).toHaveLength(1);
+      expect(settings.hooks[0].toolName).toBe('other');
+      expect(settings.otherSetting).toBe(true);
+    });
+
+    it('removes gemini hooks key when empty', async () => {
+      fs.mkdirSync(path.join(tmpHome, '.gemini'), { recursive: true });
+      fs.writeFileSync(path.join(tmpHome, '.gemini', 'settings.json'), JSON.stringify({
+        hooks: [{ type: 'BeforeTool', toolName: 'ask_user', command: ['test'] }],
+      }));
+      await post('/api/uninstall-hook', { agent: 'gemini' });
+      const settings = JSON.parse(fs.readFileSync(path.join(tmpHome, '.gemini', 'settings.json'), 'utf8'));
+      expect(settings.hooks).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -309,6 +309,30 @@ async function initAgentHooks(): Promise<void> {
             _toast('Hook update failed: network error');
           });
         });
+      } else if (agent.id === 'codex' || agent.id === 'gemini') {
+        toggle.disabled = false;
+        toggle.checked = agent.hookActive;
+        const agentLabel = agent.name;
+        toggle.addEventListener('change', () => {
+          const endpoint = toggle.checked ? '/api/install-hook' : '/api/uninstall-hook';
+          void fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agent: agent.id }),
+          }).then(async (r) => {
+            if (r.ok) {
+              status.textContent = toggle.checked ? 'Hook active' : 'Installed';
+              _toast(toggle.checked ? `${agentLabel} hook installed.` : `${agentLabel} hook removed.`);
+            } else {
+              toggle.checked = !toggle.checked;
+              const err = await r.json() as { error?: string };
+              _toast(`Hook update failed: ${err.error ?? 'unknown error'}`);
+            }
+          }).catch(() => {
+            toggle.checked = !toggle.checked;
+            _toast('Hook update failed: network error');
+          });
+        });
       } else {
         // Other agents: show installed but hook not yet supported
         toggle.disabled = true;


### PR DESCRIPTION
## Summary
- Extended `/api/install-hook` and `/api/uninstall-hook` endpoints to handle Codex CLI (`~/.codex/config.toml` TOML) and Gemini CLI (`~/.gemini/settings.json` JSON)
- Updated `/api/detect-agents` to detect active hooks for Codex and Gemini
- Enabled Codex and Gemini toggles in settings UI (previously disabled with "hooks coming soon")

## Test coverage
- Added `src/modules/__tests__/agent-hooks.test.ts` with 12 tests
- Tests cover: detect-agents (not installed, codex active, gemini active), install (codex, gemini, idempotency, shared script, unsupported agent), uninstall (codex, gemini preserving other config, empty hooks cleanup)

## Test results
- tsc: PASS
- eslint: PASS (0 errors, pre-existing warnings only)
- vitest: PASS (45/45)

## Diff stats
- Files changed: 3
- Lines: +314 / -28

Closes #56

## Cycles used
1/3