### PR TITLE
feat: agent hooks — OpenCode plugin

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -308,6 +308,9 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
           const hooks = settings.hooks || [];
           hookActive = hooks.some(h => h.type === 'BeforeTool' && h.toolName === 'ask_user');
         } catch (_) {}
+      } else if (installed && a.id === 'opencode') {
+        const pluginPath = path.join(homeDir, '.config', 'opencode', 'plugins', 'mobissh-notify.js');
+        hookActive = fs.existsSync(pluginPath);
       }
       return { name: a.name, id: a.id, installed, hookActive };
     });
@@ -366,6 +369,27 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
             });
           }
           fs.writeFileSync(configPath, JSON.stringify(settings, null, 2) + '\n');
+        } else if (agent === 'opencode') {
+          const pluginsDir = path.join(homeDir, '.config', 'opencode', 'plugins');
+          fs.mkdirSync(pluginsDir, { recursive: true });
+          const pluginPath = path.join(pluginsDir, 'mobissh-notify.js');
+          const pluginContent = `export default function plugin() {
+  return {
+    tool: {
+      execute: {
+        before: async ({ tool }) => {
+          if (tool.name === 'question') {
+            const { execFile } = await import('child_process');
+            const scriptPath = ${JSON.stringify(scriptPath)};
+            execFile(scriptPath, { env: process.env }, () => {});
+          }
+        },
+      },
+    },
+  };
+}
+`;
+          fs.writeFileSync(pluginPath, pluginContent);
         } else {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unsupported agent' }));
@@ -417,6 +441,9 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
             }
             fs.writeFileSync(configPath, JSON.stringify(settings, null, 2) + '\n');
           } catch (_) {}
+        } else if (agent === 'opencode') {
+          const pluginPath = path.join(homeDir, '.config', 'opencode', 'plugins', 'mobissh-notify.js');
+          try { fs.unlinkSync(pluginPath); } catch (_) {}
         } else {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unsupported agent' }));

--- a/src/modules/__tests__/agent-hooks.test.ts
+++ b/src/modules/__tests__/agent-hooks.test.ts
@@ -66,7 +66,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   // Clean agent config dirs between tests
-  for (const dir of ['.claude', '.codex', '.gemini']) {
+  for (const dir of ['.claude', '.codex', '.gemini', path.join('.config', 'opencode')]) {
     const p = path.join(tmpHome, dir);
     if (fs.existsSync(p)) fs.rmSync(p, { recursive: true, force: true });
   }
@@ -103,6 +103,27 @@ describe('agent hooks API', () => {
       const gemini = (json.agents as Array<{ id: string; installed: boolean; hookActive: boolean }>).find(a => a.id === 'gemini')!;
       expect(gemini.installed).toBe(true);
       expect(gemini.hookActive).toBe(true);
+    });
+
+    it('detects opencode as installed with hook active when plugin file exists', async () => {
+      const opencodeDir = path.join(tmpHome, '.config', 'opencode');
+      fs.mkdirSync(path.join(opencodeDir, 'plugins'), { recursive: true });
+      fs.writeFileSync(path.join(opencodeDir, 'opencode.json'), '{}');
+      fs.writeFileSync(path.join(opencodeDir, 'plugins', 'mobissh-notify.js'), 'export default function plugin() {}');
+      const { json } = await get('/api/detect-agents');
+      const opencode = (json.agents as Array<{ id: string; installed: boolean; hookActive: boolean }>).find(a => a.id === 'opencode')!;
+      expect(opencode.installed).toBe(true);
+      expect(opencode.hookActive).toBe(true);
+    });
+
+    it('detects opencode as installed but hook inactive when plugin file missing', async () => {
+      const opencodeDir = path.join(tmpHome, '.config', 'opencode');
+      fs.mkdirSync(opencodeDir, { recursive: true });
+      fs.writeFileSync(path.join(opencodeDir, 'opencode.json'), '{}');
+      const { json } = await get('/api/detect-agents');
+      const opencode = (json.agents as Array<{ id: string; installed: boolean; hookActive: boolean }>).find(a => a.id === 'opencode')!;
+      expect(opencode.installed).toBe(true);
+      expect(opencode.hookActive).toBe(false);
     });
   });
 
@@ -147,6 +168,32 @@ describe('agent hooks API', () => {
       await post('/api/install-hook', { agent: 'gemini' });
       const settings = JSON.parse(fs.readFileSync(path.join(tmpHome, '.gemini', 'settings.json'), 'utf8'));
       expect(settings.hooks).toHaveLength(1);
+    });
+
+    it('installs opencode plugin file', async () => {
+      const opencodeDir = path.join(tmpHome, '.config', 'opencode');
+      fs.mkdirSync(opencodeDir, { recursive: true });
+      fs.writeFileSync(path.join(opencodeDir, 'opencode.json'), '{}');
+      const { status, json } = await post('/api/install-hook', { agent: 'opencode' });
+      expect(status).toBe(200);
+      expect(json.ok).toBe(true);
+      const pluginPath = path.join(opencodeDir, 'plugins', 'mobissh-notify.js');
+      expect(fs.existsSync(pluginPath)).toBe(true);
+      const content = fs.readFileSync(pluginPath, 'utf8');
+      expect(content).toContain('notify-bell.sh');
+      expect(content).toContain('question');
+    });
+
+    it('opencode install is idempotent', async () => {
+      const opencodeDir = path.join(tmpHome, '.config', 'opencode');
+      fs.mkdirSync(opencodeDir, { recursive: true });
+      fs.writeFileSync(path.join(opencodeDir, 'opencode.json'), '{}');
+      await post('/api/install-hook', { agent: 'opencode' });
+      const { status, json } = await post('/api/install-hook', { agent: 'opencode' });
+      expect(status).toBe(200);
+      expect(json.ok).toBe(true);
+      const pluginPath = path.join(opencodeDir, 'plugins', 'mobissh-notify.js');
+      expect(fs.existsSync(pluginPath)).toBe(true);
     });
 
     it('rejects unsupported agent', async () => {
@@ -202,6 +249,23 @@ describe('agent hooks API', () => {
       await post('/api/uninstall-hook', { agent: 'gemini' });
       const settings = JSON.parse(fs.readFileSync(path.join(tmpHome, '.gemini', 'settings.json'), 'utf8'));
       expect(settings.hooks).toBeUndefined();
+    });
+
+    it('removes opencode plugin file', async () => {
+      const pluginsDir = path.join(tmpHome, '.config', 'opencode', 'plugins');
+      fs.mkdirSync(pluginsDir, { recursive: true });
+      const pluginPath = path.join(pluginsDir, 'mobissh-notify.js');
+      fs.writeFileSync(pluginPath, 'export default function plugin() {}');
+      const { status, json } = await post('/api/uninstall-hook', { agent: 'opencode' });
+      expect(status).toBe(200);
+      expect(json.ok).toBe(true);
+      expect(fs.existsSync(pluginPath)).toBe(false);
+    });
+
+    it('opencode uninstall is a no-op when plugin file does not exist', async () => {
+      const { status, json } = await post('/api/uninstall-hook', { agent: 'opencode' });
+      expect(status).toBe(200);
+      expect(json.ok).toBe(true);
     });
   });
 });

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -309,7 +309,7 @@ async function initAgentHooks(): Promise<void> {
             _toast('Hook update failed: network error');
           });
         });
-      } else if (agent.id === 'codex' || agent.id === 'gemini') {
+      } else if (agent.id === 'codex' || agent.id === 'gemini' || agent.id === 'opencode') {
         toggle.disabled = false;
         toggle.checked = agent.hookActive;
         const agentLabel = agent.name;


### PR DESCRIPTION
## Summary
- Add OpenCode hookActive detection: checks for plugin file at `~/.config/opencode/plugins/mobissh-notify.js`
- Add install handler: creates plugins dir and writes a JS plugin that calls `notify-bell.sh` when the `question` tool fires
- Add uninstall handler: removes the plugin file
- Extend `settings.ts` toggle to include `opencode` in the codex/gemini branch (same toggle handler pattern)

## Test coverage
- 2 detect tests: installed+active when plugin exists, installed+inactive when plugin missing
- 2 install tests: installs plugin file with correct content, idempotent
- 2 uninstall tests: removes plugin file, no-op when file doesn't exist
- beforeEach cleanup extended to include `.config/opencode` dir

## Test results
- tsc: PASS
- eslint: PASS (warnings are pre-existing, no new errors)
- vitest: agent-hooks suite skipped due to pre-existing `ssh2` module missing in test environment (all other suites PASS)

## Diff stats
- Files changed: 3
- Lines: +93 / -2

Closes #57

## Cycles used
1/3