### PR TITLE
feat: multi-session — session menu list and tap-to-switch

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -265,6 +265,79 @@ body.debug-ime #imePreview {
 }
 
 
+/* Session list — visible when 2+ active sessions (#60) */
+.session-list {
+  border-bottom: 1px solid var(--border);
+  padding: 4px 0;
+}
+
+.session-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 10px 16px;
+  color: var(--text);
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.session-item:active { background: var(--bg-card); }
+
+.session-item-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent);
+  flex-shrink: 0;
+}
+
+.session-item.active .session-item-dot {
+  background: var(--accent);
+}
+
+.session-item-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-item-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 4px;
+  touch-action: manipulation;
+  flex-shrink: 0;
+}
+
+.session-item-close:active { color: var(--danger); }
+
+.session-list-new {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border);
+  padding: 10px 16px;
+  color: var(--accent);
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.session-list-new:active { background: var(--bg-card); }
+
 /* Transparent backdrop — covers viewport when session menu is open so outside
    clicks (including on the xterm.js canvas) dismiss the menu. */
 #menuBackdrop {

--- a/public/index.html
+++ b/public/index.html
@@ -219,6 +219,7 @@
           <div id="notifDrawerList" class="notif-drawer-list"></div>
         </div>
         <div id="sessionMenu" class="hidden" role="menu">
+          <div id="sessionList" class="session-list hidden" role="group" aria-label="Active sessions"></div>
           <div class="session-menu-item font-size-row" role="menuitem">
             <button id="fontDecBtn"   class="font-adj-btn" title="Decrease font size">A−</button>
             <span   id="fontSizeLabel">14px</span>

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -130,6 +130,130 @@ export function setStatus(state: ConnectionStatus, text: string): void {
   }
 }
 
+// ── Session list (#60) ───────────────────────────────────────────────────────
+
+export function renderSessionList(): void {
+  const container = document.getElementById('sessionList');
+  if (!container) return;
+
+  const sessions = Array.from(appState.sessions.values());
+
+  // Hide the list when only 1 session exists
+  if (sessions.length <= 1) {
+    container.classList.add('hidden');
+    container.innerHTML = '';
+    return;
+  }
+
+  container.classList.remove('hidden');
+
+  const items = sessions.map((s) => {
+    const label = s.profile
+      ? escHtml(`${s.profile.username}@${s.profile.host}`)
+      : escHtml(s.id);
+    const isActive = s.id === appState.activeSessionId;
+    const activeClass = isActive ? ' active' : '';
+    return `<div class="session-item${activeClass}" data-session-id="${escHtml(s.id)}" role="menuitem">
+      <span class="session-item-dot" aria-hidden="true"></span>
+      <span class="session-item-label">${label}</span>
+      <button class="session-item-close" data-close-id="${escHtml(s.id)}" aria-label="Close session">✕</button>
+    </div>`;
+  }).join('');
+
+  container.innerHTML = items + '<button class="session-list-new" id="sessionListNewBtn" role="menuitem">+ New session</button>';
+
+  container.querySelectorAll<HTMLElement>('.session-item').forEach((item) => {
+    item.addEventListener('click', (e) => {
+      // Don't switch if the close button was clicked
+      const target = e.target as HTMLElement;
+      if (target.closest('.session-item-close')) return;
+      const id = item.dataset.sessionId;
+      if (id) switchSession(id);
+    });
+  });
+
+  container.querySelectorAll<HTMLElement>('.session-item-close').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const id = btn.dataset.closeId;
+      if (id) closeSession(id);
+    });
+  });
+
+  document.getElementById('sessionListNewBtn')?.addEventListener('click', () => {
+    document.getElementById('sessionMenu')?.classList.add('hidden');
+    document.getElementById('menuBackdrop')?.classList.add('hidden');
+    navigateToPanel('connect');
+  });
+}
+
+export function switchSession(id: string): void {
+  const session = appState.sessions.get(id);
+  if (!session) return;
+
+  appState.activeSessionId = id;
+
+  // Hide all terminal containers, show the active one
+  document.querySelectorAll<HTMLElement>('[data-session-id]').forEach((el) => {
+    el.classList.toggle('hidden', el.dataset.sessionId !== id);
+  });
+
+  // Fit the newly visible terminal
+  session.fitAddon?.fit();
+
+  // Update session menu button text
+  const btn = document.getElementById('sessionMenuBtn');
+  if (btn && session.profile) {
+    btn.textContent = `${session.profile.username}@${session.profile.host}`;
+  }
+
+  // Close the menu
+  document.getElementById('sessionMenu')?.classList.add('hidden');
+  document.getElementById('menuBackdrop')?.classList.add('hidden');
+
+  // Re-render session list to update active indicator
+  renderSessionList();
+}
+
+export function closeSession(id: string): void {
+  const session = appState.sessions.get(id);
+  if (!session) return;
+
+  if (session.sshConnected) {
+    if (!confirm('Disconnect and close this session?')) return;
+    // Disconnect: close the WebSocket
+    try { session.ws?.close(); } catch { /* ignore */ }
+  }
+
+  // Clean up timers
+  if (session.reconnectTimer) clearTimeout(session.reconnectTimer);
+  if (session.keepAliveTimer) clearInterval(session.keepAliveTimer);
+  session.keepAliveWorker?.terminate();
+
+  // Remove terminal DOM container
+  const termContainer = document.querySelector<HTMLElement>(`#terminal [data-session-id="${CSS.escape(id)}"]`);
+  termContainer?.remove();
+
+  appState.sessions.delete(id);
+
+  // If we just closed the active session, switch to another
+  if (appState.activeSessionId === id) {
+    const remaining = Array.from(appState.sessions.keys());
+    if (remaining.length > 0) {
+      switchSession(remaining[0]!);
+    } else {
+      appState.activeSessionId = null;
+      const btn = document.getElementById('sessionMenuBtn');
+      if (btn) {
+        btn.textContent = 'MobiSSH';
+        btn.classList.remove('connected');
+      }
+    }
+  }
+
+  renderSessionList();
+}
+
 // ── Focus IME ────────────────────────────────────────────────────────────────
 
 export function focusIME(): void {

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -198,3 +198,124 @@ test.describe('UI chrome (#110 Phase 8)', () => {
   });
 
 });
+
+test.describe('Session list (#60)', () => {
+
+  test('session list is hidden when only one session exists', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+
+    // Open session menu
+    await page.locator('#sessionMenuBtn').click();
+    await page.waitForTimeout(100);
+
+    // Session list should be hidden (only 1 session)
+    await expect(page.locator('#sessionList')).toHaveClass(/hidden/);
+  });
+
+  test('session list shows when multiple sessions are injected', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+
+    // Inject a second session via the ES module system available in the browser
+    await page.evaluate(async () => {
+      const { appState } = await import('./modules/state.js');
+      const { renderSessionList } = await import('./modules/ui.js');
+      const s2 = {
+        id: 'test-session-2',
+        profile: { username: 'alice', host: 'remote.example.com', port: 22, authType: 'password', name: 'test' },
+        terminal: null, fitAddon: null, ws: null,
+        wsConnected: false, sshConnected: false,
+        reconnectTimer: null, reconnectDelay: 2000,
+        keepAliveTimer: null, keepAliveWorker: null,
+        activeThemeName: 'dark',
+      };
+      appState.sessions.set('test-session-2', s2);
+      renderSessionList();
+    });
+
+    await page.waitForTimeout(100);
+
+    // Session list should now be visible (2 sessions)
+    await expect(page.locator('#sessionList')).not.toHaveClass(/hidden/);
+
+    // Should show both sessions as items
+    await expect(page.locator('.session-item')).toHaveCount(2);
+
+    // Should show the + New session button
+    await expect(page.locator('#sessionListNewBtn')).toBeVisible();
+  });
+
+  test('+ New session navigates to connect tab', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+
+    // Inject a second session to make the list visible
+    await page.evaluate(async () => {
+      const { appState } = await import('./modules/state.js');
+      const { renderSessionList } = await import('./modules/ui.js');
+      appState.sessions.set('test-session-2', {
+        id: 'test-session-2',
+        profile: { username: 'bob', host: 'other.host', port: 22, authType: 'password', name: 'other' },
+        terminal: null, fitAddon: null, ws: null,
+        wsConnected: false, sshConnected: false,
+        reconnectTimer: null, reconnectDelay: 2000,
+        keepAliveTimer: null, keepAliveWorker: null,
+        activeThemeName: 'dark',
+      });
+      renderSessionList();
+    });
+
+    // Open session menu and click + New session
+    await page.locator('#sessionMenuBtn').click();
+    await page.waitForTimeout(100);
+    await page.locator('#sessionListNewBtn').click();
+    await page.waitForTimeout(200);
+
+    // Should navigate to Connect panel
+    await expect(page.locator('#panel-connect')).toHaveClass(/active/);
+  });
+
+  test('session list hides again when second session is removed', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+
+    // Add and then remove a second session
+    await page.evaluate(async () => {
+      const { appState } = await import('./modules/state.js');
+      const { renderSessionList } = await import('./modules/ui.js');
+      appState.sessions.set('test-session-2', {
+        id: 'test-session-2',
+        profile: { username: 'carol', host: 'host2.local', port: 22, authType: 'password', name: 'test2' },
+        terminal: null, fitAddon: null, ws: null,
+        wsConnected: false, sshConnected: false,
+        reconnectTimer: null, reconnectDelay: 2000,
+        keepAliveTimer: null, keepAliveWorker: null,
+        activeThemeName: 'dark',
+      });
+      renderSessionList();
+    });
+
+    // Verify list is visible with 2 sessions
+    await expect(page.locator('#sessionList')).not.toHaveClass(/hidden/);
+
+    // Remove the second session
+    await page.evaluate(async () => {
+      const { appState } = await import('./modules/state.js');
+      const { renderSessionList } = await import('./modules/ui.js');
+      appState.sessions.delete('test-session-2');
+      renderSessionList();
+    });
+
+    await page.waitForTimeout(100);
+
+    // List should be hidden again
+    await expect(page.locator('#sessionList')).toHaveClass(/hidden/);
+  });
+
+  test('sessionMenuBtn shows user@host label when connected', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+
+    // After connection, session menu button should show user@host
+    const btnText = await page.locator('#sessionMenuBtn').textContent();
+    expect(btnText).toContain('testuser');
+    expect(btnText).toContain('mock-host');
+  });
+
+});


### PR DESCRIPTION
## Summary
- Add `renderSessionList()`, `switchSession()`, and `closeSession()` to `src/modules/ui.ts`
- Add `#sessionList` container inside `#sessionMenu` in `index.html` (above existing menu items)
- Add `.session-list`, `.session-item`, `.session-item-dot`, `.session-item-close`, `.session-list-new` CSS classes in `app.css`

## Design
- Session list hidden when only 1 session exists; visible when 2+ sessions
- Active session shows filled dot, others show empty dot (CSS `.session-item.active .session-item-dot`)
- Each item shows `user@host` from session profile (falls back to session id)
- Close button on each item disconnects and removes the session (confirms if connected)
- "+ New session" button closes the menu and navigates to Connect tab
- `switchSession(id)` sets `activeSessionId`, hides/shows terminal containers by `data-session-id`, calls `fitAddon.fit()`, updates `#sessionMenuBtn` text, closes menu, re-renders list
- `closeSession(id)` cleans up WS/timers, removes DOM, switches to another session if closing active

## Test coverage
- `session list is hidden when only one session exists` — verifies baseline hidden state
- `session list shows when multiple sessions are injected` — verifies list renders and item count
- `+ New session navigates to connect tab` — verifies navigation behavior
- `session list hides again when second session is removed` — verifies hide-on-single-session
- `sessionMenuBtn shows user@host label when connected` — verifies button text update

## Test results
- tsc: PASS
- eslint: PASS (no errors, pre-existing warnings only)
- vitest: PASS (49/49)

## Diff stats
- Files changed: 4
- Lines: +319 / -0

Closes #60

## Cycles used
1/3