### PR TITLE
feat: per-session keep-alive timers

### DIFF
--- a/src/modules/__tests__/keepalive.test.ts
+++ b/src/modules/__tests__/keepalive.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { webcrypto } from 'node:crypto';
+
+// Stub browser globals before any module imports
+vi.stubGlobal('crypto', webcrypto);
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+});
+vi.stubGlobal('location', { hostname: 'localhost' });
+
+// Minimal DOM mock (connection.ts registers document event listeners at module load)
+vi.stubGlobal('document', {
+  getElementById: () => null,
+  querySelector: () => null,
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  createElement: vi.fn(() => ({
+    className: '',
+    textContent: '',
+    innerHTML: '',
+    id: '',
+    appendChild: vi.fn(),
+    addEventListener: vi.fn(),
+    querySelector: vi.fn(),
+    remove: vi.fn(),
+  })),
+  body: { appendChild: vi.fn() },
+});
+
+vi.stubGlobal('WebSocket', class {
+  onopen = null; onclose = null; onmessage = null; onerror = null;
+  readyState = 1; // OPEN
+  url = 'ws://localhost:8081';
+  close = vi.fn(); send = vi.fn();
+  static OPEN = 1;
+});
+vi.stubGlobal('Worker', class {
+  onmessage = null; postMessage = vi.fn(); terminate = vi.fn();
+});
+vi.stubGlobal('navigator', { wakeLock: undefined });
+vi.stubGlobal('window', { addEventListener: vi.fn() });
+
+vi.useFakeTimers();
+
+const { _startKeepAlive, _stopKeepAlive } = await import('../connection.js');
+const { appState, createSession } = await import('../state.js');
+
+describe('per-session keep-alive timer isolation (#62)', () => {
+  beforeEach(() => {
+    appState.sessions.clear();
+    appState.activeSessionId = null;
+    // Provide a fake WS so startKeepAlive can create the Worker
+    appState.ws = { readyState: 1, url: 'ws://localhost:8081', send: vi.fn(), close: vi.fn(), onopen: null, onclose: null, onmessage: null, onerror: null } as unknown as WebSocket;
+  });
+
+  it('startKeepAlive sets timer on the target session only', () => {
+    const s1 = createSession('session-1');
+    const s2 = createSession('session-2');
+
+    _startKeepAlive('session-1');
+
+    expect(s1.keepAliveTimer).not.toBeNull();
+    expect(s2.keepAliveTimer).toBeNull();
+  });
+
+  it('stopKeepAlive clears timer on the target session only', () => {
+    const s1 = createSession('session-a');
+    const s2 = createSession('session-b');
+
+    _startKeepAlive('session-a');
+    _startKeepAlive('session-b');
+
+    expect(s1.keepAliveTimer).not.toBeNull();
+    expect(s2.keepAliveTimer).not.toBeNull();
+
+    _stopKeepAlive('session-a');
+
+    expect(s1.keepAliveTimer).toBeNull();
+    expect(s1.keepAliveWorker).toBeNull();
+    // session-b timer must survive
+    expect(s2.keepAliveTimer).not.toBeNull();
+  });
+
+  it('stopKeepAlive terminates the Worker for the target session only', () => {
+    const s1 = createSession('s1');
+    const s2 = createSession('s2');
+
+    _startKeepAlive('s1');
+    _startKeepAlive('s2');
+
+    const worker1 = s1.keepAliveWorker;
+    const worker2 = s2.keepAliveWorker;
+
+    _stopKeepAlive('s1');
+
+    // worker1 must be terminated, worker2 must not
+    expect((worker1 as { terminate: ReturnType<typeof vi.fn> } | null)?.terminate).toHaveBeenCalledTimes(1);
+    expect((worker2 as { terminate: ReturnType<typeof vi.fn> } | null)?.terminate).not.toHaveBeenCalled();
+    expect(s1.keepAliveWorker).toBeNull();
+    expect(s2.keepAliveWorker).not.toBeNull();
+  });
+
+  it('startKeepAlive is a no-op for unknown sessionId', () => {
+    // Should not throw
+    expect(() => _startKeepAlive('nonexistent')).not.toThrow();
+  });
+
+  it('stopKeepAlive is a no-op for unknown sessionId', () => {
+    expect(() => _stopKeepAlive('nonexistent')).not.toThrow();
+  });
+
+  it('stopKeepAlive clears both timer and worker on the session', () => {
+    const s = createSession('full-stop');
+    _startKeepAlive('full-stop');
+    expect(s.keepAliveTimer).not.toBeNull();
+    expect(s.keepAliveWorker).not.toBeNull();
+
+    _stopKeepAlive('full-stop');
+    expect(s.keepAliveTimer).toBeNull();
+    expect(s.keepAliveWorker).toBeNull();
+  });
+});

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -176,6 +176,7 @@ export async function connect(profile: SSHProfile): Promise<void> {
 
 function _openWebSocket(options?: { silent?: boolean }): void {
   const silent = options?.silent ?? false;
+  const sessionId = appState.activeSessionId ?? '';
 
   if (appState.ws) {
     appState.ws.onclose = null;
@@ -205,7 +206,7 @@ function _openWebSocket(options?: { silent?: boolean }): void {
     openedThisAttempt = true;
     _wsConsecFailures = 0;
     appState._wsConnected = true;
-    startKeepAlive();
+    startKeepAlive(sessionId);
     if (!appState.currentProfile) return;
     const authMsg: ConnectMessage = {
       type: 'connect',
@@ -322,7 +323,7 @@ function _openWebSocket(options?: { silent?: boolean }): void {
   appState.ws.onclose = (event) => {
     appState._wsConnected = false;
     appState.sshConnected = false;
-    stopKeepAlive();
+    stopKeepAlive(sessionId);
     if (appState.currentProfile) {
       _setStatus('disconnected', 'Disconnected');
       if (!openedThisAttempt) {
@@ -392,17 +393,23 @@ export function reconnect(): void {
 // the tab, unlike main-thread setInterval which gets throttled to ~60s.
 // The main thread also sends pings as a belt-and-suspenders fallback.
 const WS_PING_INTERVAL_MS = 25_000;
-let _keepAliveWorker: Worker | null = null;
 
-function startKeepAlive(): void {
-  stopKeepAlive();
+/** Exported for testing only. */
+export function _startKeepAlive(sessionId: string): void { startKeepAlive(sessionId); }
+/** Exported for testing only. */
+export function _stopKeepAlive(sessionId: string): void { stopKeepAlive(sessionId); }
+
+function startKeepAlive(sessionId: string): void {
+  stopKeepAlive(sessionId);
+  const session = appState.sessions.get(sessionId);
+  if (!session) return;
 
   // Main-thread keepalive (throttled in background, but works when visible)
-  appState.keepAliveTimer = setInterval(() => {
+  session.keepAliveTimer = setInterval(() => {
     if (appState.ws?.readyState === WebSocket.OPEN) {
       appState.ws.send(JSON.stringify({ type: 'ping' }));
     } else {
-      stopKeepAlive();
+      stopKeepAlive(sessionId);
     }
   }, WS_PING_INTERVAL_MS);
 
@@ -410,25 +417,27 @@ function startKeepAlive(): void {
   const wsUrl = appState.ws?.url;
   if (!wsUrl) return;
   try {
-    _keepAliveWorker = new Worker('ws-keepalive-worker.js');
-    _keepAliveWorker.onmessage = () => {
+    session.keepAliveWorker = new Worker('ws-keepalive-worker.js');
+    session.keepAliveWorker.onmessage = () => {
       // Worker's WS disconnected -- not critical, main-thread ping is still running
     };
-    _keepAliveWorker.postMessage({ command: 'start', url: wsUrl, interval: WS_PING_INTERVAL_MS });
+    session.keepAliveWorker.postMessage({ command: 'start', url: wsUrl, interval: WS_PING_INTERVAL_MS });
   } catch {
     // Worker unavailable -- main-thread setInterval is already running
   }
 }
 
-function stopKeepAlive(): void {
-  if (_keepAliveWorker) {
-    _keepAliveWorker.postMessage({ command: 'stop' });
-    _keepAliveWorker.terminate();
-    _keepAliveWorker = null;
+function stopKeepAlive(sessionId: string): void {
+  const session = appState.sessions.get(sessionId);
+  if (!session) return;
+  if (session.keepAliveWorker) {
+    session.keepAliveWorker.postMessage({ command: 'stop' });
+    session.keepAliveWorker.terminate();
+    session.keepAliveWorker = null;
   }
-  if (appState.keepAliveTimer) {
-    clearInterval(appState.keepAliveTimer);
-    appState.keepAliveTimer = null;
+  if (session.keepAliveTimer) {
+    clearInterval(session.keepAliveTimer);
+    session.keepAliveTimer = null;
   }
 }
 
@@ -468,7 +477,7 @@ document.addEventListener('visibilitychange', () => {
 export function disconnect(): void {
   stopAndDownloadRecording(); // auto-save any active recording (#54)
   cancelReconnect();
-  stopKeepAlive();
+  if (appState.activeSessionId) stopKeepAlive(appState.activeSessionId);
   releaseWakeLock();
   appState.currentProfile = null;
   appState.sshConnected = false;


### PR DESCRIPTION
## Summary
- Removed module-level `_keepAliveWorker` from `connection.ts`; each session now owns its timers via `SessionState.keepAliveTimer` and `SessionState.keepAliveWorker`
- `startKeepAlive(sessionId)` and `stopKeepAlive(sessionId)` look up the session from `appState.sessions` and operate only on that session's fields
- Call sites in `_openWebSocket` capture `sessionId` at open time and pass it through closures; `disconnect()` uses `appState.activeSessionId`

## Test coverage
- Added `src/modules/__tests__/keepalive.test.ts` with 6 Vitest unit tests
- Tests verify: timer set on target session only, stop clears target only (other session survives), Worker termination is isolated, no-op on unknown sessionId

## Test results
- tsc: PASS
- eslint: PASS (138 pre-existing warnings, 0 errors)
- vitest: PASS (6 new keepalive tests pass; `agent-hooks.test.ts` failure is pre-existing — ssh2 module not installed in test env)

## Diff stats
- Files changed: 2
- Lines: +157 / -19

Closes #62

## Cycles used
1/3