### PR TITLE
feat: add Clear and Send buttons to compose preview

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -211,12 +211,33 @@ body.debug-ime #imePreview {
   color: var(--accent);
   font-family: var(--font-mono);
   font-size: 13px;
-  padding: 3px 12px;
+  padding: 3px 8px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
+  gap: 6px;
   min-height: 24px;
 }
+.ime-preview-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ime-preview-btn {
+  background: none;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-family: var(--font-ui);
+  touch-action: manipulation;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.ime-preview-btn:active { background: var(--accent); color: #000; }
+.ime-preview-commit { border-color: var(--accent); font-weight: 600; }
 
 
 /* Key bar handle — ≡ | session identity | ▾ */

--- a/public/index.html
+++ b/public/index.html
@@ -201,7 +201,11 @@
         <button id="selectionDismissBtn" class="selection-chip-btn selection-chip-dismiss" aria-label="Dismiss">✕</button>
       </div>
       <!-- IME composition preview — shows word being composed before commit (#44) -->
-      <div id="imePreview" class="hidden" aria-live="polite" aria-atomic="true"></div>
+      <div id="imePreview" class="hidden" aria-live="polite" aria-atomic="true">
+        <span id="imePreviewText" class="ime-preview-text"></span>
+        <button id="imeClearBtn" class="ime-preview-btn" aria-label="Clear compose">Clear</button>
+        <button id="imeCommitBtn" class="ime-preview-btn ime-preview-commit" aria-label="Send compose">Send</button>
+      </div>
       <!-- Handle strip: session identity (center, swipe up/down toggles tab bar) | ▾ key bar toggle -->
       <div id="key-bar-handle" aria-label="Terminal controls">
         <button id="handleMenuBtn" class="handle-btn handle-menu-btn" title="Show tabs" aria-label="Show tabs">≡</button>

--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -55,11 +55,31 @@ export function initIMEInput(): void {
     const el = document.getElementById('imePreview');
     if (!el) return;
     if (text) {
-      el.textContent = text;
+      const textEl = document.getElementById('imePreviewText');
+      if (textEl) textEl.textContent = text;
       el.classList.remove('hidden');
     } else {
       el.classList.add('hidden');
     }
+  }
+
+  // ── Preview action buttons: Clear and Send (#74) ───────────────────────
+  const clearBtn = document.getElementById('imeClearBtn');
+  const commitBtn = document.getElementById('imeCommitBtn');
+
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      _clearIME();
+      _imePreviewShow(null);
+    });
+  }
+
+  if (commitBtn) {
+    commitBtn.addEventListener('click', () => {
+      sendSSHInput('\r');
+      _clearIME();
+      _imePreviewShow(null);
+    });
   }
 
   // ── Textarea diffing state (handles post-composition corrections) ──────

--- a/tests/ime.spec.js
+++ b/tests/ime.spec.js
@@ -219,6 +219,70 @@ test.describe('IME composition → SSH input routing', () => {
   });
 });
 
+test.describe('Issue #74 — compose preview Clear and Send buttons', () => {
+  test('Clear button hides the preview without sending', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await page.evaluate(() => { window.__mockWsSpy = []; });
+
+    // Start composition to show preview
+    await page.evaluate(() => {
+      const el = document.getElementById('imeInput');
+      el.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      el.dispatchEvent(new CompositionEvent('compositionupdate', { bubbles: true, data: 'hello' }));
+    });
+
+    const preview = page.locator('#imePreview');
+    await expect(preview).not.toHaveClass(/hidden/);
+
+    // Click Clear button
+    await page.locator('#imeClearBtn').click();
+
+    // Preview should be hidden and no input sent
+    await expect(preview).toHaveClass(/hidden/);
+    const msgs = await getInputMessages(page);
+    expect(msgs).toHaveLength(0);
+  });
+
+  test('Send button sends \\r and hides the preview', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await page.evaluate(() => { window.__mockWsSpy = []; });
+
+    // Start composition to show preview
+    await page.evaluate(() => {
+      const el = document.getElementById('imeInput');
+      el.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      el.dispatchEvent(new CompositionEvent('compositionupdate', { bubbles: true, data: 'hello' }));
+    });
+
+    const preview = page.locator('#imePreview');
+    await expect(preview).not.toHaveClass(/hidden/);
+
+    // Click Send button
+    await page.locator('#imeCommitBtn').click();
+
+    // Preview should be hidden and \r sent to SSH
+    await expect(preview).toHaveClass(/hidden/);
+    const msgs = await getInputMessages(page);
+    expect(msgs.some((m) => m.data === '\r')).toBe(true);
+  });
+
+  test('preview text is shown in the text span, not overwriting buttons', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+
+    await page.evaluate(() => {
+      const el = document.getElementById('imeInput');
+      el.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      el.dispatchEvent(new CompositionEvent('compositionupdate', { bubbles: true, data: 'typed' }));
+    });
+
+    // Text should appear in the span, not replace the entire container
+    await expect(page.locator('#imePreviewText')).toHaveText('typed');
+    // Buttons should still be present
+    await expect(page.locator('#imeClearBtn')).toBeVisible();
+    await expect(page.locator('#imeCommitBtn')).toBeVisible();
+  });
+});
+
 test.describe('Issue #85 — compositioncancel resets IME state', () => {
   test('compositioncancel clears isComposing so subsequent input is not dropped', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);


### PR DESCRIPTION
## Summary
- Added `#imeClearBtn` (Clear) and `#imeCommitBtn` (Send) buttons inside the `#imePreview` container in `index.html`
- Wired click handlers in `ime.ts`: Clear calls `_clearIME()` + hides preview; Send calls `sendSSHInput('\r')` + clears + hides preview
- Updated CSS to use a `#imePreviewText` span with `flex: 1` so buttons are pushed to the right end of the preview strip

## Test coverage
- `Clear button hides the preview without sending` — verifies clicking Clear hides preview and sends no SSH input
- `Send button sends \r and hides the preview` — verifies clicking Send hides preview and sends `\r` to SSH
- `preview text is shown in the text span, not overwriting buttons` — verifies composition text goes into the span and both buttons remain visible

## Test results
- tsc: PASS
- eslint: PASS
- vitest: PASS (agent-hooks.test.ts failure is pre-existing — ssh2 module not installed in worktree)

## Diff stats
- Files changed: 4
- Lines: +112 / -3

Closes #74

## Cycles used
1/3