### PR TITLE
fix: use AGENT_HOME so container reads host agent configs

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,8 +10,10 @@ services:
       TS_AUTHKEY: "${TS_AUTHKEY:-}"
       TS_HOSTNAME: "${TS_HOSTNAME:-mobissh}"
       TS_SERVE: "1"
+      AGENT_HOME: "/host-home"
     volumes:
       - tailscale-state:/var/lib/tailscale
+      - ${HOME}:/host-home:rw
     cap_add:
       - NET_ADMIN
       - SYS_MODULE

--- a/server/index.js
+++ b/server/index.js
@@ -281,7 +281,7 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
   const urlPath = req.url.split('?')[0];
 
   if (urlPath === '/api/detect-agents') {
-    const homeDir = process.env.HOME || os.homedir();
+    const homeDir = process.env.AGENT_HOME || process.env.HOME || os.homedir();
     const agents = [
       { name: 'Claude Code', id: 'claude', configPath: path.join(homeDir, '.claude', 'settings.json') },
       { name: 'Codex', id: 'codex', configPath: path.join(homeDir, '.codex', 'config.toml') },
@@ -325,7 +325,7 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
     req.on('end', () => {
       try {
         const { agent } = JSON.parse(body);
-        const homeDir = process.env.HOME || os.homedir();
+        const homeDir = process.env.AGENT_HOME || process.env.HOME || os.homedir();
         const hooksDir = path.join(homeDir, '.claude', 'hooks');
         const scriptPath = path.join(hooksDir, 'notify-bell.sh');
 
@@ -412,7 +412,7 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
     req.on('end', () => {
       try {
         const { agent } = JSON.parse(body);
-        const homeDir = process.env.HOME || os.homedir();
+        const homeDir = process.env.AGENT_HOME || process.env.HOME || os.homedir();
 
         if (agent === 'claude') {
           const settingsPath = path.join(homeDir, '.claude', 'settings.json');

--- a/src/modules/__tests__/agent-hooks.test.ts
+++ b/src/modules/__tests__/agent-hooks.test.ts
@@ -43,6 +43,7 @@ function get(urlPath: string): Promise<{ status: number; json: Record<string, un
 beforeAll(async () => {
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-hooks-test-'));
   process.env.HOME = tmpHome;
+  process.env.AGENT_HOME = tmpHome;
 
   // Clear require cache so server re-reads HOME
   const serverPath = path.resolve(__dirname, '../../../server/index.js');
@@ -62,6 +63,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await new Promise<void>((resolve) => { server.close(() => { resolve(); }); });
   fs.rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.AGENT_HOME;
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- Add `AGENT_HOME` env var support to all three agent-hooks API endpoints (`detect-agents`, `install-hook`, `uninstall-hook`) so the server can find host agent configs when running in Docker
- Mount the host's home directory into the container at `/host-home:rw` and set `AGENT_HOME=/host-home` in `docker-compose.prod.yml`
- Update the agent-hooks unit test to set `AGENT_HOME` alongside `HOME` so it exercises the same code path the container uses

## Root cause
The server runs in Docker where `os.homedir()` returns `/root`, but agent configs (`~/.claude/settings.json`, etc.) live on the host at `/home/dev/`. The detect-agents endpoint returned `installed: false` for all agents, disabling all toggles via `toggle.disabled = true` in settings.ts.

## Test coverage
- Updated `src/modules/__tests__/agent-hooks.test.ts` to set `process.env.AGENT_HOME = tmpHome` in `beforeAll` (and clean up in `afterAll`)
- All 18 agent-hooks tests pass with the updated code path

## Test results
- tsc: PASS
- eslint: PASS
- vitest: PASS (66/66 tests)

## Diff stats
- Files changed: 3
- Lines: +7 / -3

Closes #75

## Cycles used
1/3