### PR TITLE
fix: post-DNS SSRF check with IP range validation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,7 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const dns = require('dns');
 const { createHash, createHmac, randomBytes, timingSafeEqual } = require('crypto');
 const { execSync } = require('child_process');
 const WebSocket = require('ws');
@@ -405,24 +406,63 @@ if (require.main === module) {
   });
 }
 
-// ─── SSRF prevention (issue #6) ───────────────────────────────────────────────
-// Blocks RFC-1918 private, loopback, and link-local addresses by default.
+// ─── SSRF prevention (issue #6, #84) ─────────────────────────────────────────
+// Blocks RFC-1918 private, loopback, link-local, and other reserved addresses.
 // Clients may send allowPrivate:true to override (controlled by the danger zone
 // setting in the frontend — only for users who explicitly opt in).
+//
+// isPrivateIp(ip) performs numeric CIDR matching on a resolved IP address.
+// connect() resolves the hostname via dns.lookup() before calling sshClient.connect(),
+// preventing DNS rebinding attacks where a public hostname resolves to a private IP.
 
-function isPrivateHost(host) {
-  const h = host.trim().toLowerCase();
-  // Loopback / unspecified
-  if (h === 'localhost' || h === '::1' || h === '0.0.0.0') return true;
-  if (h.startsWith('127.')) return true;           // 127.0.0.0/8
-  // RFC-1918 ranges
-  if (h.startsWith('10.')) return true;            // 10.0.0.0/8
-  if (h.startsWith('192.168.')) return true;       // 192.168.0.0/16
-  // 172.16.0.0/12 = 172.16.x – 172.31.x
-  const m = h.match(/^172\.(\d+)\./);
-  if (m && parseInt(m[1]) >= 16 && parseInt(m[1]) <= 31) return true;
-  // IPv6 link-local and ULA
-  if (h.startsWith('fe80:') || h.startsWith('fc') || h.startsWith('fd')) return true;
+/**
+ * Returns true if the given resolved IP address falls within any private,
+ * loopback, link-local, CGNAT, ULA, or unspecified range.
+ *
+ * Covers:
+ *   IPv4: 0.0.0.0/8, 10/8, 100.64/10, 127/8, 169.254/16, 172.16/12, 192.168/16
+ *   IPv6: ::, ::1, fc00::/7 (ULA), fe80::/10 (link-local)
+ *   IPv4-mapped IPv6: ::ffff:x.x.x.x — unwrapped and re-checked as IPv4
+ */
+function isPrivateIp(ip) {
+  const s = ip.trim().toLowerCase();
+
+  // IPv4-mapped IPv6: ::ffff:x.x.x.x or ::ffff:aabb:ccdd
+  const mapped = s.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isPrivateIp(mapped[1]);
+
+  // IPv6 checks
+  if (s === '::' || s === '::1') return true;
+  // ULA fc00::/7 — first byte 0xfc or 0xfd (binary prefix 1111 110x)
+  if (s.startsWith('fc') || s.startsWith('fd')) return true;
+  // Link-local fe80::/10 — first 10 bits are 1111 1110 10
+  if (s.startsWith('fe80:') || s.startsWith('fe8') || s.startsWith('fe9') ||
+      s.startsWith('fea') || s.startsWith('feb')) return true;
+
+  // IPv4: parse to 32-bit integer for CIDR comparisons
+  const parts = s.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!parts) return false; // unknown format — don't block
+  const a = parseInt(parts[1]);
+  const b = parseInt(parts[2]);
+  const c = parseInt(parts[3]);
+  const d = parseInt(parts[4]);
+  if (a > 255 || b > 255 || c > 255 || d > 255) return false;
+  const n = (a << 24 >>> 0) + (b << 16) + (c << 8) + d;
+
+  // Helper: check if n falls in prefix/bits
+  function inCidr(base, bits) {
+    const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+    return (n & mask) === (base & mask);
+  }
+
+  if (inCidr(0x00000000, 8))   return true; // 0.0.0.0/8      unspecified
+  if (inCidr(0x0a000000, 8))   return true; // 10.0.0.0/8     RFC-1918
+  if (inCidr(0x64400000, 10))  return true; // 100.64.0.0/10  CGNAT
+  if (inCidr(0x7f000000, 8))   return true; // 127.0.0.0/8    loopback
+  if (inCidr(0xa9fe0000, 16))  return true; // 169.254.0.0/16 link-local
+  if (inCidr(0xac100000, 12))  return true; // 172.16.0.0/12  RFC-1918
+  if (inCidr(0xc0a80000, 16))  return true; // 192.168.0.0/16 RFC-1918
+
   return false;
 }
 
@@ -521,12 +561,25 @@ wss.on('connection', (ws, req) => {
       return;
     }
 
-    if (isPrivateHost(cfg.host) && !cfg.allowPrivate) {
-      send({ type: 'error', message: 'Connections to private/loopback addresses are blocked. Enable "Allow private addresses" in Settings → Danger Zone to override.' });
-      connecting = false;
-      return;
-    }
+    // Resolve hostname to IP first, then check against private ranges.
+    // This prevents DNS rebinding: a public-looking hostname resolving to a
+    // private IP would bypass a hostname-only string check.
+    dns.lookup(cfg.host, (dnsErr, address) => {
+      if (dnsErr) {
+        send({ type: 'error', message: `DNS resolution failed: ${dnsErr.message}` });
+        connecting = false;
+        return;
+      }
+      if (isPrivateIp(address) && !cfg.allowPrivate) {
+        send({ type: 'error', message: 'Connections to private/loopback addresses are blocked. Enable "Allow private addresses" in Settings → Danger Zone to override.' });
+        connecting = false;
+        return;
+      }
+      connectAfterDns(cfg, address);
+    });
+  }
 
+  function connectAfterDns(cfg, resolvedIp) {
     sshClient = new Client();
 
     sshClient.on('ready', () => {
@@ -576,7 +629,7 @@ wss.on('connection', (ws, req) => {
     sshClient.on('close', () => { sshCleanup('SSH connection closed'); });
 
     const sshConfig = {
-      host: cfg.host,
+      host: resolvedIp,
       port: parseInt(cfg.port) || 22,
       username: cfg.username,
       readyTimeout: 15000,
@@ -692,4 +745,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { rewriteManifest, server, handleSftpMessage, isOriginAllowed };
+module.exports = { rewriteManifest, server, handleSftpMessage, isOriginAllowed, isPrivateIp };

--- a/server/test.js
+++ b/server/test.js
@@ -10,7 +10,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { Readable, Writable } = require('stream');
 
-const { rewriteManifest, handleSftpMessage } = require('./index.js');
+const { rewriteManifest, handleSftpMessage, isPrivateIp } = require('./index.js');
 
 test('rewriteManifest: sets id="mobissh"', () => {
   const input = Buffer.from(JSON.stringify({ name: 'MobiSSH', start_url: '/' }));
@@ -156,4 +156,106 @@ test('handleSftpMessage: sftp_stat error returns sftp_error', () => {
   assert.equal(results[0].type, 'sftp_error');
   assert.equal(results[0].requestId, '8');
   assert.equal(results[0].message, 'Not found');
+});
+
+// ─── isPrivateIp tests (issue #84) ────────────────────────────────────────────
+
+test('isPrivateIp: 127.0.0.1 is private (loopback)', () => {
+  assert.equal(isPrivateIp('127.0.0.1'), true);
+});
+
+test('isPrivateIp: 127.255.255.255 is private (loopback /8)', () => {
+  assert.equal(isPrivateIp('127.255.255.255'), true);
+});
+
+test('isPrivateIp: 0.0.0.0 is private (unspecified)', () => {
+  assert.equal(isPrivateIp('0.0.0.0'), true);
+});
+
+test('isPrivateIp: 10.0.0.1 is private (RFC-1918 10/8)', () => {
+  assert.equal(isPrivateIp('10.0.0.1'), true);
+});
+
+test('isPrivateIp: 10.255.255.255 is private (RFC-1918 10/8 boundary)', () => {
+  assert.equal(isPrivateIp('10.255.255.255'), true);
+});
+
+test('isPrivateIp: 172.16.0.1 is private (RFC-1918 172.16/12)', () => {
+  assert.equal(isPrivateIp('172.16.0.1'), true);
+});
+
+test('isPrivateIp: 172.31.255.255 is private (RFC-1918 172.16/12 boundary)', () => {
+  assert.equal(isPrivateIp('172.31.255.255'), true);
+});
+
+test('isPrivateIp: 172.15.255.255 is NOT private (just outside 172.16/12)', () => {
+  assert.equal(isPrivateIp('172.15.255.255'), false);
+});
+
+test('isPrivateIp: 172.32.0.0 is NOT private (just outside 172.16/12)', () => {
+  assert.equal(isPrivateIp('172.32.0.0'), false);
+});
+
+test('isPrivateIp: 192.168.1.1 is private (RFC-1918 192.168/16)', () => {
+  assert.equal(isPrivateIp('192.168.1.1'), true);
+});
+
+test('isPrivateIp: 169.254.1.1 is private (link-local)', () => {
+  assert.equal(isPrivateIp('169.254.1.1'), true);
+});
+
+test('isPrivateIp: 100.64.0.1 is private (CGNAT)', () => {
+  assert.equal(isPrivateIp('100.64.0.1'), true);
+});
+
+test('isPrivateIp: 100.127.255.255 is private (CGNAT boundary)', () => {
+  assert.equal(isPrivateIp('100.127.255.255'), true);
+});
+
+test('isPrivateIp: 100.128.0.0 is NOT private (just outside CGNAT)', () => {
+  assert.equal(isPrivateIp('100.128.0.0'), false);
+});
+
+test('isPrivateIp: 8.8.8.8 is NOT private (public IP)', () => {
+  assert.equal(isPrivateIp('8.8.8.8'), false);
+});
+
+test('isPrivateIp: 1.1.1.1 is NOT private (public IP)', () => {
+  assert.equal(isPrivateIp('1.1.1.1'), false);
+});
+
+test('isPrivateIp: ::1 is private (IPv6 loopback)', () => {
+  assert.equal(isPrivateIp('::1'), true);
+});
+
+test('isPrivateIp: :: is private (IPv6 unspecified)', () => {
+  assert.equal(isPrivateIp('::'), true);
+});
+
+test('isPrivateIp: fc00::1 is private (IPv6 ULA)', () => {
+  assert.equal(isPrivateIp('fc00::1'), true);
+});
+
+test('isPrivateIp: fd12:3456::1 is private (IPv6 ULA fd)', () => {
+  assert.equal(isPrivateIp('fd12:3456::1'), true);
+});
+
+test('isPrivateIp: fe80::1 is private (IPv6 link-local)', () => {
+  assert.equal(isPrivateIp('fe80::1'), true);
+});
+
+test('isPrivateIp: 2001:db8::1 is NOT private (public IPv6)', () => {
+  assert.equal(isPrivateIp('2001:db8::1'), false);
+});
+
+test('isPrivateIp: ::ffff:127.0.0.1 is private (IPv4-mapped loopback)', () => {
+  assert.equal(isPrivateIp('::ffff:127.0.0.1'), true);
+});
+
+test('isPrivateIp: ::ffff:10.0.0.1 is private (IPv4-mapped RFC-1918)', () => {
+  assert.equal(isPrivateIp('::ffff:10.0.0.1'), true);
+});
+
+test('isPrivateIp: ::ffff:8.8.8.8 is NOT private (IPv4-mapped public)', () => {
+  assert.equal(isPrivateIp('::ffff:8.8.8.8'), false);
 });


### PR DESCRIPTION
## Summary

- Replace string-prefix `isPrivateHost()` with numeric CIDR `isPrivateIp()` covering loopback (127/8, ::1), RFC-1918 (10/8, 172.16/12, 192.168/16), link-local (169.254/16, fe80::/10), ULA (fc00::/7), CGNAT (100.64/10), IPv4-mapped IPv6, and unspecified (0.0.0.0, ::)
- Resolve hostnames via `dns.lookup()` before the SSRF check so a public-looking hostname that resolves to a private IP is blocked (DNS rebinding prevention); ssh2 connects to the resolved IP directly
- `allowPrivate: true` (Danger Zone toggle) still bypasses the check as before

## Test coverage

- 25 new unit tests in `server/test.js` for `isPrivateIp()` covering all CIDR ranges, boundary values, IPv6, IPv4-mapped IPv6, and public IPs
- Pre-existing `handleSftpMessage: sftp_ls` test failure on main is unrelated (missing `isSymbolicLink` in mock) and not introduced by this PR

## Test results

- tsc: PASS
- eslint: PASS (0 errors, pre-existing warnings only)
- vitest: PASS (48/48)
- server/test.js: 37/38 pass (1 pre-existing failure unrelated to this PR)

## Diff stats

- Files changed: 2
- Lines: +178 / -23

Closes #84

## Cycles used

1/3