### PR TITLE
fix: add Origin header validation to prevent CSWSH

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -48,6 +48,7 @@ const { createHash, createHmac, randomBytes, timingSafeEqual } = require('crypto
 const { execSync } = require('child_process');
 const WebSocket = require('ws');
 const { Client } = require('ssh2');
+const { isOriginAllowed } = require('./origin');
 
 const PORT = process.env.PORT || 8081;
 const HOST = process.env.HOST || '0.0.0.0';
@@ -56,6 +57,16 @@ const HOST = process.env.HOST || '0.0.0.0';
 const BASE_PATH = (process.env.BASE_PATH || '').replace(/\/$/, '');
 
 const PUBLIC_DIR = path.resolve(__dirname, '..', 'public');
+
+// ─── CSWSH prevention (issue #83) ─────────────────────────────────────────────
+// WS_ORIGIN_ALLOWLIST: comma-separated list of additional allowed origins.
+// Example: WS_ORIGIN_ALLOWLIST=https://myapp.tailnet.ts.net,https://localhost:8081
+
+// Parse WS_ORIGIN_ALLOWLIST once at startup.
+const WS_ORIGIN_ALLOWLIST = (process.env.WS_ORIGIN_ALLOWLIST || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
 
 // ─── WS upgrade authentication (issue #93) ────────────────────────────────────
 // Per-boot secret — never stored, never logged, never leaves this process.
@@ -323,6 +334,15 @@ const wss = new WebSocket.Server({
   server,
   maxPayload: MAX_MESSAGE_SIZE,
   verifyClient({ req }, callback) {
+    // Origin check runs regardless of TS_SERVE mode (#83).
+    const origin = req.headers['origin'];
+    const host = req.headers['host'];
+    if (!isOriginAllowed(origin, host, WS_ORIGIN_ALLOWLIST)) {
+      console.warn(`[ssh-bridge] Rejected WS upgrade: Origin "${origin}" does not match Host "${host}"`);
+      callback(false, 401, 'Forbidden origin');
+      return;
+    }
+
     // Skip WS token auth when behind tailscale serve -- it strips query params
     // from WebSocket upgrade requests (tailscale/tailscale#18651).
     // Tailscale provides network-level auth; token is redundant.
@@ -672,4 +692,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { rewriteManifest, server, handleSftpMessage };
+module.exports = { rewriteManifest, server, handleSftpMessage, isOriginAllowed };

--- a/server/origin.js
+++ b/server/origin.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * CSWSH prevention (issue #83).
+ *
+ * Cross-Site WebSocket Hijacking: a malicious page can open a WS connection to
+ * this server using the victim's cookies/credentials. Comparing the Origin
+ * header against the Host header defeats CSWSH without breaking non-browser
+ * clients (native tools like wscat omit Origin, which we allow).
+ *
+ * @param {string|undefined} origin   - value of the Origin request header
+ * @param {string|undefined} host     - value of the Host request header
+ * @param {string[]}         allowlist - extra allowed origin URLs
+ * @returns {boolean} true if the connection should be permitted
+ */
+function isOriginAllowed(origin, host, allowlist) {
+  // Non-browser clients (wscat, ssh2 tools) omit Origin — allow them.
+  if (!origin) return true;
+
+  // Extract just the hostname+port from the Origin URL for comparison.
+  let originHost;
+  try {
+    originHost = new URL(origin).host;
+  } catch (_) {
+    // Malformed Origin header — reject it.
+    return false;
+  }
+
+  // Same-origin: Origin host matches the HTTP Host header.
+  if (host && originHost === host) return true;
+
+  // Allowlist: explicit extra origins (normalised to their host component).
+  for (const allowed of allowlist) {
+    try {
+      if (new URL(allowed).host === originHost) return true;
+    } catch (_) {
+      // Skip malformed entries in the allowlist.
+    }
+  }
+
+  return false;
+}
+
+module.exports = { isOriginAllowed };

--- a/src/modules/__tests__/ws-origin.test.ts
+++ b/src/modules/__tests__/ws-origin.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for Origin header validation (CSWSH prevention, issue #83).
+ *
+ * Tests the isOriginAllowed() function from server/origin.js.
+ * That module has zero external dependencies so it runs without any mocking.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const req = createRequire(import.meta.url);
+const { isOriginAllowed } = req('../../../server/origin.js') as {
+  isOriginAllowed: (origin: string | undefined, host: string | undefined, allowlist: string[]) => boolean;
+};
+
+describe('isOriginAllowed (CSWSH prevention, #83)', () => {
+  describe('same-origin', () => {
+    it('allows when Origin host matches Host header', () => {
+      expect(isOriginAllowed('http://localhost:8081', 'localhost:8081', [])).toBe(true);
+    });
+
+    it('allows https origin matching https host', () => {
+      expect(isOriginAllowed('https://myapp.tailnet.ts.net', 'myapp.tailnet.ts.net', [])).toBe(true);
+    });
+  });
+
+  describe('cross-origin', () => {
+    it('rejects when Origin host does not match Host header', () => {
+      expect(isOriginAllowed('http://evil.example.com', 'localhost:8081', [])).toBe(false);
+    });
+
+    it('rejects cross-origin even when Host is absent', () => {
+      expect(isOriginAllowed('http://evil.example.com', undefined, [])).toBe(false);
+    });
+
+    it('rejects malformed Origin header', () => {
+      expect(isOriginAllowed('not-a-url', 'localhost:8081', [])).toBe(false);
+    });
+  });
+
+  describe('missing Origin header', () => {
+    it('allows when Origin is absent (non-browser client)', () => {
+      expect(isOriginAllowed(undefined, 'localhost:8081', [])).toBe(true);
+    });
+
+    it('allows when Origin is empty string', () => {
+      expect(isOriginAllowed('', 'localhost:8081', [])).toBe(true);
+    });
+  });
+
+  describe('allowlist', () => {
+    it('allows an origin matching an allowlist entry', () => {
+      expect(isOriginAllowed(
+        'https://other.tailnet.ts.net',
+        'localhost:8081',
+        ['https://other.tailnet.ts.net'],
+      )).toBe(true);
+    });
+
+    it('rejects an origin not in the allowlist and not same-origin', () => {
+      expect(isOriginAllowed(
+        'https://evil.example.com',
+        'localhost:8081',
+        ['https://other.tailnet.ts.net'],
+      )).toBe(false);
+    });
+
+    it('skips malformed allowlist entries without crashing', () => {
+      expect(isOriginAllowed(
+        'http://localhost:8081',
+        'localhost:8081',
+        ['not-a-url', 'also-bad'],
+      )).toBe(true);
+    });
+  });
+
+  describe('TS_SERVE mode context', () => {
+    it('same-origin still passes (TS_SERVE does not bypass origin check)', () => {
+      // The origin check runs regardless of TS_SERVE; TS_SERVE only skips WS token auth.
+      expect(isOriginAllowed('https://myapp.tailnet.ts.net', 'myapp.tailnet.ts.net', [])).toBe(true);
+    });
+
+    it('cross-origin is still rejected (TS_SERVE does not exempt cross-origin)', () => {
+      expect(isOriginAllowed('https://evil.example.com', 'myapp.tailnet.ts.net', [])).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Origin header validation to the WebSocket `verifyClient` callback to prevent Cross-Site WebSocket Hijacking (CSWSH)
- Extracted into `server/origin.js` (zero deps, pure function) for clean testability
- Origin check runs unconditionally — even in `TS_SERVE=1` mode where WS token auth is skipped

## Details
- `isOriginAllowed(origin, host, allowlist)` compares the `Origin` header against the `Host` header
- Missing Origin is allowed (non-browser clients like wscat/native tools do not send it)
- Malformed Origin URLs are rejected
- `WS_ORIGIN_ALLOWLIST` env var accepts comma-separated additional origins for multi-origin deployments
- `TS_SERVE=1` continues to skip WS token auth but Origin check still runs

## Test coverage
- `src/modules/__tests__/ws-origin.test.ts` — 12 unit tests covering:
  - Same-origin upgrade succeeds
  - Cross-origin upgrade is rejected
  - Missing Origin header is allowed
  - Empty string Origin is allowed
  - Malformed Origin is rejected
  - Allowlisted origin succeeds
  - Non-allowlisted cross-origin is rejected
  - Malformed allowlist entries are skipped without crashing
  - TS_SERVE mode: same-origin still passes
  - TS_SERVE mode: cross-origin still rejected

## Test results
- tsc: PASS
- eslint: PASS
- vitest: PASS (60/60 tests, 12 new)

## Diff stats
- Files changed: 3
- Lines: +152 / -1

Closes #83

## Cycles used
1/3