### PR TITLE
security: disable clipboard addon by default, add opt-in setting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -623,6 +623,17 @@
           </label>
         </div>
 
+        <div class="danger-zone-item">
+          <div class="danger-zone-item-info">
+            <span class="danger-zone-item-label">Remote clipboard access</span>
+            <p class="hint">Allows the remote server to read/write your clipboard via OSC 52. Only enable for trusted servers. Requires page reload.</p>
+          </div>
+          <label class="toggle" aria-label="Allow remote clipboard access">
+            <input type="checkbox" id="enableRemoteClipboard" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+
         <button id="resetAppBtn" class="danger-btn">Reset app (clears all data &amp; cache)</button>
       </div>
 

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -86,6 +86,17 @@ export function initSettingsPanel(): void {
     });
   }
 
+  const remoteClipEl = document.getElementById('enableRemoteClipboard') as HTMLInputElement | null;
+  if (remoteClipEl) {
+    remoteClipEl.checked = localStorage.getItem('enableRemoteClipboard') === 'true';
+    remoteClipEl.addEventListener('change', () => {
+      localStorage.setItem('enableRemoteClipboard', String(remoteClipEl.checked));
+      _toast(remoteClipEl.checked
+        ? '⚠ Remote clipboard enabled. Reload to apply.'
+        : 'Remote clipboard disabled. Reload to apply.');
+    });
+  }
+
   const pinchEl = document.getElementById('enablePinchZoom') as HTMLInputElement | null;
   if (pinchEl) {
     pinchEl.checked = localStorage.getItem('enablePinchZoom') !== 'false';

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -97,7 +97,9 @@ export function initTerminal(): void {
 
   appState.fitAddon = new FitAddon.FitAddon();
   appState.terminal.loadAddon(appState.fitAddon);
-  appState.terminal.loadAddon(new ClipboardAddon.ClipboardAddon());
+  if (localStorage.getItem('enableRemoteClipboard') === 'true') {
+    appState.terminal.loadAddon(new ClipboardAddon.ClipboardAddon());
+  }
   appState.terminal.open(document.getElementById('terminal')!);
   appState.fitAddon.fit();
   applyTheme(appState.activeThemeName);


### PR DESCRIPTION
## Summary

- ClipboardAddon (OSC 52 read/write) was loaded unconditionally, allowing remote SSH servers to request clipboard access
- Now disabled by default; opt-in toggle added in Settings > Danger Zone
- Three files changed: `terminal.ts` (conditional load), `settings.ts` (toggle wiring), `index.html` (UI)

Fixes #85

## Test plan

- [ ] Verify clipboard addon is NOT loaded by default (OSC 52 sequences should be ignored)
- [ ] Enable "Remote clipboard access" in Danger Zone, reload, verify addon loads
- [ ] Toggle shows toast with reload reminder
- [ ] Fast gate passes