### PR TITLE
fix: exempt CGNAT (100.64/10) from SSRF guard when TS_SERVE=1

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -416,6 +416,22 @@ if (require.main === module) {
 // preventing DNS rebinding attacks where a public hostname resolves to a private IP.
 
 /**
+ * Returns true if the given resolved IPv4 address falls within the CGNAT range
+ * 100.64.0.0/10 (used by Tailscale).
+ */
+function isCgnatIp(ip) {
+  const s = ip.trim().toLowerCase();
+  const parts = s.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!parts) return false;
+  const a = parseInt(parts[1]);
+  const b = parseInt(parts[2]);
+  if (a > 255 || b > 255) return false;
+  const n = (a << 24 >>> 0) + (b << 16);
+  const mask = (~0 << (32 - 10)) >>> 0;
+  return (n & mask) === (0x64400000 & mask);
+}
+
+/**
  * Returns true if the given resolved IP address falls within any private,
  * loopback, link-local, CGNAT, ULA, or unspecified range.
  *
@@ -570,7 +586,12 @@ wss.on('connection', (ws, req) => {
         connecting = false;
         return;
       }
-      if (isPrivateIp(address) && !cfg.allowPrivate) {
+      // In Tailscale mode (TS_SERVE=1), exempt CGNAT (100.64.0.0/10) since
+      // Tailscale node addresses live in that range — this is the primary
+      // deployment target. All other private ranges remain blocked (#91).
+      const isTailscaleMode = process.env.TS_SERVE === '1';
+      const blockedPrivate = isPrivateIp(address) && !(isTailscaleMode && isCgnatIp(address));
+      if (blockedPrivate && !cfg.allowPrivate) {
         send({ type: 'error', message: 'Connections to private/loopback addresses are blocked. Enable "Allow private addresses" in Settings → Danger Zone to override.' });
         connecting = false;
         return;
@@ -745,4 +766,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { rewriteManifest, server, handleSftpMessage, isOriginAllowed, isPrivateIp };
+module.exports = { rewriteManifest, server, handleSftpMessage, isOriginAllowed, isPrivateIp, isCgnatIp };

--- a/server/test.js
+++ b/server/test.js
@@ -10,7 +10,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { Readable, Writable } = require('stream');
 
-const { rewriteManifest, handleSftpMessage, isPrivateIp } = require('./index.js');
+const { rewriteManifest, handleSftpMessage, isPrivateIp, isCgnatIp } = require('./index.js');
 
 test('rewriteManifest: sets id="mobissh"', () => {
   const input = Buffer.from(JSON.stringify({ name: 'MobiSSH', start_url: '/' }));
@@ -258,4 +258,75 @@ test('isPrivateIp: ::ffff:10.0.0.1 is private (IPv4-mapped RFC-1918)', () => {
 
 test('isPrivateIp: ::ffff:8.8.8.8 is NOT private (IPv4-mapped public)', () => {
   assert.equal(isPrivateIp('::ffff:8.8.8.8'), false);
+});
+
+// ─── isCgnatIp tests (issue #91) ──────────────────────────────────────────────
+
+test('isCgnatIp: 100.64.0.1 is CGNAT', () => {
+  assert.equal(isCgnatIp('100.64.0.1'), true);
+});
+
+test('isCgnatIp: 100.127.255.255 is CGNAT (boundary)', () => {
+  assert.equal(isCgnatIp('100.127.255.255'), true);
+});
+
+test('isCgnatIp: 100.63.255.255 is NOT CGNAT (just below range)', () => {
+  assert.equal(isCgnatIp('100.63.255.255'), false);
+});
+
+test('isCgnatIp: 100.128.0.0 is NOT CGNAT (just above range)', () => {
+  assert.equal(isCgnatIp('100.128.0.0'), false);
+});
+
+test('isCgnatIp: 10.0.0.1 is NOT CGNAT', () => {
+  assert.equal(isCgnatIp('10.0.0.1'), false);
+});
+
+test('isCgnatIp: 192.168.1.1 is NOT CGNAT', () => {
+  assert.equal(isCgnatIp('192.168.1.1'), false);
+});
+
+// ─── TS_SERVE CGNAT exemption tests (issue #91) ───────────────────────────────
+// These tests verify the connect()-level logic by directly testing the
+// isPrivateIp + isCgnatIp combination that the connect() function uses.
+
+test('CGNAT allowed when TS_SERVE=1: 100.64.x.x is still private via isPrivateIp', () => {
+  // isPrivateIp still classifies CGNAT as private — the exemption lives in connect()
+  assert.equal(isPrivateIp('100.64.100.5'), true);
+});
+
+test('CGNAT exemption logic: TS_SERVE=1 allows 100.64.x.x', () => {
+  // Simulate the connect() guard: blocked = isPrivateIp && !(tsMode && isCgnat)
+  const ip = '100.64.100.5';
+  const tsMode = true;
+  const blocked = isPrivateIp(ip) && !(tsMode && isCgnatIp(ip));
+  assert.equal(blocked, false);
+});
+
+test('CGNAT exemption logic: no TS_SERVE blocks 100.64.x.x', () => {
+  const ip = '100.64.100.5';
+  const tsMode = false;
+  const blocked = isPrivateIp(ip) && !(tsMode && isCgnatIp(ip));
+  assert.equal(blocked, true);
+});
+
+test('CGNAT exemption logic: TS_SERVE=1 still blocks 192.168.x.x', () => {
+  const ip = '192.168.1.1';
+  const tsMode = true;
+  const blocked = isPrivateIp(ip) && !(tsMode && isCgnatIp(ip));
+  assert.equal(blocked, true);
+});
+
+test('CGNAT exemption logic: TS_SERVE=1 still blocks 127.0.0.1', () => {
+  const ip = '127.0.0.1';
+  const tsMode = true;
+  const blocked = isPrivateIp(ip) && !(tsMode && isCgnatIp(ip));
+  assert.equal(blocked, true);
+});
+
+test('CGNAT exemption logic: TS_SERVE=1 still blocks 10.0.0.1', () => {
+  const ip = '10.0.0.1';
+  const tsMode = true;
+  const blocked = isPrivateIp(ip) && !(tsMode && isCgnatIp(ip));
+  assert.equal(blocked, true);
 });


### PR DESCRIPTION
## Summary
- Adds `isCgnatIp(ip)` helper that identifies the 100.64.0.0/10 (CGNAT/Tailscale) range
- When `TS_SERVE=1`, exempts CGNAT addresses from the SSRF block in `connect()` — all other private ranges (127/8, 10/8, 172.16/12, 192.168/16, etc.) remain blocked
- Exports `isCgnatIp` from `server/index.js` for unit testing

## Test coverage
- 6 `isCgnatIp` unit tests: range boundaries (100.64.0.1, 100.127.255.255), just-outside (100.63.x, 100.128.x), and non-CGNAT addresses
- 6 CGNAT exemption logic tests simulating the `connect()` guard: `TS_SERVE=1` allows 100.64.x.x, no `TS_SERVE` blocks it, 192.168.x.x/127.0.0.1/10.x.x.x remain blocked even with `TS_SERVE=1`

## Test results
- tsc: PASS
- eslint: PASS (warnings are pre-existing)
- vitest: PASS (60/60)
- server/test.js: 49/50 pass — test #6 (`sftp_ls isSymbolicLink`) was already failing on main before this change

## Diff stats
- Files changed: 2
- Lines: +95 / -3

Closes #91

## Cycles used
1/3