### PR TITLE
feat: key bar editor -- data model and persistence

### DIFF
--- a/src/modules/__tests__/keybar-config.test.ts
+++ b/src/modules/__tests__/keybar-config.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock localStorage before importing the module
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+};
+vi.stubGlobal('localStorage', localStorageMock);
+
+const {
+  loadKeyBarConfig,
+  saveKeyBarConfig,
+  resetKeyBarConfig,
+  DEFAULT_KEY_BAR_CONFIG,
+} = await import('../keybar-config.js');
+
+describe('keybar-config', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  describe('DEFAULT_KEY_BAR_CONFIG', () => {
+    it('has two rows', () => {
+      expect(DEFAULT_KEY_BAR_CONFIG).toHaveLength(2);
+    });
+
+    it('row-keys contains editing keys', () => {
+      const row = DEFAULT_KEY_BAR_CONFIG.find((r) => r.id === 'row-keys');
+      expect(row).toBeDefined();
+      const ids = row!.buttons.map((b) => b.id);
+      expect(ids).toContain('keyTab');
+      expect(ids).toContain('keySlash');
+      expect(ids).toContain('keyPipe');
+      expect(ids).toContain('keyDash');
+    });
+
+    it('row-nav contains arrow and navigation keys', () => {
+      const row = DEFAULT_KEY_BAR_CONFIG.find((r) => r.id === 'row-nav');
+      expect(row).toBeDefined();
+      const ids = row!.buttons.map((b) => b.id);
+      expect(ids).toContain('keyEsc');
+      expect(ids).toContain('keyUp');
+      expect(ids).toContain('keyDown');
+      expect(ids).toContain('keyLeft');
+      expect(ids).toContain('keyRight');
+      expect(ids).toContain('keyHome');
+      expect(ids).toContain('keyEnd');
+      expect(ids).toContain('keyPgUp');
+      expect(ids).toContain('keyPgDn');
+    });
+
+    it('sequences match expected terminal escape codes', () => {
+      const navRow = DEFAULT_KEY_BAR_CONFIG.find((r) => r.id === 'row-nav')!;
+      const up = navRow.buttons.find((b) => b.id === 'keyUp');
+      expect(up?.sequence).toBe('\x1b[A');
+      const esc = navRow.buttons.find((b) => b.id === 'keyEsc');
+      expect(esc?.sequence).toBe('\x1b');
+    });
+  });
+
+  describe('loadKeyBarConfig', () => {
+    it('returns defaults when localStorage is empty', () => {
+      const config = loadKeyBarConfig();
+      expect(config).toEqual(DEFAULT_KEY_BAR_CONFIG);
+    });
+
+    it('returns saved config when present and valid', () => {
+      const custom = [
+        { id: 'row-custom', buttons: [{ id: 'keyF1', label: 'F1', sequence: '\x1bOP' }] },
+      ];
+      storage.set('keyBarConfig', JSON.stringify(custom));
+      const config = loadKeyBarConfig();
+      expect(config).toEqual(custom);
+    });
+
+    it('returns defaults when stored data is corrupt JSON', () => {
+      storage.set('keyBarConfig', '{not-valid-json}');
+      const config = loadKeyBarConfig();
+      expect(config).toEqual(DEFAULT_KEY_BAR_CONFIG);
+    });
+
+    it('returns defaults when stored data fails schema validation (not array)', () => {
+      storage.set('keyBarConfig', JSON.stringify({ id: 'bad' }));
+      const config = loadKeyBarConfig();
+      expect(config).toEqual(DEFAULT_KEY_BAR_CONFIG);
+    });
+
+    it('returns defaults when a row is missing id', () => {
+      const bad = [{ buttons: [{ id: 'k1', label: 'K', sequence: 'k' }] }];
+      storage.set('keyBarConfig', JSON.stringify(bad));
+      const config = loadKeyBarConfig();
+      expect(config).toEqual(DEFAULT_KEY_BAR_CONFIG);
+    });
+
+    it('returns defaults when a button is missing sequence', () => {
+      const bad = [{ id: 'row-x', buttons: [{ id: 'k1', label: 'K' }] }];
+      storage.set('keyBarConfig', JSON.stringify(bad));
+      const config = loadKeyBarConfig();
+      expect(config).toEqual(DEFAULT_KEY_BAR_CONFIG);
+    });
+  });
+
+  describe('saveKeyBarConfig', () => {
+    it('persists config to localStorage', () => {
+      const custom = [
+        { id: 'row-custom', buttons: [{ id: 'keyF1', label: 'F1', sequence: '\x1bOP' }] },
+      ];
+      saveKeyBarConfig(custom);
+      const raw = storage.get('keyBarConfig');
+      expect(raw).toBeDefined();
+      expect(JSON.parse(raw!)).toEqual(custom);
+    });
+
+    it('round-trips through load after save', () => {
+      saveKeyBarConfig(DEFAULT_KEY_BAR_CONFIG);
+      const loaded = loadKeyBarConfig();
+      expect(loaded).toEqual(DEFAULT_KEY_BAR_CONFIG);
+    });
+  });
+
+  describe('resetKeyBarConfig', () => {
+    it('removes saved config from localStorage', () => {
+      saveKeyBarConfig(DEFAULT_KEY_BAR_CONFIG);
+      expect(storage.has('keyBarConfig')).toBe(true);
+      resetKeyBarConfig();
+      expect(storage.has('keyBarConfig')).toBe(false);
+    });
+
+    it('causes loadKeyBarConfig to return defaults after reset', () => {
+      const custom = [
+        { id: 'row-x', buttons: [{ id: 'k1', label: 'K1', sequence: 'k' }] },
+      ];
+      saveKeyBarConfig(custom);
+      resetKeyBarConfig();
+      const config = loadKeyBarConfig();
+      expect(config).toEqual(DEFAULT_KEY_BAR_CONFIG);
+    });
+  });
+});

--- a/src/modules/keybar-config.ts
+++ b/src/modules/keybar-config.ts
@@ -1,0 +1,86 @@
+/**
+ * modules/keybar-config.ts — Key bar configuration data model and persistence.
+ *
+ * Defines the KeyBarConfig type, default configuration matching the current
+ * hardcoded key bar buttons, and load/save/reset helpers backed by localStorage.
+ */
+
+export interface KeyBarButton {
+  id: string;
+  label: string;
+  sequence: string;
+  modifiers?: string[];
+}
+
+export interface KeyBarRow {
+  id: string;
+  buttons: KeyBarButton[];
+}
+
+export type KeyBarConfig = KeyBarRow[];
+
+const STORAGE_KEY = 'keyBarConfig';
+
+export const DEFAULT_KEY_BAR_CONFIG: KeyBarConfig = [
+  {
+    id: 'row-keys',
+    buttons: [
+      { id: 'keyTab',   label: '↹',    sequence: '\t' },
+      { id: 'keySlash', label: '/',    sequence: '/' },
+      { id: 'keyPipe',  label: '|',    sequence: '|' },
+      { id: 'keyDash',  label: '-',    sequence: '-' },
+    ],
+  },
+  {
+    id: 'row-nav',
+    buttons: [
+      { id: 'keyEsc',   label: 'Esc',  sequence: '\x1b' },
+      { id: 'keyUp',    label: '▲',    sequence: '\x1b[A' },
+      { id: 'keyDown',  label: '▼',    sequence: '\x1b[B' },
+      { id: 'keyLeft',  label: '◀',    sequence: '\x1b[D' },
+      { id: 'keyRight', label: '▶',    sequence: '\x1b[C' },
+      { id: 'keyHome',  label: 'Home', sequence: '\x1b[H' },
+      { id: 'keyEnd',   label: 'End',  sequence: '\x1b[F' },
+      { id: 'keyPgUp',  label: 'PgUp', sequence: '\x1b[5~' },
+      { id: 'keyPgDn',  label: 'PgDn', sequence: '\x1b[6~' },
+    ],
+  },
+];
+
+export function loadKeyBarConfig(): KeyBarConfig {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return DEFAULT_KEY_BAR_CONFIG;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidKeyBarConfig(parsed)) return DEFAULT_KEY_BAR_CONFIG;
+    return parsed;
+  } catch {
+    return DEFAULT_KEY_BAR_CONFIG;
+  }
+}
+
+export function saveKeyBarConfig(config: KeyBarConfig): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+}
+
+export function resetKeyBarConfig(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+function isValidKeyBarConfig(value: unknown): value is KeyBarConfig {
+  if (!Array.isArray(value)) return false;
+  for (const row of value) {
+    if (typeof row !== 'object' || row === null) return false;
+    const r = row as Record<string, unknown>;
+    if (typeof r['id'] !== 'string') return false;
+    if (!Array.isArray(r['buttons'])) return false;
+    for (const btn of r['buttons'] as unknown[]) {
+      if (typeof btn !== 'object' || btn === null) return false;
+      const b = btn as Record<string, unknown>;
+      if (typeof b['id'] !== 'string') return false;
+      if (typeof b['label'] !== 'string') return false;
+      if (typeof b['sequence'] !== 'string') return false;
+    }
+  }
+  return true;
+}

--- a/src/modules/state.ts
+++ b/src/modules/state.ts
@@ -9,6 +9,7 @@
 
 import type { AppState, SessionState } from './types.js';
 import { RECONNECT } from './constants.js';
+import { DEFAULT_KEY_BAR_CONFIG } from './keybar-config.js';
 
 export const appState: AppState = {
   // Multi-session infrastructure
@@ -46,6 +47,9 @@ export const appState: AppState = {
   recording: false,
   recordingStartTime: null,
   recordingEvents: [],
+
+  // Key bar configuration (#80)
+  keyBarConfig: DEFAULT_KEY_BAR_CONFIG,
 };
 
 export function currentSession(): SessionState | undefined {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -6,6 +6,8 @@
  * runtime cost — TypeScript erases type-only imports during compilation.
  */
 
+import type { KeyBarConfig } from './keybar-config.js';
+
 // ── Domain types ────────────────────────────────────────────────────────────
 
 export interface SSHProfile {
@@ -123,6 +125,9 @@ export interface AppState {
   recording: boolean;
   recordingStartTime: number | null;
   recordingEvents: [number, string, string][];
+
+  // Key bar configuration (#80)
+  keyBarConfig: KeyBarConfig;
 }
 
 // ── CSS layout constants ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `KeyBarConfig` type (array of `KeyBarRow`, each with `KeyBarButton[]`) in new `src/modules/keybar-config.ts`
- Implement `DEFAULT_KEY_BAR_CONFIG` matching the current hardcoded key bar buttons from `ui.ts` lines ~588-612 (two rows: editing keys and nav keys)
- Add `loadKeyBarConfig()`, `saveKeyBarConfig()`, `resetKeyBarConfig()` backed by localStorage with corrupt-data fallback to defaults
- Wire `keyBarConfig: KeyBarConfig` into `AppState` (types.ts) and initialize it from `DEFAULT_KEY_BAR_CONFIG` in state.ts

## Test coverage
- New unit test file `src/modules/__tests__/keybar-config.test.ts` with 14 tests
- Tests cover: default config structure, correct escape sequences, load from empty storage, load valid saved config, corrupt JSON fallback, schema validation failures (missing id, missing sequence), save round-trip, reset + load returns defaults

## Test results
- tsc: PASS
- eslint: PASS
- vitest: PASS (74 tests, 8 files)

## Diff stats
- Files changed: 4
- Lines: +239 / 0

Closes #80

## Cycles used
1/3