### PR TITLE
fix: make connection error dialog dismissable (#92)

### DIFF
--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -8,6 +8,7 @@
 
 import type { ConnectionDeps, ConnectionStatus, ServerMessage, ConnectMessage, SSHProfile } from './types.js';
 import { vaultLoad } from './vault.js';
+import { showErrorDialog } from './ui.js';
 
 // [SFTP_MSG] -- keep in sync with types.ts SERVER_MESSAGE sftp types and WS router below
 type SftpMsg = Extract<ServerMessage, { type: 'sftp_ls_result' | 'sftp_error' | 'sftp_download_result' | 'sftp_upload_result' | 'sftp_stat_result' | 'sftp_rename_result' | 'sftp_delete_result' | 'sftp_realpath_result' }>;
@@ -267,7 +268,7 @@ function _openWebSocket(options?: { silent?: boolean }): void {
         break;
 
       case 'error':
-        if (!silent) _showConnectionStatus(`Error: ${msg.message}`);
+        showErrorDialog(`Connection error:\n\n${msg.message}`);
         break;
 
       case 'disconnected':
@@ -331,7 +332,8 @@ function _openWebSocket(options?: { silent?: boolean }): void {
         _wsConsecFailures++;
         if (_wsConsecFailures >= WS_MAX_AUTH_FAILURES) {
           _wsConsecFailures = 0;
-          _showConnectionStatus('Connection rejected repeatedly. Your session token may have expired — reload the page to get a fresh one.');
+          _dismissConnectionStatus();
+          showErrorDialog('Connection rejected repeatedly.\n\nYour session token may have expired — reload the page to get a fresh one.');
           _setStatus('disconnected', 'Auth failed — reload to reconnect');
           return; // stop the reconnect loop
         }
@@ -355,7 +357,7 @@ function _openWebSocket(options?: { silent?: boolean }): void {
   };
 
   appState.ws.onerror = () => {
-    if (!silent) _showConnectionStatus('WebSocket error — check server URL in Settings.');
+    if (!silent) showErrorDialog('WebSocket error — check server URL in Settings.');
   };
 }
 

--- a/tests/connection.spec.js
+++ b/tests/connection.spec.js
@@ -198,4 +198,30 @@ test.describe('Connection lifecycle (#110 Phase 7)', () => {
     expect(response).toBeTruthy();
   });
 
+  test('server error message shows dismissable error dialog (#92)', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+
+    // Simulate a non-recoverable server error (e.g., SSRF block)
+    mockSshServer.sendToPage({
+      type: 'error',
+      message: 'Connections to private/loopback addresses are blocked.',
+    });
+
+    // The error dialog should appear (not the connection status overlay)
+    const errorDialog = page.locator('#errorDialogOverlay');
+    await expect(errorDialog).toBeVisible({ timeout: 3000 });
+
+    // The error text should include the server message
+    const errorText = await page.locator('#errorDialogText').textContent();
+    expect(errorText).toContain('Connections to private/loopback addresses are blocked.');
+
+    // A Dismiss button must be present and visible
+    const dismissBtn = page.locator('#errorDialogDismiss');
+    await expect(dismissBtn).toBeVisible();
+
+    // Clicking Dismiss should close the dialog
+    await dismissBtn.click();
+    await expect(errorDialog).not.toBeVisible();
+  });
+
 });


### PR DESCRIPTION
## Summary
- Switch non-recoverable connection errors from `_showConnectionStatus()` to `showErrorDialog()` in `connection.ts`
- Affected cases: server `error` messages (SSRF block, auth failure, key parse errors), consecutive WS auth rejection loop, and `onerror` handler
- `showErrorDialog()` shows the existing `#errorDialogOverlay` which has a wired Dismiss button, resolving the user trap

## Test coverage
- Added `'server error message shows dismissable error dialog (#92)'` to `tests/connection.spec.js`
- Test sends a server `{ type: 'error', message: '...' }`, verifies `#errorDialogOverlay` becomes visible, confirms Dismiss button is present, and clicks Dismiss to verify the dialog closes

## Test results
- tsc: PASS
- eslint: PASS
- vitest: PASS

## Diff stats
- Files changed: 2
- Lines: +31 / -3

Closes #92

## Cycles used
1/3