### PR TITLE
fix: detect OpenSSH new-format encrypted keys for passphrase prompt (#97)

### DIFF
--- a/src/modules/__tests__/connection.test.ts
+++ b/src/modules/__tests__/connection.test.ts
@@ -65,7 +65,7 @@ vi.stubGlobal('window', {
   },
 });
 
-const { _getPassphraseCache } = await import('../connection.js');
+const { _getPassphraseCache, _isKeyEncrypted } = await import('../connection.js');
 
 describe('Key passphrase cache (#54)', () => {
   beforeEach(() => {
@@ -99,5 +99,54 @@ describe('Key passphrase cache (#54)', () => {
     cache.set('key-2', 'pass-2');
     expect(cache.get('key-1')).toBe('pass-1');
     expect(cache.get('key-2')).toBe('pass-2');
+  });
+});
+
+describe('_isKeyEncrypted (#97)', () => {
+  it('detects old-format PEM encrypted key (contains ENCRYPTED)', () => {
+    const key = [
+      '-----BEGIN RSA PRIVATE KEY-----',
+      'Proc-Type: 4,ENCRYPTED',
+      'DEK-Info: AES-128-CBC,AABBCCDD',
+      'dGVzdGRhdGE=',
+      '-----END RSA PRIVATE KEY-----',
+    ].join('\n');
+    expect(_isKeyEncrypted(key)).toBe(true);
+  });
+
+  it('returns false for old-format unencrypted PEM key', () => {
+    const key = [
+      '-----BEGIN RSA PRIVATE KEY-----',
+      'dGVzdGRhdGE=',
+      '-----END RSA PRIVATE KEY-----',
+    ].join('\n');
+    expect(_isKeyEncrypted(key)).toBe(false);
+  });
+
+  it('detects new-format OpenSSH encrypted key (aes256-ctr cipher)', () => {
+    const key = [
+      '-----BEGIN OPENSSH PRIVATE KEY-----',
+      'b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0',
+      '-----END OPENSSH PRIVATE KEY-----',
+    ].join('\n');
+    expect(_isKeyEncrypted(key)).toBe(true);
+  });
+
+  it('returns false for new-format OpenSSH unencrypted key (none cipher)', () => {
+    const key = [
+      '-----BEGIN OPENSSH PRIVATE KEY-----',
+      'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQ==',
+      '-----END OPENSSH PRIVATE KEY-----',
+    ].join('\n');
+    expect(_isKeyEncrypted(key)).toBe(false);
+  });
+
+  it('defaults to encrypted when OpenSSH key has invalid/truncated data', () => {
+    const key = [
+      '-----BEGIN OPENSSH PRIVATE KEY-----',
+      'AAAA',
+      '-----END OPENSSH PRIVATE KEY-----',
+    ].join('\n');
+    expect(_isKeyEncrypted(key)).toBe(true);
   });
 });

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -66,8 +66,44 @@ export function _getPassphraseCache(): Map<string, string> {
 }
 
 /** Returns true if the PEM key data appears to be passphrase-encrypted. */
-function _isKeyEncrypted(keyData: string): boolean {
-  return keyData.includes('ENCRYPTED');
+export function _isKeyEncrypted(keyData: string): boolean {
+  // Old-format PEM keys (RSA/DSA/EC) contain "ENCRYPTED" in the header
+  if (keyData.includes('ENCRYPTED')) return true;
+
+  // New-format OpenSSH keys: parse binary header to check cipher field
+  if (keyData.includes('-----BEGIN OPENSSH PRIVATE KEY-----')) {
+    try {
+      const b64 = keyData
+        .replace(/-----BEGIN OPENSSH PRIVATE KEY-----/, '')
+        .replace(/-----END OPENSSH PRIVATE KEY-----/, '')
+        .replace(/\s+/g, '');
+      const bin = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+
+      // AUTH_MAGIC = "openssh-key-v1\0" (15 bytes)
+      const magic = 'openssh-key-v1\0';
+      if (bin.length < magic.length + 4) return true; // too short, assume encrypted
+
+      for (let i = 0; i < magic.length; i++) {
+        if (bin[i] !== magic.charCodeAt(i)) return true; // bad magic, assume encrypted
+      }
+
+      // Read ciphername length (4-byte big-endian) then ciphername string
+      const offset = magic.length;
+      const b0 = bin[offset] ?? 0;
+      const b1 = bin[offset + 1] ?? 0;
+      const b2 = bin[offset + 2] ?? 0;
+      const b3 = bin[offset + 3] ?? 0;
+      const cipherLen = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+      if (cipherLen <= 0 || offset + 4 + cipherLen > bin.length) return true; // invalid, assume encrypted
+
+      const cipherName = new TextDecoder().decode(bin.slice(offset + 4, offset + 4 + cipherLen));
+      return cipherName !== 'none';
+    } catch {
+      return true; // parsing failed, assume encrypted (safe default)
+    }
+  }
+
+  return false;
 }
 
 /** Show the passphrase prompt dialog and return the entered passphrase, or null on cancel. */


### PR DESCRIPTION
Fixes #97. Updates _isKeyEncrypted() to parse the binary header of OpenSSH new-format keys and check the cipher field, in addition to the existing ENCRYPTED text check for old-format PEM keys.