### PR TITLE
fix: remove copy-from-buffer button and add hamburger icon to toggle-nav-bar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -231,7 +231,6 @@
             <span   id="fontSizeLabel">14px</span>
             <button id="fontIncBtn"   class="font-adj-btn" title="Increase font size">A+</button>
           </div>
-          <button id="sessionCopyBufferBtn"  class="session-menu-item" role="menuitem">Copy from buffer…</button>
           <button id="sessionResetBtn"      class="session-menu-item" role="menuitem">Reset terminal</button>
           <button id="sessionClearBtn"      class="session-menu-item" role="menuitem">Clear scrollback</button>
           <div class="session-menu-item rec-row" role="group" aria-label="Recording">
@@ -245,7 +244,7 @@
           </div>
           <button id="sessionThemeBtn"      class="session-menu-item" role="menuitem">Theme: Dark ▸</button>
           <button id="sessionReconnectBtn"  class="session-menu-item" role="menuitem">Reconnect</button>
-          <button id="sessionNavBarBtn"     class="session-menu-item" role="menuitem">Toggle nav bar</button>
+          <button id="sessionNavBarBtn"     class="session-menu-item" role="menuitem">≡ Toggle nav bar</button>
           <button id="sessionDisconnectBtn" class="session-menu-item danger" role="menuitem">Disconnect</button>
         </div>
       </div>

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -331,11 +331,6 @@ export function initSessionMenu(): void {
     _applyFontSize((parseInt(localStorage.getItem('fontSize') ?? '14') || 14) + 1);
   });
 
-  document.getElementById('sessionCopyBufferBtn')!.addEventListener('click', () => {
-    closeMenu();
-    toast('Buffer copy coming soon');
-  });
-
   document.getElementById('sessionResetBtn')!.addEventListener('click', () => {
     closeMenu();
     if (!appState.sshConnected) return;


### PR DESCRIPTION
## Summary
- Remove non-functional "Copy from buffer…" button (`sessionCopyBufferBtn`) from session menu HTML and its stub event listener from `ui.ts`
- Prefix "Toggle nav bar" button (`sessionNavBarBtn`) label with ≡ hamburger icon to match the navbar toggle button style

## Test coverage
- Pre-existing unit tests pass (72 tests); 3 pre-existing suites fail due to unrelated `getComputedStyle` issue on main
- tsc and eslint both pass clean

## Test results
- tsc: PASS
- eslint: PASS
- vitest: 6/9 suites pass (3 pre-existing failures on main unrelated to these changes)

## Diff stats
- Files changed: 2
- Lines: +1 / -7

Closes #113
Closes #114

## Cycles used
1/3