### PR TITLE
fix: sanitize bell notification text to strip ANSI and control chars

### DIFF
--- a/src/modules/__tests__/terminal.test.ts
+++ b/src/modules/__tests__/terminal.test.ts
@@ -49,7 +49,7 @@ vi.stubGlobal('window', {
 
 vi.useFakeTimers();
 
-const { getNotifications, clearNotifications, _addNotification } = await import('../terminal.js');
+const { getNotifications, clearNotifications, _addNotification, _sanitizeNotifText } = await import('../terminal.js');
 
 // Helper: configure shouldNotify() to allow notifications
 function enableNotifications(backgroundOnly = false): void {
@@ -213,5 +213,74 @@ describe('background-only filtering (#94)', () => {
     // document.visibilityState is 'visible' from enableNotifications(false)
     _addNotification('foreground message');
     expect(getNotifications().length).toBe(1);
+  });
+});
+
+describe('_sanitizeNotifText (#109)', () => {
+  it('strips CSI ANSI escape sequences', () => {
+    expect(_sanitizeNotifText('\x1b[1;32mhello\x1b[0m')).toBe('hello');
+  });
+
+  it('strips OSC escape sequences', () => {
+    expect(_sanitizeNotifText('\x1b]0;title\x07hello')).toBe('hello');
+  });
+
+  it('strips OSC sequences with ST terminator', () => {
+    expect(_sanitizeNotifText('\x1b]0;title\x1b\\hello')).toBe('hello');
+  });
+
+  it('removes control characters (non-printable ASCII)', () => {
+    expect(_sanitizeNotifText('hello\x01\x02\x1fworld')).toBe('helloworld');
+  });
+
+  it('removes DEL (U+007F) character', () => {
+    expect(_sanitizeNotifText('hel\x7flo')).toBe('hello');
+  });
+
+  it('removes C1 control characters (U+0080-U+009F)', () => {
+    expect(_sanitizeNotifText('hel\x80\x9flo')).toBe('hello');
+  });
+
+  it('removes Unicode block/replacement characters (▯ and \uFFFD)', () => {
+    expect(_sanitizeNotifText('▯▯ accept edits on (shift+tab)')).toBe('accept edits on (shift+tab)');
+    expect(_sanitizeNotifText('\uFFFD data \uFFFD')).toBe('data');
+  });
+
+  it('collapses multiple spaces to a single space', () => {
+    expect(_sanitizeNotifText('hello   world')).toBe('hello world');
+  });
+
+  it('truncates text longer than 120 characters with ellipsis', () => {
+    const long = 'a'.repeat(130);
+    const result = _sanitizeNotifText(long);
+    expect(result.length).toBe(120);
+    expect(result.endsWith('...')).toBe(true);
+  });
+
+  it('returns Terminal bell for empty string', () => {
+    expect(_sanitizeNotifText('')).toBe('Terminal bell');
+  });
+
+  it('returns Terminal bell for string shorter than 3 chars after sanitization', () => {
+    expect(_sanitizeNotifText('ab')).toBe('Terminal bell');
+    expect(_sanitizeNotifText('a')).toBe('Terminal bell');
+  });
+
+  it('returns Terminal bell for string that is all control chars', () => {
+    expect(_sanitizeNotifText('\x1b[1m\x1b[0m\x01\x02')).toBe('Terminal bell');
+  });
+
+  it('returns Terminal bell for string that is only replacement chars', () => {
+    expect(_sanitizeNotifText('▯▯▯')).toBe('Terminal bell');
+  });
+
+  it('preserves clean text unchanged (up to 120 chars)', () => {
+    expect(_sanitizeNotifText('Build complete: all tests passed')).toBe('Build complete: all tests passed');
+  });
+
+  it('handles mixed content: ANSI + replacement chars + real text', () => {
+    const raw = '\x1b[32m▯▯ accept edits on (shift+tab to cycle) · e...\x1b[0m';
+    const result = _sanitizeNotifText(raw);
+    expect(result).toBe('accept edits on (shift+tab to cycle) · e...');
   });
 });

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -15,6 +15,27 @@ const _notifications: NotifEntry[] = [];
 const NOTIF_MAX = 50;
 const NOTIF_EXPIRY_MS = 30 * 60 * 1000; // 30 minutes
 
+export function _sanitizeNotifText(raw: string): string {
+  let s = raw;
+  // Strip ANSI escape sequences: CSI (\x1b[...), OSC (\x1b]...), and other \x1b sequences
+  /* eslint-disable no-control-regex */
+  s = s.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
+  s = s.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+  s = s.replace(/\x1b[@-Z\\-_]/g, '');
+  // Remove control characters: U+0000-U+001F (except space 0x20), U+007F, U+0080-U+009F
+  s = s.replace(/[\x00-\x1f\x7f\x80-\x9f]/g, '');
+  /* eslint-enable no-control-regex */
+  // Remove Unicode replacement / block characters
+  s = s.replace(/[▯\uFFFD]/g, '');
+  // Collapse whitespace runs to single space and trim
+  s = s.replace(/\s+/g, ' ').trim();
+  // Truncate to 120 chars with ellipsis
+  if (s.length > 120) s = s.slice(0, 117) + '...';
+  // Fall back to default if result is empty or too short
+  if (s.length < 3) return 'Terminal bell';
+  return s;
+}
+
 export function getNotifications(): readonly NotifEntry[] {
   const cutoff = Date.now() - NOTIF_EXPIRY_MS;
   let removed = false;
@@ -121,23 +142,25 @@ export function initTerminal(): void {
     let body = 'Terminal bell';
     for (let i = buffer.cursorY; i >= 0; i--) {
       const line = buffer.getLine(i)?.translateToString(true).trim();
-      if (line) { body = line; break; }
+      if (line) { body = _sanitizeNotifText(line); break; }
     }
     _addNotification(body);
     if (shouldNotify()) fireNotification('MobiSSH', body);
   });
 
   appState.terminal.parser.registerOscHandler(9, (data: string) => {
-    _addNotification(data);
-    if (shouldNotify()) fireNotification('MobiSSH', data);
+    const body = _sanitizeNotifText(data);
+    _addNotification(body);
+    if (shouldNotify()) fireNotification('MobiSSH', body);
     return true;
   });
 
   appState.terminal.parser.registerOscHandler(777, (data: string) => {
     const parts = data.split(';');
     if (parts[0] === 'notify') {
-      _addNotification(parts[2] ?? '');
-      if (shouldNotify()) fireNotification(parts[1] ?? 'MobiSSH', parts[2] ?? '');
+      const body = _sanitizeNotifText(parts[2] ?? '');
+      _addNotification(body);
+      if (shouldNotify()) fireNotification(parts[1] ?? 'MobiSSH', body);
     }
     return true;
   });


### PR DESCRIPTION
## Summary
- Add `_sanitizeNotifText(raw: string): string` to `terminal.ts` that strips ANSI escape sequences (CSI, OSC), control characters (U+0000-U+001F, U+007F, U+0080-U+009F), Unicode block/replacement chars (▯, U+FFFD), collapses whitespace, truncates to 120 chars, and falls back to `'Terminal bell'` for empty/short results
- Apply sanitization in all three notification paths: `onBell` handler, OSC 9 handler, and OSC 777 handler
- 15 new unit tests covering all sanitization cases

## Test coverage
- Added `describe('_sanitizeNotifText (#109)', ...)` with 15 test cases in `src/modules/__tests__/terminal.test.ts`
- Tests verify: CSI ANSI stripping, OSC stripping (BEL and ST terminators), control char removal, DEL removal, C1 control char removal, replacement char removal, whitespace collapse, 120-char truncation with ellipsis, empty/short fallback, all-control fallback, all-replacement fallback, clean passthrough, and real-world mixed content

## Test results
- tsc: PASS
- eslint: PASS (no errors; pre-existing warnings only)
- vitest: 87 tests pass (15 new), 3 pre-existing suite failures (connection.test.ts, keepalive.test.ts, profile-theme.test.ts — all fail with `getComputedStyle is not defined`, unrelated to this change)

## Diff stats
- Files changed: 2
- Lines: +98 / -6

Closes #109

## Cycles used
1/3