### PR TITLE
fix: position IME preview opposite terminal cursor (#106)

### DIFF
--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -117,7 +117,24 @@ export function initIMEInput(): void {
   const commitBtn = document.getElementById('imeCommitBtn');
   const dockToggle = document.getElementById('imeDockToggle');
 
-  let _dockPosition = localStorage.getItem('imeDockPosition') === 'bottom' ? 'bottom' : 'top';
+  let _dockPosition: 'top' | 'bottom' = localStorage.getItem('imeDockPosition') === 'bottom' ? 'bottom' : 'top';
+  let _manualDock = false;
+
+  /**
+   * Compute effective dock position: if the user explicitly toggled, use that.
+   * Otherwise, auto-select based on terminal cursor position — place the preview
+   * opposite the cursor so it doesn't obscure the active line.
+   * Falls back to _dockPosition (persisted) when terminal is unavailable.
+   */
+  function _effectiveDock(): 'top' | 'bottom' {
+    if (_manualDock) return _dockPosition;
+    const term = appState.terminal;
+    if (!term) return _dockPosition;
+    const cursorY = term.buffer.active.cursorY;
+    const rows = term.rows;
+    // Cursor in top half → show preview at bottom; cursor in bottom half → show at top
+    return cursorY < rows / 2 ? 'bottom' : 'top';
+  }
 
   /** Position the textarea + action bar using visualViewport to avoid the keyboard. */
   function _positionIME(): void {
@@ -125,8 +142,9 @@ export function initIMEInput(): void {
     const viewH = vv ? vv.height : window.innerHeight;
     const viewTop = vv ? vv.offsetTop : 0;
     const actionH = 36; // matches CSS .ime-action-btn height
+    const dock = _effectiveDock();
 
-    if (_dockPosition === 'top') {
+    if (dock === 'top') {
       // Top: just below viewport top
       const top = viewTop + 4;
       ime.style.top = `${String(top)}px`;
@@ -211,7 +229,10 @@ export function initIMEInput(): void {
   });
 
   _onAction(dockToggle, () => {
-    _dockPosition = _dockPosition === 'top' ? 'bottom' : 'top';
+    // Determine what auto-positioning would choose, then flip from that
+    const auto = _effectiveDock();
+    _dockPosition = auto === 'top' ? 'bottom' : 'top';
+    _manualDock = true;
     localStorage.setItem('imeDockPosition', _dockPosition);
     _positionIME();
     focusIME();
@@ -246,6 +267,7 @@ export function initIMEInput(): void {
         ime.style.height = '';
         _hideActions();
         appState.isComposing = false;
+        _manualDock = false;
         break;
 
       case 'composing':

--- a/tests/ime.spec.js
+++ b/tests/ime.spec.js
@@ -680,3 +680,127 @@ test.describe('IME state machine — compose + preview (#106)', () => {
     expect(val).toBe('');
   });
 });
+
+// ── IME cursor-based auto-positioning (#106) ──────────────────────────────────
+
+test.describe('IME auto-positioning based on cursor (#106)', () => {
+  /**
+   * Stub appState.terminal with a fake buffer so _effectiveDock() can read
+   * cursorY and rows without a real xterm instance.
+   */
+  async function stubTerminalCursor(page, cursorY, rows) {
+    await page.evaluate(({ cy, r }) => {
+      // Access appState via the module (already loaded by the app)
+      // We mock it by patching the object in place using a dynamic import
+      return import('./modules/state.js').then(({ appState: state }) => {
+        if (!state.terminal) {
+          // Create a minimal stub if no real terminal
+          state.terminal = {
+            buffer: { active: { cursorY: cy } },
+            rows: r,
+          };
+        } else {
+          // Override cursor position on the real terminal buffer proxy
+          Object.defineProperty(state.terminal.buffer.active, 'cursorY', {
+            get: () => cy, configurable: true,
+          });
+          Object.defineProperty(state.terminal, 'rows', {
+            get: () => r, configurable: true,
+          });
+        }
+      });
+    }, { cy: cursorY, r: rows });
+  }
+
+  test('cursor in top half → IME preview positioned at bottom', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await enableComposePreview(page);
+
+    // Place cursor in top half (row 3 of 24 rows)
+    await stubTerminalCursor(page, 3, 24);
+
+    await swipeCompose(page, 'hello');
+    await page.waitForTimeout(100);
+
+    // IME should be visible and positioned at bottom (bottom style set, top = 'auto')
+    await expect(page.locator('#imeInput')).toHaveClass(/ime-visible/);
+    const imeStyle = await page.locator('#imeInput').evaluate((el) => ({
+      bottom: el.style.bottom,
+      top: el.style.top,
+    }));
+    expect(imeStyle.top).toBe('auto');
+    expect(imeStyle.bottom).not.toBe('');
+    expect(imeStyle.bottom).not.toBe('auto');
+  });
+
+  test('cursor in bottom half → IME preview positioned at top', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await enableComposePreview(page);
+
+    // Place cursor in bottom half (row 20 of 24 rows)
+    await stubTerminalCursor(page, 20, 24);
+
+    await swipeCompose(page, 'world');
+    await page.waitForTimeout(100);
+
+    // IME should be visible and positioned at top (top style set, bottom = 'auto')
+    await expect(page.locator('#imeInput')).toHaveClass(/ime-visible/);
+    const imeStyle = await page.locator('#imeInput').evaluate((el) => ({
+      bottom: el.style.bottom,
+      top: el.style.top,
+    }));
+    expect(imeStyle.bottom).toBe('auto');
+    expect(imeStyle.top).not.toBe('');
+    expect(imeStyle.top).not.toBe('auto');
+  });
+
+  test('no terminal → defaults to stored _dockPosition (top)', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await enableComposePreview(page);
+
+    // Remove terminal from appState to simulate disconnected state
+    await page.evaluate(() => {
+      return import('./modules/state.js').then(({ appState: state }) => {
+        state.terminal = null;
+      });
+    });
+
+    await swipeCompose(page, 'fallback');
+    await page.waitForTimeout(100);
+
+    // IME should be visible; default dock is 'top' (localStorage not set)
+    await expect(page.locator('#imeInput')).toHaveClass(/ime-visible/);
+    const imeStyle = await page.locator('#imeInput').evaluate((el) => ({
+      bottom: el.style.bottom,
+      top: el.style.top,
+    }));
+    // Default _dockPosition is 'top'
+    expect(imeStyle.bottom).toBe('auto');
+    expect(imeStyle.top).not.toBe('auto');
+  });
+
+  test('manual dock toggle overrides auto-positioning within same composition', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await enableComposePreview(page);
+
+    // Cursor in top half → auto would pick bottom
+    await stubTerminalCursor(page, 3, 24);
+    await swipeCompose(page, 'test');
+    await page.waitForTimeout(100);
+
+    // Verify auto picked bottom
+    const before = await page.locator('#imeInput').evaluate((el) => el.style.top);
+    expect(before).toBe('auto');
+
+    // User clicks dock toggle — should flip to top
+    await page.locator('#imeDockToggle').click();
+    await page.waitForTimeout(100);
+
+    const after = await page.locator('#imeInput').evaluate((el) => ({
+      bottom: el.style.bottom,
+      top: el.style.top,
+    }));
+    expect(after.bottom).toBe('auto');
+    expect(after.top).not.toBe('auto');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the static `_dockPosition` check in `_positionIME()` with a new `_effectiveDock()` helper that reads `appState.terminal.buffer.active.cursorY` and `appState.terminal.rows` to auto-select top/bottom placement opposite the cursor's vertical half
- Manual dock toggle (`imeDockToggle`) still works: it sets `_manualDock = true` and flips from whatever auto would choose; the override clears on `_transition('idle')` so each new composition cycle picks up fresh auto-positioning
- When no terminal is available (not connected), falls back to the persisted `_dockPosition` value

## Test coverage
- Added `test.describe('IME auto-positioning based on cursor (#106)')` in `tests/ime.spec.js` with 4 tests:
  1. Cursor in top half → IME positioned at bottom (verifies `top === 'auto'`)
  2. Cursor in bottom half → IME positioned at top (verifies `bottom === 'auto'`)
  3. No terminal → defaults to stored `_dockPosition` ('top')
  4. Manual dock toggle overrides auto-positioning within same composition

## Test results
- tsc: PASS
- eslint: PASS (warnings are all pre-existing, no new issues)
- vitest: 3 pre-existing failures (`getComputedStyle is not defined` in connection/keepalive/profile-theme test suites — identical failures on main branch before this PR)

## Diff stats
- Files changed: 2
- Lines: +149 / -3

Closes #106

## Cycles used
1/3