### PR TITLE
fix: direct mode Enter key not sending carriage return

### DIFF
--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -810,17 +810,21 @@ export function initIMEInput(): void {
 
   // Intercept text BEFORE it modifies the field value — characters never
   // appear in the input, so Chrome autocomplete sees nothing to suggest.
+  // Only preventDefault() when we handle the event; unrecognised inputTypes
+  // fall through to the keydown handler (which has KEY_MAP['Enter'] = '\r').
   let _sentByBeforeInput = false;
   directEl.addEventListener('beforeinput', (e) => {
-    e.preventDefault();
     _sentByBeforeInput = false;
     if (e.inputType === 'insertText' && e.data) {
+      e.preventDefault();
       _sendDirectText(e.data);
       _sentByBeforeInput = true;
     } else if (e.inputType === 'insertLineBreak' || e.inputType === 'insertParagraph') {
+      e.preventDefault();
       sendSSHInput('\r');
       _sentByBeforeInput = true;
     } else if (e.inputType === 'deleteContentBackward') {
+      e.preventDefault();
       sendSSHInput('\x7f');
       _sentByBeforeInput = true;
     }

--- a/tests/ime.spec.js
+++ b/tests/ime.spec.js
@@ -814,3 +814,74 @@ test.describe('IME auto-positioning based on cursor (#106)', () => {
     expect(after.top).not.toBe('auto');
   });
 });
+
+// ── Issue #129 — direct mode Enter key (#129) ─────────────────────────────────
+
+test.describe('Issue #129 — direct mode Enter sends \\r', () => {
+  /**
+   * Switch from compose mode (default after connect) to direct mode by
+   * clicking the compose toggle, then focus #directInput.
+   */
+  async function enableDirectMode(page) {
+    await page.evaluate(() => {
+      const btn = document.getElementById('composeModeBtn');
+      // composeModeBtn is active when imeMode (compose) is on — click to turn it off
+      if (btn && btn.classList.contains('active')) btn.click();
+    });
+    await page.waitForTimeout(100);
+    await page.locator('#directInput').focus().catch(() => {});
+    await page.waitForTimeout(50);
+  }
+
+  test('Enter key in direct mode sends \\r via keydown KEY_MAP', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await enableDirectMode(page);
+    await page.evaluate(() => { window.__mockWsSpy = []; });
+
+    // Press Enter — Playwright fires a real keydown with e.key === 'Enter'
+    await page.locator('#directInput').press('Enter');
+    await page.waitForTimeout(100);
+
+    const msgs = await getInputMessages(page);
+    expect(msgs.some((m) => m.data === '\r')).toBe(true);
+  });
+
+  test('insertLineBreak beforeinput in direct mode sends \\r', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await enableDirectMode(page);
+    await page.evaluate(() => { window.__mockWsSpy = []; });
+
+    // Simulate Gboard-style insertLineBreak on the directInput field
+    await page.evaluate(() => {
+      const el = document.getElementById('directInput');
+      el.dispatchEvent(new InputEvent('beforeinput', {
+        bubbles: true, cancelable: true, inputType: 'insertLineBreak',
+      }));
+    });
+    await page.waitForTimeout(100);
+
+    const msgs = await getInputMessages(page);
+    expect(msgs.some((m) => m.data === '\r')).toBe(true);
+  });
+
+  test('unrecognised beforeinput does not block subsequent keydown Enter', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await enableDirectMode(page);
+    await page.evaluate(() => { window.__mockWsSpy = []; });
+
+    // Fire a beforeinput with an inputType we don't handle, then keydown Enter
+    // This simulates some mobile keyboards that fire 'insertText' with null data
+    // or unknown inputType before keydown.
+    await page.evaluate(() => {
+      const el = document.getElementById('directInput');
+      el.dispatchEvent(new InputEvent('beforeinput', {
+        bubbles: true, cancelable: true, inputType: 'insertUnknownType', data: null,
+      }));
+    });
+    await page.locator('#directInput').press('Enter');
+    await page.waitForTimeout(100);
+
+    const msgs = await getInputMessages(page);
+    expect(msgs.some((m) => m.data === '\r')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Move `e.preventDefault()` inside each handled inputType branch in the direct mode `beforeinput` handler, instead of calling it unconditionally before any type check
- Unrecognised `inputType` values (e.g. from soft keyboards that fire neither `insertLineBreak` nor `insertParagraph` for Enter) now fall through to the `keydown` handler, which maps `Enter` → `\r` via `KEY_MAP`
- No other changes to direct mode logic

## Test coverage
- Added `tests/ime.spec.js` describe block "Issue #129 — direct mode Enter sends \\r"
- Test 1: Press Enter via Playwright `press('Enter')` in direct mode → verifies `\r` sent to SSH
- Test 2: Fire `insertLineBreak` beforeinput on `#directInput` → verifies `\r` sent
- Test 3: Fire unrecognised `insertUnknownType` beforeinput then press Enter → verifies `\r` still sent (regression for the original bug)

## Test results
- tsc: PASS
- eslint: PASS
- vitest: PASS (3 pre-existing failures in `connection.test.ts`, `keepalive.test.ts`, `profile-theme.test.ts` due to `getComputedStyle is not defined` — present on main before this PR)

## Diff stats
- Files changed: 2
- Lines: +76 / -1

Closes #129

## Cycles used
1/3