### PR TITLE
fix: lazy-init ROOT_CSS to fix getComputedStyle error in vitest

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -26,7 +26,7 @@ import {
   initFilesPanel, initLongPressTooltips,
 } from './modules/ui.js';
 import {
-  ROOT_CSS, initTerminal, handleResize, initKeyboardAwareness,
+  getRootCSS, initTerminal, handleResize, initKeyboardAwareness,
   getKeyboardVisible, applyFontSize, applyTheme,
 } from './modules/terminal.js';
 
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
   try {
     initDebugOverlay();
     initTerminal();
-    initUI({ keyboardVisible: getKeyboardVisible, ROOT_CSS, applyFontSize, applyTheme });
+    initUI({ keyboardVisible: getKeyboardVisible, ROOT_CSS: getRootCSS(), applyFontSize, applyTheme });
     initIME({ handleResize, applyFontSize });
     initIMEInput();
     initSelection();

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -72,15 +72,19 @@ function _updateBellBadge(): void {
   badge.textContent = String(count);
 }
 
-// ── CSS layout constants (read from :root once; JS never hardcodes px values) ─
+// ── CSS layout constants (read from :root on first access; JS never hardcodes px values) ─
 
-export const ROOT_CSS: RootCSS = (() => {
-  const s = getComputedStyle(document.documentElement);
-  return {
-    tabHeight: s.getPropertyValue('--tab-height').trim(),
-    keybarHeight: s.getPropertyValue('--keybar-height').trim(),
-  };
-})();
+let _rootCSS: RootCSS | null = null;
+export function getRootCSS(): RootCSS {
+  if (!_rootCSS) {
+    const s = getComputedStyle(document.documentElement);
+    _rootCSS = {
+      tabHeight: s.getPropertyValue('--tab-height').trim(),
+      keybarHeight: s.getPropertyValue('--keybar-height').trim(),
+    };
+  }
+  return _rootCSS;
+}
 
 // ── Terminal ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replace the top-level IIFE `ROOT_CSS` in `terminal.ts` with a lazy getter `getRootCSS()` that only calls `getComputedStyle` on first access
- Update `app.ts` to import and call `getRootCSS()` instead of the old `ROOT_CSS` constant
- Fixes `ReferenceError: getComputedStyle is not defined` in JSDOM-based vitest environments for all suites that transitively import `terminal.ts`

## Test coverage
- All 9 vitest suites now pass (108 tests), including the previously-failing connection.test.ts, keepalive.test.ts, and profile-theme.test.ts
- No new tests needed — the fix resolves the module-load-time error that was blocking existing tests

## Test results
- tsc: PASS
- eslint: FAIL (2 pre-existing errors in ime.ts for deprecated keyCode; 138 pre-existing warnings — not introduced by this change, confirmed by checking lint on main before the fix)
- vitest: PASS (9/9 suites, 108/108 tests)

## Diff stats
- Files changed: 2
- Lines: +15 / -11

Closes #133

## Cycles used
1/3