### PR TITLE
chore: headless tests — add Playwright layer tags

### DIFF
--- a/tests/connection.spec.js
+++ b/tests/connection.spec.js
@@ -8,7 +8,7 @@
 
 const { test, expect, setupConnected } = require('./fixtures.js');
 
-test.describe('Connection lifecycle (#110 Phase 7)', () => {
+test.describe('Connection lifecycle (#110 Phase 7)', { tag: '@headless-adequate' }, () => {
 
   test('connect message includes host, port, username, and password', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);

--- a/tests/ime.spec.js
+++ b/tests/ime.spec.js
@@ -139,7 +139,7 @@ async function setupConnected(page, mockSshServer) {
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
-test.describe('IME composition → SSH input routing', () => {
+test.describe('IME composition → SSH input routing', { tag: '@device-critical' }, () => {
   test('compositionend text is forwarded to SSH stream', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
 
@@ -229,7 +229,7 @@ test.describe('IME composition → SSH input routing', () => {
   });
 });
 
-test.describe('Issue #74 — compose action buttons Clear and Send', () => {
+test.describe('Issue #74 — compose action buttons Clear and Send', { tag: '@device-critical' }, () => {
   test('Clear button hides actions and clears textarea without sending', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
     await page.evaluate(() => { window.__mockWsSpy = []; });
@@ -293,7 +293,7 @@ test.describe('Issue #74 — compose action buttons Clear and Send', () => {
   });
 });
 
-test.describe('Issue #85 — compositioncancel resets IME state', () => {
+test.describe('Issue #85 — compositioncancel resets IME state', { tag: '@device-critical' }, () => {
   test('compositioncancel clears isComposing so subsequent input is not dropped', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
     await page.evaluate(() => { window.__mockWsSpy = []; });
@@ -335,7 +335,7 @@ test.describe('Issue #85 — compositioncancel resets IME state', () => {
   });
 });
 
-test.describe('Key bar buttons → SSH input', () => {
+test.describe('Key bar buttons → SSH input', { tag: '@headless-adequate' }, () => {
   test('Esc button sends \\x1b', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
     await page.evaluate(() => { window.__mockWsSpy = []; });
@@ -432,7 +432,7 @@ async function swipeCompose(page, text) {
 
 const SM_DIR = path.join(__dirname, '..', 'test-results', 'screenshots', 'state-machine');
 
-test.describe('IME state machine — compose + preview (#106)', () => {
+test.describe('IME state machine — compose + preview (#106)', { tag: '@device-critical' }, () => {
 
   test('preview mode holds text — nothing sent until commit', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
@@ -693,7 +693,7 @@ test.describe('IME state machine — compose + preview (#106)', () => {
 
 // ── IME cursor-based auto-positioning (#106) ──────────────────────────────────
 
-test.describe('IME auto-positioning based on cursor (#106)', () => {
+test.describe('IME auto-positioning based on cursor (#106)', { tag: '@device-critical' }, () => {
   /**
    * Stub appState.terminal with a fake buffer so _effectiveDock() can read
    * cursorY and rows without a real xterm instance.
@@ -817,7 +817,7 @@ test.describe('IME auto-positioning based on cursor (#106)', () => {
 
 // ── Issue #129 — direct mode Enter key (#129) ─────────────────────────────────
 
-test.describe('Issue #129 — direct mode Enter sends \\r', () => {
+test.describe('Issue #129 — direct mode Enter sends \\r', { tag: '@device-critical' }, () => {
   /**
    * Switch from compose mode (default after connect) to direct mode by
    * clicking the compose toggle, then focus #directInput.

--- a/tests/layout.spec.js
+++ b/tests/layout.spec.js
@@ -10,7 +10,7 @@
 
 const { test, expect, COMPOSE_INPUT_ID, openConnectAdvanced } = require('./fixtures.js');
 
-test.describe('Initial page load', () => {
+test.describe('Initial page load', { tag: '@device-critical' }, () => {
   test.beforeEach(async ({ page }) => {
     // Collect JS errors — any uncaught exception will surface in the
     // 'no JS errors on page load' test below.
@@ -141,7 +141,7 @@ test.describe('Initial page load', () => {
   });
 });
 
-test.describe('Tab navigation', () => {
+test.describe('Tab navigation', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => localStorage.clear());
     await page.goto('./');
@@ -174,7 +174,7 @@ test.describe('Tab navigation', () => {
   });
 });
 
-test.describe('Connect form', () => {
+test.describe('Connect form', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => localStorage.clear());
     await page.goto('./');
@@ -274,7 +274,7 @@ test.describe('Connect form', () => {
   });
 });
 
-test.describe('Settings panel', () => {
+test.describe('Settings panel', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => localStorage.clear());
     await page.goto('./');
@@ -325,7 +325,7 @@ test.describe('Settings panel', () => {
 
 // ─── Issue #87 — tab bar text selection prevention ──────────────────────────
 
-test.describe('Issue #87 — tab buttons prevent text selection on long-press', () => {
+test.describe('Issue #87 — tab buttons prevent text selection on long-press', { tag: '@device-critical' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('./');
     await page.waitForSelector('.xterm-screen', { timeout: 5000 });
@@ -349,7 +349,7 @@ test.describe('Issue #87 — tab buttons prevent text selection on long-press', 
 
 // ─── Issue #89 — key bar key repeat ─────────────────────────────────────────
 
-test.describe('Issue #89 — key bar buttons use pointer events for repeat', () => {
+test.describe('Issue #89 — key bar buttons use pointer events for repeat', { tag: '@device-critical' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('./');
     await page.waitForSelector('.xterm-screen', { timeout: 5000 });
@@ -378,7 +378,7 @@ test.describe('Issue #89 — key bar buttons use pointer events for repeat', () 
 
 // ─── Issue #71 regressions ──────────────────────────────────────────────────
 
-test.describe('Issue #71 — no redundant status indicator', () => {
+test.describe('Issue #71 — no redundant status indicator', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('./');
     await page.waitForSelector('.xterm-screen', { timeout: 5000 });

--- a/tests/notifications.spec.js
+++ b/tests/notifications.spec.js
@@ -55,7 +55,7 @@ function clearNotifications(page) {
   return page.evaluate(() => { window.__notifications = []; });
 }
 
-test.describe('Terminal notifications (#200)', () => {
+test.describe('Terminal notifications (#200)', { tag: '@headless-adequate' }, () => {
 
   test('bell character triggers notification with terminal context', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
@@ -166,7 +166,7 @@ test.describe('Terminal notifications (#200)', () => {
   });
 });
 
-test.describe('Bell badge UI (#33)', () => {
+test.describe('Bell badge UI (#33)', { tag: '@headless-adequate' }, () => {
 
   test('bell icon hidden initially, shows with count after bell', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
@@ -243,7 +243,7 @@ test.describe('Bell badge UI (#33)', () => {
   });
 });
 
-test.describe('Test notification button (#32)', () => {
+test.describe('Test notification button (#32)', { tag: '@headless-adequate' }, () => {
 
   test('test notification button uses ServiceWorker.showNotification', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);

--- a/tests/panels.spec.js
+++ b/tests/panels.spec.js
@@ -25,7 +25,7 @@ async function showTabBar(page) {
   await page.waitForSelector('#tabBar:not(.hidden)', { timeout: 2000 });
 }
 
-test.describe('Panel navigation smoke', () => {
+test.describe('Panel navigation smoke', { tag: '@headless-adequate' }, () => {
 
   test('all tabs render their panel without console errors (no connection)', async ({ page }) => {
     const consoleErrors = [];
@@ -66,7 +66,7 @@ test.describe('Panel navigation smoke', () => {
 
 });
 
-test.describe('Files panel', () => {
+test.describe('Files panel', { tag: '@headless-adequate' }, () => {
 
   test('shows loading state without errors when not connected', async ({ page }) => {
     const consoleErrors = [];

--- a/tests/production.spec.js
+++ b/tests/production.spec.js
@@ -9,7 +9,7 @@ const { test, expect } = require('@playwright/test');
 
 const PROD_URL = 'https://mobissh.tailbe5094.ts.net/';
 
-test.describe('Production endpoint', () => {
+test.describe('Production endpoint', { tag: '@headless-adequate' }, () => {
 
   test('serves HTML over HTTPS', async ({ page }) => {
     const response = await page.goto(PROD_URL, { waitUntil: 'networkidle' });

--- a/tests/profiles.spec.js
+++ b/tests/profiles.spec.js
@@ -57,7 +57,7 @@ async function injectMockVault(page) {
   });
 }
 
-test.describe('Profile & key storage (#110 Phase 5)', () => {
+test.describe('Profile & key storage (#110 Phase 5)', { tag: '@headless-adequate' }, () => {
 
   test('profile upsert updates in place on same host+port+username', async ({ page, mockSshServer }) => {
     await injectMockVault(page);

--- a/tests/pwa-install.spec.js
+++ b/tests/pwa-install.spec.js
@@ -49,7 +49,7 @@ self.addEventListener('fetch', () => {});
 
 // ── 1. beforeinstallprompt ────────────────────────────────────────────────────
 
-test.describe('Issue #97 — 1. beforeinstallprompt', () => {
+test.describe('Issue #97 — 1. beforeinstallprompt', { tag: '@device-critical' }, () => {
   test(
     'beforeinstallprompt fires when manifest + SW meet Chrome install criteria',
     async ({ browser, browserName }) => {
@@ -92,7 +92,7 @@ test.describe('Issue #97 — 1. beforeinstallprompt', () => {
 
 // ── 2. SW v3→v4 upgrade ───────────────────────────────────────────────────────
 
-test.describe('Issue #97 — 2. SW v3→v4 upgrade', () => {
+test.describe('Issue #97 — 2. SW v3→v4 upgrade', { tag: '@device-critical' }, () => {
   test(
     'activating v4 SW purges mobissh-v3 cache and caches recovery.js',
     async ({ browser, browserName }) => {
@@ -172,7 +172,7 @@ test.describe('Issue #97 — 2. SW v3→v4 upgrade', () => {
 
 // ── 3. ?reset=1 clears caches ─────────────────────────────────────────────────
 
-test.describe('Issue #97 — 3. ?reset=1 cache clear', () => {
+test.describe('Issue #97 — 3. ?reset=1 cache clear', { tag: '@device-critical' }, () => {
   test(
     '?reset=1 clears caches and redirects to base URL (recovery.js fallback path)',
     async ({ page }) => {
@@ -253,7 +253,7 @@ test.describe('Issue #97 — 3. ?reset=1 cache clear', () => {
 
 // ── 4. Recovery overlay ───────────────────────────────────────────────────────
 
-test.describe('Issue #97 — 4. Recovery overlay', () => {
+test.describe('Issue #97 — 4. Recovery overlay', { tag: '@device-critical' }, () => {
   test(
     'recovery overlay becomes visible after 8s boot timeout when app.js fails',
     { timeout: 15_000 },
@@ -280,7 +280,7 @@ test.describe('Issue #97 — 4. Recovery overlay', () => {
 
 // ── 5. Manifest fields ────────────────────────────────────────────────────────
 
-test.describe('Issue #97 — 5. Manifest fields', () => {
+test.describe('Issue #97 — 5. Manifest fields', { tag: '@device-critical' }, () => {
   test(
     'manifest.json is served with correct PWA identity fields',
     async ({ request }) => {

--- a/tests/recording.spec.js
+++ b/tests/recording.spec.js
@@ -14,7 +14,7 @@ async function openSessionMenu(page) {
   await page.waitForSelector('#sessionMenu:not(.hidden)', { timeout: 2000 });
 }
 
-test.describe('Session recording (#54)', () => {
+test.describe('Session recording (#54)', { tag: '@headless-adequate' }, () => {
 
   test('start recording toggles hidden class on buttons', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);

--- a/tests/routing.spec.js
+++ b/tests/routing.spec.js
@@ -8,7 +8,7 @@
 const { test, expect } = require('./fixtures.js');
 const { setupConnected } = require('./fixtures.js');
 
-test.describe('Hash routing (#137)', () => {
+test.describe('Hash routing (#137)', { tag: '@headless-adequate' }, () => {
 
   test('tab click updates location.hash', async ({ page }) => {
     await page.goto('./');

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -8,7 +8,7 @@
 
 const { test, expect } = require('./fixtures.js');
 
-test.describe('Settings panel (#110 Phase 6)', () => {
+test.describe('Settings panel (#110 Phase 6)', { tag: '@headless-adequate' }, () => {
 
   test('saving a wss:// URL persists to localStorage', async ({ page }) => {
     await page.addInitScript(() => { localStorage.clear(); });

--- a/tests/terminal.spec.js
+++ b/tests/terminal.spec.js
@@ -6,7 +6,7 @@
 
 const { test, expect, setupConnected } = require('./fixtures.js');
 
-test.describe('Terminal (#110 Phase 10)', () => {
+test.describe('Terminal (#110 Phase 10)', { tag: '@device-critical' }, () => {
   test('xterm.js terminal is created and visible on load', async ({ page }) => {
     await page.addInitScript(() => { localStorage.clear(); });
     await page.goto('./');

--- a/tests/tui.spec.js
+++ b/tests/tui.spec.js
@@ -50,7 +50,7 @@ async function pressKey(page, keyInit) {
 
 // ── Rendering: ANSI sequences ─────────────────────────────────────────────────
 
-test.describe('TUI rendering — ANSI sequences pass through without errors', () => {
+test.describe('TUI rendering — ANSI sequences pass through without errors', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page, mockSshServer }) => {
     page._jsErrors = [];
     page.on('pageerror', (err) => page._jsErrors.push(err.message));
@@ -121,7 +121,7 @@ test.describe('TUI rendering — ANSI sequences pass through without errors', ()
 
 // ── Rendering: box-drawing characters ────────────────────────────────────────
 
-test.describe('TUI rendering — box-drawing characters', () => {
+test.describe('TUI rendering — box-drawing characters', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page, mockSshServer }) => {
     page._jsErrors = [];
     page.on('pageerror', (err) => page._jsErrors.push(err.message));
@@ -180,7 +180,7 @@ test.describe('TUI rendering — box-drawing characters', () => {
 
 // ── Alternate screen buffer (smcup / rmcup) ───────────────────────────────────
 
-test.describe('TUI rendering — alternate screen buffer (smcup/rmcup)', () => {
+test.describe('TUI rendering — alternate screen buffer (smcup/rmcup)', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page, mockSshServer }) => {
     page._jsErrors = [];
     page.on('pageerror', (err) => page._jsErrors.push(err.message));
@@ -245,7 +245,7 @@ test.describe('TUI rendering — alternate screen buffer (smcup/rmcup)', () => {
 
 // ── Terminal dimensions ───────────────────────────────────────────────────────
 
-test.describe('Terminal dimensions for TUI apps', () => {
+test.describe('Terminal dimensions for TUI apps', { tag: '@headless-adequate' }, () => {
   test('resize message sent after connect has non-zero cols and rows', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
     const resizes = await getResizeMessages(page);
@@ -287,7 +287,7 @@ test.describe('Terminal dimensions for TUI apps', () => {
 // VT sequences sourced from xterm terminfo / KEY_MAP in app.js:
 //   F1–F4 use SS3 (ESC O);  F5–F12 use CSI Ps ~ (tilde format, skips 16).
 
-test.describe('TUI input — function keys F1–F12', () => {
+test.describe('TUI input — function keys F1–F12', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
     await page.evaluate(() => { window.__mockWsSpy = []; });
@@ -323,7 +323,7 @@ test.describe('TUI input — function keys F1–F12', () => {
 // Navigation keys used by TUI text editors (vim, nano) and pagers (less, man).
 // ArrowLeft/Right complete the set (Up/Down already in ime.spec.js key bar tests).
 
-test.describe('TUI input — navigation keys via keydown', () => {
+test.describe('TUI input — navigation keys via keydown', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
     await page.evaluate(() => { window.__mockWsSpy = []; });
@@ -368,7 +368,7 @@ test.describe('TUI input — navigation keys via keydown', () => {
 // sticky-modifier path.  These tests cover the hardware keyboard path
 // (ctrlKey: true in KeyboardEvent).
 
-test.describe('TUI input — Ctrl combos via hardware keyboard', () => {
+test.describe('TUI input — Ctrl combos via hardware keyboard', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
     await page.evaluate(() => { window.__mockWsSpy = []; });
@@ -403,7 +403,7 @@ test.describe('TUI input — Ctrl combos via hardware keyboard', () => {
 // TUI apps require but that aren't easily typed on an on-screen keyboard.
 // Tests cover the buttons added for issue #53 that weren't in ime.spec.js.
 
-test.describe('Key bar navigation buttons for TUI apps', () => {
+test.describe('Key bar navigation buttons for TUI apps', { tag: '@headless-adequate' }, () => {
   test.beforeEach(async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
     await page.evaluate(() => { window.__mockWsSpy = []; });

--- a/tests/ui-screenshots.spec.js
+++ b/tests/ui-screenshots.spec.js
@@ -43,7 +43,7 @@ async function setupIMEComposition(page, mockSshServer, text) {
 
 // ── IME Action Buttons (#106) ─────────────────────────────────────────────
 
-test.describe('IME action buttons visual states (#106)', () => {
+test.describe('IME action buttons visual states (#106)', { tag: '@device-critical' }, () => {
 
   test('action buttons appear on composition — bottom dock (default)', async ({ page, mockSshServer }) => {
     await setupIMEComposition(page, mockSshServer, 'hello world');
@@ -95,7 +95,7 @@ test.describe('IME action buttons visual states (#106)', () => {
 
 // ── Connection status dialog (#105) ─────────────────────────────────────────
 
-test.describe('Connection status dialog visual states (#105)', () => {
+test.describe('Connection status dialog visual states (#105)', { tag: '@device-critical' }, () => {
 
   test('connection status overlay has cancel button when disconnected', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
@@ -121,7 +121,7 @@ test.describe('Connection status dialog visual states (#105)', () => {
 
 // ── Cold start + tab layouts ────────────────────────────────────────────────
 
-test.describe('Layout screenshots', () => {
+test.describe('Layout screenshots', { tag: '@device-critical' }, () => {
 
   test('cold start — terminal tab', async ({ page }) => {
     await page.goto('./');

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -15,7 +15,7 @@ async function showTabBar(page) {
   await page.waitForSelector('#tabBar:not(.hidden)', { timeout: 2000 });
 }
 
-test.describe('UI chrome (#110 Phase 8)', () => {
+test.describe('UI chrome (#110 Phase 8)', { tag: '@device-critical' }, () => {
 
   test('session menu "Toggle nav bar" shows and hides the tab bar (#149)', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
@@ -199,7 +199,7 @@ test.describe('UI chrome (#110 Phase 8)', () => {
 
 });
 
-test.describe('Session list (#60)', () => {
+test.describe('Session list (#60)', { tag: '@headless-adequate' }, () => {
 
   test('session list is hidden when only one session exists', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);
@@ -324,7 +324,7 @@ test.describe('Session list (#60)', () => {
 
 });
 
-test.describe('Long-press tooltip hints (#111)', () => {
+test.describe('Long-press tooltip hints (#111)', { tag: '@device-critical' }, () => {
 
   test('toolbar buttons have data-tooltip attributes', async ({ page }) => {
     await page.addInitScript(() => { localStorage.clear(); });

--- a/tests/vault.spec.js
+++ b/tests/vault.spec.js
@@ -25,7 +25,7 @@ async function revealConnectForm(page) {
   }
 }
 
-test.describe('Credential vault (#14)', () => {
+test.describe('Credential vault (#14)', { tag: '@headless-adequate' }, () => {
 
   test('saving a profile stores encrypted credentials in sshVault (not plaintext)', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);


### PR DESCRIPTION
## Summary
- Added `{ tag: '@device-critical' }` or `{ tag: '@headless-adequate' }` to every `test.describe` block in `tests/*.spec.js` (16 files, 46 describe blocks total)
- Used Playwright's built-in tag API: `test.describe('name', { tag: '@...' }, () => { ... })`
- No test logic changed — metadata-only additions

## Test coverage
- No new test logic; the change is purely metadata tagging
- All existing tests continue to pass as before (test logic untouched)

## Test results
- tsc: PASS
- eslint: pre-existing errors in `src/modules/ime.ts` (keyCode deprecation) and warnings elsewhere — unrelated to this PR
- vitest: 3 pre-existing failures (`connection.test.ts`, `keepalive.test.ts`, `profile-theme.test.ts` — `getComputedStyle` not defined in jsdom) — unrelated to this PR; 88 tests pass

## Diff stats
- Files changed: 16
- Lines: +46 / -46

Closes #125

## Cycles used
1/3