### PR TITLE
feat: allow custom PWA title for multiple installations

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -50,6 +50,7 @@ const { execSync } = require('child_process');
 const WebSocket = require('ws');
 const { Client } = require('ssh2');
 const { isOriginAllowed } = require('./origin');
+const { rewriteManifest } = require('./manifest');
 
 const PORT = process.env.PORT || 8081;
 const HOST = process.env.HOST || '0.0.0.0';
@@ -115,22 +116,6 @@ const MIME = {
   '.png':  'image/png',
   '.ico':  'image/x-icon',
 };
-
-/**
- * Rewrite manifest.json fields so the PWA installs correctly under any
- * reverse-proxy subpath (#83).
- *
- * - id: stable "mobissh" identity prevents collision with other apps
- * - start_url / scope: "./" is relative to the manifest URL, so Chrome
- *   resolves them to the correct subpath regardless of where the app is hosted
- */
-function rewriteManifest(buf) {
-  const manifest = JSON.parse(buf.toString());
-  manifest.id = 'mobissh';
-  manifest.start_url = './#connect';
-  manifest.scope = './';
-  return Buffer.from(JSON.stringify(manifest));
-}
 
 // ─── SFTP message handler (exported for unit tests) ──────────────────────────
 
@@ -289,10 +274,16 @@ log('\\nDone. Redirecting...');setTimeout(()=>location.href='./',1500)})();
       );
       data = Buffer.from(html);
     }
-    // Rewrite manifest.json when serving under a subpath so the PWA installs
-    // at the correct path and has a stable identity (#83).
-    if (path.basename(filePath) === 'manifest.json' && BASE_PATH) {
-      try { data = rewriteManifest(data); } catch (_) {}
+    // Rewrite manifest.json: always apply stable identity + subpath rewrites (#83).
+    // Also accept ?name= query param to customise name/short_name for multi-install (#131).
+    if (path.basename(filePath) === 'manifest.json') {
+      try {
+        const manifestUrl = new URL(req.url, 'http://localhost');
+        const customName = manifestUrl.searchParams.get('name') || '';
+        if (BASE_PATH || customName) {
+          data = rewriteManifest(data, customName);
+        }
+      } catch (_) {}
     }
     res.writeHead(200, {
       'Content-Type': MIME[ext] || 'application/octet-stream',

--- a/server/manifest.js
+++ b/server/manifest.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Dynamic manifest.json rewriting.
+ *
+ * Rewrites manifest.json fields so the PWA installs correctly under any
+ * reverse-proxy subpath (#83), and supports custom name/short_name via a
+ * query parameter for multi-installation support (#131).
+ *
+ * - id: stable "mobissh" identity prevents collision with other apps
+ * - start_url / scope: "./" is relative to the manifest URL, so Chrome
+ *   resolves them to the correct subpath regardless of where the app is hosted
+ * - name / short_name: overridden when customName is provided (#131)
+ *   Allows multiple installs with distinct home-screen titles.
+ *
+ * @param {Buffer} buf         - raw manifest.json file contents
+ * @param {string} [customName] - optional custom name/short_name override
+ * @returns {Buffer} rewritten manifest as a Buffer
+ */
+function rewriteManifest(buf, customName) {
+  const manifest = JSON.parse(buf.toString());
+  manifest.id = 'mobissh';
+  manifest.start_url = './#connect';
+  manifest.scope = './';
+  if (customName) {
+    manifest.name = customName;
+    manifest.short_name = customName;
+  }
+  return Buffer.from(JSON.stringify(manifest));
+}
+
+module.exports = { rewriteManifest };

--- a/src/modules/__tests__/manifest-name.test.ts
+++ b/src/modules/__tests__/manifest-name.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for dynamic manifest name rewriting (#131).
+ *
+ * Tests the rewriteManifest() function from server/index.js with a
+ * custom name parameter for multi-install PWA support.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const req = createRequire(import.meta.url);
+const { rewriteManifest } = req('../../../server/manifest.js') as {
+  rewriteManifest: (buf: Buffer, customName?: string) => Buffer;
+};
+
+const DEFAULT_MANIFEST = JSON.stringify({
+  name: 'MobiSSH',
+  short_name: 'MobiSSH',
+  description: 'Mobile-first SSH PWA',
+  start_url: './#connect',
+  scope: './',
+  display: 'standalone',
+  background_color: '#0d0d1a',
+  theme_color: '#1a1a2e',
+  icons: [{ src: 'icon-192.svg', sizes: '192x192', type: 'image/svg+xml', purpose: 'any maskable' }],
+});
+
+describe('rewriteManifest — custom name (#131)', () => {
+  it('returns default name when no customName provided', () => {
+    const result = JSON.parse(rewriteManifest(Buffer.from(DEFAULT_MANIFEST)).toString());
+    expect(result.name).toBe('MobiSSH');
+    expect(result.short_name).toBe('MobiSSH');
+  });
+
+  it('returns default name when customName is empty string', () => {
+    const result = JSON.parse(rewriteManifest(Buffer.from(DEFAULT_MANIFEST), '').toString());
+    expect(result.name).toBe('MobiSSH');
+    expect(result.short_name).toBe('MobiSSH');
+  });
+
+  it('overrides name and short_name when customName is provided', () => {
+    const result = JSON.parse(rewriteManifest(Buffer.from(DEFAULT_MANIFEST), 'fd-mobissh').toString());
+    expect(result.name).toBe('fd-mobissh');
+    expect(result.short_name).toBe('fd-mobissh');
+  });
+
+  it('still sets stable id, start_url, and scope with custom name', () => {
+    const result = JSON.parse(rewriteManifest(Buffer.from(DEFAULT_MANIFEST), 'Work SSH').toString());
+    expect(result.id).toBe('mobissh');
+    expect(result.start_url).toBe('./#connect');
+    expect(result.scope).toBe('./');
+  });
+
+  it('preserves other manifest fields when custom name is provided', () => {
+    const result = JSON.parse(rewriteManifest(Buffer.from(DEFAULT_MANIFEST), 'My SSH').toString());
+    expect(result.display).toBe('standalone');
+    expect(result.icons).toHaveLength(1);
+    expect(result.description).toBe('Mobile-first SSH PWA');
+  });
+});

--- a/tests/pwa-install.spec.js
+++ b/tests/pwa-install.spec.js
@@ -315,3 +315,42 @@ test.describe('Issue #97 — 5. Manifest fields', () => {
     }
   );
 });
+
+// ── 6. Custom PWA title (#131) ────────────────────────────────────────────────
+
+test.describe('Issue #131 — Custom PWA title via ?name= query param', () => {
+  test(
+    'manifest.json returns default name when no ?name= param',
+    async ({ request }) => {
+      const response = await request.get(BASE_URL + 'manifest.json');
+      expect(response.ok()).toBe(true);
+      const manifest = await response.json();
+      expect(manifest.name).toBe('MobiSSH');
+      expect(manifest.short_name).toBe('MobiSSH');
+    }
+  );
+
+  test(
+    'manifest.json with ?name= returns custom name and short_name',
+    async ({ request }) => {
+      const response = await request.get(BASE_URL + 'manifest.json?name=fd-mobissh');
+      expect(response.ok()).toBe(true);
+      const manifest = await response.json();
+      expect(manifest.name).toBe('fd-mobissh');
+      expect(manifest.short_name).toBe('fd-mobissh');
+    }
+  );
+
+  test(
+    'manifest.json with ?name= preserves stable id, start_url, and scope',
+    async ({ request }) => {
+      const response = await request.get(BASE_URL + 'manifest.json?name=Work+SSH');
+      expect(response.ok()).toBe(true);
+      const manifest = await response.json();
+      expect(manifest.id).toBe('mobissh');
+      expect(manifest.start_url).toBe('./#connect');
+      expect(manifest.scope).toBe('./');
+      expect(manifest.name).toBe('Work SSH');
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Serve `manifest.json` dynamically: read `?name=` query param to override `name` and `short_name` fields
- Extract `rewriteManifest` into `server/manifest.js` (standalone, no heavy deps) to enable unit testing
- The HTML `<link rel="manifest" href="manifest.json">` is unchanged; browser will request it, and the server customises the response

## Test coverage
- Added `src/modules/__tests__/manifest-name.test.ts` — 5 Vitest unit tests for `rewriteManifest` with and without custom name
- Added 3 Playwright tests in `tests/pwa-install.spec.js` (section 6) verifying the HTTP endpoint: default name, custom name, stable id/start_url/scope preserved

## Test results
- tsc: PASS
- eslint: PASS (pre-existing warnings only, none in new code)
- vitest: PASS (5 new tests pass; 3 pre-existing failures in connection/keepalive/profile-theme unrelated to this change)

## Diff stats
- Files changed: 4
- Lines: +142 / -20

Closes #131

## Cycles used
1/3