### PR TITLE
fix: long-press tooltip dismisses keyboard

### DIFF
--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -117,6 +117,9 @@ export function initLongPressTooltips(): void {
     const text = target.dataset['tooltip'];
     if (!text) return;
 
+    // Prevent focus loss that would dismiss the keyboard (#124)
+    if (_keyboardVisible()) e.preventDefault();
+
     if (_tooltipTimer) clearTimeout(_tooltipTimer);
     _tooltipTimer = setTimeout(() => {
       _tooltipTimer = null;
@@ -132,7 +135,7 @@ export function initLongPressTooltips(): void {
       el.style.setProperty('--tooltip-left', `${String(left)}px`);
       el.style.setProperty('--tooltip-top', `${String(top)}px`);
     }, 500);
-  }, { passive: true });
+  });
 
   document.addEventListener('touchend', _hideTooltip, { passive: true });
   document.addEventListener('touchmove', _hideTooltip, { passive: true });

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -425,4 +425,74 @@ test.describe('Long-press tooltip hints (#111)', () => {
     }
   });
 
+  test('touchstart on tooltip button calls preventDefault when keyboard is visible (#124)', async ({ page }) => {
+    await page.addInitScript(() => { localStorage.clear(); });
+    await page.goto('./');
+    await page.waitForSelector('.xterm-screen', { timeout: 8000 });
+
+    // Inject a keyboardVisible override that returns true, simulating an open keyboard
+    await page.evaluate(async () => {
+      const { initUI } = await import('./modules/ui.js');
+      initUI({
+        keyboardVisible: () => true,
+        ROOT_CSS: { tabHeight: '56px', keybarHeight: '34px' },
+        applyFontSize: () => {},
+        applyTheme: () => {},
+      });
+    });
+
+    const btn = page.locator('#composeModeBtn');
+
+    // Spy on preventDefault by patching the prototype before dispatching the event
+    const preventDefaultCalled = await btn.evaluate((el) => {
+      let called = false;
+      const orig = TouchEvent.prototype.preventDefault;
+      TouchEvent.prototype.preventDefault = function() { called = true; orig.call(this); };
+      try {
+        const touch = new Touch({ identifier: 1, target: el, clientX: 0, clientY: 0 });
+        el.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], changedTouches: [touch], bubbles: true, cancelable: true }));
+      } finally {
+        TouchEvent.prototype.preventDefault = orig;
+      }
+      return called;
+    });
+
+    expect(preventDefaultCalled).toBe(true);
+  });
+
+  test('touchstart on tooltip button does not call preventDefault when keyboard is hidden (#124)', async ({ page }) => {
+    await page.addInitScript(() => { localStorage.clear(); });
+    await page.goto('./');
+    await page.waitForSelector('.xterm-screen', { timeout: 8000 });
+
+    // Default: keyboardVisible returns false (no keyboard open)
+    await page.evaluate(async () => {
+      const { initUI } = await import('./modules/ui.js');
+      initUI({
+        keyboardVisible: () => false,
+        ROOT_CSS: { tabHeight: '56px', keybarHeight: '34px' },
+        applyFontSize: () => {},
+        applyTheme: () => {},
+      });
+    });
+
+    const btn = page.locator('#composeModeBtn');
+
+    // Spy on preventDefault — should NOT be called when keyboard is hidden
+    const preventDefaultCalled = await btn.evaluate((el) => {
+      let called = false;
+      const orig = TouchEvent.prototype.preventDefault;
+      TouchEvent.prototype.preventDefault = function() { called = true; orig.call(this); };
+      try {
+        const touch = new Touch({ identifier: 1, target: el, clientX: 0, clientY: 0 });
+        el.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], changedTouches: [touch], bubbles: true, cancelable: true }));
+      } finally {
+        TouchEvent.prototype.preventDefault = orig;
+      }
+      return called;
+    });
+
+    expect(preventDefaultCalled).toBe(false);
+  });
+
 });


### PR DESCRIPTION
## Summary
- Remove `passive: true` from the `touchstart` listener in `initLongPressTooltips()` so `preventDefault()` can be called on the event
- Call `e.preventDefault()` when `_keyboardVisible()` returns true to prevent focus loss on the IME textarea, matching the pattern used for `#key-bar-handle` in #115
- This stops the keyboard from dismissing when a user long-presses a toolbar icon to see its tooltip hint

## Test coverage
- Added `touchstart on tooltip button calls preventDefault when keyboard is visible (#124)` — injects a `keyboardVisible: () => true` override via `initUI`, then spies on `TouchEvent.prototype.preventDefault` to verify it is called during `touchstart` on a `[data-tooltip]` button
- Added `touchstart on tooltip button does not call preventDefault when keyboard is hidden (#124)` — same spy pattern with `keyboardVisible: () => false`, verifies `preventDefault` is NOT called (no regression for the keyboard-hidden case)

## Test results
- tsc: PASS
- eslint: PASS (pre-existing errors in `ime.ts` unrelated to this change)
- vitest: PASS (3 pre-existing failures in connection/keepalive/profile-theme suites due to `getComputedStyle` missing in jsdom — unrelated)

## Diff stats
- Files changed: 2
- Lines: +74 / -1

Closes #124

## Cycles used
1/3