### PR TITLE
feat: preview countdown and idle timeout as settings panel controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -493,6 +493,34 @@
 
       <hr />
 
+      <h3>Compose Preview</h3>
+      <div class="setting-row">
+        <div class="setting-row-info">
+          <span class="setting-row-label">Countdown duration</span>
+          <p class="hint">How long the countdown ring runs before auto-committing text.</p>
+        </div>
+        <select id="previewCountdownDuration">
+          <option value="3000">3s</option>
+          <option value="5000">5s</option>
+          <option value="10000">10s</option>
+          <option value="Infinity">Never</option>
+        </select>
+      </div>
+      <div class="setting-row">
+        <div class="setting-row-info">
+          <span class="setting-row-label">Idle timeout</span>
+          <p class="hint">Grace period before the countdown ring starts after you stop typing.</p>
+        </div>
+        <select id="previewIdleTimeout">
+          <option value="1000">1s</option>
+          <option value="1500">1.5s</option>
+          <option value="2000">2s</option>
+          <option value="3000">3s</option>
+        </select>
+      </div>
+
+      <hr />
+
       <h3>Gestures</h3>
       <div class="setting-row">
         <div class="setting-row-info">

--- a/src/modules/__tests__/settings-countdown.test.ts
+++ b/src/modules/__tests__/settings-countdown.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock localStorage before importing modules
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+};
+vi.stubGlobal('localStorage', localStorageMock);
+vi.stubGlobal('location', { hostname: 'localhost', host: 'localhost:8081' });
+
+vi.stubGlobal('document', {
+  getElementById: () => null,
+  querySelector: () => null,
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  documentElement: {
+    style: { setProperty: vi.fn() },
+    dataset: {},
+    classList: { toggle: vi.fn(), add: vi.fn(), remove: vi.fn() },
+  },
+  createElement: vi.fn(() => ({
+    className: '',
+    textContent: '',
+    innerHTML: '',
+    appendChild: vi.fn(),
+    addEventListener: vi.fn(),
+    querySelector: vi.fn(),
+  })),
+  fonts: { ready: Promise.resolve() },
+  body: { appendChild: vi.fn(), classList: { add: vi.fn(), remove: vi.fn(), toggle: vi.fn() } },
+});
+
+vi.stubGlobal('window', {
+  addEventListener: vi.fn(),
+  visualViewport: null,
+  outerHeight: 900,
+});
+
+vi.stubGlobal('Notification', { permission: 'granted' });
+vi.stubGlobal('getComputedStyle', () => ({ getPropertyValue: () => '' }));
+
+const {
+  getPreviewTimeout,
+  setPreviewTimeout,
+  getPreviewIdleDelay,
+  setPreviewIdleDelay,
+  PREVIEW_DURATIONS,
+  PREVIEW_IDLE_DELAYS,
+} = await import('../ime.js');
+
+describe('settings-countdown (#181)', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  describe('PREVIEW_DURATIONS', () => {
+    it('contains expected duration values', () => {
+      expect(PREVIEW_DURATIONS).toContain(3000);
+      expect(PREVIEW_DURATIONS).toContain(5000);
+      expect(PREVIEW_DURATIONS).toContain(10000);
+      expect(PREVIEW_DURATIONS).toContain(Infinity);
+    });
+  });
+
+  describe('PREVIEW_IDLE_DELAYS', () => {
+    it('contains expected idle delay values', () => {
+      expect(PREVIEW_IDLE_DELAYS).toContain(1000);
+      expect(PREVIEW_IDLE_DELAYS).toContain(1500);
+      expect(PREVIEW_IDLE_DELAYS).toContain(2000);
+      expect(PREVIEW_IDLE_DELAYS).toContain(3000);
+    });
+  });
+
+  describe('getPreviewTimeout / setPreviewTimeout', () => {
+    it('defaults to 3000 when no localStorage value', () => {
+      expect(getPreviewTimeout()).toBe(3000);
+    });
+
+    it('persists value to localStorage on set', () => {
+      setPreviewTimeout(5000);
+      expect(storage.get('imePreviewTimeout')).toBe('5000');
+    });
+
+    it('returns persisted value after set', () => {
+      setPreviewTimeout(10000);
+      expect(getPreviewTimeout()).toBe(10000);
+    });
+
+    it('persists Infinity as string', () => {
+      setPreviewTimeout(Infinity);
+      expect(storage.get('imePreviewTimeout')).toBe('Infinity');
+    });
+
+    it('returns Infinity after setting Infinity', () => {
+      setPreviewTimeout(Infinity);
+      expect(getPreviewTimeout()).toBe(Infinity);
+    });
+  });
+
+  describe('getPreviewIdleDelay / setPreviewIdleDelay', () => {
+    it('defaults to 1500 when no localStorage value', () => {
+      expect(getPreviewIdleDelay()).toBe(1500);
+    });
+
+    it('persists value to localStorage on set', () => {
+      setPreviewIdleDelay(2000);
+      expect(storage.get('imePreviewIdleDelay')).toBe('2000');
+    });
+
+    it('returns persisted value after set', () => {
+      setPreviewIdleDelay(3000);
+      expect(getPreviewIdleDelay()).toBe(3000);
+    });
+
+    it('loads from localStorage on get', () => {
+      storage.set('imePreviewIdleDelay', '1000');
+      expect(getPreviewIdleDelay()).toBe(1000);
+    });
+  });
+});

--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -33,11 +33,20 @@ let _imeState: IMEState = 'idle';
 /** Whether "preview mode" is enabled — accumulate compositions for review. */
 let _previewMode = localStorage.getItem('imePreviewMode') === 'true';
 
-/** Idle grace period before countdown ring starts (ms). */
-const PREVIEW_IDLE_DELAY = 1500;
+/** Idle grace period options (ms) (#181). */
+export const PREVIEW_IDLE_DELAYS = [1000, 1500, 2000, 3000] as const;
+type PreviewIdleDelay = typeof PREVIEW_IDLE_DELAYS[number];
+
+/** Load persisted idle delay or default to 1500ms (#181). */
+let _previewIdleDelay: PreviewIdleDelay = (() => {
+  const stored = localStorage.getItem('imePreviewIdleDelay');
+  const n = Number(stored);
+  if (n === 1000 || n === 1500 || n === 2000 || n === 3000) return n;
+  return 1500;
+})();
 
 /** Visible countdown durations in ms. Infinity = never auto-commit (#169). */
-const PREVIEW_DURATIONS = [3000, 5000, 10000, Infinity] as const;
+export const PREVIEW_DURATIONS = [3000, 5000, 10000, Infinity] as const;
 type PreviewDuration = typeof PREVIEW_DURATIONS[number];
 
 /** Load persisted countdown duration or default to 3000ms. */
@@ -48,6 +57,37 @@ let _previewTimeout: PreviewDuration = (() => {
   if (n === 3000 || n === 5000 || n === 10000) return n;
   return 3000;
 })();
+
+/** Get the current countdown duration (reads localStorage to pick up external changes). */
+export function getPreviewTimeout(): PreviewDuration {
+  const stored = localStorage.getItem('imePreviewTimeout');
+  if (stored === 'Infinity') return (_previewTimeout = Infinity);
+  const n = Number(stored);
+  if (n === 3000 || n === 5000 || n === 10000) return (_previewTimeout = n);
+  return _previewTimeout;
+}
+
+/** Set and persist the countdown duration (#181). */
+export function setPreviewTimeout(val: PreviewDuration): void {
+  _previewTimeout = val;
+  localStorage.setItem('imePreviewTimeout', String(val));
+}
+
+/** Get the current idle delay (reads localStorage to pick up external changes). */
+export function getPreviewIdleDelay(): PreviewIdleDelay {
+  const stored = localStorage.getItem('imePreviewIdleDelay');
+  const n = Number(stored);
+  if (n === 1000 || n === 1500 || n === 2000 || n === 3000) return (_previewIdleDelay = n);
+  return _previewIdleDelay;
+}
+
+/** Set and persist the idle delay (#181). */
+export function setPreviewIdleDelay(val: number): void {
+  if (val === 1000 || val === 1500 || val === 2000 || val === 3000) {
+    _previewIdleDelay = val;
+    localStorage.setItem('imePreviewIdleDelay', String(val));
+  }
+}
 
 /** Cycle to the next countdown duration and persist. */
 function _cyclePreviewDuration(): void {
@@ -532,7 +572,7 @@ export function initIMEInput(): void {
         }
         _transition('idle');
       }, _previewTimeout);
-    }, PREVIEW_IDLE_DELAY);
+    }, _previewIdleDelay);
   }
 
   // Register callback so toggleComposeMode() can commit+clear active preview

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -9,6 +9,7 @@ import type { SettingsDeps } from './types.js';
 import { getDefaultWsUrl, THEMES } from './constants.js';
 import type { ThemeName } from './types.js';
 import { showErrorDialog } from './ui.js';
+import { getPreviewTimeout, setPreviewTimeout, getPreviewIdleDelay, setPreviewIdleDelay } from './ime.js';
 
 
 let _toast = (_msg: string): void => {};
@@ -221,6 +222,23 @@ export function initSettingsPanel(): void {
       const dock = dockEl.checked ? 'left' : 'right';
       localStorage.setItem('keyControlsDock', dock);
       document.documentElement.classList.toggle('key-dock-left', dock === 'left');
+    });
+  }
+
+  const countdownEl = document.getElementById('previewCountdownDuration') as HTMLSelectElement | null;
+  if (countdownEl) {
+    countdownEl.value = String(getPreviewTimeout());
+    countdownEl.addEventListener('change', () => {
+      const val = countdownEl.value === 'Infinity' ? Infinity : Number(countdownEl.value);
+      setPreviewTimeout(val);
+    });
+  }
+
+  const idleEl = document.getElementById('previewIdleTimeout') as HTMLSelectElement | null;
+  if (idleEl) {
+    idleEl.value = String(getPreviewIdleDelay());
+    idleEl.addEventListener('change', () => {
+      setPreviewIdleDelay(Number(idleEl.value));
     });
   }
 


### PR DESCRIPTION
## Summary
- Add "Compose Preview" section to Settings panel with two select controls: countdown duration (3s/5s/10s/Never) and idle timeout (1s/1.5s/2s/3s)
- Export `getPreviewTimeout`, `setPreviewTimeout`, `getPreviewIdleDelay`, `setPreviewIdleDelay`, `PREVIEW_DURATIONS`, `PREVIEW_IDLE_DELAYS` from `ime.ts` so settings can read/write without duplicating localStorage logic
- Idle delay is now configurable via settings (was hardcoded at 1500ms)

## TDD Analysis
- Type: feature (new settings UI)
- Behavior change: yes (new controls, configurable idle delay)
- TDD approach: smoketest + behavior

## Test coverage
- **Existing tests updated**: none needed (no behavior changed in existing code paths)
- **New tests added (fail->pass)**: `src/modules/__tests__/settings-countdown.test.ts` — 11 tests covering:
  - PREVIEW_DURATIONS contains expected values
  - PREVIEW_IDLE_DELAYS contains expected values
  - getPreviewTimeout defaults to 3000
  - setPreviewTimeout persists to localStorage
  - getPreviewTimeout returns persisted value
  - Infinity round-trips correctly
  - getPreviewIdleDelay defaults to 1500
  - setPreviewIdleDelay persists to localStorage
  - getPreviewIdleDelay returns persisted value
  - getPreviewIdleDelay loads from localStorage
- **Smoketest**: exported constants and getter/setter functions exist and are callable

## Test results
- tsc: PASS
- eslint: PASS (0 new errors; 2 pre-existing errors in ui.ts)
- vitest: PASS (124 tests, 11 new)

## Diff stats
- Files changed: 4
- Lines: +215 / -4

Closes #181

## Cycles used
1/3