### PR TITLE
test: backfill test coverage for SFTP chunked transfer pipeline

### DIFF
--- a/src/modules/__tests__/chunked-download.test.ts
+++ b/src/modules/__tests__/chunked-download.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import type { ServerMessage } from '../types.js';
+
+/**
+ * Type-level tests for chunked download message types.
+ *
+ * These verify that the ServerMessage discriminated union includes
+ * sftp_download_meta, sftp_download_chunk, and sftp_download_end
+ * with the correct field shapes. A compilation failure here means
+ * the types are out of sync with the server protocol.
+ */
+
+describe('ServerMessage download types', () => {
+  it('sftp_download_meta has requestId and size fields', () => {
+    const msg: ServerMessage = {
+      type: 'sftp_download_meta',
+      requestId: 'dl-1',
+      size: 1024,
+    };
+    expect(msg.type).toBe('sftp_download_meta');
+    if (msg.type === 'sftp_download_meta') {
+      expect(msg.requestId).toBe('dl-1');
+      expect(msg.size).toBe(1024);
+    }
+  });
+
+  it('sftp_download_chunk has requestId, offset, and data fields', () => {
+    const msg: ServerMessage = {
+      type: 'sftp_download_chunk',
+      requestId: 'dl-2',
+      offset: 0,
+      data: 'aGVsbG8=', // base64
+    };
+    expect(msg.type).toBe('sftp_download_chunk');
+    if (msg.type === 'sftp_download_chunk') {
+      expect(msg.requestId).toBe('dl-2');
+      expect(msg.offset).toBe(0);
+      expect(msg.data).toBe('aGVsbG8=');
+    }
+  });
+
+  it('sftp_download_end has requestId field', () => {
+    const msg: ServerMessage = {
+      type: 'sftp_download_end',
+      requestId: 'dl-3',
+    };
+    expect(msg.type).toBe('sftp_download_end');
+    if (msg.type === 'sftp_download_end') {
+      expect(msg.requestId).toBe('dl-3');
+    }
+  });
+
+  it('sftp_download_result has requestId and optional data/ok/error', () => {
+    // Full download (non-chunked) result
+    const msg: ServerMessage = {
+      type: 'sftp_download_result',
+      requestId: 'dl-4',
+      data: 'dGVzdA==',
+    };
+    expect(msg.type).toBe('sftp_download_result');
+
+    // Error variant
+    const errMsg: ServerMessage = {
+      type: 'sftp_download_result',
+      requestId: 'dl-5',
+      ok: false,
+      error: 'No such file',
+    };
+    expect(errMsg.type).toBe('sftp_download_result');
+  });
+
+  it('sftp_upload_ack has requestId and offset fields', () => {
+    // Included here since it is part of the chunked transfer protocol
+    const msg: ServerMessage = {
+      type: 'sftp_upload_ack',
+      requestId: 'up-1',
+      offset: 4096,
+    };
+    expect(msg.type).toBe('sftp_upload_ack');
+    if (msg.type === 'sftp_upload_ack') {
+      expect(msg.requestId).toBe('up-1');
+      expect(msg.offset).toBe(4096);
+    }
+  });
+});

--- a/src/modules/__tests__/chunked-upload.test.ts
+++ b/src/modules/__tests__/chunked-upload.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { webcrypto } from 'node:crypto';
+
+// Stub browser globals before any module imports
+vi.stubGlobal('crypto', webcrypto);
+
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+};
+vi.stubGlobal('localStorage', localStorageMock);
+vi.stubGlobal('location', { hostname: 'localhost' });
+
+vi.stubGlobal('document', {
+  getElementById: () => null,
+  querySelector: () => null,
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  createElement: vi.fn(() => ({
+    className: '',
+    textContent: '',
+    innerHTML: '',
+    id: '',
+    appendChild: vi.fn(),
+    addEventListener: vi.fn(),
+    querySelector: vi.fn(),
+    remove: vi.fn(),
+  })),
+  body: { appendChild: vi.fn() },
+});
+
+const wsSendSpy = vi.fn();
+vi.stubGlobal('WebSocket', Object.assign(
+  class {
+    onopen = null; onclose = null; onmessage = null; onerror = null;
+    readyState = 1; // OPEN
+    url = 'ws://localhost:8081';
+    close = vi.fn();
+    send = wsSendSpy;
+  },
+  { OPEN: 1, CLOSED: 3 },
+));
+vi.stubGlobal('Worker', class { onmessage = null; postMessage = vi.fn(); terminate = vi.fn(); });
+vi.stubGlobal('navigator', { wakeLock: undefined });
+vi.stubGlobal('window', {
+  addEventListener: vi.fn(),
+});
+
+const {
+  _uint8ToBase64,
+  _resolveAck,
+  uploadFileChunked,
+  sendSftpUploadCancel,
+  CHUNK_SIZE,
+} = await import('../connection.js');
+
+// Access appState to wire up a mock WS
+const { appState } = await import('../state.js');
+
+describe('_uint8ToBase64', () => {
+  it('encodes an empty array', () => {
+    expect(_uint8ToBase64(new Uint8Array([]))).toBe('');
+  });
+
+  it('encodes a small array correctly', () => {
+    // "Hello" in ASCII = [72, 101, 108, 108, 111]
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+    expect(_uint8ToBase64(bytes)).toBe(btoa('Hello'));
+  });
+
+  it('encodes a single byte', () => {
+    const bytes = new Uint8Array([65]); // 'A'
+    expect(_uint8ToBase64(bytes)).toBe(btoa('A'));
+  });
+
+  it('handles a large array (> 32KB block boundary)', () => {
+    // Create a 40KB array to cross the 32KB block boundary
+    const size = 40 * 1024;
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < size; i++) bytes[i] = i % 256;
+    const result = _uint8ToBase64(bytes);
+    // Verify by decoding back
+    const decoded = Uint8Array.from(atob(result), (c) => c.charCodeAt(0));
+    expect(decoded.length).toBe(size);
+    for (let i = 0; i < size; i++) {
+      expect(decoded[i]).toBe(i % 256);
+    }
+  });
+
+  it('encodes binary data with all byte values 0-255', () => {
+    const bytes = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) bytes[i] = i;
+    const result = _uint8ToBase64(bytes);
+    const decoded = Uint8Array.from(atob(result), (c) => c.charCodeAt(0));
+    expect(decoded).toEqual(bytes);
+  });
+});
+
+describe('_resolveAck', () => {
+  it('is a callable function', () => {
+    expect(typeof _resolveAck).toBe('function');
+  });
+
+  it('does not throw when called with an unknown requestId', () => {
+    expect(() => _resolveAck('unknown-id', 0)).not.toThrow();
+  });
+});
+
+describe('CHUNK_SIZE', () => {
+  it('is 192 KB', () => {
+    expect(CHUNK_SIZE).toBe(192 * 1024);
+  });
+});
+
+describe('uploadFileChunked', () => {
+  beforeEach(() => {
+    wsSendSpy.mockClear();
+    // Set up a mock WS on appState
+    const mockWs = new WebSocket('ws://localhost:8081');
+    mockWs.readyState = WebSocket.OPEN;
+    mockWs.send = wsSendSpy;
+    appState.ws = mockWs;
+    appState.sshConnected = true;
+  });
+
+  it('throws when not connected', async () => {
+    appState.sshConnected = false;
+    const file = new File(['test'], 'test.txt');
+    await expect(
+      uploadFileChunked('/remote/path.txt', file, 'req-1', vi.fn()),
+    ).rejects.toThrow('Not connected');
+  });
+
+  it('sends start message with correct fields', async () => {
+    const file = new File(['hello world'], 'test.txt');
+
+    // Start upload but resolve the initial ack immediately
+    const uploadPromise = uploadFileChunked('/remote/path.txt', file, 'req-start', vi.fn());
+
+    // The start message should have been sent
+    expect(wsSendSpy).toHaveBeenCalledTimes(1);
+    const startMsg = JSON.parse(wsSendSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(startMsg.type).toBe('sftp_upload_start');
+    expect(startMsg.path).toBe('/remote/path.txt');
+    expect(startMsg.size).toBe(file.size);
+    expect(startMsg.requestId).toBe('req-start');
+    expect(startMsg.fingerprint).toBe(`${String(file.size)}-test.txt`);
+
+    // Resolve the initial ack (offset 0 = no resume)
+    _resolveAck('req-start', 0);
+
+    // Now chunks will be sent. Resolve acks for each chunk as they come.
+    // File is small (11 bytes), so just one chunk.
+    await vi.waitFor(() => {
+      expect(wsSendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    }, { timeout: 500 });
+
+    // Resolve the chunk ack
+    _resolveAck('req-start', 11);
+
+    await uploadPromise;
+
+    // Verify chunk message was sent
+    const chunkMsg = JSON.parse(wsSendSpy.mock.calls[1][0] as string) as Record<string, unknown>;
+    expect(chunkMsg.type).toBe('sftp_upload_chunk');
+    expect(chunkMsg.requestId).toBe('req-start');
+
+    // Verify end message was sent
+    const endMsg = JSON.parse(wsSendSpy.mock.calls[2][0] as string) as Record<string, unknown>;
+    expect(endMsg.type).toBe('sftp_upload_end');
+    expect(endMsg.requestId).toBe('req-start');
+  });
+
+  it('calls onProgress with sent/total bytes', async () => {
+    const content = 'hello world test data';
+    const file = new File([content], 'progress.txt');
+    const onProgress = vi.fn();
+
+    const uploadPromise = uploadFileChunked('/remote/progress.txt', file, 'req-prog', onProgress);
+
+    // Resolve initial ack
+    _resolveAck('req-prog', 0);
+
+    // Wait for chunk send
+    await vi.waitFor(() => {
+      expect(wsSendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    }, { timeout: 500 });
+
+    // Resolve chunk ack
+    _resolveAck('req-prog', content.length);
+
+    await uploadPromise;
+
+    // onProgress should have been called with bytesSent and totalBytes
+    expect(onProgress).toHaveBeenCalled();
+    const lastCall = onProgress.mock.calls[onProgress.mock.calls.length - 1][0] as { bytesSent: number; totalBytes: number };
+    expect(lastCall.totalBytes).toBe(file.size);
+    expect(lastCall.bytesSent).toBe(file.size);
+  });
+});
+
+describe('sendSftpUploadCancel', () => {
+  beforeEach(() => {
+    wsSendSpy.mockClear();
+    const mockWs = new WebSocket('ws://localhost:8081');
+    mockWs.readyState = WebSocket.OPEN;
+    mockWs.send = wsSendSpy;
+    appState.ws = mockWs;
+    appState.sshConnected = true;
+  });
+
+  it('sends cancel message when connected', () => {
+    sendSftpUploadCancel('req-cancel');
+    expect(wsSendSpy).toHaveBeenCalledTimes(1);
+    const msg = JSON.parse(wsSendSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(msg.type).toBe('sftp_upload_cancel');
+    expect(msg.requestId).toBe('req-cancel');
+  });
+
+  it('does not send when disconnected', () => {
+    appState.sshConnected = false;
+    sendSftpUploadCancel('req-cancel-disc');
+    expect(wsSendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -15,13 +15,13 @@ type SftpMsg = Extract<ServerMessage, { type: 'sftp_ls_result' | 'sftp_error' | 
 let _sftpHandler: ((msg: SftpMsg) => void) | null = null;
 export function setSftpHandler(fn: (msg: SftpMsg) => void): void { _sftpHandler = fn; }
 
-const CHUNK_SIZE = 192 * 1024; // 192 KB per chunk
+export const CHUNK_SIZE = 192 * 1024; // 192 KB per chunk
 
 // Pending ack resolvers: requestId -> resolve function
 const _ackResolvers = new Map<string, (offset: number) => void>();
 
 /** Base64-encode a Uint8Array without btoa+fromCharCode (which fails on large arrays). */
-function _uint8ToBase64(bytes: Uint8Array): string {
+export function _uint8ToBase64(bytes: Uint8Array): string {
   const BLOCK = 0x8000; // 32 KB blocks to avoid call stack overflow
   let binary = '';
   for (let i = 0; i < bytes.length; i += BLOCK) {


### PR DESCRIPTION
## Summary
- Add 13 unit tests for the chunked upload pipeline: `_uint8ToBase64` encoding (empty, small, large, boundary-crossing arrays), `uploadFileChunked` start/chunk/end message flow with ack resolution, `onProgress` callback, `sendSftpUploadCancel`, `_resolveAck`, `CHUNK_SIZE` constant
- Add 5 type-level tests for chunked download `ServerMessage` variants: `sftp_download_meta`, `sftp_download_chunk`, `sftp_download_end`, `sftp_download_result`, `sftp_upload_ack` field shapes
- Export `_uint8ToBase64` and `CHUNK_SIZE` from `connection.ts` for testability (no behavior change)

## TDD Analysis
- Type: chore (test-only)
- Behavior change: no
- TDD approach: write tests that verify existing behavior passes

## Test coverage
- **Existing tests updated**: none needed
- **New tests added (fail->pass)**: `chunked-upload.test.ts` (13 tests), `chunked-download.test.ts` (5 tests)
- **Smoketest**: `_uint8ToBase64` callable and encodes correctly, `uploadFileChunked` sends correct WS messages, `ServerMessage` union includes all chunked transfer types

## Test results
- tsc: PASS
- eslint: PASS (pre-existing warnings only, 0 new)
- vitest: PASS (153 tests, 18 new)

## Diff stats
- Files changed: 3
- Lines: +317 / -2

Closes #196

## Cycles used
1/3