### PR TITLE
fix: autocorrect word replacement sends correct backspaces (#177)

### DIFF
--- a/src/modules/__tests__/send-diff.test.ts
+++ b/src/modules/__tests__/send-diff.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { computeDiff } from '../ime-diff.js';
+
+describe('computeDiff — autocorrect word replacement (#177)', () => {
+  it('returns empty for identical strings', () => {
+    expect(computeDiff('hello', 'hello')).toEqual({ deletions: 0, insertion: '' });
+  });
+
+  it('handles simple append', () => {
+    expect(computeDiff('hel', 'hello')).toEqual({ deletions: 0, insertion: 'lo' });
+  });
+
+  it('handles suffix-only fix (typo correction)', () => {
+    // "terminl" → "terminal": backspace 1 char, type "al"
+    expect(computeDiff('terminl', 'terminal')).toEqual({ deletions: 1, insertion: 'al' });
+  });
+
+  it('handles full word replacement with no common chars', () => {
+    // "terminal" → "preview": backspace entire word, type new word
+    expect(computeDiff('terminal', 'preview')).toEqual({ deletions: 8, insertion: 'preview' });
+  });
+
+  it('handles word replacement with misleading common suffix', () => {
+    // "test" → "best": common suffix "est" in string terms, but backspace works
+    // from cursor (end), so we can't skip over the suffix. Must delete all 4
+    // chars and retype "best".
+    const result = computeDiff('test', 'best');
+    expect(result.deletions).toBe(4);
+    expect(result.insertion).toBe('best');
+  });
+
+  it('handles partial word replacement with common prefix', () => {
+    // "hello world" → "hello earth": common prefix "hello ", delete "world" (5), type "earth"
+    expect(computeDiff('hello world', 'hello earth')).toEqual({ deletions: 5, insertion: 'earth' });
+  });
+
+  it('handles replacement where common suffix misleads (cat→bat)', () => {
+    // "cat" → "bat": suffix "at" is common in string terms, but backspace from
+    // end deletes "at" not "c". Must delete 3 chars and type "bat".
+    const result = computeDiff('cat', 'bat');
+    expect(result.deletions).toBe(3);
+    expect(result.insertion).toBe('bat');
+  });
+
+  it('handles replacement with common prefix AND misleading suffix', () => {
+    // "testing" → "tearing": prefix "te", then must delete "sting" (5) and type "aring"
+    const result = computeDiff('testing', 'tearing');
+    expect(result.deletions).toBe(5);
+    expect(result.insertion).toBe('aring');
+  });
+
+  it('handles simple deletion', () => {
+    expect(computeDiff('hello', 'hell')).toEqual({ deletions: 1, insertion: '' });
+  });
+
+  it('handles empty old value', () => {
+    expect(computeDiff('', 'hello')).toEqual({ deletions: 0, insertion: 'hello' });
+  });
+
+  it('handles empty new value', () => {
+    expect(computeDiff('hello', '')).toEqual({ deletions: 5, insertion: '' });
+  });
+});

--- a/src/modules/ime-diff.ts
+++ b/src/modules/ime-diff.ts
@@ -1,0 +1,40 @@
+/**
+ * modules/ime-diff.ts — cursor-relative diff for IME autocorrect
+ *
+ * Computes the minimal {deletions, insertion} to transform oldVal → newVal
+ * assuming the cursor is at the end of oldVal and deletions are backspaces.
+ *
+ * Extracted from _sendDiff in ime.ts for testability (#177).
+ */
+
+export interface DiffResult {
+  /** Number of backspace (DEL) characters to send. */
+  deletions: number;
+  /** Text to insert after backspacing. */
+  insertion: string;
+}
+
+/**
+ * Compute the diff between oldVal and newVal as cursor-relative operations.
+ *
+ * Since backspace deletes from the end (cursor position), only a common prefix
+ * can be preserved. A "common suffix" in string terms would require the cursor
+ * to skip over it, which backspace cannot do. So we only use the common prefix.
+ */
+export function computeDiff(oldVal: string, newVal: string): DiffResult {
+  if (oldVal === newVal) return { deletions: 0, insertion: '' };
+
+  // Find longest common prefix — this is the only part we can keep,
+  // because backspace always deletes from the end.
+  let prefix = 0;
+  while (prefix < oldVal.length && prefix < newVal.length && oldVal[prefix] === newVal[prefix]) {
+    prefix++;
+  }
+
+  // Everything after the common prefix in oldVal must be deleted (backspaced from end).
+  const deletions = oldVal.length - prefix;
+  // Everything after the common prefix in newVal must be inserted.
+  const insertion = newVal.slice(prefix);
+
+  return { deletions, insertion };
+}

--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -22,6 +22,7 @@ import { appState } from './state.js';
 import { sendSSHInput } from './connection.js';
 import { focusIME, setCtrlActive } from './ui.js';
 import { isSelectionActive } from './selection.js';
+import { computeDiff } from './ime-diff.js';
 
 let _handleResize = (): void => {};
 let _applyFontSize = (_size: number): void => {};
@@ -603,16 +604,7 @@ export function initIMEInput(): void {
 
   /** Diff old vs new value: send backspaces to erase changed region + replacement text. */
   function _sendDiff(oldVal: string, newVal: string): void {
-    if (oldVal === newVal) return;
-    // Find longest common prefix
-    let prefix = 0;
-    while (prefix < oldVal.length && prefix < newVal.length && oldVal[prefix] === newVal[prefix]) prefix++;
-    // Find longest common suffix (not overlapping prefix)
-    let suffix = 0;
-    while (suffix < oldVal.length - prefix && suffix < newVal.length - prefix &&
-           oldVal[oldVal.length - 1 - suffix] === newVal[newVal.length - 1 - suffix]) suffix++;
-    const deletions = oldVal.length - prefix - suffix;
-    const insertion = newVal.slice(prefix, newVal.length - suffix);
+    const { deletions, insertion } = computeDiff(oldVal, newVal);
     if (deletions > 0) sendSSHInput('\x7f'.repeat(deletions));
     if (insertion) sendSSHInput(insertion);
   }


### PR DESCRIPTION
## Summary
- Fixed `_sendDiff` which used a common-suffix optimization that produced garbled output for full word replacements (e.g. "test" to "best", "cat" to "bat")
- Backspace deletes from cursor (end of string), so a common suffix in string terms is unreachable without cursor movement — only common prefix can be preserved
- Extracted diff logic to `ime-diff.ts` with prefix-only algorithm for testability

## TDD Analysis
- Type: bug fix
- Behavior change: no (restoring correct behavior)
- TDD approach: full

## Test coverage
- **Existing tests updated**: none needed
- **New tests added (fail->pass)**: `src/modules/__tests__/send-diff.test.ts` — 11 tests covering identical strings, appends, suffix typo fixes, full word replacements, misleading common suffixes ("test"->"best", "cat"->"bat"), common prefix + misleading suffix ("testing"->"tearing"), deletions, and empty edge cases
- **Smoketest**: computeDiff is callable and returns correct DiffResult shape

## Test results
- tsc: PASS
- eslint: PASS (warnings only, pre-existing)
- vitest: PASS (153 tests, 11 new)

## Diff stats
- Files changed: 3
- Lines: +105 / -10

Closes #177

## Cycles used
1/3