### PR TITLE
fix: Transfer tab upload throws 'Not connected' despite active SSH session

### DIFF
--- a/src/modules/__tests__/chunked-upload.test.ts
+++ b/src/modules/__tests__/chunked-upload.test.ts
@@ -128,12 +128,43 @@ describe('uploadFileChunked', () => {
     appState.sshConnected = true;
   });
 
-  it('throws when not connected', async () => {
-    appState.sshConnected = false;
+  it('throws when WS is null', async () => {
+    appState.ws = null;
     const file = new File(['test'], 'test.txt');
     await expect(
       uploadFileChunked('/remote/path.txt', file, 'req-1', vi.fn()),
     ).rejects.toThrow('Not connected');
+  });
+
+  it('throws when WS is not OPEN', async () => {
+    appState.ws!.readyState = WebSocket.CLOSED;
+    const file = new File(['test'], 'test.txt');
+    await expect(
+      uploadFileChunked('/remote/path.txt', file, 'req-ws-closed', vi.fn()),
+    ).rejects.toThrow('Not connected');
+  });
+
+  it('does not throw when sshConnected is false but WS is OPEN (#194)', async () => {
+    // Bug #194: uploadFileChunked checked appState.sshConnected which could be
+    // false even though the WS is open and SFTP operations work fine.
+    appState.sshConnected = false;
+    const file = new File(['test'], 'test.txt');
+
+    const uploadPromise = uploadFileChunked('/remote/path.txt', file, 'req-194', vi.fn());
+
+    // Should have sent start message (not thrown)
+    expect(wsSendSpy).toHaveBeenCalledTimes(1);
+    const startMsg = JSON.parse(wsSendSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(startMsg.type).toBe('sftp_upload_start');
+
+    // Resolve acks to let the upload complete
+    _resolveAck('req-194', 0);
+    await vi.waitFor(() => {
+      expect(wsSendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    }, { timeout: 500 });
+    _resolveAck('req-194', 4);
+
+    await uploadPromise;
   });
 
   it('sends start message with correct fields', async () => {

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -54,7 +54,7 @@ export async function uploadFileChunked(
   requestId: string,
   onProgress: (p: UploadProgress) => void
 ): Promise<void> {
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) {
+  if (!appState.ws || appState.ws.readyState !== WebSocket.OPEN) {
     throw new Error('Not connected');
   }
 


### PR DESCRIPTION
## Summary
- Remove `appState.sshConnected` from `uploadFileChunked()` connection guard, keeping only the WS readyState check
- This aligns the upload guard with the mid-upload check (line 102) and fixes "Not connected" errors when the Transfer tab upload is used while Explore tab SFTP operations work fine

## TDD Analysis
- Type: bug fix
- Behavior change: no (restoring expected behavior)
- TDD approach: full (regression test written first, confirmed fail, then fix applied)

## Test coverage
- **Existing tests updated**: split "throws when not connected" into two precise tests (WS null, WS CLOSED)
- **New tests added (fail->pass)**: `does not throw when sshConnected is false but WS is OPEN (#194)` -- reproduces the exact bug scenario
- **Smoketest**: upload completes successfully with sshConnected=false when WS is OPEN

## Test results
- tsc: PASS
- eslint: PASS (warnings only, all pre-existing)
- vitest: PASS (15 tests in chunked-upload, 3 new)

## Diff stats
- Files changed: 2
- Lines: +34 / -3

Closes #194

## Cycles used
1/3