### PR TITLE
fix: voice composition e.data fallback in preview mode (#135, #163)

### DIFF
--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -764,6 +764,9 @@ export function initIMEInput(): void {
 
     // Compose + preview: hold text for review (nothing sent until commit)
     if (appState.imeMode && _previewMode) {
+      // Ensure textarea has the text — voice dictation may leave ime.value
+      // empty while e.data carries the composed text (#163)
+      if (!ime.value && e.data) ime.value = e.data;
       _transition('previewing');
       _lastSentValue = '';
       _scheduleClear();


### PR DESCRIPTION
## Summary
- Fix #163: voice dictation compositionend with empty `ime.value` but populated `e.data` now correctly writes text to textarea in compose+preview mode
- #135 (voice typing first word only): confirmed already fixed by current IME state machine; regression tests added and passing
- Regression tests for both issues added to `tests/ime.spec.js` (already merged to main via #214)

## TDD Analysis
- Type: bug fix
- Behavior change: no
- TDD approach: full (wrote failing test, then fixed)

## Test coverage
- **Existing tests updated**: none needed
- **New tests added (fail-to-pass)**:
  - `Issue #135 — voice typing multi-word composition` (3 tests): compose+preview holds full text, text survives 2s, non-preview sends full text
  - `Issue #163 — compositionend e.data fallback` (2 tests): e.data fallback in direct mode, e.data fallback in compose+preview mode
- **Smoketest**: voice composition text appears in textarea and is sendable

## Test results
- tsc: PASS
- eslint: pre-existing error in unrelated worktree (not this branch)
- vitest: PASS (176 tests)
- playwright (new tests): PASS (15/15 across pixel-7, iphone-14, chromium)

## Diff stats
- Files changed: 1
- Lines: +3 / -0

Closes #163
Closes #135

## Cycles used
1/3