### PR TITLE
feat: slim session menu — narrow width, remove dead CSS

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -366,7 +366,7 @@ html, body {
   transform: translateX(-50%);
   width: max-content;
   min-width: 180px;
-  max-width: min(260px, 90vw);
+  max-width: min(220px, 90vw);
   z-index: 200;
   background: var(--bg-panel);
   border: 1px solid var(--border);
@@ -479,47 +479,6 @@ html, body {
 .session-menu-item:first-child { border-top: none; }
 .session-menu-item:active { background: var(--bg-card); }
 .session-menu-item.danger { color: var(--danger); }
-
-/* Inline button rows — recording (#54, #156), Ctrl shortcuts (#102) */
-.rec-row, .ctrl-row { display: flex; align-items: center; gap: 8px; cursor: default; }
-.rec-row:active, .ctrl-row:active { background: none; }
-.rec-btn, .ctrl-btn {
-  flex: 1;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  color: var(--text);
-  border-radius: 4px;
-  padding: 8px 4px;
-  font-size: 13px;
-  font-weight: 600;
-  text-align: center;
-  cursor: pointer;
-  touch-action: manipulation;
-}
-.rec-btn:active, .ctrl-btn:active { opacity: 0.7; }
-.rec-btn.rec-stop { color: var(--danger); border-color: var(--danger); }
-.rec-indicator {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--danger);
-  font-weight: 600;
-  white-space: nowrap;
-}
-.rec-indicator::before {
-  content: '';
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--danger);
-  flex-shrink: 0;
-  animation: recPulse 1.2s ease-in-out infinite;
-}
-
-@keyframes recPulse {
-  0%, 100% { opacity: 1; }
-  50%      { opacity: 0.3; }
-}
 
 /* Font size row — inline +/− controls that keep menu open */
 .font-size-row {

--- a/src/modules/__tests__/session-menu-slim.test.ts
+++ b/src/modules/__tests__/session-menu-slim.test.ts
@@ -64,4 +64,21 @@ describe('issue-217: slim session menu', () => {
       expect(html).not.toContain('rec-row');
     });
   });
+
+  describe('session menu CSS', () => {
+    const css = readFileSync(resolve(__dirname, '../../../public/app.css'), 'utf-8');
+
+    it('has narrower max-width (220px or less)', () => {
+      const match = css.match(/#sessionMenu\s*\{[^}]*max-width:\s*min\((\d+)px/);
+      expect(match).toBeTruthy();
+      expect(Number(match![1])).toBeLessThanOrEqual(220);
+    });
+
+    it('does not contain dead .rec-row or .ctrl-row styles', () => {
+      expect(css).not.toContain('.rec-row');
+      expect(css).not.toContain('.ctrl-row');
+      expect(css).not.toContain('.rec-btn');
+      expect(css).not.toContain('.ctrl-btn');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Reduced `#sessionMenu` max-width from 260px to 220px for a slimmer menu
- Removed dead CSS for `.rec-row`, `.ctrl-row`, `.rec-btn`, `.ctrl-btn` (buttons already removed from HTML)
- Added 2 new CSS assertion tests verifying narrower max-width and absence of dead styles

## TDD Analysis
- Type: feature (UI cleanup)
- Behavior change: yes (menu narrower, dead styles removed)
- TDD approach: smoketest-only

## Test coverage
- **Existing tests updated**: none needed (all 7 existing tests still pass)
- **New tests added (fail->pass)**: 2 CSS tests — max-width <= 220px, no dead .rec-row/.ctrl-row styles
- **Smoketest**: Ctrl+C/Z in key bar config, Record button absent from HTML, menu CSS narrowed

## Test results
- tsc: PASS
- eslint: PASS (1 pre-existing error, 137 pre-existing warnings — none from this PR)
- vitest: PASS (9 tests in session-menu-slim, 2 new)

## Diff stats
- Files changed: 2
- Lines: +18 / -42

Closes #217

## Cycles used
1/3