### PR TITLE
fix: merge mobile notifications with tag (#160)

### DIFF
--- a/src/modules/__tests__/notification-tag.test.ts
+++ b/src/modules/__tests__/notification-tag.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Stub browser globals BEFORE any module imports
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+});
+
+vi.stubGlobal('location', { hostname: 'localhost' });
+
+vi.stubGlobal('document', {
+  getElementById: () => null,
+  querySelector: () => null,
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  hasFocus: () => true,
+  documentElement: {
+    style: { setProperty: vi.fn() },
+    dataset: {},
+  },
+  createElement: vi.fn(() => ({
+    className: '', textContent: '', innerHTML: '',
+    appendChild: vi.fn(), addEventListener: vi.fn(), querySelector: vi.fn(),
+  })),
+  fonts: { ready: Promise.resolve() },
+  body: { appendChild: vi.fn() },
+});
+
+vi.stubGlobal('getComputedStyle', () => ({
+  getPropertyValue: () => '',
+}));
+
+vi.stubGlobal('Notification', { permission: 'granted' });
+
+vi.stubGlobal('window', {
+  addEventListener: vi.fn(),
+  visualViewport: null,
+  outerHeight: 900,
+});
+
+// Track showNotification calls with full options
+const mockShowNotification = vi.fn((_title: string, _options?: Record<string, unknown>) => {
+  return Promise.resolve();
+});
+
+vi.stubGlobal('navigator', {
+  serviceWorker: {
+    ready: Promise.resolve({ showNotification: mockShowNotification }),
+  },
+});
+
+vi.useFakeTimers();
+
+const { fireNotification } = await import('../terminal.js');
+
+describe('notification tag (#160)', () => {
+  beforeEach(() => {
+    mockShowNotification.mockClear();
+  });
+
+  it('passes tag: mobissh-agent to showNotification from terminal', async () => {
+    fireNotification('MobiSSH', 'Build complete');
+    // fireNotification uses navigator.serviceWorker.ready (microtask)
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(mockShowNotification).toHaveBeenCalledOnce();
+    const [title, options] = mockShowNotification.mock.calls[0];
+    expect(title).toBe('MobiSSH');
+    expect(options).toHaveProperty('tag', 'mobissh-agent');
+    expect(options).toHaveProperty('body', 'Build complete');
+  });
+
+  it('includes tag alongside body in every call', async () => {
+    fireNotification('Custom Title', 'Deployment finished');
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(mockShowNotification).toHaveBeenCalledOnce();
+    const [, options] = mockShowNotification.mock.calls[0];
+    expect(options).toMatchObject({
+      body: 'Deployment finished',
+      tag: 'mobissh-agent',
+    });
+  });
+});

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -188,7 +188,7 @@ export function initSettingsPanel(): void {
       const sendNotification = (): void => {
         void navigator.serviceWorker.ready.then((reg) => {
           console.log('[settings] SW registration ready, showing notification');
-          return reg.showNotification('MobiSSH', { body: 'Test notification' });
+          return reg.showNotification('MobiSSH', { body: 'Test notification', tag: 'mobissh-agent' });
         }).then(() => {
           console.log('[settings] Notification shown via SW');
           _toast('Notification sent.');

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -106,10 +106,10 @@ function shouldNotify(): boolean {
   return true;
 }
 
-function fireNotification(title: string, body: string): void {
+export function fireNotification(title: string, body: string): void {
   if (!('serviceWorker' in navigator)) return;
   void navigator.serviceWorker.ready.then((reg) => {
-    return reg.showNotification(title, { body });
+    return reg.showNotification(title, { body, tag: 'mobissh-agent' });
   }).then(() => {
     _lastNotifTime = Date.now();
   }).catch(() => { /* permission may have been revoked */ });

--- a/tests/notifications.spec.js
+++ b/tests/notifications.spec.js
@@ -29,7 +29,7 @@ async function enableNotifications(page) {
     // Mock ServiceWorkerRegistration.showNotification
     const mockReg = {
       showNotification: (title, options) => {
-        window.__notifications.push({ title, body: options?.body ?? '' });
+        window.__notifications.push({ title, body: options?.body ?? '', tag: options?.tag ?? '' });
         return Promise.resolve();
       },
     };
@@ -244,6 +244,28 @@ test.describe('Bell badge UI (#33)', { tag: '@headless-adequate' }, () => {
 });
 
 test.describe('Test notification button (#32)', { tag: '@headless-adequate' }, () => {
+
+  test('test notification includes tag: mobissh-agent (#160)', async ({ page, mockSshServer }) => {
+    await setupConnected(page, mockSshServer);
+    await enableNotifications(page);
+
+    // Navigate to settings
+    await page.evaluate(() => {
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+      document.querySelector('[data-panel="settings"]')?.classList.add('active');
+      document.getElementById('panel-settings')?.classList.add('active');
+    });
+    await page.waitForTimeout(200);
+
+    // Click the test notification button
+    await page.click('#testNotifBtn');
+    await page.waitForTimeout(500);
+
+    const notifs = await getNotifications(page);
+    expect(notifs.length).toBe(1);
+    expect(notifs[0].tag).toBe('mobissh-agent');
+  });
 
   test('test notification button uses ServiceWorker.showNotification', async ({ page, mockSshServer }) => {
     await setupConnected(page, mockSshServer);


### PR DESCRIPTION
## Summary
- Add `tag: 'mobissh-agent'` to all `showNotification` calls (terminal.ts and settings.ts)
- Notifications with the same tag replace each other instead of stacking on mobile
- Export `fireNotification` for direct unit testing

## TDD Analysis
- Type: feature
- Behavior change: yes (notifications merge instead of stacking)
- TDD approach: full

## Test coverage
- **Existing tests updated**: `tests/notifications.spec.js` mock now captures `tag` property
- **New tests added (fail->pass)**: `src/modules/__tests__/notification-tag.test.ts` (2 tests verifying tag is passed to showNotification)
- **Smoketest**: Playwright test `test notification includes tag: mobissh-agent (#160)` verifies tag in settings test notification

## Test results
- tsc: PASS
- eslint: PASS (1 pre-existing error on main, no new issues)
- vitest: PASS (236 tests, 2 new)

## Diff stats
- Files changed: 4
- Lines: +116 / -4

Closes #160

## Cycles used
1/3