### PR TITLE
feat: per-session terminal creation (#261)

### DIFF
--- a/src/modules/__tests__/session-terminal.test.ts
+++ b/src/modules/__tests__/session-terminal.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for per-session terminal creation (#261)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Stub browser globals before importing modules
+
+const terminalInstances: { open: ReturnType<typeof vi.fn>; loadAddon: ReturnType<typeof vi.fn>; onBell: ReturnType<typeof vi.fn>; writeln: ReturnType<typeof vi.fn>; parser: { registerOscHandler: ReturnType<typeof vi.fn> }; options: Record<string, unknown>; buffer: { active: { cursorY: number; getLine: ReturnType<typeof vi.fn> } } }[] = [];
+const fitAddonInstances: { fit: ReturnType<typeof vi.fn> }[] = [];
+
+// Use function constructor pattern (not arrow fn) so `new Terminal(...)` works
+vi.stubGlobal('Terminal', function TerminalMock() {
+  const inst = {
+    open: vi.fn(),
+    loadAddon: vi.fn(),
+    onBell: vi.fn(),
+    writeln: vi.fn(),
+    parser: { registerOscHandler: vi.fn() },
+    options: {} as Record<string, unknown>,
+    buffer: { active: { cursorY: 0, getLine: vi.fn() } },
+  };
+  terminalInstances.push(inst);
+  return inst;
+});
+
+vi.stubGlobal('FitAddon', { FitAddon: function FitAddonMock() {
+  const inst = { fit: vi.fn() };
+  fitAddonInstances.push(inst);
+  return inst;
+} });
+
+vi.stubGlobal('ClipboardAddon', { ClipboardAddon: vi.fn() });
+
+// Track createElement calls and appended children
+const createdDivs: Array<{ tagName: string; dataset: Record<string, string>; style: Record<string, string>; className: string; children: unknown[]; appendChild: ReturnType<typeof vi.fn> }> = [];
+const terminalContainerChildren: unknown[] = [];
+const terminalContainer = {
+  tagName: 'DIV',
+  id: 'terminal',
+  dataset: {} as Record<string, string>,
+  appendChild: vi.fn((child: unknown) => {
+    terminalContainerChildren.push(child);
+    return child;
+  }),
+  querySelector: vi.fn(() => null),
+};
+
+const elementsById: Record<string, unknown> = {
+  terminal: terminalContainer,
+};
+
+vi.stubGlobal('document', {
+  getElementById: vi.fn((id: string) => elementsById[id] ?? null),
+  createElement: vi.fn((tag: string) => {
+    const el = {
+      tagName: tag.toUpperCase(),
+      dataset: {} as Record<string, string>,
+      style: { display: '', width: '', height: '' } as Record<string, string>,
+      className: '',
+      children: [] as unknown[],
+      appendChild: vi.fn(function (this: { children: unknown[] }, child: unknown) {
+        this.children.push(child);
+        return child;
+      }),
+      classList: {
+        add: vi.fn(),
+        toggle: vi.fn(),
+        contains: vi.fn(() => false),
+      },
+      setAttribute: vi.fn(),
+    };
+    createdDivs.push(el);
+    return el;
+  }),
+  documentElement: {
+    style: { setProperty: vi.fn() },
+    dataset: {},
+  },
+  hasFocus: vi.fn(() => true),
+  visibilityState: 'visible',
+  fonts: { ready: Promise.resolve() },
+  querySelector: vi.fn(() => null),
+  querySelectorAll: vi.fn(() => []),
+  addEventListener: vi.fn(),
+});
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+});
+
+vi.stubGlobal('window', {
+  addEventListener: vi.fn(),
+  visualViewport: null,
+  outerHeight: 800,
+});
+
+vi.stubGlobal('Notification', { permission: 'default' });
+vi.stubGlobal('navigator', { serviceWorker: undefined });
+vi.stubGlobal('getComputedStyle', vi.fn(() => ({
+  getPropertyValue: vi.fn(() => '48px'),
+})));
+vi.stubGlobal('CSS', { escape: (s: string) => s });
+vi.stubGlobal('WebSocket', { OPEN: 1 });
+vi.stubGlobal('performance', { now: vi.fn(() => 0) });
+vi.stubGlobal('location', { hostname: 'localhost' });
+
+const { createSessionTerminal } = await import('../terminal.js');
+
+describe('createSessionTerminal (#261)', () => {
+  beforeEach(() => {
+    createdDivs.length = 0;
+    terminalInstances.length = 0;
+    fitAddonInstances.length = 0;
+    terminalContainerChildren.length = 0;
+    storage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('returns an object with terminal and fitAddon', () => {
+    const result = createSessionTerminal('test-session-1');
+    expect(result).toHaveProperty('terminal');
+    expect(result).toHaveProperty('fitAddon');
+    expect(result.terminal).toBeDefined();
+    expect(result.fitAddon).toBeDefined();
+  });
+
+  it('creates a DOM container with data-session-id', () => {
+    const sessionId = 'myhost:22:user:1234';
+    createSessionTerminal(sessionId);
+
+    // Should have created a div element
+    expect(document.createElement).toHaveBeenCalledWith('div');
+
+    // Find the created div with the correct session ID
+    const sessionDiv = createdDivs.find(
+      (el) => el.dataset['sessionId'] === sessionId
+    );
+    expect(sessionDiv).toBeDefined();
+  });
+
+  it('appends session container to #terminal', () => {
+    createSessionTerminal('sess-1');
+    expect(terminalContainer.appendChild).toHaveBeenCalled();
+    // The first child appended should be the session div
+    expect(terminalContainerChildren.length).toBeGreaterThan(0);
+    const child = terminalContainerChildren[0] as { dataset: Record<string, string> };
+    expect(child.dataset['sessionId']).toBe('sess-1');
+  });
+
+  it('opens terminal in the session container, not #terminal directly', () => {
+    createSessionTerminal('sess-2');
+    // The Terminal.open should be called with the session div
+    expect(terminalInstances.length).toBeGreaterThan(0);
+    const openArg = terminalInstances[0]!.open.mock.calls[0]?.[0] as { dataset: Record<string, string> };
+    expect(openArg.dataset['sessionId']).toBe('sess-2');
+  });
+
+  it('wires bell handler on the new terminal', () => {
+    createSessionTerminal('sess-3');
+    expect(terminalInstances[0]!.onBell).toHaveBeenCalled();
+  });
+
+  it('wires OSC 9 and OSC 777 handlers', () => {
+    createSessionTerminal('sess-4');
+    const calls = terminalInstances[0]!.parser.registerOscHandler.mock.calls;
+    expect(calls.length).toBe(2);
+    expect(calls[0]![0]).toBe(9);
+    expect(calls[1]![0]).toBe(777);
+  });
+
+  it('creates a new Terminal and FitAddon instance per call', () => {
+    createSessionTerminal('sess-a');
+    createSessionTerminal('sess-b');
+    expect(terminalInstances.length).toBe(2);
+    expect(fitAddonInstances.length).toBe(2);
+  });
+});

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -225,6 +225,7 @@ export function sendSftpRealpath(requestId: string): void {
 }
 import { getDefaultWsUrl, RECONNECT, escHtml } from './constants.js';
 import { appState, createSession } from './state.js';
+import { createSessionTerminal } from './terminal.js';
 import { stopAndDownloadRecording } from './recording.js';
 
 let _toast = (_msg: string): void => {};
@@ -415,6 +416,11 @@ export async function connect(profile: SSHProfile): Promise<void> {
   session.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
   session.activeThemeName = appState.activeThemeName;
   appState.activeSessionId = sessionId;
+
+  // Create per-session terminal instance (#261)
+  const { terminal, fitAddon } = createSessionTerminal(sessionId);
+  session.terminal = terminal;
+  session.fitAddon = fitAddon;
 
   _openWebSocket();
 }

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -205,6 +205,74 @@ export function initTerminal(): void {
   appState.terminal.writeln('');
 }
 
+/**
+ * Create a Terminal + FitAddon for a specific session, in its own DOM container
+ * inside #terminal with data-session-id. Returns { terminal, fitAddon } for the
+ * caller to store in SessionState. (#261 — Part A of multi-terminal infrastructure)
+ */
+export function createSessionTerminal(sessionId: string): { terminal: Terminal; fitAddon: FitAddon.FitAddon } {
+  const fontSize = parseFloat(localStorage.getItem('fontSize') ?? '14') || 14;
+  const savedFont = localStorage.getItem('termFont') ?? 'monospace';
+  const fontFamily = FONT_FAMILIES[savedFont] ?? FONT_FAMILIES.monospace;
+
+  const terminal = new Terminal({
+    fontFamily,
+    fontSize,
+    theme: THEMES[appState.activeThemeName].theme,
+    cursorBlink: true,
+    scrollback: 5000,
+    convertEol: false,
+  });
+
+  const fitAddon = new FitAddon.FitAddon();
+  terminal.loadAddon(fitAddon);
+  if (localStorage.getItem('enableRemoteClipboard') === 'true') {
+    terminal.loadAddon(new ClipboardAddon.ClipboardAddon());
+  }
+
+  // Create a per-session container div inside #terminal
+  const container = document.createElement('div');
+  container.dataset['sessionId'] = sessionId;
+  container.style.width = '100%';
+  container.style.height = '100%';
+  document.getElementById('terminal')!.appendChild(container);
+
+  terminal.open(container);
+  fitAddon.fit();
+
+  // Wire bell handler
+  terminal.onBell(() => {
+    const buffer = terminal.buffer.active;
+    let body = 'Terminal bell';
+    for (let i = buffer.cursorY; i >= 0; i--) {
+      const line = buffer.getLine(i)?.translateToString(true).trim();
+      if (line) { body = _sanitizeNotifText(line); break; }
+    }
+    _addNotification(body);
+    if (shouldNotify()) fireNotification('MobiSSH', body);
+  });
+
+  // Wire OSC handlers
+  terminal.parser.registerOscHandler(9, (data: string) => {
+    const body = _sanitizeNotifText(data);
+    _addNotification(body);
+    if (shouldNotify()) fireNotification('MobiSSH', body);
+    return true;
+  });
+
+  terminal.parser.registerOscHandler(777, (data: string) => {
+    const parts = data.split(';');
+    if (parts[0] === 'notify') {
+      const body = _sanitizeNotifText(parts[2] ?? '');
+      _addNotification(body);
+      if (shouldNotify()) fireNotification(parts[1] ?? 'MobiSSH', body);
+    }
+    return true;
+  });
+
+  return { terminal, fitAddon };
+}
+
 function _toggleNotifDrawer(show?: boolean): void {
   const drawer = document.getElementById('notifDrawer');
   if (!drawer) return;


### PR DESCRIPTION
## Summary
- Add `createSessionTerminal(sessionId)` to `terminal.ts` that creates a Terminal + FitAddon in a per-session DOM container (`<div data-session-id="...">`) inside `#terminal`
- Wire bell handler, OSC 9, and OSC 777 handlers on each new terminal instance
- Call `createSessionTerminal` from `connect()` in `connection.ts`, storing terminal/fitAddon in SessionState

## TDD Analysis
- Type: feature
- Behavior change: yes (new per-session terminal creation on connect)
- TDD approach: full

## Test coverage
- **Existing tests updated**: none needed (all 236 existing tests pass unchanged)
- **New tests added (fail->pass)**: `src/modules/__tests__/session-terminal.test.ts` (7 tests)
  - Returns terminal and fitAddon
  - Creates DOM container with data-session-id
  - Appends session container to #terminal
  - Opens terminal in session container (not #terminal directly)
  - Wires bell handler
  - Wires OSC 9 and OSC 777 handlers
  - Creates new instances per call
- **Smoketest**: createSessionTerminal returns { terminal, fitAddon }, DOM container has correct data-session-id

## Test results
- tsc: PASS
- eslint: PASS (0 errors, 13 pre-existing warnings)
- vitest: PASS (243 tests, 7 new)

## Diff stats
- Files changed: 3
- Lines: +255 / -0 (181 lines are the new test file)

Closes #261

## Cycles used
1/3