### PR TITLE
feat: #103 Part B — mirror state removal

### DIFF
--- a/src/modules/__tests__/chunked-upload.test.ts
+++ b/src/modules/__tests__/chunked-upload.test.ts
@@ -60,7 +60,7 @@ const {
 } = await import('../connection.js');
 
 // Access appState to wire up a mock WS
-const { appState } = await import('../state.js');
+const { appState, createSession } = await import('../state.js');
 
 describe('_uint8ToBase64', () => {
   it('encodes an empty array', () => {
@@ -120,16 +120,20 @@ describe('CHUNK_SIZE', () => {
 describe('uploadFileChunked', () => {
   beforeEach(() => {
     wsSendSpy.mockClear();
-    // Set up a mock WS that auto-responds with sftp_upload_result after sftp_upload_end
+    appState.sessions.clear();
+    // Set up a mock WS on a session
     const mockWs = new WebSocket('ws://localhost:8081');
     mockWs.readyState = WebSocket.OPEN;
     mockWs.send = wsSendSpy;
-    appState.ws = mockWs;
-    appState.sshConnected = true;
+    const session = createSession('upload-test');
+    appState.activeSessionId = 'upload-test';
+    session.ws = mockWs;
+    session.sshConnected = true;
   });
 
   it('throws when WS is null', async () => {
-    appState.ws = null;
+    const session = appState.sessions.get('upload-test')!;
+    session.ws = null;
     const file = new File(['test'], 'test.txt');
     await expect(
       uploadFileChunked('/remote/path.txt', file, 'req-1', vi.fn()),
@@ -137,7 +141,7 @@ describe('uploadFileChunked', () => {
   });
 
   it('throws when WS is not OPEN', async () => {
-    appState.ws!.readyState = WebSocket.CLOSED;
+    appState.sessions.get('upload-test')!.ws!.readyState = WebSocket.CLOSED;
     const file = new File(['test'], 'test.txt');
     await expect(
       uploadFileChunked('/remote/path.txt', file, 'req-ws-closed', vi.fn()),
@@ -145,9 +149,9 @@ describe('uploadFileChunked', () => {
   });
 
   it('does not throw when sshConnected is false but WS is OPEN (#194)', async () => {
-    // Bug #194: uploadFileChunked checked appState.sshConnected which could be
+    // Bug #194: uploadFileChunked checked session.sshConnected which could be
     // false even though the WS is open and SFTP operations work fine.
-    appState.sshConnected = false;
+    appState.sessions.get('upload-test')!.sshConnected = false;
     const file = new File(['test'], 'test.txt');
 
     const uploadPromise = uploadFileChunked('/remote/path.txt', file, 'req-194', vi.fn());
@@ -238,11 +242,14 @@ describe('uploadFileChunked', () => {
 describe('sendSftpUploadCancel', () => {
   beforeEach(() => {
     wsSendSpy.mockClear();
+    appState.sessions.clear();
     const mockWs = new WebSocket('ws://localhost:8081');
     mockWs.readyState = WebSocket.OPEN;
     mockWs.send = wsSendSpy;
-    appState.ws = mockWs;
-    appState.sshConnected = true;
+    const session = createSession('cancel-test');
+    appState.activeSessionId = 'cancel-test';
+    session.ws = mockWs;
+    session.sshConnected = true;
   });
 
   it('sends cancel message when connected', () => {
@@ -254,7 +261,7 @@ describe('sendSftpUploadCancel', () => {
   });
 
   it('does not send when disconnected', () => {
-    appState.sshConnected = false;
+    appState.sessions.get('cancel-test')!.sshConnected = false;
     sendSftpUploadCancel('req-cancel-disc');
     expect(wsSendSpy).not.toHaveBeenCalled();
   });

--- a/src/modules/__tests__/keepalive.test.ts
+++ b/src/modules/__tests__/keepalive.test.ts
@@ -56,12 +56,12 @@ describe('per-session keep-alive timer isolation (#62)', () => {
   beforeEach(() => {
     appState.sessions.clear();
     appState.activeSessionId = null;
-    // Provide a fake WS so startKeepAlive can create the Worker
-    appState.ws = { readyState: 1, url: 'ws://localhost:8081', send: vi.fn(), close: vi.fn(), onopen: null, onclose: null, onmessage: null, onerror: null } as unknown as WebSocket;
   });
 
   it('startKeepAlive sets timer on the target session only', () => {
+    const fakeWs = { readyState: 1, url: 'ws://localhost:8081', send: vi.fn(), close: vi.fn(), onopen: null, onclose: null, onmessage: null, onerror: null } as unknown as WebSocket;
     const s1 = createSession('session-1');
+    s1.ws = fakeWs;
     const s2 = createSession('session-2');
 
     _startKeepAlive('session-1');
@@ -71,8 +71,11 @@ describe('per-session keep-alive timer isolation (#62)', () => {
   });
 
   it('stopKeepAlive clears timer on the target session only', () => {
+    const fakeWs = { readyState: 1, url: 'ws://localhost:8081', send: vi.fn(), close: vi.fn(), onopen: null, onclose: null, onmessage: null, onerror: null } as unknown as WebSocket;
     const s1 = createSession('session-a');
+    s1.ws = fakeWs;
     const s2 = createSession('session-b');
+    s2.ws = fakeWs;
 
     _startKeepAlive('session-a');
     _startKeepAlive('session-b');
@@ -89,8 +92,11 @@ describe('per-session keep-alive timer isolation (#62)', () => {
   });
 
   it('stopKeepAlive terminates the Worker for the target session only', () => {
+    const fakeWs = { readyState: 1, url: 'ws://localhost:8081', send: vi.fn(), close: vi.fn(), onopen: null, onclose: null, onmessage: null, onerror: null } as unknown as WebSocket;
     const s1 = createSession('s1');
+    s1.ws = fakeWs;
     const s2 = createSession('s2');
+    s2.ws = fakeWs;
 
     _startKeepAlive('s1');
     _startKeepAlive('s2');
@@ -117,7 +123,9 @@ describe('per-session keep-alive timer isolation (#62)', () => {
   });
 
   it('stopKeepAlive clears both timer and worker on the session', () => {
+    const fakeWs = { readyState: 1, url: 'ws://localhost:8081', send: vi.fn(), close: vi.fn(), onopen: null, onclose: null, onmessage: null, onerror: null } as unknown as WebSocket;
     const s = createSession('full-stop');
+    s.ws = fakeWs;
     _startKeepAlive('full-stop');
     expect(s.keepAliveTimer).not.toBeNull();
     expect(s.keepAliveWorker).not.toBeNull();

--- a/src/modules/__tests__/visibility-reconnect.test.ts
+++ b/src/modules/__tests__/visibility-reconnect.test.ts
@@ -87,19 +87,25 @@ vi.useFakeTimers();
 
 const { cancelReconnect, scheduleReconnect, _probeZombieConnection } = await import('../connection.js');
 const { appState, createSession } = await import('../state.js');
-const { RECONNECT } = await import('../constants.js');
+
+/** Helper: create a session with profile and optional WS */
+function _setupSession(opts?: { ws?: unknown; profile?: boolean; connected?: boolean }): void {
+  const profile = { name: 'test', host: 'test', port: 22, username: 'test', authType: 'password' as const };
+  const session = createSession('test-session');
+  appState.activeSessionId = 'test-session';
+  if (opts?.profile !== false) session.profile = profile;
+  if (opts?.ws !== undefined) session.ws = opts.ws as WebSocket;
+  if (opts?.connected) {
+    session.wsConnected = true;
+    session.sshConnected = true;
+  }
+}
 
 describe('visibility-triggered reconnect (#153)', () => {
   beforeEach(() => {
     storage.clear();
     appState.sessions.clear();
     appState.activeSessionId = null;
-    appState.ws = null;
-    appState._wsConnected = false;
-    appState.sshConnected = false;
-    appState.currentProfile = null;
-    appState.reconnectTimer = null;
-    appState.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
     appState.hasConnected = false;
     _visibilityState = 'visible';
     lastWsInstance = null;
@@ -112,8 +118,7 @@ describe('visibility-triggered reconnect (#153)', () => {
 
   it('reconnects immediately when WS is closed on resume', () => {
     // Simulate having a profile and a dead WS
-    appState.currentProfile = { name: 'test', host: 'test', port: 22, username: 'test', authType: 'password' as const };
-    appState.ws = null; // WS already gone
+    _setupSession({ ws: null });
 
     // Go hidden then visible
     _visibilityState = 'hidden';
@@ -126,9 +131,7 @@ describe('visibility-triggered reconnect (#153)', () => {
   });
 
   it('does not reconnect when no profile is set', () => {
-    appState.currentProfile = null;
-    appState.ws = null;
-
+    // No session at all — no profile
     _visibilityState = 'visible';
     visibilityHandler?.();
 
@@ -147,13 +150,7 @@ describe('visibility-triggered reconnect (#153)', () => {
       onmessage: null,
       onerror: null,
     };
-    appState.ws = fakeWs as unknown as WebSocket;
-    appState._wsConnected = true;
-    appState.sshConnected = true;
-    appState.currentProfile = { name: 'test', host: 'test', port: 22, username: 'test', authType: 'password' as const };
-    const session = createSession('test-session');
-    appState.activeSessionId = 'test-session';
-    session.profile = appState.currentProfile;
+    _setupSession({ ws: fakeWs, connected: true });
 
     // Resume from background
     _visibilityState = 'visible';
@@ -174,13 +171,7 @@ describe('visibility-triggered reconnect (#153)', () => {
       onmessage: null as ((e?: unknown) => void) | null,
       onerror: null,
     };
-    appState.ws = fakeWs as unknown as WebSocket;
-    appState._wsConnected = true;
-    appState.sshConnected = true;
-    appState.currentProfile = { name: 'test', host: 'test', port: 22, username: 'test', authType: 'password' as const };
-    const session = createSession('test-session');
-    appState.activeSessionId = 'test-session';
-    session.profile = appState.currentProfile;
+    _setupSession({ ws: fakeWs, connected: true });
 
     // Resume — starts probe
     _visibilityState = 'visible';
@@ -204,13 +195,7 @@ describe('visibility-triggered reconnect (#153)', () => {
       onmessage: null as ((e?: unknown) => void) | null,
       onerror: null,
     };
-    appState.ws = fakeWs as unknown as WebSocket;
-    appState._wsConnected = true;
-    appState.sshConnected = true;
-    appState.currentProfile = { name: 'test', host: 'test', port: 22, username: 'test', authType: 'password' as const };
-    const session = createSession('test-session');
-    appState.activeSessionId = 'test-session';
-    session.profile = appState.currentProfile;
+    _setupSession({ ws: fakeWs, connected: true });
 
     // Resume — starts probe
     _visibilityState = 'visible';
@@ -228,12 +213,12 @@ describe('visibility-triggered reconnect (#153)', () => {
   });
 
   it('dismisses pending reconnect timer on resume', () => {
-    appState.currentProfile = { name: 'test', host: 'test', port: 22, username: 'test', authType: 'password' as const };
-    appState.ws = null;
+    _setupSession({ ws: null });
 
     // Schedule a reconnect with backoff
     scheduleReconnect();
-    expect(appState.reconnectTimer).not.toBeNull();
+    const session = appState.sessions.get('test-session')!;
+    expect(session.reconnectTimer).not.toBeNull();
 
     // Resume
     _visibilityState = 'visible';
@@ -245,8 +230,7 @@ describe('visibility-triggered reconnect (#153)', () => {
   });
 
   it('dismisses error dialog overlay on resume reconnect', () => {
-    appState.currentProfile = { name: 'test', host: 'test', port: 22, username: 'test', authType: 'password' as const };
-    appState.ws = null;
+    _setupSession({ ws: null });
 
     _visibilityState = 'visible';
     visibilityHandler?.();
@@ -258,10 +242,8 @@ describe('visibility-triggered reconnect (#153)', () => {
 describe('_probeZombieConnection (#153)', () => {
   beforeEach(() => {
     storage.clear();
-    appState.ws = null;
-    appState._wsConnected = false;
-    appState.sshConnected = false;
-    appState.currentProfile = null;
+    appState.sessions.clear();
+    appState.activeSessionId = null;
     lastWsInstance = null;
   });
 
@@ -270,8 +252,7 @@ describe('_probeZombieConnection (#153)', () => {
   });
 
   it('does nothing when WS is null', () => {
-    appState.ws = null;
-    // Should not throw
+    // No session — should not throw
     expect(() => _probeZombieConnection()).not.toThrow();
   });
 
@@ -282,7 +263,7 @@ describe('_probeZombieConnection (#153)', () => {
       close: vi.fn(),
       onmessage: null,
     };
-    appState.ws = fakeWs as unknown as WebSocket;
+    _setupSession({ ws: fakeWs });
     _probeZombieConnection();
     expect(fakeWs.send).not.toHaveBeenCalled();
   });

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -54,7 +54,8 @@ export async function uploadFileChunked(
   requestId: string,
   onProgress: (p: UploadProgress) => void
 ): Promise<void> {
-  if (!appState.ws || appState.ws.readyState !== WebSocket.OPEN) {
+  const session = currentSession();
+  if (!session?.ws || session.ws.readyState !== WebSocket.OPEN) {
     throw new Error('Not connected');
   }
 
@@ -69,7 +70,7 @@ export async function uploadFileChunked(
   const fingerprint = `${String(file.size)}-${file.name}`;
 
   // Send start message
-  appState.ws.send(JSON.stringify({
+  session.ws.send(JSON.stringify({
     type: 'sftp_upload_start',
     path,
     size: file.size,
@@ -110,8 +111,9 @@ export async function uploadFileChunked(
         }
 
         // Runtime check: ws may change across await boundaries
+        const ws = currentSession()?.ws;
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (!appState.ws || appState.ws.readyState !== WebSocket.OPEN) {
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
           throw new Error('Connection lost during upload');
         }
 
@@ -123,8 +125,8 @@ export async function uploadFileChunked(
         const encodeMs = performance.now() - tEncode;
         totalEncodeMs += encodeMs;
 
-        const buffered = appState.ws.bufferedAmount;
-        appState.ws.send(JSON.stringify({
+        const buffered = ws.bufferedAmount;
+        ws.send(JSON.stringify({
           type: 'sftp_upload_chunk',
           requestId,
           data,
@@ -158,9 +160,10 @@ export async function uploadFileChunked(
   }
 
   // Send end message and wait for server confirmation
+  const endWs = currentSession()?.ws;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (appState.ws && appState.ws.readyState === WebSocket.OPEN) {
-    appState.ws.send(JSON.stringify({
+  if (endWs && endWs.readyState === WebSocket.OPEN) {
+    endWs.send(JSON.stringify({
       type: 'sftp_upload_end',
       requestId
     }));
@@ -187,8 +190,9 @@ export async function uploadFileChunked(
 export function sendSftpUploadCancel(requestId: string): void {
   // Reject any pending ack so the upload loop throws
   _ackResolvers.delete(requestId);
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
-  appState.ws.send(JSON.stringify({ type: 'sftp_upload_cancel', requestId }));
+  const session = currentSession();
+  if (!session?.sshConnected || !session.ws || session.ws.readyState !== WebSocket.OPEN) return;
+  session.ws.send(JSON.stringify({ type: 'sftp_upload_cancel', requestId }));
 }
 
 /** Resolve a pending ack. Called from the WS message handler. */
@@ -200,31 +204,37 @@ export function _resolveAck(requestId: string, offset: number): void {
   }
 }
 export function sendSftpLs(path: string, requestId: string): void {
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
-  appState.ws.send(JSON.stringify({ type: 'sftp_ls', path, requestId }));
+  const session = currentSession();
+  if (!session?.sshConnected || !session.ws || session.ws.readyState !== WebSocket.OPEN) return;
+  session.ws.send(JSON.stringify({ type: 'sftp_ls', path, requestId }));
 }
 export function sendSftpDownload(path: string, requestId: string): void {
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
-  appState.ws.send(JSON.stringify({ type: 'sftp_download', path, requestId }));
+  const session = currentSession();
+  if (!session?.sshConnected || !session.ws || session.ws.readyState !== WebSocket.OPEN) return;
+  session.ws.send(JSON.stringify({ type: 'sftp_download', path, requestId }));
 }
 export function sendSftpUpload(path: string, data: string, requestId: string): void {
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
-  appState.ws.send(JSON.stringify({ type: 'sftp_upload', path, data, requestId }));
+  const session = currentSession();
+  if (!session?.sshConnected || !session.ws || session.ws.readyState !== WebSocket.OPEN) return;
+  session.ws.send(JSON.stringify({ type: 'sftp_upload', path, data, requestId }));
 }
 export function sendSftpRename(oldPath: string, newPath: string, requestId: string): void {
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
-  appState.ws.send(JSON.stringify({ type: 'sftp_rename', oldPath, newPath, requestId }));
+  const session = currentSession();
+  if (!session?.sshConnected || !session.ws || session.ws.readyState !== WebSocket.OPEN) return;
+  session.ws.send(JSON.stringify({ type: 'sftp_rename', oldPath, newPath, requestId }));
 }
 export function sendSftpDelete(path: string, requestId: string): void {
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
-  appState.ws.send(JSON.stringify({ type: 'sftp_delete', path, requestId }));
+  const session = currentSession();
+  if (!session?.sshConnected || !session.ws || session.ws.readyState !== WebSocket.OPEN) return;
+  session.ws.send(JSON.stringify({ type: 'sftp_delete', path, requestId }));
 }
 export function sendSftpRealpath(requestId: string): void {
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
-  appState.ws.send(JSON.stringify({ type: 'sftp_realpath', requestId }));
+  const session = currentSession();
+  if (!session?.sshConnected || !session.ws || session.ws.readyState !== WebSocket.OPEN) return;
+  session.ws.send(JSON.stringify({ type: 'sftp_realpath', requestId }));
 }
 import { getDefaultWsUrl, RECONNECT, escHtml } from './constants.js';
-import { appState, createSession } from './state.js';
+import { appState, currentSession, createSession } from './state.js';
 import { createSessionTerminal } from './terminal.js';
 import { stopAndDownloadRecording } from './recording.js';
 
@@ -241,8 +251,9 @@ let _writeRaf: number | null = null;
 
 function _flushTerminalWrite(): void {
   _writeRaf = null;
-  if (_writeBuf && appState.terminal) {
-    appState.terminal.write(_writeBuf);
+  const terminal = currentSession()?.terminal;
+  if (_writeBuf && terminal) {
+    terminal.write(_writeBuf);
     _writeBuf = '';
   }
 }
@@ -404,8 +415,6 @@ export async function connect(profile: SSHProfile): Promise<void> {
     }
   }
 
-  appState.currentProfile = profile;
-  appState.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
   _wsConsecFailures = 0;
   cancelReconnect();
 
@@ -428,11 +437,12 @@ export async function connect(profile: SSHProfile): Promise<void> {
 function _openWebSocket(options?: { silent?: boolean }): void {
   const silent = options?.silent ?? false;
   const sessionId = appState.activeSessionId ?? '';
+  const session = currentSession();
 
-  if (appState.ws) {
-    appState.ws.onclose = null;
-    appState.ws.close();
-    appState.ws = null;
+  if (session?.ws) {
+    session.ws.onclose = null;
+    session.ws.close();
+    session.ws = null;
   }
 
   const baseUrl = localStorage.getItem('wsUrl') ?? getDefaultWsUrl();
@@ -443,9 +453,10 @@ function _openWebSocket(options?: { silent?: boolean }): void {
   if (!silent) _showConnectionStatus(`Connecting to ${baseUrl}…`);
 
   let openedThisAttempt = false;
+  let newWs: WebSocket;
 
   try {
-    appState.ws = new WebSocket(wsUrl);
+    newWs = new WebSocket(wsUrl);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     _showConnectionStatus(`WebSocket error: ${message}`);
@@ -453,44 +464,49 @@ function _openWebSocket(options?: { silent?: boolean }): void {
     return;
   }
 
-  appState.ws.onopen = () => {
+  if (session) session.ws = newWs;
+
+  newWs.onopen = () => {
     openedThisAttempt = true;
     _wsConsecFailures = 0;
-    appState._wsConnected = true;
+    if (session) session.wsConnected = true;
     startKeepAlive(sessionId);
-    if (!appState.currentProfile) return;
+    const profile = session?.profile;
+    if (!profile) return;
     const authMsg: ConnectMessage = {
       type: 'connect',
-      host: appState.currentProfile.host,
-      port: appState.currentProfile.port || 22,
-      username: appState.currentProfile.username,
+      host: profile.host,
+      port: profile.port || 22,
+      username: profile.username,
     };
-    if (appState.currentProfile.authType === 'key' && appState.currentProfile.privateKey) {
-      authMsg.privateKey = appState.currentProfile.privateKey;
-      if (appState.currentProfile.passphrase) authMsg.passphrase = appState.currentProfile.passphrase;
+    if (profile.authType === 'key' && profile.privateKey) {
+      authMsg.privateKey = profile.privateKey;
+      if (profile.passphrase) authMsg.passphrase = profile.passphrase;
     } else {
-      authMsg.password = appState.currentProfile.password ?? '';
+      authMsg.password = profile.password ?? '';
     }
-    if (appState.currentProfile.initialCommand) authMsg.initialCommand = appState.currentProfile.initialCommand;
+    if (profile.initialCommand) authMsg.initialCommand = profile.initialCommand;
     if (localStorage.getItem('allowPrivateHosts') === 'true') authMsg.allowPrivate = true;
-    appState.ws?.send(JSON.stringify(authMsg));
-    if (!silent) _showConnectionStatus(`SSH → ${appState.currentProfile.username}@${appState.currentProfile.host}:${String(appState.currentProfile.port || 22)}…`);
+    newWs.send(JSON.stringify(authMsg));
+    if (!silent) _showConnectionStatus(`SSH → ${profile.username}@${profile.host}:${String(profile.port || 22)}…`);
   };
 
-  appState.ws.onmessage = (event: MessageEvent) => {
+  newWs.onmessage = (event: MessageEvent) => {
     let msg: ServerMessage;
     try { msg = JSON.parse(event.data as string) as ServerMessage; } catch { return; }
 
     switch (msg.type) {
       case 'connected':
-        appState.sshConnected = true;
-        appState.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
+        if (session) {
+          session.sshConnected = true;
+          session.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
+        }
         void acquireWakeLock();
         // Reset terminal modes so stale mouse tracking from a previous session
         // doesn't cause scroll gestures to send SGR codes to a plain shell (#81)
-        appState.terminal?.reset();
-        if (appState.currentProfile) {
-          _setStatus('connected', `${appState.currentProfile.username}@${appState.currentProfile.host}`);
+        session?.terminal?.reset();
+        if (session?.profile) {
+          _setStatus('connected', `${session.profile.username}@${session.profile.host}`);
         }
         if (silent) {
           _dismissConnectionStatus();
@@ -499,7 +515,7 @@ function _openWebSocket(options?: { silent?: boolean }): void {
           _dismissConnectionStatus(1500);
         }
         // Sync terminal size to server
-        appState.ws?.send(JSON.stringify({ type: 'resize', cols: appState.terminal?.cols ?? 80, rows: appState.terminal?.rows ?? 24 }));
+        newWs.send(JSON.stringify({ type: 'resize', cols: session?.terminal?.cols ?? 80, rows: session?.terminal?.rows ?? 24 }));
         // On first connect: collapse nav chrome and switch to terminal (#36).
         // On reconnect: leave the tab bar as-is so user isn't interrupted.
         if (!appState.hasConnected) {
@@ -522,7 +538,7 @@ function _openWebSocket(options?: { silent?: boolean }): void {
         break;
 
       case 'disconnected':
-        appState.sshConnected = false;
+        if (session) session.sshConnected = false;
         _setStatus('disconnected', 'Disconnected');
         if (!silent) _showConnectionStatus(`Disconnected: ${msg.reason ?? 'unknown reason'}`);
         stopAndDownloadRecording(); // auto-save recording on SSH disconnect (#54)
@@ -554,10 +570,10 @@ function _openWebSocket(options?: { silent?: boolean }): void {
               knownHosts[hostKey] = { fingerprint: msg.fingerprint, keyType: msg.keyType, addedAt: new Date().toISOString() };
               localStorage.setItem('knownHosts', JSON.stringify(knownHosts));
             }
-            appState.ws?.send(JSON.stringify({ type: 'hostkey_response', accepted }));
+            currentSession()?.ws?.send(JSON.stringify({ type: 'hostkey_response', accepted }));
           });
         } else if (known.fingerprint === msg.fingerprint) {
-          appState.ws?.send(JSON.stringify({ type: 'hostkey_response', accepted: true }));
+          currentSession()?.ws?.send(JSON.stringify({ type: 'hostkey_response', accepted: true }));
         } else {
           _showHostKeyPrompt(msg, known.fingerprint, (accepted) => {
             if (accepted) {
@@ -565,7 +581,7 @@ function _openWebSocket(options?: { silent?: boolean }): void {
               updated[hostKey] = { fingerprint: msg.fingerprint, keyType: msg.keyType, addedAt: new Date().toISOString() };
               localStorage.setItem('knownHosts', JSON.stringify(updated));
             }
-            appState.ws?.send(JSON.stringify({ type: 'hostkey_response', accepted }));
+            currentSession()?.ws?.send(JSON.stringify({ type: 'hostkey_response', accepted }));
           });
         }
         break;
@@ -573,11 +589,13 @@ function _openWebSocket(options?: { silent?: boolean }): void {
     }
   };
 
-  appState.ws.onclose = (event) => {
-    appState._wsConnected = false;
-    appState.sshConnected = false;
+  newWs.onclose = (event) => {
+    if (session) {
+      session.wsConnected = false;
+      session.sshConnected = false;
+    }
     stopKeepAlive(sessionId);
-    if (appState.currentProfile) {
+    if (session?.profile) {
       _setStatus('disconnected', 'Disconnected');
       if (!openedThisAttempt) {
         // Connection closed before onopen — likely an auth rejection (HTTP 401).
@@ -608,37 +626,42 @@ function _openWebSocket(options?: { silent?: boolean }): void {
     }
   };
 
-  appState.ws.onerror = () => {
+  newWs.onerror = () => {
     if (!silent) showErrorDialog('WebSocket error — check server URL in Settings.');
   };
 }
 
 export function scheduleReconnect(): void {
-  if (!appState.currentProfile) return;
+  const session = currentSession();
+  if (!session?.profile) return;
 
-  const delaySec = Math.round(appState.reconnectDelay / 1000);
+  const delaySec = Math.round(session.reconnectDelay / 1000);
   _toast(`Reconnecting in ${String(delaySec)}s…`);
   _setStatus('connecting', `Reconnecting in ${String(delaySec)}s…`);
   _showConnectionStatus(`Reconnecting in ${String(delaySec)}s…`);
 
-  appState.reconnectTimer = setTimeout(() => {
-    appState.reconnectDelay = Math.min(
-      appState.reconnectDelay * RECONNECT.BACKOFF_FACTOR,
-      RECONNECT.MAX_DELAY_MS
-    );
+  session.reconnectTimer = setTimeout(() => {
+    const s = currentSession();
+    if (s) {
+      s.reconnectDelay = Math.min(
+        s.reconnectDelay * RECONNECT.BACKOFF_FACTOR,
+        RECONNECT.MAX_DELAY_MS
+      );
+    }
     _openWebSocket({ silent: true });
-  }, appState.reconnectDelay);
+  }, session.reconnectDelay);
 }
 
 export function cancelReconnect(): void {
-  if (appState.reconnectTimer) {
-    clearTimeout(appState.reconnectTimer);
-    appState.reconnectTimer = null;
+  const session = currentSession();
+  if (session?.reconnectTimer) {
+    clearTimeout(session.reconnectTimer);
+    session.reconnectTimer = null;
   }
 }
 
 export function reconnect(): void {
-  if (appState.currentProfile) _openWebSocket();
+  if (currentSession()?.profile) _openWebSocket();
 }
 
 // Application-layer keepalive (#29, #204): sends a ping every 25s so NAT/proxies
@@ -660,15 +683,16 @@ function startKeepAlive(sessionId: string): void {
 
   // Main-thread keepalive (throttled in background, but works when visible)
   session.keepAliveTimer = setInterval(() => {
-    if (appState.ws?.readyState === WebSocket.OPEN) {
-      appState.ws.send(JSON.stringify({ type: 'ping' }));
+    const ws = currentSession()?.ws;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'ping' }));
     } else {
       stopKeepAlive(sessionId);
     }
   }, WS_PING_INTERVAL_MS);
 
   // Worker keepalive: opens a separate WS that pings even when tab is frozen
-  const wsUrl = appState.ws?.url;
+  const wsUrl = session.ws?.url;
   if (!wsUrl) return;
   try {
     session.keepAliveWorker = new Worker('ws-keepalive-worker.js');
@@ -720,13 +744,14 @@ let _zombieProbeTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Exported for testing. */
 export function _probeZombieConnection(): void {
-  if (!appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
+  const sessionWs = currentSession()?.ws;
+  if (!sessionWs || sessionWs.readyState !== WebSocket.OPEN) return;
 
   // Send an application-layer ping to provoke a response or trigger a close
-  appState.ws.send(JSON.stringify({ type: 'ping' }));
+  sessionWs.send(JSON.stringify({ type: 'ping' }));
 
   // Wrap onmessage: any incoming data proves the connection is alive
-  const ws = appState.ws;
+  const ws = sessionWs;
   const origOnMessage = ws.onmessage;
   const cancelProbe = (): void => {
     if (_zombieProbeTimer) {
@@ -753,15 +778,16 @@ export function _probeZombieConnection(): void {
 // probe for zombie connections, and reacquire the wake lock. (#153)
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'visible') {
-    if (appState.sshConnected) void acquireWakeLock();
-    if (appState.currentProfile && (!appState.ws || appState.ws.readyState !== WebSocket.OPEN)) {
+    const session = currentSession();
+    if (session?.sshConnected) void acquireWakeLock();
+    if (session?.profile && (!session.ws || session.ws.readyState !== WebSocket.OPEN)) {
       cancelReconnect();
       _dismissConnectionStatus();
       // Dismiss any error dialog left by failed reconnect attempts while hidden
       document.getElementById('errorDialogOverlay')?.classList.add('hidden');
       _toast('Reconnecting…');
       _openWebSocket({ silent: true });
-    } else if (appState.currentProfile && appState.ws?.readyState === WebSocket.OPEN) {
+    } else if (session?.profile && session.ws?.readyState === WebSocket.OPEN) {
       // WS appears open — probe for zombie connection (#153)
       _probeZombieConnection();
     }
@@ -775,15 +801,18 @@ export function disconnect(): void {
   cancelReconnect();
   if (appState.activeSessionId) stopKeepAlive(appState.activeSessionId);
   releaseWakeLock();
-  appState.currentProfile = null;
-  appState.sshConnected = false;
-  appState._wsConnected = false;
+  const session = currentSession();
+  if (session) {
+    session.profile = null;
+    session.sshConnected = false;
+    session.wsConnected = false;
+  }
 
-  if (appState.ws) {
-    appState.ws.onclose = null;
-    try { appState.ws.send(JSON.stringify({ type: 'disconnect' })); } catch { /* may already be closed */ }
-    appState.ws.close();
-    appState.ws = null;
+  if (session?.ws) {
+    session.ws.onclose = null;
+    try { session.ws.send(JSON.stringify({ type: 'disconnect' })); } catch { /* may already be closed */ }
+    session.ws.close();
+    session.ws = null;
   }
 
   _setStatus('disconnected', 'Disconnected');
@@ -791,8 +820,9 @@ export function disconnect(): void {
 }
 
 export function sendSSHInput(data: string): void {
-  if (!appState.sshConnected || !appState.ws || appState.ws.readyState !== WebSocket.OPEN) return;
-  appState.ws.send(JSON.stringify({ type: 'input', data }));
+  const session = currentSession();
+  if (!session?.sshConnected || !session.ws || session.ws.readyState !== WebSocket.OPEN) return;
+  session.ws.send(JSON.stringify({ type: 'input', data }));
 }
 
 // ── Connection status overlay (#172) ─────────────────────────────────────────

--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -18,7 +18,7 @@
 
 import type { IMEDeps } from './types.js';
 import { KEY_MAP, isMediaKey } from './constants.js';
-import { appState } from './state.js';
+import { appState, currentSession } from './state.js';
 import { sendSSHInput } from './connection.js';
 import { focusIME, setCtrlActive } from './ui.js';
 import { isSelectionActive } from './selection.js';
@@ -184,8 +184,9 @@ const _PASSWORD_RE = /(?:password|passphrase|PIN)[^:]*:\s*$/i;
 let _pwdListenerSetup = false;
 
 function _checkPasswordPrompt(el: HTMLTextAreaElement): void {
-  if (!appState.terminal) return;
-  const buf = appState.terminal.buffer.active;
+  const terminal = currentSession()?.terminal;
+  if (!terminal) return;
+  const buf = terminal.buffer.active;
   const lastLine = (buf.getLine(buf.cursorY)?.translateToString(true) ?? '').trimEnd();
   el.setAttribute('autocomplete', _PASSWORD_RE.test(lastLine) ? 'new-password' : 'off');
 }
@@ -255,9 +256,10 @@ export function initIMEInput(): void {
   // Register cursor-move listener once the terminal is available, and re-check
   // whenever focus lands on the textarea (covers the "prompt just appeared" case).
   function _lazySetupPwdListener(): void {
-    if (_pwdListenerSetup || !appState.terminal) return;
+    const terminal = currentSession()?.terminal;
+    if (_pwdListenerSetup || !terminal) return;
     _pwdListenerSetup = true;
-    appState.terminal.onCursorMove(() => { _checkPasswordPrompt(ime); });
+    terminal.onCursorMove(() => { _checkPasswordPrompt(ime); });
   }
   ime.addEventListener('focus', () => {
     _lazySetupPwdListener();
@@ -337,7 +339,7 @@ export function initIMEInput(): void {
    */
   function _effectiveDock(): 'top' | 'bottom' {
     if (_manualDock) return _dockPosition;
-    const term = appState.terminal;
+    const term = currentSession()?.terminal;
     if (!term) return _dockPosition;
     const cursorY = term.buffer.active.cursorY;
     const rows = term.rows;
@@ -969,9 +971,10 @@ export function initIMEInput(): void {
 
   function _flushScroll(): void {
     _scrollRafId = null;
-    if (_pendingLines !== 0 && appState.terminal) {
+    const flushTerm = currentSession()?.terminal;
+    if (_pendingLines !== 0 && flushTerm) {
       console.log('[scroll] flush scrollLines=', _pendingLines);
-      appState.terminal.scrollLines(_pendingLines);
+      flushTerm.scrollLines(_pendingLines);
       _pendingLines = 0;
     }
     if (_pendingSGR && _pendingSGR.count > 0) {
@@ -1015,14 +1018,15 @@ export function initIMEInput(): void {
     // browser's native scroll/bounce so it doesn't fight our handler.
     if (_isTouchScroll) e.preventDefault();
 
-    if (_isTouchScroll && appState.terminal) {
-      const cellH = Math.max(20, (appState.terminal.options.fontSize ?? 14) * 1.5);
+    const scrollTerm = currentSession()?.terminal;
+    if (_isTouchScroll && scrollTerm) {
+      const cellH = Math.max(20, (scrollTerm.options.fontSize ?? 14) * 1.5);
       const targetLines = Math.round(totalDy / cellH);
       const delta = targetLines - _scrolledLines;
       if (delta !== 0) {
         _scrolledLines = targetLines;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- xterm modes is untyped
-        const termUnk = appState.terminal as unknown as Record<string, unknown>;
+        const termUnk = scrollTerm as unknown as Record<string, unknown>;
         const mouseMode = termUnk.modes &&
           (termUnk.modes as Record<string, unknown>).mouseTrackingMode;
         console.log('[scroll] delta=', delta, 'mouseMode=', mouseMode);
@@ -1035,10 +1039,10 @@ export function initIMEInput(): void {
             ? (delta > 0 ? 65 : 64)
             : (delta > 0 ? 64 : 65);
           const rect = termEl.getBoundingClientRect();
-          const col = Math.max(1, Math.min(appState.terminal.cols,
-            Math.floor((e.touches[0]!.clientX - rect.left) / (rect.width / appState.terminal.cols)) + 1));
-          const row = Math.max(1, Math.min(appState.terminal.rows,
-            Math.floor((e.touches[0]!.clientY - rect.top) / (rect.height / appState.terminal.rows)) + 1));
+          const col = Math.max(1, Math.min(scrollTerm.cols,
+            Math.floor((e.touches[0]!.clientX - rect.left) / (rect.width / scrollTerm.cols)) + 1));
+          const row = Math.max(1, Math.min(scrollTerm.rows,
+            Math.floor((e.touches[0]!.clientY - rect.top) / (rect.height / scrollTerm.rows)) + 1));
           const count = Math.abs(delta);
           if (_pendingSGR?.btn === btn) {
             _pendingSGR.count += count;
@@ -1115,8 +1119,9 @@ export function initIMEInput(): void {
   termEl.addEventListener('touchstart', (e) => {
     if (e.touches.length !== 2 || !_pinchEnabled()) return;
     _pinchStartDist = _pinchDist(e.touches);
-    _pinchStartSize = appState.terminal
-      ? (appState.terminal.options.fontSize ?? 14)
+    const pinchTerm = currentSession()?.terminal;
+    _pinchStartSize = pinchTerm
+      ? (pinchTerm.options.fontSize ?? 14)
       : (parseInt(localStorage.getItem('fontSize') ?? '14') || 14);
     e.preventDefault();
   }, { passive: false });

--- a/src/modules/recording.ts
+++ b/src/modules/recording.ts
@@ -10,7 +10,7 @@
  */
 
 import type { RecordingDeps, AsciicastHeader } from './types.js';
-import { appState } from './state.js';
+import { appState, currentSession } from './state.js';
 
 // Injected dependency — set by initRecording()
 let _toast = (_msg: string): void => {};
@@ -37,13 +37,14 @@ export function stopAndDownloadRecording(): void {
 }
 
 async function _downloadCastFile(): Promise<void> {
+  const session = currentSession();
   const header: AsciicastHeader = {
     version: 2,
-    width: appState.terminal ? appState.terminal.cols : 220,
-    height: appState.terminal ? appState.terminal.rows : 50,
+    width: session?.terminal ? session.terminal.cols : 220,
+    height: session?.terminal ? session.terminal.rows : 50,
     timestamp: Math.floor((appState.recordingStartTime ?? 0) / 1000),
-    title: appState.currentProfile
-      ? `${appState.currentProfile.username}@${appState.currentProfile.host}:${String(appState.currentProfile.port || 22)}`
+    title: session?.profile
+      ? `${session.profile.username}@${session.profile.host}:${String(session.profile.port || 22)}`
       : 'MobiSSH Session',
   };
   const lines = [JSON.stringify(header), ...appState.recordingEvents.map((e) => JSON.stringify(e))].join('\n');

--- a/src/modules/selection.ts
+++ b/src/modules/selection.ts
@@ -15,7 +15,7 @@
  * canvas using the theme's selectionBackground. No DOM overlay.
  */
 
-import { appState } from './state.js';
+import { currentSession } from './state.js';
 import { sendSSHInput } from './connection.js';
 import { toast, focusIME } from './ui.js';
 import { getKeyboardVisible } from './terminal.js';
@@ -141,9 +141,10 @@ export function initSelection(): void {
     if (_selectionLevel === 'unit') {
       // Contract URL/path selection down to just the word at tap position
       const pos = _touchToBufferPos(e.clientX, e.clientY);
-      if (pos && appState.terminal) {
+      const term = currentSession()?.terminal;
+      if (pos && term) {
         const [startCol, startRow, len] = _wordAt(pos.row, pos.col);
-        appState.terminal.select(startCol, startRow, len);
+        term.select(startCol, startRow, len);
         _selectionLevel = 'word';
         return;
       }
@@ -164,16 +165,18 @@ export function initSelection(): void {
 
   document.getElementById('selectionVisibleBtn')!.addEventListener('click', (e) => {
     e.stopPropagation();
-    if (!appState.terminal) return;
-    const buf = appState.terminal.buffer.active;
-    appState.terminal.selectLines(buf.viewportY, buf.viewportY + appState.terminal.rows - 1);
+    const visTerm = currentSession()?.terminal;
+    if (!visTerm) return;
+    const buf = visTerm.buffer.active;
+    visTerm.selectLines(buf.viewportY, buf.viewportY + visTerm.rows - 1);
     _hideChip();
   });
 
   document.getElementById('selectionAllBtn')!.addEventListener('click', (e) => {
     e.stopPropagation();
-    if (!appState.terminal) return;
-    appState.terminal.selectAll();
+    const allTerm = currentSession()?.terminal;
+    if (!allTerm) return;
+    allTerm.selectAll();
     _hideChip();
   });
 
@@ -186,7 +189,7 @@ export function initSelection(): void {
 
   copyBtn.addEventListener('click', (e) => {
     e.stopPropagation();
-    const sel = appState.terminal?.getSelection();
+    const sel = currentSession()?.terminal?.getSelection();
     if (sel) {
       void navigator.clipboard.writeText(sel)
         .then(() => { toast('Copied'); _showPasteIfClipboard(); })
@@ -245,7 +248,7 @@ export function initSelection(): void {
     if (_selectionActive) {
       _selectionActive = false;
       _hideChip();
-      appState.terminal?.clearSelection();
+      currentSession()?.terminal?.clearSelection();
       copyBtn.classList.add('hidden');
       pasteBtn.classList.add('hidden');
       if (_keyboardWasVisible) setTimeout(focusIME, 50);
@@ -279,7 +282,7 @@ export function initSelection(): void {
     _selectionActive = false;
     _dragActive = false;
     _hideChip();
-    appState.terminal?.clearSelection();
+    currentSession()?.terminal?.clearSelection();
     copyBtn.classList.add('hidden');
     pasteBtn.classList.add('hidden');
     // Pop the history entry we pushed (unless back gesture already did it)
@@ -297,7 +300,7 @@ export function initSelection(): void {
 
   /** Convert CSS client coordinates to {col, bufferRow} in the terminal. */
   function _touchToBufferPos(clientX: number, clientY: number): { col: number; row: number } | null {
-    const term = appState.terminal;
+    const term = currentSession()?.terminal;
     if (!term) return null;
     const screen = term.element?.querySelector('.xterm-screen');
     if (!screen) return null;
@@ -317,7 +320,7 @@ export function initSelection(): void {
    * the first buffer row, and the column count per row.
    */
   function _getLogicalLine(bufferRow: number): { text: string; firstRow: number; cols: number } {
-    const term = appState.terminal;
+    const term = currentSession()?.terminal;
     if (!term) return { text: '', firstRow: bufferRow, cols: 1 };
     const buf = term.buffer.active;
     const cols = term.cols;
@@ -347,7 +350,7 @@ export function initSelection(): void {
    * Handles URLs that wrap across multiple terminal rows.
    */
   function _selectableUnitAt(bufferRow: number, col: number): [number, number, number] {
-    const term = appState.terminal;
+    const term = currentSession()?.terminal;
     if (!term) return [col, bufferRow, 1];
 
     // Build the full logical line (joining wrapped rows)
@@ -394,7 +397,7 @@ export function initSelection(): void {
    *  Uses tighter word boundaries that break on URL/path delimiters so
    *  contracting a URL selects a path segment, not the entire URL. */
   function _wordAt(bufferRow: number, col: number): [number, number, number] {
-    const term = appState.terminal;
+    const term = currentSession()?.terminal;
     if (!term) return [col, bufferRow, 1];
     const { text, firstRow, cols } = _getLogicalLine(bufferRow);
     if (!text) return [col, bufferRow, 1];
@@ -415,9 +418,10 @@ export function initSelection(): void {
   /** Word/URL-select at touch position. Called on long-press. */
   function _startDragSelect(clientX: number, clientY: number): void {
     const pos = _touchToBufferPos(clientX, clientY);
-    if (!pos || !appState.terminal) return;
+    const dragTerm = currentSession()?.terminal;
+    if (!pos || !dragTerm) return;
     const [startCol, startRow, len] = _selectableUnitAt(pos.row, pos.col);
-    appState.terminal.select(startCol, startRow, len);
+    dragTerm.select(startCol, startRow, len);
     _selectionLevel = 'unit';
     _anchorCol = pos.col;
     _anchorRow = pos.row;
@@ -426,7 +430,8 @@ export function initSelection(): void {
 
   /** Extend selection from anchor to current touch position. */
   function _extendDragSelect(clientX: number, clientY: number): void {
-    if (!_dragActive || !appState.terminal) return;
+    const extTerm = currentSession()?.terminal;
+    if (!_dragActive || !extTerm) return;
     _hideChip();
     const pos = _touchToBufferPos(clientX, clientY);
     if (!pos) return;
@@ -440,12 +445,12 @@ export function initSelection(): void {
       endCol = pos.col; endRow = pos.row;
     }
     if (startRow === endRow) {
-      appState.terminal.select(startCol, startRow, endCol - startCol + 1);
+      extTerm.select(startCol, startRow, endCol - startCol + 1);
     } else {
       // Multi-line: select from startCol to end of startRow, full middle rows,
       // start of endRow to endCol. Use selectLines for simplicity, then we can
       // refine later if character-level multi-line is needed.
-      appState.terminal.selectLines(startRow, endRow);
+      extTerm.selectLines(startRow, endRow);
     }
   }
 
@@ -460,9 +465,10 @@ export function initSelection(): void {
 // ── Selection watcher ────────────────────────────────────────────────────────
 
 function _watchSelection(copyBtn: HTMLElement): void {
-  if (!appState.terminal) return;
-  appState.terminal.onSelectionChange(() => {
-    const sel = appState.terminal?.getSelection();
+  const watchTerm = currentSession()?.terminal;
+  if (!watchTerm) return;
+  watchTerm.onSelectionChange(() => {
+    const sel = currentSession()?.terminal?.getSelection();
     if (sel) {
       _selectionActive = true;
       copyBtn.classList.remove('hidden');

--- a/src/modules/state.ts
+++ b/src/modules/state.ts
@@ -16,17 +16,6 @@ export const appState: AppState = {
   sessions: new Map<string, SessionState>(),
   activeSessionId: null,
 
-  // Core terminal and connection
-  terminal: null,
-  fitAddon: null,
-  ws: null,
-  _wsConnected: false,
-  sshConnected: false,
-  currentProfile: null,
-  reconnectTimer: null,
-  reconnectDelay: RECONNECT.INITIAL_DELAY_MS,
-  keepAliveTimer: null,
-
   // Input state
   isComposing: false,
   ctrlActive: false,

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -4,7 +4,7 @@
 
 import type { ThemeName, RootCSS } from './types.js';
 import { THEMES, ANSI, FONT_SIZE, escHtml } from './constants.js';
-import { appState } from './state.js';
+import { appState, currentSession, createSession } from './state.js';
 
 interface NotifEntry {
   time: number;
@@ -128,7 +128,11 @@ export function initTerminal(): void {
   const savedFont = localStorage.getItem('termFont') ?? 'monospace';
   const fontFamily = FONT_FAMILIES[savedFont] ?? FONT_FAMILIES.monospace;
 
-  appState.terminal = new Terminal({
+  // Create a lobby session for the welcome terminal
+  const lobby = createSession('lobby');
+  appState.activeSessionId = 'lobby';
+
+  const terminal = new Terminal({
     fontFamily,
     fontSize,
     theme: THEMES[appState.activeThemeName].theme,
@@ -137,17 +141,21 @@ export function initTerminal(): void {
     convertEol: false,
   });
 
-  appState.fitAddon = new FitAddon.FitAddon();
-  appState.terminal.loadAddon(appState.fitAddon);
+  const fitAddon = new FitAddon.FitAddon();
+  terminal.loadAddon(fitAddon);
   if (localStorage.getItem('enableRemoteClipboard') === 'true') {
-    appState.terminal.loadAddon(new ClipboardAddon.ClipboardAddon());
+    terminal.loadAddon(new ClipboardAddon.ClipboardAddon());
   }
-  appState.terminal.open(document.getElementById('terminal')!);
-  appState.fitAddon.fit();
+  terminal.open(document.getElementById('terminal')!);
+  fitAddon.fit();
+
+  lobby.terminal = terminal;
+  lobby.fitAddon = fitAddon;
+
   applyTheme(appState.activeThemeName);
 
-  appState.terminal.onBell(() => {
-    const buffer = appState.terminal!.buffer.active;
+  terminal.onBell(() => {
+    const buffer = terminal.buffer.active;
     let body = 'Terminal bell';
     for (let i = buffer.cursorY; i >= 0; i--) {
       const line = buffer.getLine(i)?.translateToString(true).trim();
@@ -157,14 +165,14 @@ export function initTerminal(): void {
     if (shouldNotify()) fireNotification('MobiSSH', body);
   });
 
-  appState.terminal.parser.registerOscHandler(9, (data: string) => {
+  terminal.parser.registerOscHandler(9, (data: string) => {
     const body = _sanitizeNotifText(data);
     _addNotification(body);
     if (shouldNotify()) fireNotification('MobiSSH', body);
     return true;
   });
 
-  appState.terminal.parser.registerOscHandler(777, (data: string) => {
+  terminal.parser.registerOscHandler(777, (data: string) => {
     const parts = data.split(';');
     if (parts[0] === 'notify') {
       const body = _sanitizeNotifText(parts[2] ?? '');
@@ -192,17 +200,18 @@ export function initTerminal(): void {
 
   // Re-measure character cells after web fonts finish loading (#71)
   void document.fonts.ready.then(() => {
-    if (!appState.terminal || !fontFamily) return;
-    appState.terminal.options.fontFamily = fontFamily;
-    appState.fitAddon?.fit();
+    const t = currentSession()?.terminal;
+    if (!t || !fontFamily) return;
+    t.options.fontFamily = fontFamily;
+    currentSession()?.fitAddon?.fit();
   });
 
   window.addEventListener('resize', handleResize);
 
   // Show welcome banner
-  appState.terminal.writeln(ANSI.bold(ANSI.green('MobiSSH')));
-  appState.terminal.writeln(ANSI.dim('Tap terminal to activate keyboard  •  Use Connect tab to open a session'));
-  appState.terminal.writeln('');
+  terminal.writeln(ANSI.bold(ANSI.green('MobiSSH')));
+  terminal.writeln(ANSI.dim('Tap terminal to activate keyboard  •  Use Connect tab to open a session'));
+  terminal.writeln('');
 }
 
 /**
@@ -317,12 +326,13 @@ function _renderNotifDrawer(): void {
 }
 
 export function handleResize(): void {
-  appState.fitAddon?.fit();
-  if (appState.sshConnected && appState.ws?.readyState === WebSocket.OPEN) {
-    appState.ws.send(JSON.stringify({
+  const session = currentSession();
+  session?.fitAddon?.fit();
+  if (session?.sshConnected && session.ws?.readyState === WebSocket.OPEN) {
+    session.ws.send(JSON.stringify({
       type: 'resize',
-      cols: appState.terminal?.cols ?? 80,
-      rows: appState.terminal?.rows ?? 24,
+      cols: session.terminal?.cols ?? 80,
+      rows: session.terminal?.rows ?? 24,
     }));
   }
 }
@@ -362,11 +372,12 @@ export function initKeyboardAwareness(): void {
       document.documentElement.style.setProperty('--viewport-height', `${String(h)}px`);
     }
 
-    appState.fitAddon?.fit();
-    appState.terminal?.scrollToBottom();
+    const session = currentSession();
+    session?.fitAddon?.fit();
+    session?.terminal?.scrollToBottom();
 
-    if (appState.sshConnected && appState.ws?.readyState === WebSocket.OPEN) {
-      appState.ws.send(JSON.stringify({ type: 'resize', cols: appState.terminal?.cols ?? 80, rows: appState.terminal?.rows ?? 24 }));
+    if (session?.sshConnected && session.ws?.readyState === WebSocket.OPEN) {
+      session.ws.send(JSON.stringify({ type: 'resize', cols: session.terminal?.cols ?? 80, rows: session.terminal?.rows ?? 24 }));
     }
   }
 
@@ -385,11 +396,12 @@ export function applyFontSize(size: number): void {
   const sizeStr = Number.isInteger(size) ? String(size) : size.toFixed(1);
   if (labelEl) labelEl.textContent = `${sizeStr}px`;
   if (menuLabel) menuLabel.textContent = `${sizeStr}px`;
-  if (appState.terminal) {
-    appState.terminal.options.fontSize = size;
-    appState.fitAddon?.fit();
-    if (appState.sshConnected && appState.ws?.readyState === WebSocket.OPEN) {
-      appState.ws.send(JSON.stringify({ type: 'resize', cols: appState.terminal.cols, rows: appState.terminal.rows }));
+  const session = currentSession();
+  if (session?.terminal) {
+    session.terminal.options.fontSize = size;
+    session.fitAddon?.fit();
+    if (session.sshConnected && session.ws?.readyState === WebSocket.OPEN) {
+      session.ws.send(JSON.stringify({ type: 'resize', cols: session.terminal.cols, rows: session.terminal.rows }));
     }
   }
 }
@@ -398,7 +410,8 @@ export function applyTheme(name: string, { persist = false } = {}): void {
   if (!((name as ThemeName) in THEMES)) return;
   const t = THEMES[name as ThemeName];
   appState.activeThemeName = name as ThemeName;
-  if (appState.terminal) appState.terminal.options.theme = t.theme;
+  const term = currentSession()?.terminal;
+  if (term) term.options.theme = t.theme;
   if (persist) localStorage.setItem('termTheme', name);
   const { style } = document.documentElement;
   style.setProperty('--terminal-bg', t.theme.background);

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -94,16 +94,6 @@ export interface AppState {
   // Multi-session infrastructure
   sessions: Map<string, SessionState>;
   activeSessionId: string | null;
-  // Core terminal and connection
-  terminal: Terminal | null;
-  fitAddon: FitAddon.FitAddon | null;
-  ws: WebSocket | null;
-  _wsConnected: boolean;
-  sshConnected: boolean;
-  currentProfile: SSHProfile | null;
-  reconnectTimer: ReturnType<typeof setTimeout> | null;
-  reconnectDelay: number;
-  keepAliveTimer: ReturnType<typeof setInterval> | null;
 
   // Input state
   isComposing: boolean;

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -7,7 +7,7 @@
 
 import type { UIDeps, ConnectionStatus, RootCSS, ThemeName, SftpEntry } from './types.js';
 import { KEY_REPEAT, THEMES, THEME_ORDER, escHtml } from './constants.js';
-import { appState } from './state.js';
+import { appState, currentSession } from './state.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- backward compat: sendSftpUpload kept for legacy callers
 import { sendSSHInput, disconnect, reconnect, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath, uploadFileChunked, sendSftpUploadCancel } from './connection.js';
 import { saveProfile, connectFromProfile, newConnection } from './profiles.js';
@@ -52,7 +52,7 @@ export function navigateToPanel(
   document.getElementById(`panel-${panel}`)?.classList.add('active');
 
   if (panel === 'terminal') {
-    setTimeout(() => { appState.fitAddon?.fit(); focusIME(); }, 50);
+    setTimeout(() => { currentSession()?.fitAddon?.fit(); focusIME(); }, 50);
   }
   // Tab bar stays visible when switching panels -- user needs to navigate
   // between terminal and files. The handle bar toggle still hides/shows it.
@@ -355,7 +355,7 @@ export function initSessionMenu(): void {
 
   menuBtn.addEventListener('click', (e) => {
     e.stopPropagation();
-    if (!appState.sshConnected) return;
+    if (!currentSession()?.sshConnected) return;
     const wasHidden = menu.classList.toggle('hidden');
     backdrop.classList.toggle('hidden', wasHidden);
   });
@@ -409,14 +409,14 @@ export function initSessionMenu(): void {
 
   document.getElementById('sessionResetBtn')!.addEventListener('click', () => {
     closeMenu();
-    if (!appState.sshConnected) return;
+    if (!currentSession()?.sshConnected) return;
     sendSSHInput('\x1bc');
-    appState.terminal?.reset();
+    currentSession()?.terminal?.reset();
   });
 
   document.getElementById('sessionClearBtn')!.addEventListener('click', () => {
     closeMenu();
-    appState.terminal?.clear();
+    currentSession()?.terminal?.clear();
   });
 
 
@@ -744,13 +744,14 @@ export function initTerminalResizeObserver(): void {
   _resizeObserverActive = true;
 
   const observer = new ResizeObserver(() => {
-    appState.fitAddon?.fit();
-    appState.terminal?.scrollToBottom();
-    if (appState.sshConnected && appState.ws?.readyState === WebSocket.OPEN) {
-      appState.ws.send(JSON.stringify({
+    const session = currentSession();
+    session?.fitAddon?.fit();
+    session?.terminal?.scrollToBottom();
+    if (session?.sshConnected && session.ws?.readyState === WebSocket.OPEN) {
+      session.ws.send(JSON.stringify({
         type: 'resize',
-        cols: appState.terminal?.cols ?? 80,
-        rows: appState.terminal?.rows ?? 24,
+        cols: session.terminal?.cols ?? 80,
+        rows: session.terminal?.rows ?? 24,
       }));
     }
   });
@@ -1029,10 +1030,12 @@ function _downloadSelectedFiles(panel: HTMLElement): void {
 /** Wait for WS connection to be open, polling every 500ms up to timeoutMs. */
 function _waitForConnection(timeoutMs: number): Promise<void> {
   return new Promise((resolve, reject) => {
-    if (appState.ws && appState.ws.readyState === WebSocket.OPEN) { resolve(); return; }
+    const ws = currentSession()?.ws;
+    if (ws && ws.readyState === WebSocket.OPEN) { resolve(); return; }
     const start = Date.now();
     const interval = setInterval(() => {
-      if (appState.ws && appState.ws.readyState === WebSocket.OPEN) {
+      const sessionWs = currentSession()?.ws;
+      if (sessionWs && sessionWs.readyState === WebSocket.OPEN) {
         clearInterval(interval);
         resolve();
       } else if (Date.now() - start > timeoutMs) {


### PR DESCRIPTION
## Summary
- Remove 9 mirror fields from `AppState` interface and `appState` object: `terminal`, `fitAddon`, `ws`, `_wsConnected`, `sshConnected`, `currentProfile`, `reconnectTimer`, `reconnectDelay`, `keepAliveTimer`
- Migrate all consumer modules (connection.ts, terminal.ts, ime.ts, selection.ts, recording.ts, ui.ts) to read/write these fields via `currentSession()` instead
- Create a "lobby" session in `initTerminal()` so the welcome screen terminal lives in session state from boot
- Update 3 test files to set state on sessions instead of the now-removed appState mirror fields

## TDD Analysis
- Type: refactor
- Behavior change: no
- TDD approach: existing tests must still pass (no new behavioral tests needed)

## Test coverage
- **Existing tests updated**: `keepalive.test.ts`, `chunked-upload.test.ts`, `visibility-reconnect.test.ts` — all updated to use session-based state
- **New tests added (fail->pass)**: none needed (pure refactor)
- **Smoketest**: 243 existing tests pass

## Test results
- tsc: PASS
- eslint: PASS (1 pre-existing error in ui.ts unrelated to this PR)
- vitest: PASS (24 files, 243 tests)

## Diff stats
- Files changed: 11
- Lines: +295 / -262

Closes #262

## Cycles used
1/3