### PR TITLE
fix: gh-ops.sh integrate handles worktree-held branch deletion

### DIFF
--- a/scripts/gh-ops.sh
+++ b/scripts/gh-ops.sh
@@ -52,7 +52,9 @@ _cleanup_pr_worktree() {
       fi
     done
     git worktree prune 2>/dev/null || true
-    git branch -D "$branch" 2>/dev/null || true
+    if ! git branch -D "$branch" 2>/dev/null; then
+      echo "Skipping local branch deletion — worktree holds it (cleanup deferred to release)" >&2
+    fi
     # Full worktree cleanup deferred to release — prune handles the merged branch
   fi
 }
@@ -247,7 +249,18 @@ case "$CMD" in
 
     # Step 1: Merge PR — worktree cleanup deferred to release (#235)
     echo "==> Merging PR #${PR_NUM} (${STRATEGY#--})" >&2
-    gh pr merge "$PR_NUM" "$STRATEGY" --delete-branch
+    MERGE_ERR=""
+    if ! MERGE_ERR=$(gh pr merge "$PR_NUM" "$STRATEGY" --delete-branch 2>&1); then
+      case "$MERGE_ERR" in
+        *"used by worktree"*)
+          echo "Skipping local branch deletion — worktree holds it (cleanup deferred to release)" >&2
+          ;;
+        *)
+          echo "$MERGE_ERR" >&2
+          exit 1
+          ;;
+      esac
+    fi
 
     # Step 2: Close issue
     echo "==> Closing issue #${ISSUE_NUM}" >&2


### PR DESCRIPTION
## Summary
- Catch "used by worktree" errors in `_cleanup_pr_worktree` and `integrate` subcommand so local branch deletion failure doesn't cause a non-zero exit
- Log a descriptive message ("Skipping local branch deletion -- worktree holds it (cleanup deferred to release)") instead of silently swallowing or fatally exiting
- Real merge failures still exit non-zero

## TDD Analysis
- Type: bug fix
- Behavior change: no
- TDD approach: exploratory (shell script, hard to unit test)

## Test coverage
- **Existing tests updated**: none needed
- **New tests added**: none (shell script error handling; verified via syntax check and manual review)
- **Smoketest**: `bash -n scripts/gh-ops.sh` passes

## Test results
- tsc: N/A (shell script only)
- eslint: N/A (shell script only)
- vitest: N/A (shell script only)
- bash -n: PASS

## Diff stats
- Files changed: 1
- Lines: +15 / -2

Closes #273

## Cycles used
1/3