### PR TITLE
feat: per-session theme persistence (#104)

### DIFF
--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -423,7 +423,6 @@ export async function connect(profile: SSHProfile): Promise<void> {
   const session = createSession(sessionId);
   session.profile = profile;
   session.reconnectDelay = RECONNECT.INITIAL_DELAY_MS;
-  session.activeThemeName = appState.activeThemeName;
   appState.activeSessionId = sessionId;
 
   // Create per-session terminal instance (#261)

--- a/src/modules/state.ts
+++ b/src/modules/state.ts
@@ -47,9 +47,14 @@ export function currentSession(): SessionState | undefined {
 }
 
 export function createSession(id: string): SessionState {
+  let _profile: SessionState['profile'] = null;
   const session: SessionState = {
     id,
-    profile: null,
+    get profile() { return _profile; },
+    set profile(p: SessionState['profile']) {
+      _profile = p;
+      if (p?.theme) session.activeThemeName = p.theme;
+    },
     terminal: null,
     fitAddon: null,
     ws: null,

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -8,6 +8,7 @@
 import type { UIDeps, ConnectionStatus, RootCSS, ThemeName, SftpEntry } from './types.js';
 import { KEY_REPEAT, THEMES, THEME_ORDER, escHtml } from './constants.js';
 import { appState, currentSession } from './state.js';
+import { applyTheme } from './terminal.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- backward compat: sendSftpUpload kept for legacy callers
 import { sendSSHInput, disconnect, reconnect, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath, uploadFileChunked, sendSftpUploadCancel } from './connection.js';
 import { saveProfile, connectFromProfile, newConnection } from './profiles.js';
@@ -268,6 +269,9 @@ export function switchSession(id: string): void {
   document.querySelectorAll<HTMLElement>('[data-session-id]').forEach((el) => {
     el.classList.toggle('hidden', el.dataset.sessionId !== id);
   });
+
+  // Restore per-session theme (#104)
+  applyTheme(session.activeThemeName);
 
   // Fit the newly visible terminal
   session.fitAddon?.fit();


### PR DESCRIPTION
## Summary
- Session's `activeThemeName` is now auto-set from `profile.theme` when a profile is assigned (via property setter on SessionState)
- `switchSession()` calls `applyTheme(session.activeThemeName)` to restore the theme when switching between sessions
- Removed redundant `session.activeThemeName = appState.activeThemeName` in `connect()` since `createSession` already initializes it and the profile setter overrides when needed

## TDD Analysis
- Type: feature
- Behavior change: yes
- TDD approach: full (tests pre-existed as red baseline)

## Test coverage
- **Existing tests updated**: none needed
- **New tests added (fail-to-pass)**: 5 tests in `session-theme.test.ts` went from fail to pass
- **Smoketest**: theme applied on connect, theme restored on switch, applyTheme called on switchSession

## Test results
- tsc: PASS
- eslint: PASS
- vitest: PASS (276 tests, 0 new — all pre-existing)

## Diff stats
- Files changed: 3
- Lines: +10 / -2

Closes #104

## Cycles used
1/3