### PR TITLE
feat: session lifecycle state machine (#286)

### DIFF
--- a/src/modules/state.ts
+++ b/src/modules/state.ts
@@ -7,9 +7,22 @@
  * without relying on shared global scope.
  */
 
-import type { AppState, SessionState } from './types.js';
+import type { AppState, SessionState, SessionLifecycleState } from './types.js';
 import { RECONNECT } from './constants.js';
 import { DEFAULT_KEY_BAR_CONFIG } from './keybar-config.js';
+
+/** Valid transitions for the session lifecycle state machine. */
+const VALID_TRANSITIONS: Record<SessionLifecycleState, readonly SessionLifecycleState[]> = {
+  idle: ['connecting', 'closed'],
+  connecting: ['authenticating', 'failed', 'closed'],
+  authenticating: ['connected', 'failed', 'closed'],
+  connected: ['soft_disconnected', 'disconnected', 'closed'],
+  soft_disconnected: ['reconnecting', 'disconnected', 'closed'],
+  reconnecting: ['authenticating', 'connected', 'failed', 'closed'],
+  failed: ['closed'],
+  disconnected: ['closed'],
+  closed: [],
+};
 
 export const appState: AppState = {
   // Multi-session infrastructure
@@ -50,6 +63,7 @@ export function createSession(id: string): SessionState {
   let _profile: SessionState['profile'] = null;
   const session: SessionState = {
     id,
+    state: 'idle',
     get profile() { return _profile; },
     set profile(p: SessionState['profile']) {
       _profile = p;
@@ -68,4 +82,29 @@ export function createSession(id: string): SessionState {
   };
   appState.sessions.set(id, session);
   return session;
+}
+
+/**
+ * Transition a session to a new lifecycle state.
+ * Throws if the session doesn't exist or the transition is invalid.
+ * Removes the session from the map when transitioning to 'closed'.
+ */
+export function transitionSession(id: string, targetState: SessionLifecycleState): void {
+  const session = appState.sessions.get(id);
+  if (!session) {
+    throw new Error(`Session "${id}" not found`);
+  }
+
+  const allowed = VALID_TRANSITIONS[session.state];
+  if (!allowed.includes(targetState)) {
+    throw new Error(
+      `Invalid transition: "${session.state}" -> "${targetState}" for session "${id}"`,
+    );
+  }
+
+  session.state = targetState;
+
+  if (targetState === 'closed') {
+    appState.sessions.delete(id);
+  }
 }

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -44,6 +44,17 @@ export interface VaultMeta {
 
 export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected';
 
+export type SessionLifecycleState =
+  | 'idle'
+  | 'connecting'
+  | 'authenticating'
+  | 'connected'
+  | 'soft_disconnected'
+  | 'reconnecting'
+  | 'disconnected'
+  | 'failed'
+  | 'closed';
+
 // ── Terminal theme ──────────────────────────────────────────────────────────
 
 export interface TerminalTheme {
@@ -75,6 +86,7 @@ export interface ThemeEntry {
 
 export interface SessionState {
   id: string;
+  state: SessionLifecycleState;
   profile: SSHProfile | null;
   terminal: Terminal | null;
   fitAddon: FitAddon.FitAddon | null;


### PR DESCRIPTION
## Summary
- Add `SessionLifecycleState` string union type to `types.ts`
- Add `state` field to `SessionState` interface, initialized to `'idle'` in `createSession()`
- Export `transitionSession(id, targetState)` from `state.ts` with validated transition graph
- Sessions are removed from the map when transitioned to `'closed'`

Phase 1 only: existing boolean fields (`wsConnected`, `sshConnected`) are unchanged. Integration with `connection.ts` is a separate issue.

## Test plan
- [x] All 22 session-lifecycle tests pass
- [x] Full suite (329 tests) passes with no regressions

Closes #286