### PR TITLE
fix: reposition action bar after history navigation

### DIFF
--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -308,6 +308,7 @@ export function initIMEInput(): void {
     if (text !== null) {
       ime.value = text;
       _autoResizeTextarea(ime);
+      _positionIME();
       if (_imeState === 'idle') _transition('previewing');
       _cancelTimers();
       if ('vibrate' in navigator) navigator.vibrate(10);


### PR DESCRIPTION
## Summary
- Add missing `_positionIME()` call after `_autoResizeTextarea()` in `_loadHistoryEntry()` so the action bar repositions when history navigation changes textarea height

## Test plan
- [ ] Open IME preview mode on mobile
- [ ] Type several commands of different lengths and send them (builds history)
- [ ] Use history buttons to navigate — verify action bar follows textarea size changes
- [ ] Test in all dock positions (hover-top, hover-bottom, cursor-follow, dock-above, dock-below)

Closes #265