### PR TITLE
fix: prevent zombie session after failed reconnect (#341)

### DIFF
--- a/src/modules/__tests__/zombie-session.test.ts
+++ b/src/modules/__tests__/zombie-session.test.ts
@@ -1,0 +1,99 @@
+/**
+ * TDD tests for zombie session after failed reconnect (#341).
+ *
+ * Three bugs:
+ * 1. switchSession doesn't call focusIME — survivor has no input
+ * 2. closeSession bypasses state machine — skips AbortController abort
+ * 3. _openWebSocket relies on activeSessionId instead of explicit sessionId
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const uiSrc = readFileSync(resolve(__dirname, '../ui.ts'), 'utf-8');
+const connectionSrc = readFileSync(resolve(__dirname, '../connection.ts'), 'utf-8');
+
+/** Extract a function body from source, handling type annotations. */
+function extractFnBody(src: string, fnName: string): string {
+  const fnStart = src.indexOf(fnName);
+  if (fnStart === -1) return '';
+  const sigEnd = src.indexOf('{', src.indexOf(')', fnStart));
+  if (sigEnd === -1) return '';
+  let depth = 0, fnEnd = sigEnd;
+  for (let i = sigEnd; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    if (src[i] === '}') depth--;
+    if (depth === 0) { fnEnd = i + 1; break; }
+  }
+  return src.slice(fnStart, fnEnd);
+}
+
+describe('Zombie session prevention (#341)', () => {
+
+  // ── Bug 1: switchSession must call focusIME ──
+
+  describe('switchSession calls focusIME', () => {
+    it('switchSession function body contains focusIME call', () => {
+      const body = extractFnBody(uiSrc, 'function switchSession');
+      expect(body.length).toBeGreaterThan(50);
+      expect(body).toContain('focusIME');
+    });
+  });
+
+  // ── Bug 2: closeSession must use transitionSession, not sessions.delete ──
+
+  describe('closeSession uses state machine', () => {
+    it('closeSession does NOT directly call sessions.delete', () => {
+      const body = extractFnBody(uiSrc, 'function closeSession');
+      expect(body.length).toBeGreaterThan(50);
+      // Should not have direct map deletion
+      expect(body).not.toMatch(/sessions\.delete\s*\(/);
+      expect(body).not.toMatch(/appState\.sessions\.delete\s*\(/);
+    });
+
+    it('closeSession calls transitionSession to closed', () => {
+      const body = extractFnBody(uiSrc, 'function closeSession');
+      expect(body.length).toBeGreaterThan(50);
+      expect(body).toMatch(/transitionSession\s*\(/);
+      expect(body).toContain("'closed'");
+    });
+  });
+
+  // ── Bug 3: _openWebSocket takes explicit sessionId ──
+
+  describe('_openWebSocket uses explicit sessionId', () => {
+    it('_openWebSocket accepts sessionId parameter', () => {
+      // The function signature should accept sessionId, not rely on currentSession()
+      const fnStart = connectionSrc.indexOf('function _openWebSocket');
+      expect(fnStart).toBeGreaterThan(-1);
+      const sigEnd = connectionSrc.indexOf(')', fnStart);
+      const signature = connectionSrc.slice(fnStart, sigEnd + 1);
+      expect(signature).toMatch(/sessionId|session_id|sid/i);
+    });
+
+    it('_openWebSocket does not call currentSession() for its main session reference', () => {
+      const body = extractFnBody(connectionSrc, 'function _openWebSocket');
+      expect(body.length).toBeGreaterThan(100);
+      // Should not use currentSession() to get the session it operates on.
+      // It may still use currentSession() in callbacks for the ACTIVE session,
+      // but the primary session variable should come from the parameter.
+      // Check that `let session = currentSession()` or `const session = currentSession()`
+      // at the top of the function is gone.
+      expect(body).not.toMatch(/(?:let|const)\s+session\s*=\s*currentSession\s*\(\s*\)/);
+    });
+
+    it('visibilitychange handler passes sessionId to _openWebSocket', () => {
+      // The visibilitychange handler should pass the session id explicitly
+      // instead of mutating appState.activeSessionId
+      const visStart = connectionSrc.indexOf('visibilitychange');
+      expect(visStart).toBeGreaterThan(-1);
+      const visBlock = connectionSrc.slice(visStart, visStart + 800);
+      // Should pass sid/sessionId to _openWebSocket, not rely on activeSessionId swap
+      const passesId = visBlock.includes('_openWebSocket(') &&
+        (visBlock.match(/_openWebSocket\s*\(\s*\{[^}]*sessionId/s) ||
+         visBlock.match(/_openWebSocket\s*\(\s*sid/) ||
+         visBlock.match(/_openWebSocket\s*\([^)]*sid[^)]*\)/));
+      expect(passesId).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -454,10 +454,10 @@ export async function connect(profile: SSHProfile): Promise<void> {
   _openWebSocket();
 }
 
-function _openWebSocket(options?: { silent?: boolean }): void {
+function _openWebSocket(options?: { silent?: boolean; sessionId?: string }): void {
   const silent = options?.silent ?? false;
-  const sessionId = appState.activeSessionId ?? '';
-  const session = currentSession();
+  const sessionId = options?.sessionId ?? appState.activeSessionId ?? '';
+  const session = appState.sessions.get(sessionId) ?? null;
 
   // User-initiated connections navigate to terminal once SSH is established (#309)
   if (!silent && sessionId) _pendingNavigateSessions.add(sessionId);
@@ -700,7 +700,7 @@ function _openWebSocket(options?: { silent?: boolean }): void {
     if (!event.wasClean) {
       if (document.visibilityState === 'visible') {
         _toast('Reconnecting…');
-        _openWebSocket({ silent: true });
+        _openWebSocket({ silent: true, sessionId });
       } else {
         scheduleReconnect();
       }
@@ -715,20 +715,21 @@ function _openWebSocket(options?: { silent?: boolean }): void {
 export function scheduleReconnect(): void {
   const session = currentSession();
   if (!session?.profile) return;
+  const sid = appState.activeSessionId ?? '';
 
   const delaySec = Math.round(session.reconnectDelay / 1000);
   _toast(`Reconnecting in ${String(delaySec)}s…`);
   _setStatus('connecting', `Reconnecting in ${String(delaySec)}s…`);
 
   session.reconnectTimer = setTimeout(() => {
-    const s = currentSession();
+    const s = appState.sessions.get(sid);
     if (s) {
       s.reconnectDelay = Math.min(
         s.reconnectDelay * RECONNECT.BACKOFF_FACTOR,
         RECONNECT.MAX_DELAY_MS
       );
     }
-    _openWebSocket({ silent: true });
+    _openWebSocket({ silent: true, sessionId: sid });
   }, session.reconnectDelay);
 }
 
@@ -867,19 +868,17 @@ document.addEventListener('visibilitychange', () => {
     for (const [sid, session] of appState.sessions) {
       if (!session.profile) continue;
       if (!session.ws || session.ws.readyState !== WebSocket.OPEN) {
-        // Temporarily set active so _openWebSocket targets this session
-        appState.activeSessionId = sid;
         cancelReconnect();
-        _openWebSocket({ silent: true });
+        _openWebSocket({ silent: true, sessionId: sid });
         reconnected = true;
       } else {
         // WS is open — probe for zombie connection
+        const prevActive = appState.activeSessionId;
         appState.activeSessionId = sid;
         _probeZombieConnection();
+        appState.activeSessionId = prevActive;
       }
     }
-    // Restore the session the user was viewing
-    appState.activeSessionId = savedActiveId;
     if (reconnected) _toast('Reconnecting sessions…');
   } else {
     releaseWakeLock();

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -7,7 +7,7 @@
 
 import type { UIDeps, ConnectionStatus, RootCSS, ThemeName, SftpEntry } from './types.js';
 import { KEY_REPEAT, THEMES, THEME_ORDER, escHtml } from './constants.js';
-import { appState, currentSession, isSessionConnected, onStateChange } from './state.js';
+import { appState, currentSession, isSessionConnected, onStateChange, transitionSession } from './state.js';
 import { applyTheme } from './terminal.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- backward compat: sendSftpUpload kept for legacy callers
 import { sendSSHInput, disconnect, reconnect, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath, uploadFileChunked, sendSftpUploadCancel } from './connection.js';
@@ -313,6 +313,9 @@ export function switchSession(id: string): void {
 
   // Re-render session list to update active indicator
   renderSessionList();
+
+  // Restore IME focus so keyboard input reaches the session (#341)
+  focusIME();
 }
 
 export function closeSession(id: string): void {
@@ -321,20 +324,17 @@ export function closeSession(id: string): void {
 
   if (isSessionConnected(session)) {
     if (!confirm('Disconnect and close this session?')) return;
-    // Disconnect: close the WebSocket
-    try { session.ws?.close(); } catch { /* ignore */ }
   }
 
-  // Clean up timers
-  if (session.reconnectTimer) clearTimeout(session.reconnectTimer);
-  if (session.keepAliveTimer) clearInterval(session.keepAliveTimer);
-  session.keepAliveWorker?.terminate();
+  // Transition through state machine — handles WS close, AbortController abort,
+  // timer cleanup, terminal dispose via the 'closed' effect (#341)
+  if (session.state !== 'closed') {
+    transitionSession(id, 'closed');
+  }
 
   // Remove terminal DOM container
   const termContainer = document.querySelector<HTMLElement>(`#terminal [data-session-id="${CSS.escape(id)}"]`);
   termContainer?.remove();
-
-  appState.sessions.delete(id);
 
   // If we just closed the active session, switch to another or go to Connect
   if (appState.activeSessionId === id) {


### PR DESCRIPTION
switchSession calls focusIME, closeSession uses transitionSession('closed'), _openWebSocket accepts explicit sessionId. 6 TDD tests green. Closes #341