### PR TITLE
fix: guard fit() against hidden/zero-height containers (#316)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MobiSSH -- Claude Code Context
 
-> **Active TRACE**: `.traces/trace-multi-session-isolation-011716/` — per-session terminal + mirror state removal
+> **Active TRACE**: `.traces/trace-session-dock-revert-triage-20260326-025645/` — dock revert, state machine migration, session lifecycle fixes
 
 ## Command Hygiene (read this first)
 - **One script per Bash call.** No `&&` chains, no `;` sequences, no compound commands.

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -295,8 +295,16 @@ function _renderNotifDrawer(): void {
 
 export function handleResize(): void {
   const session = currentSession();
-  session?.fitAddon?.fit();
-  if (session && isSessionConnected(session) && session.ws?.readyState === WebSocket.OPEN) {
+  if (!session) return;
+  // Only fit if the session's terminal container is visible and has dimensions.
+  // Background sessions receive resize events (keyboard show/hide) but fitting
+  // them gives zero dimensions that persist when switching back (#316).
+  const container = document.querySelector<HTMLElement>(
+    `#terminal [data-session-id="${CSS.escape(session.id)}"]`
+  );
+  if (!container || container.offsetHeight === 0) return;
+  session.fitAddon?.fit();
+  if (isSessionConnected(session) && session.ws?.readyState === WebSocket.OPEN) {
     session.ws.send(JSON.stringify({
       type: 'resize',
       cols: session.terminal?.cols ?? 80,
@@ -341,7 +349,11 @@ export function initKeyboardAwareness(): void {
     }
 
     const session = currentSession();
-    session?.fitAddon?.fit();
+    // Guard: only fit if session container is visible (#316)
+    if (session) {
+      const c = document.querySelector<HTMLElement>(`#terminal [data-session-id="${CSS.escape(session.id)}"]`);
+      if (c && c.offsetHeight > 0) session.fitAddon?.fit();
+    }
     session?.terminal?.scrollToBottom();
 
     if (session && isSessionConnected(session) && session.ws?.readyState === WebSocket.OPEN) {

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -287,19 +287,28 @@ export function switchSession(id: string): void {
   }
 
   // Fit the newly visible terminal and sync dimensions to server.
-  // Use rAF to ensure the browser has laid out the now-visible container
-  // before measuring — fit() on a just-unhidden element can return stale
-  // zero dimensions. (#312)
-  requestAnimationFrame(() => {
-    session.fitAddon?.fit();
-    if (isSessionConnected(session) && session.ws?.readyState === WebSocket.OPEN) {
-      session.ws.send(JSON.stringify({
-        type: 'resize',
-        cols: session.terminal?.cols ?? 80,
-        rows: session.terminal?.rows ?? 24,
-      }));
+  // A single rAF isn't sufficient — the browser may not have completed layout
+  // for the just-unhidden container by the next frame, especially on mobile
+  // where keyboard adjustments delay layout. Use double-rAF + fallback. (#316)
+  const fitAndResize = (): void => {
+    if (!session.fitAddon || !session.terminal) return;
+    const container = document.querySelector<HTMLElement>(`#terminal [data-session-id="${CSS.escape(session.id)}"]`);
+    if (container && container.offsetHeight > 0) {
+      session.fitAddon.fit();
+      if (isSessionConnected(session) && session.ws?.readyState === WebSocket.OPEN) {
+        session.ws.send(JSON.stringify({
+          type: 'resize',
+          cols: session.terminal.cols ?? 80,
+          rows: session.terminal.rows ?? 24,
+        }));
+      }
+    } else {
+      // Container still has zero height — try again next frame
+      requestAnimationFrame(fitAndResize);
     }
-  });
+  };
+  // Double-rAF: first frame for layout, second for measurement
+  requestAnimationFrame(() => requestAnimationFrame(fitAndResize));
 
   // Update session menu button text
   const btn = document.getElementById('sessionMenuBtn');


### PR DESCRIPTION
Double-rAF retry in switchSession, zero-height guard in handleResize and visualViewport handler. Prevents background sessions from getting zero-dimension fits. Closes #316