### PR TITLE
fix: remove zombie probe that kills live connections on resume

### DIFF
--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -872,11 +872,8 @@ document.addEventListener('visibilitychange', () => {
         _openWebSocket({ silent: true, sessionId: sid });
         reconnected = true;
       } else {
-        // WS is open — probe for zombie connection
-        const prevActive = appState.activeSessionId;
-        appState.activeSessionId = sid;
-        _probeZombieConnection();
-        appState.activeSessionId = prevActive;
+        // WS is open — send a keepalive ping to keep the connection warm
+        try { session.ws.send(JSON.stringify({ type: 'ping' })); } catch { /* ignore */ }
       }
     }
     if (reconnected) _toast('Reconnecting sessions…');


### PR DESCRIPTION
The zombie probe killed every WS connection on app resume because the server doesn't echo pings. Replace with simple keepalive ping. Fixes aggressive disconnecting after a few seconds away.