### PR TITLE
feat: profile backup — encrypted import/export

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -692,6 +692,13 @@
         <button id="resetAppBtn" class="danger-btn">Reset app (clears all data &amp; cache)</button>
       </div>
 
+      <div class="settings-section">
+        <h3 class="settings-section-title">Backup</h3>
+        <button id="exportBackupBtn" class="secondary-btn">Download Backup</button>
+        <button id="importBackupBtn" class="secondary-btn">Import Backup</button>
+        <input type="file" id="importBackupFile" accept=".json" hidden>
+      </div>
+
       <p id="versionInfo" class="version-info"></p>
     </div>
   </div>

--- a/src/modules/__tests__/backup.test.ts
+++ b/src/modules/__tests__/backup.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock localStorage before importing modules
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+};
+vi.stubGlobal('localStorage', localStorageMock);
+vi.stubGlobal('location', { hostname: 'localhost', host: 'localhost:8081', reload: vi.fn() });
+
+let lastCreatedElement: Record<string, unknown> = {};
+vi.stubGlobal('document', {
+  getElementById: () => null,
+  querySelector: () => null,
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  documentElement: {
+    style: { setProperty: vi.fn() },
+    dataset: {},
+    classList: { toggle: vi.fn(), add: vi.fn(), remove: vi.fn() },
+  },
+  createElement: vi.fn(() => {
+    lastCreatedElement = {
+      href: '',
+      download: '',
+      click: vi.fn(),
+      className: '',
+      textContent: '',
+      innerHTML: '',
+      appendChild: vi.fn(),
+      addEventListener: vi.fn(),
+      querySelector: vi.fn(),
+    };
+    return lastCreatedElement;
+  }),
+  fonts: { ready: Promise.resolve() },
+  body: { appendChild: vi.fn(), removeChild: vi.fn(), classList: { add: vi.fn(), remove: vi.fn(), toggle: vi.fn() } },
+});
+
+vi.stubGlobal('window', {
+  addEventListener: vi.fn(),
+  visualViewport: null,
+  outerHeight: 900,
+});
+
+vi.stubGlobal('Notification', { permission: 'granted' });
+vi.stubGlobal('getComputedStyle', () => ({ getPropertyValue: () => '' }));
+let lastBlobParts: unknown[] = [];
+vi.stubGlobal('Blob', class {
+  parts: unknown[];
+  constructor(parts: unknown[]) { this.parts = parts; lastBlobParts = parts; }
+});
+
+// Keep real URL constructor but add blob methods
+const RealURL = globalThis.URL;
+vi.stubGlobal('URL', Object.assign(
+  function UrlShim(...args: ConstructorParameters<typeof RealURL>) { return new RealURL(...args); },
+  {
+    prototype: RealURL.prototype,
+    createObjectURL: vi.fn(() => 'blob:test'),
+    revokeObjectURL: vi.fn(),
+  }
+));
+
+let toastMessages: string[] = [];
+const { exportBackup, importBackup } = await import('../settings.js');
+const { initSettings } = await import('../settings.js');
+initSettings({
+  toast: (msg: string) => { toastMessages.push(msg); },
+  applyFontSize: vi.fn(),
+  applyTheme: vi.fn(),
+});
+
+describe('backup export (#337)', () => {
+  beforeEach(() => {
+    storage.clear();
+    toastMessages = [];
+    lastBlobParts = [];
+  });
+
+  it('produces valid JSON with version, profiles, and vault fields', () => {
+    storage.set('sshProfiles', JSON.stringify([
+      { name: 'test', host: 'example.com', port: 22, username: 'user', authType: 'password', vaultId: 'v1', initialCommand: '' },
+    ]));
+    storage.set('sshVault', '{"v1":{"iv":"abc","ct":"def"}}');
+    storage.set('vaultMeta', '{"salt":"xyz","dekPw":{"iv":"a","ct":"b"}}');
+
+    exportBackup();
+
+    const jsonStr = lastBlobParts[0] as string;
+    const parsed = JSON.parse(jsonStr);
+    expect(parsed.version).toBe(1);
+    expect(parsed.exported).toBeDefined();
+    expect(parsed.profiles).toHaveLength(1);
+    expect(parsed.profiles[0].host).toBe('example.com');
+    expect(parsed.vault.encrypted).toBe('{"v1":{"iv":"abc","ct":"def"}}');
+    expect(parsed.vault.meta).toBe('{"salt":"xyz","dekPw":{"iv":"a","ct":"b"}}');
+  });
+
+  it('exports empty profiles array when no profiles exist', () => {
+    exportBackup();
+
+    const jsonStr = lastBlobParts[0] as string;
+    const parsed = JSON.parse(jsonStr);
+    expect(parsed.profiles).toEqual([]);
+    expect(parsed.version).toBe(1);
+  });
+
+  it('triggers file download with correct filename', () => {
+    exportBackup();
+    expect(lastCreatedElement.download).toMatch(/^mobissh-backup-\d{4}-\d{2}-\d{2}\.json$/);
+    expect((lastCreatedElement.click as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+});
+
+describe('backup import (#337)', () => {
+  beforeEach(() => {
+    storage.clear();
+    toastMessages = [];
+  });
+
+  it('imports profiles via upsert (no duplicates)', async () => {
+    storage.set('sshProfiles', JSON.stringify([
+      { name: 'existing', host: 'a.com', port: 22, username: 'root', authType: 'password', vaultId: 'v1', initialCommand: '' },
+    ]));
+
+    const backup = {
+      version: 1,
+      exported: '2026-03-27T00:00:00Z',
+      profiles: [
+        { name: 'updated', host: 'a.com', port: 22, username: 'root', authType: 'key', vaultId: 'v2', initialCommand: '' },
+        { name: 'new', host: 'b.com', port: 22, username: 'admin', authType: 'password', vaultId: 'v3', initialCommand: '' },
+      ],
+      vault: { encrypted: null, meta: null },
+    };
+    const file = { text: () => Promise.resolve(JSON.stringify(backup)) } as unknown as File;
+
+    await importBackup(file);
+
+    const profiles = JSON.parse(storage.get('sshProfiles')!);
+    expect(profiles).toHaveLength(2);
+    expect(profiles[0].name).toBe('updated');
+    expect(profiles[1].name).toBe('new');
+  });
+
+  it('shows error toast on invalid JSON', async () => {
+    const file = { text: () => Promise.resolve('not json{{{') } as unknown as File;
+    await importBackup(file);
+    expect(toastMessages).toContain('Invalid backup file — not valid JSON.');
+  });
+
+  it('shows error toast on unsupported version', async () => {
+    const backup = { version: 99, profiles: [], vault: { encrypted: null, meta: null } };
+    const file = { text: () => Promise.resolve(JSON.stringify(backup)) } as unknown as File;
+    await importBackup(file);
+    expect(toastMessages[0]).toMatch(/Unsupported backup version/);
+  });
+
+  it('imports vault encrypted blob without decrypting', async () => {
+    const vaultBlob = '{"v1":{"iv":"abc","ct":"def"}}';
+    const vaultMeta = '{"salt":"xyz","dekPw":{"iv":"a","ct":"b"}}';
+    const backup = {
+      version: 1,
+      exported: '2026-03-27T00:00:00Z',
+      profiles: [],
+      vault: { encrypted: vaultBlob, meta: vaultMeta },
+    };
+    const file = { text: () => Promise.resolve(JSON.stringify(backup)) } as unknown as File;
+
+    await importBackup(file);
+
+    expect(storage.get('sshVault')).toBe(vaultBlob);
+    expect(storage.get('vaultMeta')).toBe(vaultMeta);
+  });
+
+  it('shows summary toast with profile count', async () => {
+    const backup = {
+      version: 1,
+      exported: '2026-03-27T00:00:00Z',
+      profiles: [
+        { name: 'srv1', host: 'a.com', port: 22, username: 'root', authType: 'password', vaultId: 'v1', initialCommand: '' },
+        { name: 'srv2', host: 'b.com', port: 22, username: 'admin', authType: 'password', vaultId: 'v2', initialCommand: '' },
+      ],
+      vault: { encrypted: '{"data":"enc"}', meta: null },
+    };
+    const file = { text: () => Promise.resolve(JSON.stringify(backup)) } as unknown as File;
+
+    await importBackup(file);
+
+    expect(toastMessages[0]).toMatch(/Imported 2 profiles/);
+    expect(toastMessages[0]).toMatch(/credentials imported/);
+  });
+});

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -11,6 +11,7 @@ import { resetKeyBarConfig } from './keybar-config.js';
 import type { ThemeName } from './types.js';
 import { showErrorDialog } from './ui.js';
 import { getPreviewTimeout, setPreviewTimeout, getPreviewIdleDelay, setPreviewIdleDelay } from './ime.js';
+import { getProfiles } from './profiles.js';
 
 
 /** Declarative schema for validatable localStorage keys. */
@@ -301,12 +302,130 @@ export function initSettingsPanel(): void {
     void clearCacheAndReload();
   });
 
+  document.getElementById('exportBackupBtn')?.addEventListener('click', () => {
+    exportBackup();
+  });
+
+  const importBtn = document.getElementById('importBackupBtn');
+  const importFile = document.getElementById('importBackupFile') as HTMLInputElement | null;
+  if (importBtn && importFile) {
+    importBtn.addEventListener('click', () => { importFile.click(); });
+    importFile.addEventListener('change', () => {
+      const file = importFile.files?.[0];
+      if (file) void importBackup(file);
+      importFile.value = '';
+    });
+  }
+
   const versionEl = document.getElementById('versionInfo');
   const versionMeta = document.querySelector<HTMLMetaElement>('meta[name="app-version"]');
   if (versionEl && versionMeta?.content) {
     const [version, hash] = versionMeta.content.split(':');
     versionEl.textContent = `MobiSSH v${version ?? '?'} \u00b7 ${hash ?? '?'}`;
   }
+}
+
+// Backup export/import
+
+const BACKUP_VERSION = 1;
+
+interface BackupFile {
+  version: number;
+  exported: string;
+  profiles: unknown[];
+  vault?: {
+    encrypted: string | null;
+    meta: string | null;
+  };
+}
+
+export function exportBackup(): void {
+  const profiles = getProfiles();
+  const vaultData = localStorage.getItem('sshVault');
+  const vaultMeta = localStorage.getItem('vaultMeta');
+
+  const backup: BackupFile = {
+    version: BACKUP_VERSION,
+    exported: new Date().toISOString(),
+    profiles,
+    vault: {
+      encrypted: vaultData,
+      meta: vaultMeta,
+    },
+  };
+
+  const blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  const date = new Date().toISOString().slice(0, 10);
+  a.download = `mobissh-backup-${date}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+  _toast(`Exported ${String(profiles.length)} profiles.`);
+}
+
+export async function importBackup(file: File): Promise<void> {
+  let text: string;
+  try {
+    text = await file.text();
+  } catch {
+    _toast('Failed to read backup file.');
+    return;
+  }
+
+  let backup: BackupFile;
+  try {
+    backup = JSON.parse(text) as BackupFile;
+  } catch {
+    _toast('Invalid backup file — not valid JSON.');
+    return;
+  }
+
+  if (typeof backup.version !== 'number' || backup.version > BACKUP_VERSION) {
+    _toast(`Unsupported backup version: ${String(backup.version)}`);
+    return;
+  }
+
+  if (!Array.isArray(backup.profiles)) {
+    _toast('Invalid backup file — missing profiles.');
+    return;
+  }
+
+  // Upsert profiles (match on host+port+username)
+  const existing = getProfiles();
+  let imported = 0;
+  for (const p of backup.profiles) {
+    const profile = p as { host?: string; port?: number; username?: string };
+    if (!profile.host || !profile.username) continue;
+    const idx = existing.findIndex(
+      (e) => e.host === profile.host &&
+             String(e.port || 22) === String(profile.port || 22) &&
+             e.username === profile.username
+    );
+    if (idx >= 0) {
+      existing[idx] = p as typeof existing[0];
+    } else {
+      existing.push(p as typeof existing[0]);
+    }
+    imported++;
+  }
+  localStorage.setItem('sshProfiles', JSON.stringify(existing));
+
+  // Import vault data (encrypted blob — stays encrypted)
+  let credsImported = false;
+  if (backup.vault?.encrypted) {
+    localStorage.setItem('sshVault', backup.vault.encrypted);
+    credsImported = true;
+  }
+  if (backup.vault?.meta) {
+    localStorage.setItem('vaultMeta', backup.vault.meta);
+  }
+
+  const credMsg = credsImported ? ', credentials imported (enter vault passphrase to unlock)' : '';
+  _toast(`Imported ${String(imported)} profiles${credMsg}`);
 }
 
 export function registerServiceWorker(): void {


### PR DESCRIPTION
## Summary
- Add "Download Backup" and "Import Backup" buttons to the Settings panel
- Export packages all profiles and the encrypted vault blob (ciphertext, not plaintext) as a single JSON file
- Import upserts profiles by host+port+username to avoid duplicates, and restores the encrypted vault blob to localStorage

## Security
- Vault data stays encrypted in the backup file -- no keys or passphrases exported
- Backup file structure is validated before import (version check, JSON parse, profiles array)

## Test plan
- [x] `npx vitest run src/modules/__tests__/backup.test.ts` -- 8 tests pass
- [x] `npx tsc --noEmit` -- clean
- [x] `npx eslint` on changed files -- 0 errors (3 pre-existing warnings)
- [ ] Manual: verify Download Backup produces valid JSON file
- [ ] Manual: verify Import Backup upserts profiles correctly

Closes #337