### PR TITLE
test: update tests for buffered terminal + reconnect refactor

### DIFF
--- a/src/modules/__tests__/background-reconnect.test.ts
+++ b/src/modules/__tests__/background-reconnect.test.ts
@@ -208,6 +208,8 @@ function makeFakeWs(overrides?: Partial<{ readyState: number }>) {
 
 describe('Background reconnect — behavioral (#354)', () => {
   beforeEach(() => {
+    // Flush pending probe timers so _zombieProbeTimers map is cleaned up
+    vi.runAllTimers();
     storage.clear();
     appState.sessions.clear();
     appState.activeSessionId = null;

--- a/src/modules/__tests__/session-handle-wiring.test.ts
+++ b/src/modules/__tests__/session-handle-wiring.test.ts
@@ -32,14 +32,16 @@ describe('SessionHandle wiring (#374)', () => {
       expect(connectionSrc).toMatch(/export\s+function\s+removeSessionHandle/);
     });
 
-    it('uses handle.fitIfVisible in visibilitychange instead of setTimeout fit', () => {
-      // The old pattern had setTimeout(() => { active.fitAddon.fit(); ... }, 500)
-      // The new pattern uses handle.fitIfVisible()
+    it('visibilitychange reconnects sessions and probes zombies instead of fitting', () => {
+      // The handler reconnects dropped sessions (active immediate, others 3s delay)
+      // and calls _probeZombieConnection() for open WS sessions. No fitIfVisible.
       const visStart = connectionSrc.indexOf("document.addEventListener('visibilitychange'");
       const visBlock = connectionSrc.slice(visStart, visStart + 1200);
-      expect(visBlock).toContain('fitIfVisible');
-      // No more delayed setTimeout for fit after visibility restore
-      expect(visBlock).not.toMatch(/setTimeout\s*\(\s*\(\)\s*=>\s*\{[^}]*fitAddon\.fit/);
+      expect(visBlock).toContain('_probeZombieConnection');
+      expect(visBlock).toContain('_openWebSocket');
+      // No fitIfVisible or fitAddon.fit in the visibility handler
+      expect(visBlock).not.toContain('fitIfVisible');
+      expect(visBlock).not.toMatch(/fitAddon\.fit/);
     });
   });
 
@@ -61,20 +63,22 @@ describe('SessionHandle wiring (#374)', () => {
       expect(switchFn).toContain('.hide()');
     });
 
-    it('switchSession uses handle.fitIfVisible instead of triple-fit', () => {
+    it('switchSession does unconditional reconnect instead of fitIfVisible', () => {
       const switchStart = uiSrc.indexOf('export function switchSession');
       const switchEnd = uiSrc.indexOf('\nexport function', switchStart + 1);
       const switchFn = uiSrc.slice(switchStart, switchEnd > 0 ? switchEnd : switchStart + 2000);
-      expect(switchFn).toContain('fitIfVisible');
-      // Should NOT have the old rAF + ResizeObserver + setTimeout pattern
+      // switchSession reconnects when not connected — no explicit fit call
+      expect(switchFn).toContain('reconnect');
+      expect(switchFn).not.toContain('fitIfVisible');
       expect(switchFn).not.toContain('requestAnimationFrame(doFit)');
     });
 
-    it('navigateToPanel uses fitIfVisible instead of setTimeout chain', () => {
+    it('navigateToPanel uses handle.fit() instead of setTimeout chain', () => {
       const navStart = uiSrc.indexOf('export function navigateToPanel');
       const navEnd = uiSrc.indexOf('\nexport function', navStart + 1);
       const navFn = uiSrc.slice(navStart, navEnd > 0 ? navEnd : navStart + 1500);
-      expect(navFn).toContain('fitIfVisible');
+      expect(navFn).toContain('handle.fit()');
+      expect(navFn).not.toContain('fitIfVisible');
       expect(navFn).not.toContain('setTimeout(fitAndRefresh, 500)');
     });
 
@@ -102,12 +106,14 @@ describe('SessionHandle wiring (#374)', () => {
       expect(terminalSrc).toMatch(/export\s+function\s+setSessionHandleLookup/);
     });
 
-    it('handleResize delegates to SessionHandle when available', () => {
-      const handleFn = terminalSrc.slice(
-        terminalSrc.indexOf('export function handleResize'),
-        terminalSrc.indexOf('export function handleResize') + 400
-      );
-      expect(handleFn).toContain('fitIfVisible');
+    it('handleResize is a no-op (terminals resize via ResizeObserver)', () => {
+      const handleStart = terminalSrc.indexOf('export function handleResize');
+      const handleEnd = terminalSrc.indexOf('}', handleStart);
+      const handleFn = terminalSrc.slice(handleStart, handleEnd + 1);
+      // handleResize is now a no-op — no fit, no delegate
+      expect(handleFn).not.toContain('fitIfVisible');
+      expect(handleFn).not.toContain('fitAddon');
+      expect(handleFn).toContain('No-op');
     });
   });
 });

--- a/src/modules/__tests__/session-handle.test.ts
+++ b/src/modules/__tests__/session-handle.test.ts
@@ -222,27 +222,20 @@ describe('SessionHandle (#374)', () => {
       expect(container!.classList.add).toHaveBeenCalledWith('hidden');
     });
 
-    it('fitIfVisible() calls fitAddon.fit() when container has non-zero height', () => {
+    it('fit() calls fitAddon.fit() when container has non-zero height', () => {
       const handle = new SessionHandle('sess-fit', { name: 'test', host: 'localhost', port: 22, username: 'user', authType: 'password' as const });
       // offsetHeight defaults to 500 (non-zero) in our mock
-      handle.fitIfVisible();
+      handle.fit();
       expect(fitAddonInstances[0]!.fit).toHaveBeenCalled();
     });
 
-    it('fitIfVisible() does NOT call fitAddon.fit() when container has zero height', () => {
+    it('fit() does NOT call fitAddon.fit() when container has zero height', () => {
       const handle = new SessionHandle('sess-nofit', { name: 'test', host: 'localhost', port: 22, username: 'user', authType: 'password' as const });
       const container = createdDivs.find(el => el.dataset['sessionId'] === 'sess-nofit');
       // Simulate zero height (hidden/collapsed container)
       container!.offsetHeight = 0;
-      handle.fitIfVisible();
+      handle.fit();
       expect(fitAddonInstances[0]!.fit).not.toHaveBeenCalled();
-    });
-
-    it('fitIfVisible() calls terminal.refresh() after fit', () => {
-      const handle = new SessionHandle('sess-refresh', { name: 'test', host: 'localhost', port: 22, username: 'user', authType: 'password' as const });
-      handle.fitIfVisible();
-      expect(fitAddonInstances[0]!.fit).toHaveBeenCalled();
-      expect(terminalInstances[0]!.refresh).toHaveBeenCalled();
     });
   });
 

--- a/src/modules/__tests__/session-routing.test.ts
+++ b/src/modules/__tests__/session-routing.test.ts
@@ -203,8 +203,8 @@ describe('session routing (#263)', () => {
     });
   });
 
-  describe('handleResize sends to active session WS', () => {
-    it('sends resize message with correct cols/rows', () => {
+  describe('handleResize is a no-op (terminals resize via ResizeObserver)', () => {
+    it('does not send resize or call fit (no-op)', () => {
       const s1 = createSession('resize-sess');
       const ws1 = makeMockWs();
       const terminal = makeMockTerminal();
@@ -217,13 +217,12 @@ describe('session routing (#263)', () => {
       appState.activeSessionId = 'resize-sess';
       handleResize();
 
-      expect(fitAddon.fit).toHaveBeenCalled();
-      expect(ws1.send).toHaveBeenCalledWith(
-        JSON.stringify({ type: 'resize', cols: 120, rows: 40 }),
-      );
+      // handleResize is now a no-op — ResizeObserver on each SessionHandle handles fit
+      expect(fitAddon.fit).not.toHaveBeenCalled();
+      expect(ws1.send).not.toHaveBeenCalled();
     });
 
-    it('does not send resize to inactive session', () => {
+    it('does not send resize to any session (no-op)', () => {
       const s1 = createSession('sess-a');
       const s2 = createSession('sess-b');
       const ws1 = makeMockWs();
@@ -240,13 +239,13 @@ describe('session routing (#263)', () => {
       appState.activeSessionId = 'sess-a';
       handleResize();
 
-      expect(ws1.send).toHaveBeenCalled();
+      expect(ws1.send).not.toHaveBeenCalled();
       expect(ws2.send).not.toHaveBeenCalled();
     });
   });
 
   describe('switchSession triggers fit on new session', () => {
-    it('calls fitAddon.fit() on the target session', () => {
+    it('sets activeSessionId to target (no explicit fit — handled by show())', () => {
       const s1 = createSession('sw-1');
       const s2 = createSession('sw-2');
       const fit1 = makeMockFitAddon();
@@ -258,7 +257,8 @@ describe('session routing (#263)', () => {
       switchSession('sw-2');
 
       expect(appState.activeSessionId).toBe('sw-2');
-      expect(fit2.fit).toHaveBeenCalled();
+      // switchSession no longer calls fitAddon.fit() explicitly —
+      // fit happens via SessionHandle.show() or ResizeObserver
     });
 
     it('sets activeSessionId so subsequent input routes to the new session', () => {

--- a/src/modules/__tests__/visibility-reconnect.test.ts
+++ b/src/modules/__tests__/visibility-reconnect.test.ts
@@ -67,6 +67,15 @@ vi.stubGlobal('WebSocket', class {
   url: string;
   close = vi.fn();
   send = vi.fn();
+  private _listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+  addEventListener = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    if (!this._listeners[event]) this._listeners[event] = [];
+    this._listeners[event]!.push(handler);
+  });
+  removeEventListener = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    const list = this._listeners[event];
+    if (list) this._listeners[event] = list.filter(h => h !== handler);
+  });
   static OPEN = 1;
   static CLOSED = 3;
   static CLOSING = 2;
@@ -104,6 +113,7 @@ function _setupSession(opts?: { ws?: unknown; profile?: boolean; connected?: boo
 
 describe('visibility-triggered reconnect (#153)', () => {
   beforeEach(() => {
+    vi.runAllTimers();
     storage.clear();
     appState.sessions.clear();
     appState.activeSessionId = null;
@@ -242,6 +252,7 @@ describe('visibility-triggered reconnect (#153)', () => {
 
 describe('_probeZombieConnection (#153)', () => {
   beforeEach(() => {
+    vi.runAllTimers();
     storage.clear();
     appState.sessions.clear();
     appState.activeSessionId = null;

--- a/src/modules/__tests__/zombie-session.test.ts
+++ b/src/modules/__tests__/zombie-session.test.ts
@@ -87,10 +87,10 @@ describe('Zombie session prevention (#341)', () => {
       // instead of mutating appState.activeSessionId
       const visStart = connectionSrc.indexOf('visibilitychange');
       expect(visStart).toBeGreaterThan(-1);
-      const visBlock = connectionSrc.slice(visStart, visStart + 800);
-      // Should pass sid/sessionId to _openWebSocket, not rely on activeSessionId swap
+      const visBlock = connectionSrc.slice(visStart, visStart + 1200);
+      // Should pass sid/sessionId to _openWebSocket via options object or argument
       const passesId = visBlock.includes('_openWebSocket(') &&
-        (visBlock.match(/_openWebSocket\s*\(\s*\{[^}]*sessionId/s) ||
+        (visBlock.match(/_openWebSocket\s*\(\s*\{[^}]*sessionId\s*:\s*sid/s) ||
          visBlock.match(/_openWebSocket\s*\(\s*sid/) ||
          visBlock.match(/_openWebSocket\s*\([^)]*sid[^)]*\)/));
       expect(passesId).toBeTruthy();


### PR DESCRIPTION
## Summary
- Fix 16 unit test failures caused by the SessionHandle buffered terminal + reconnect refactor (#374)
- Rename `fitIfVisible` references to `fit` in session-handle tests
- Remove deleted `terminal.refresh()` test
- Update structural wiring tests: handleResize is no-op, visibilitychange uses staggered reconnect + zombie probe, navigateToPanel calls `handle.fit()`, switchSession does unconditional reconnect
- Update session-routing tests: handleResize no longer sends resize, switchSession no longer calls fitAddon.fit()
- Add `addEventListener`/`removeEventListener` to WebSocket mock in visibility-reconnect tests
- Fix zombie-session regex to match options-object `sessionId` pattern
- Add `vi.runAllTimers()` to flush stale `_zombieProbeTimers` between tests

## Test plan
- [x] `scripts/test-unit.sh` — all 16 target failures fixed
- [x] Pre-existing failures unchanged (session-peek 16, sftp-preview 3, ime-action-bar 1, session-ui-state 1)
- [x] No implementation code changed — test-only PR

Generated with [Claude Code](https://claude.com/claude-code)