### PR TITLE
fix: defer theme application until session connects (#364)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
     initFilesPanel();
     initLongPressTooltips();
     initRecording({ toast });
-    initProfiles({ toast, navigateToConnect: () => { navigateToPanel('connect'); }, applyTheme });
+    initProfiles({ toast, navigateToConnect: () => { navigateToPanel('connect'); } });
     initSettings({ toast, applyFontSize, applyTheme });
     initConnection({ toast, setStatus, focusIME, applyTabBarVisibility: _applyTabBarVisibility });
     initSessionMenu();

--- a/src/modules/__tests__/connect-theme-defer.test.ts
+++ b/src/modules/__tests__/connect-theme-defer.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression test for #364: theme should NOT change until session connects.
+ *
+ * connectFromProfile was applying the profile's theme immediately after
+ * calling connect(), before the WebSocket completes SSH handshake.
+ * Theme should only be applied when the session reaches 'connected' state.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('theme deferred until connected (#364)', () => {
+  it('connectFromProfile does NOT call applyTheme after connect()', () => {
+    // Read profiles.ts source and verify applyTheme is not called after connect()
+    const src = readFileSync(resolve(__dirname, '..', 'profiles.ts'), 'utf-8');
+    const connectFromProfileMatch = src.match(
+      /export\s+async\s+function\s+connectFromProfile[\s\S]*?^}/m,
+    );
+    expect(connectFromProfileMatch).toBeTruthy();
+    const body = connectFromProfileMatch![0];
+
+    // There should be NO _applyTheme call in connectFromProfile
+    expect(body).not.toContain('_applyTheme');
+    expect(body).not.toContain('applyTheme');
+  });
+
+  it('connection.ts applies theme in the connected message handler', () => {
+    // Read connection.ts source and verify applyTheme is called in the 'connected' case
+    const src = readFileSync(resolve(__dirname, '..', 'connection.ts'), 'utf-8');
+
+    // Find the 'connected' case block in _openWebSocket
+    const connectedCase = src.match(/case\s+'connected':[\s\S]*?break;/);
+    expect(connectedCase).toBeTruthy();
+
+    // It should apply the session's theme
+    expect(connectedCase![0]).toMatch(/applyTheme/);
+  });
+});

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -239,7 +239,7 @@ export function sendSftpRealpath(requestId: string): void {
 }
 import { getDefaultWsUrl, RECONNECT, escHtml } from './constants.js';
 import { appState, currentSession, createSession, transitionSession, isSessionConnected, onStateChange } from './state.js';
-import { createSessionTerminal, setSessionHandleLookup } from './terminal.js';
+import { createSessionTerminal, setSessionHandleLookup, applyTheme } from './terminal.js';
 import { SessionHandle } from './session.js';
 
 // SessionHandle instances stored alongside SessionState for terminal lifecycle (#374)
@@ -608,6 +608,12 @@ function _openWebSocket(options?: { silent?: boolean; sessionId?: string }): voi
         if (_connectTimeout) { clearTimeout(_connectTimeout); _connectTimeout = null; }
         // Dismiss any visible overlay (happy path: overlay never appeared)
         _dismissConnectionStatus();
+        // Apply the session's theme now that SSH is established (#364).
+        // Theme was previously applied in connectFromProfile before connection
+        // completed, causing a visible theme flash on the Connect panel.
+        if (session?.activeThemeName) {
+          applyTheme(session.activeThemeName);
+        }
         // Navigate to terminal now that SSH is established (#309).
         // Only for user-initiated connections — reconnects don't navigate.
         // navigateToPanel triggers fit() on the active session, giving it

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -17,12 +17,10 @@ export { escHtml };
 
 let _toast = (_msg: string): void => {};
 let _navigateToConnect = (): void => {};
-let _applyTheme = (_name: string, _opts?: { persist?: boolean }): void => {};
 
-export function initProfiles({ toast, navigateToConnect, applyTheme }: ProfilesDeps): void {
+export function initProfiles({ toast, navigateToConnect }: ProfilesDeps): void {
   _toast = toast;
   _navigateToConnect = navigateToConnect;
-  _applyTheme = applyTheme;
 }
 
 // Profile storage
@@ -320,9 +318,7 @@ export async function connectFromProfile(idx: number): Promise<boolean> {
   }
 
   await connect(sshProfile);
-  if (sshProfile.theme) {
-    _applyTheme(sshProfile.theme, { persist: false });
-  }
+  // Theme is applied when the session reaches 'connected' state (#364)
   return true;
 }
 

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -160,7 +160,6 @@ export interface RecordingDeps {
 export interface ProfilesDeps {
   toast: (msg: string) => void;
   navigateToConnect: () => void;
-  applyTheme: (name: string, opts?: { persist?: boolean }) => void;
 }
 
 export interface SettingsDeps {


### PR DESCRIPTION
## Summary
- Removed premature `applyTheme` call from `connectFromProfile` in profiles.ts — theme was applied immediately after `connect()` returned, before SSH handshake completed
- Added `applyTheme` call in the `'connected'` message handler in connection.ts, so theme only changes when the session is actually connected and terminal panel is about to show
- Cleaned up unused `applyTheme` dependency from `ProfilesDeps` interface and `initProfiles` wiring

## TDD Analysis
- Type: bug fix
- Behavior change: no — restores intended behavior
- TDD approach: full (source-structural tests)

## Test coverage
- **Existing tests updated**: none needed — all existing theme tests pass
- **New tests added (fail->pass)**: `connect-theme-defer.test.ts` — verifies connectFromProfile no longer calls applyTheme, and connection.ts applies theme in the connected handler
- **Smoketest**: structural verification that theme application is wired to the correct lifecycle event

## Test results
- tsc: PASS
- eslint: pre-existing failure (unrelated to changes)
- vitest: PASS (all theme tests green)

## Diff stats
- Files changed: 5 (4 source + 1 test)
- Lines: +51 / -9

Closes #364

## Cycles used
1/3