### PR TITLE
fix: restore IME preview overlay after dock cycle + panel navigation

### DIFF
--- a/src/modules/ime.ts
+++ b/src/modules/ime.ts
@@ -139,6 +139,8 @@ export function cycleDockPosition(): DockPosition {
 export function isPreviewMode(): boolean { return _previewMode; }
 /** Callback set by initIMEInput to clear preview state (commits text). */
 let _clearPreviewCallback: (() => void) | null = null;
+/** Callback set by initIMEInput to restore overlay after panel navigation (#395). */
+let _restoreOverlayCallback: (() => void) | null = null;
 
 // ── Preview commit history ring buffer (#254) ────────────────────────────────
 const HISTORY_MAX = 20;
@@ -201,6 +203,13 @@ export function togglePreviewMode(): void {
 /** Clear any active preview — called when compose mode is toggled off. */
 export function clearIMEPreview(): void {
   if (_clearPreviewCallback) _clearPreviewCallback();
+}
+
+/** Restore IME overlay after returning to the terminal panel (#395).
+ *  If the state machine is still in previewing/editing, re-show the overlay
+ *  and restart the auto-clear timer so the preview doesn't silently vanish. */
+export function restoreIMEOverlay(): void {
+  if (_restoreOverlayCallback) _restoreOverlayCallback();
 }
 
 /** Query the current IME state (for tests and debugging). */
@@ -469,6 +478,8 @@ export function initIMEInput(): void {
   _onAction(dockToggle, () => {
     cycleDockPosition();
     _positionIME();
+    // Reset auto-clear timer — user is interacting with the IME (#395)
+    if (_imeState === 'previewing') _scheduleClear();
     focusIME();
   });
 
@@ -683,6 +694,14 @@ export function initIMEInput(): void {
     if (text) sendSSHInput(text);
     _recordHistory(text);
     _transition('idle');
+  };
+
+  // Register callback so panel navigation can restore the overlay (#395)
+  _restoreOverlayCallback = () => {
+    if (_imeState === 'previewing' || _imeState === 'editing') {
+      _showIMEOverlay();
+      if (_imeState === 'previewing') _scheduleClear();
+    }
   };
 
 

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -12,7 +12,7 @@ import { applyTheme, _addNotification, fireNotification } from './terminal.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- backward compat: sendSftpUpload kept for legacy callers
 import { sendSSHInput, sendSSHInputToAll, disconnect, reconnect, probeSession, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath, uploadFileChunked, sendSftpUploadCancel, getSessionHandle, removeSessionHandle } from './connection.js';
 import { saveProfile, connectFromProfile, newConnection, loadProfiles, removeRecentSession } from './profiles.js';
-import { clearIMEPreview } from './ime.js';
+import { clearIMEPreview, restoreIMEOverlay } from './ime.js';
 import { isPreviewable, createPreviewPanel } from './sftp-preview.js';
 
 /** Update session menu button text without clobbering child elements like badges (#355). */
@@ -69,6 +69,8 @@ export function navigateToPanel(
       handle.fit();
     }
     focusIME();
+    // Restore IME preview overlay if it was active before panel switch (#395)
+    restoreIMEOverlay();
   }
   if (panel === 'connect') {
     // Only refresh if the form isn't already visible (avoids clobbering edit-in-progress)


### PR DESCRIPTION
## Summary
- Export `restoreIMEOverlay()` from `ime.ts` that re-shows the preview overlay and restarts the auto-clear timer when the IME state machine is still in `previewing` or `editing`
- Call `restoreIMEOverlay()` from `navigateToPanel()` when switching back to the terminal panel, so the preview is restored after panel navigation
- Reset the auto-clear timer when the dock position button is cycled, since the user is actively interacting with the IME and the timer should not silently expire

## Test plan
- [ ] Enable IME preview mode, type text to enter previewing state
- [ ] Cycle the dock position button
- [ ] Navigate away from the terminal panel (e.g., to Connect)
- [ ] Navigate back to the terminal panel — verify the preview overlay is still visible
- [ ] Verify the auto-clear countdown restarts correctly after returning
- [ ] Verify `npx tsc` compiles without errors
- [ ] Verify no unit test regressions (`scripts/test-unit.sh`)

Fixes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)