### PR TITLE
fix: shrink approval buttons, replace SVG ring with VU-meter bar

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -824,7 +824,7 @@ html, body {
 }
 .approval-btn {
   flex: 1;
-  padding: 12px 8px;
+  padding: 6px 8px;
   border: 2px solid var(--accent);
   border-radius: 6px;
   background: var(--accent);
@@ -865,36 +865,12 @@ html, body {
   font-size: 12px;
   opacity: 0.7;
 }
-.approval-ring {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 36px;
-  height: 36px;
-  transform: translate(-50%, -50%) rotate(-90deg);
-  pointer-events: none;
-}
-.approval-ring-track,
-.approval-ring-progress {
-  fill: none;
-  stroke-width: 3;
-}
-.approval-ring-track {
-  stroke: transparent;
-}
-.approval-ring-progress {
-  stroke: transparent;
-  stroke-linecap: round;
-}
-.approval-btn.countdown-active {
-  position: relative;
-  overflow: visible;
-}
-.approval-btn.countdown-active .approval-ring-track {
-  stroke: rgba(255, 255, 255, 0.15);
-}
-.approval-btn.countdown-active .approval-ring-progress {
-  stroke: var(--bg-deep);
+.approval-vu-bar {
+  height: 3px;
+  background: var(--bg-deep);
+  opacity: 0.5;
+  width: 100%;
+  border-radius: 0 0 4px 4px;
 }
 .approval-auto-row {
   display: flex;

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -1186,23 +1186,20 @@ export function initApprovalBar(): void {
 
       if (targetBtn) {
         targetBtn.classList.add('countdown-active');
-        if (!targetBtn.querySelector('.approval-ring')) {
-          targetBtn.insertAdjacentHTML('beforeend',
-            '<svg class="approval-ring" viewBox="0 0 36 36">' +
-            '<circle class="approval-ring-track" cx="18" cy="18" r="16" />' +
-            '<circle class="approval-ring-progress" cx="18" cy="18" r="16" />' +
-            '</svg>');
-        }
-        const progress = targetBtn.querySelector('.approval-ring-progress') as SVGCircleElement | null;
-        const circumference = 2 * Math.PI * 16;
-        if (progress) {
-          progress.style.strokeDasharray = String(circumference);
-          progress.style.strokeDashoffset = '0';
-          progress.style.transition = `stroke-dashoffset ${String(sec)}s linear`;
-          void progress.getBoundingClientRect();
-          progress.style.strokeDashoffset = String(circumference);
-        }
       }
+
+      // Insert VU-meter bar at bottom of approval bar
+      let vuBar = bar!.querySelector('.approval-vu-bar') as HTMLDivElement | null;
+      if (!vuBar) {
+        vuBar = document.createElement('div');
+        vuBar.className = 'approval-vu-bar';
+        bar!.appendChild(vuBar);
+      }
+      vuBar.style.width = '100%';
+      vuBar.style.transition = 'none';
+      void vuBar.getBoundingClientRect();
+      vuBar.style.transition = `width ${String(sec)}s linear`;
+      vuBar.style.width = '0%';
 
       let remaining = sec;
       countdownEl = document.createElement('span');
@@ -1226,10 +1223,10 @@ export function initApprovalBar(): void {
       if (countdownEl) { countdownEl.textContent = ''; countdownEl = null; }
       if (targetBtn) {
         targetBtn.classList.remove('countdown-active');
-        const ring = targetBtn.querySelector('.approval-ring');
-        if (ring) ring.remove();
         targetBtn = null;
       }
+      const vuBar = bar!.querySelector('.approval-vu-bar');
+      if (vuBar) vuBar.remove();
     }
 
     autoCheck.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- Shrink approval bar Yes/No buttons vertically (padding `12px 8px` to `6px 8px`)
- Replace circular SVG countdown ring with a horizontal VU-meter bar that shrinks from 100% to 0% width along the bottom of the approval bar
- Remove unused `.approval-ring`, `.approval-ring-track`, `.approval-ring-progress` CSS rules

## TDD Analysis
- Type: bug fix (UI polish)
- Behavior change: no (visual only, countdown logic unchanged)
- TDD approach: smoketest-only (CSS/visual)

## Test coverage
- **Existing tests updated**: none needed (no tests reference approval ring)
- **New tests added (fail->pass)**: none (CSS-only visual change, not unit-testable)
- **Smoketest**: countdown mechanism unchanged, auto-accept timer still fires

## Test results
- tsc: PASS
- eslint: pre-existing config issue (eslint ignores src/ glob)
- vitest: 5 pre-existing failures (22 tests), 0 new failures introduced

## Diff stats
- Files changed: 2
- Lines: +22 / -49

Closes #408

## Cycles used
1/3