### PR TITLE
fix: SW fetch handler respects Cache-Control no-store

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -113,10 +113,13 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(
     fetch(event.request)
       .then((response) => {
-        // Update cache with fresh response
+        // Update cache with fresh response (skip no-store — may contain sensitive data)
         if (response.ok) {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          const cc = response.headers.get('Cache-Control') || '';
+          if (!cc.includes('no-store')) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
         }
         return response;
       })

--- a/src/modules/__tests__/sw-cache-control.test.ts
+++ b/src/modules/__tests__/sw-cache-control.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Tests that the service worker respects Cache-Control: no-store by NOT caching
+ * responses that include that header. This is a security requirement — index.html
+ * contains a ws-token meta tag that must never persist to disk cache.
+ */
+
+// Read sw.js source to verify the check exists in the actual code
+const swSource = readFileSync(join(__dirname, '../../../public/sw.js'), 'utf-8');
+
+describe('sw.js Cache-Control: no-store', () => {
+  it('should check Cache-Control header before calling cache.put', () => {
+    // The fetch handler must inspect Cache-Control before caching
+    // Look for the pattern: check no-store BEFORE cache.put
+    const hasCacheControlCheck = /headers\.get\(['"]Cache-Control['"]\)/.test(swSource);
+    const hasNoStoreCheck = /no-store/.test(swSource);
+
+    expect(hasCacheControlCheck).toBe(true);
+    expect(hasNoStoreCheck).toBe(true);
+  });
+
+  it('should not unconditionally cache all ok responses', () => {
+    // The old pattern was: if (response.ok) { cache.put(...) }
+    // The new pattern must have a no-store guard between response.ok and cache.put
+    //
+    // Extract the fetch handler section (between 'fetch' listener and the closing)
+    const fetchSection = swSource.match(
+      /addEventListener\('fetch'[\s\S]*?if\s*\(response\.ok\)\s*\{([\s\S]*?)return response/
+    );
+    expect(fetchSection).not.toBeNull();
+
+    const cacheBlock = fetchSection![1];
+    // The block between response.ok and cache.put must contain a no-store check
+    const hasGuard = /no-store/.test(cacheBlock);
+    expect(hasGuard).toBe(true);
+  });
+
+  it('should still have cache.put for responses without no-store', () => {
+    // cache.put should still exist — it's needed for cacheable responses
+    const hasCachePut = /cache\.put/.test(swSource);
+    expect(hasCachePut).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-store` check in SW fetch handler before caching responses
- Prevents sensitive data (ws-token in index.html) from being persisted to disk cache
- Install-time cache (SHELL_FILES) still provides offline fallback — only runtime caching is gated

## TDD Analysis
- Type: bug fix (security)
- Behavior change: no — server already sends no-store on all responses, so runtime caching was writing data that should not have been cached
- TDD approach: full

## Test coverage
- **Existing tests updated**: none needed
- **New tests added (fail→pass)**: `sw-cache-control.test.ts` — 3 tests verifying the no-store guard exists in sw.js source, that it gates cache.put, and that cache.put still exists for cacheable responses
- **Smoketest**: verifies Cache-Control header check is present in the fetch handler

## Test results
- tsc: PASS
- eslint: pre-existing config issue (not related)
- vitest: PASS (3 new tests, 7 pre-existing failures in unrelated tests)

## Diff stats
- Files changed: 2 (public/sw.js + new test)
- Lines: +52 / -3

Closes #243

## Cycles used
1/3