### PR TITLE
fix: status modal close/cancel buttons non-functional (#417)

### DIFF
--- a/src/modules/__tests__/modal-cancel.test.ts
+++ b/src/modules/__tests__/modal-cancel.test.ts
@@ -207,4 +207,41 @@ describe('Modal cancel button responsiveness (#388)', () => {
       expect(callsDisconnect || abortsCycle || cancelsReconnect).toBe(true);
     });
   });
+
+  // ── 8. Cancel button passes sessionId to disconnect (#417) ──────────
+
+  describe('cancel button targets correct session (#417)', () => {
+    it('_showConnectionStatus accepts sessionId option', () => {
+      const fnBody = extractFnBody(connectionSrc, 'function _showConnectionStatus');
+      expect(fnBody.length).toBeGreaterThan(50);
+      // Signature should accept sessionId in opts
+      expect(fnBody).toContain('sessionId');
+    });
+
+    it('cancel button passes sessionId to disconnect', () => {
+      const fnBody = extractFnBody(connectionSrc, 'function _showConnectionStatus');
+      expect(fnBody.length).toBeGreaterThan(50);
+      // The cancel handler should call disconnect with a captured sessionId,
+      // not disconnect() with no args which falls back to activeSessionId
+      expect(fnBody).toContain('disconnect(sid');
+    });
+
+    it('_openWebSocket passes sessionId when creating the overlay', () => {
+      const fnBody = extractFnBody(connectionSrc, 'function _openWebSocket');
+      expect(fnBody.length).toBeGreaterThan(50);
+      // At least one _showConnectionStatus call should include sessionId
+      expect(fnBody).toContain('sessionId');
+      expect(fnBody).toContain('_showConnectionStatus');
+    });
+  });
+
+  // ── 9. Error dialog dismiss calls cancelReconnect (#417) ────────────
+
+  describe('error dialog dismiss cancels reconnect (#417)', () => {
+    it('showErrorDialog dismiss handler calls cancelReconnect', () => {
+      const fnBody = extractFnBody(uiSrc, 'function showErrorDialog');
+      expect(fnBody.length).toBeGreaterThan(50);
+      expect(fnBody).toContain('cancelReconnect');
+    });
+  });
 });

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -554,7 +554,7 @@ function _openWebSocket(options?: { silent?: boolean; sessionId?: string }): voi
     newWs = new WebSocket(wsUrl);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    _showConnectionStatus(`WebSocket error: ${message}`, { error: true });
+    _showConnectionStatus(`WebSocket error: ${message}`, { error: true, sessionId });
     scheduleReconnect();
     return;
   }
@@ -567,7 +567,7 @@ function _openWebSocket(options?: { silent?: boolean; sessionId?: string }): voi
     const probeWs = newWs; // capture so the closure inspects *this* attempt
     _connectTimeout = setTimeout(() => {
       _connectTimeout = null;
-      _showConnectionStatus(`Connecting to ${baseUrl}…`);
+      _showConnectionStatus(`Connecting to ${baseUrl}…`, { sessionId });
       _showConnectionStatus('Running diagnostic…');
       void probeConnectLayers({
         onLine: typeof navigator !== 'undefined' ? navigator.onLine : true,
@@ -1174,7 +1174,7 @@ export function sendSSHInputToAll(data: string): void {
 
 let _currentOverlay: HTMLDivElement | null = null;
 
-function _showConnectionStatus(message: string, opts?: { error?: boolean }): void {
+function _showConnectionStatus(message: string, opts?: { error?: boolean; sessionId?: string }): void {
   // Reuse existing overlay — append message to scrollable log
   if (_currentOverlay) {
     const log = _currentOverlay.querySelector('.conn-status-log');
@@ -1193,6 +1193,9 @@ function _showConnectionStatus(message: string, opts?: { error?: boolean }): voi
     return;
   }
 
+  // Capture sessionId for the cancel button closure (#417)
+  const sid = opts?.sessionId;
+
   const overlay = document.createElement('div');
   overlay.id = 'connectionStatusOverlay';
   overlay.className = 'conn-status-overlay';
@@ -1209,11 +1212,12 @@ function _showConnectionStatus(message: string, opts?: { error?: boolean }): voi
   dialog.appendChild(log);
 
   // Cancel button is always present — calls disconnect() for full cleanup (#105)
+  // Pass captured sessionId so disconnect targets the correct session (#417)
   const btn = document.createElement('button');
   btn.className = 'conn-status-cancel';
   btn.textContent = 'Cancel';
   btn.addEventListener('click', () => {
-    disconnect();
+    disconnect(sid);
     _dismissConnectionStatus();
   });
   dialog.appendChild(btn);

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -10,7 +10,7 @@ import { KEY_REPEAT, THEMES, THEME_ORDER, escHtml } from './constants.js';
 import { appState, currentSession, isSessionConnected, onStateChange, transitionSession } from './state.js';
 import { applyTheme, _addNotification, fireNotification } from './terminal.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- backward compat: sendSftpUpload kept for legacy callers
-import { sendSSHInput, sendSSHInputToAll, disconnect, reconnect, probeSession, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath, uploadFileChunked, sendSftpUploadCancel, getSessionHandle, removeSessionHandle } from './connection.js';
+import { sendSSHInput, sendSSHInputToAll, disconnect, reconnect, probeSession, cancelReconnect, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath, uploadFileChunked, sendSftpUploadCancel, getSessionHandle, removeSessionHandle } from './connection.js';
 import { saveProfile, connectFromProfile, newConnection, loadProfiles, removeRecentSession, getRecentSessions } from './profiles.js';
 import { clearIMEPreview, restoreIMEOverlay } from './ime.js';
 import { isPreviewable, createPreviewPanel } from './sftp-preview.js';
@@ -202,6 +202,8 @@ export function showErrorDialog(message: string): void {
   overlay.classList.remove('hidden');
   dismiss?.addEventListener('click', () => {
     overlay.classList.add('hidden');
+    // Cancel any background reconnect loop so it doesn't re-show the dialog (#417)
+    cancelReconnect();
   }, { once: true });
 }
 


### PR DESCRIPTION
## Summary
- Fix cancel button in connection status overlay to pass the correct sessionId to `disconnect()` instead of relying on `activeSessionId` which may be stale
- Fix error dialog dismiss handler to call `cancelReconnect()` so background reconnect loops don't re-show the dialog immediately after dismissal
- Thread sessionId through `_showConnectionStatus` from `_openWebSocket` so the cancel button closure captures the right session

## TDD Analysis
- Type: bug fix
- Behavior change: no
- TDD approach: full (structural source-inspection tests)

## Test coverage
- **Existing tests updated**: none needed (all 12 existing tests still pass)
- **New tests added (fail->pass)**: 4 tests in `modal-cancel.test.ts`
  - `_showConnectionStatus accepts sessionId option`
  - `cancel button passes sessionId to disconnect`
  - `_openWebSocket passes sessionId when creating the overlay`
  - `showErrorDialog dismiss handler calls cancelReconnect`
- **Smoketest**: structural tests verify code patterns exist in source

## Test results
- tsc: PASS
- eslint: SKIP (pre-existing config issue with .eslintignore)
- vitest: PASS (16 tests, 4 new)

## Diff stats
- Files changed: 3
- Lines: +48 / -5

Closes #417

## Cycles used
1/3