### PR TITLE
fix: resolve key passphrase on reconnect path

### DIFF
--- a/src/modules/__tests__/connection.test.ts
+++ b/src/modules/__tests__/connection.test.ts
@@ -65,7 +65,20 @@ vi.stubGlobal('window', {
   },
 });
 
-const { _getPassphraseCache, _isKeyEncrypted } = await import('../connection.js');
+// Mock vault module for _resolvePassphrase tests
+vi.mock('../vault.js', () => ({
+  vaultLoad: vi.fn(),
+  createVault: vi.fn(),
+  unlockVault: vi.fn(),
+  vaultStore: vi.fn(),
+  vaultDelete: vi.fn(),
+  isVaultUnlocked: vi.fn(() => false),
+}));
+
+const { vaultLoad } = await import('../vault.js');
+const vaultLoadMock = vi.mocked(vaultLoad);
+
+const { _getPassphraseCache, _isKeyEncrypted, _resolvePassphrase } = await import('../connection.js');
 
 describe('Key passphrase cache (#54)', () => {
   beforeEach(() => {
@@ -99,6 +112,95 @@ describe('Key passphrase cache (#54)', () => {
     cache.set('key-2', 'pass-2');
     expect(cache.get('key-1')).toBe('pass-1');
     expect(cache.get('key-2')).toBe('pass-2');
+  });
+});
+
+describe('_resolvePassphrase (#418)', () => {
+  const encryptedKey = [
+    '-----BEGIN RSA PRIVATE KEY-----',
+    'Proc-Type: 4,ENCRYPTED',
+    'DEK-Info: AES-128-CBC,AABBCCDD',
+    'dGVzdGRhdGE=',
+    '-----END RSA PRIVATE KEY-----',
+  ].join('\n');
+
+  const unencryptedKey = [
+    '-----BEGIN RSA PRIVATE KEY-----',
+    'dGVzdGRhdGE=',
+    '-----END RSA PRIVATE KEY-----',
+  ].join('\n');
+
+  beforeEach(() => {
+    _getPassphraseCache().clear();
+    vaultLoadMock.mockReset();
+  });
+
+  it('returns ok immediately for password auth profiles', async () => {
+    const profile = { name: 'test', host: 'h', port: 22, username: 'u', authType: 'password' as const, password: 'pw' };
+    expect(await _resolvePassphrase(profile)).toBe('ok');
+  });
+
+  it('returns ok for key auth with unencrypted key', async () => {
+    const profile = { name: 'test', host: 'h', port: 22, username: 'u', authType: 'key' as const, privateKey: unencryptedKey };
+    expect(await _resolvePassphrase(profile)).toBe('ok');
+  });
+
+  it('resolves passphrase from cache for encrypted key', async () => {
+    _getPassphraseCache().set('vault-1', 'cached-pass');
+    const profile = { name: 'test', host: 'h', port: 22, username: 'u', authType: 'key' as const, privateKey: encryptedKey, keyVaultId: 'vault-1' };
+    expect(await _resolvePassphrase(profile)).toBe('ok');
+    expect(profile.passphrase).toBe('cached-pass');
+  });
+
+  it('loads key from vault when privateKey is missing', async () => {
+    vaultLoadMock.mockResolvedValue({ data: unencryptedKey });
+    const profile = { name: 'test', host: 'h', port: 22, username: 'u', authType: 'key' as const, keyVaultId: 'vault-1' };
+    expect(await _resolvePassphrase(profile)).toBe('ok');
+    expect(profile.privateKey).toBe(unencryptedKey);
+  });
+
+  it('returns no-key when vault load fails', async () => {
+    vaultLoadMock.mockResolvedValue(null);
+    const profile = { name: 'test', host: 'h', port: 22, username: 'u', authType: 'key' as const, keyVaultId: 'vault-1' };
+    expect(await _resolvePassphrase(profile)).toBe('no-key');
+  });
+
+  it('prompts user when encrypted key has no cached passphrase', async () => {
+    // Simulate user clicking OK with a passphrase
+    mockOkBtn.addEventListener.mockImplementation((_event: string, handler: () => void) => {
+      mockInput.value = 'user-entered-pass';
+      setTimeout(handler, 0);
+    });
+
+    const profile = { name: 'test', host: 'h', port: 22, username: 'u', authType: 'key' as const, privateKey: encryptedKey, keyVaultId: 'vault-2' };
+    const result = await _resolvePassphrase(profile);
+    expect(result).toBe('ok');
+    expect(profile.passphrase).toBe('user-entered-pass');
+    // Passphrase should be cached
+    expect(_getPassphraseCache().get('vault-2')).toBe('user-entered-pass');
+
+    // Clean up mock
+    mockOkBtn.addEventListener.mockReset();
+  });
+
+  it('returns cancelled when user dismisses passphrase prompt', async () => {
+    // Simulate user clicking Cancel
+    mockCancelBtn.addEventListener.mockImplementation((_event: string, handler: () => void) => {
+      setTimeout(handler, 0);
+    });
+
+    const profile = { name: 'test', host: 'h', port: 22, username: 'u', authType: 'key' as const, privateKey: encryptedKey, keyVaultId: 'vault-3' };
+    const result = await _resolvePassphrase(profile);
+    expect(result).toBe('cancelled');
+
+    // Clean up mock
+    mockCancelBtn.addEventListener.mockReset();
+  });
+
+  it('skips resolution when passphrase is already set on profile', async () => {
+    const profile = { name: 'test', host: 'h', port: 22, username: 'u', authType: 'key' as const, privateKey: encryptedKey, passphrase: 'already-set' };
+    expect(await _resolvePassphrase(profile)).toBe('ok');
+    expect(profile.passphrase).toBe('already-set');
   });
 });
 

--- a/src/modules/connection.ts
+++ b/src/modules/connection.ts
@@ -420,6 +420,42 @@ function _promptPassphrase(): Promise<string | null> {
   });
 }
 
+/**
+ * Resolve the passphrase for an SSH key profile. Loads the key from vault if
+ * needed, checks the in-memory cache, and prompts the user if necessary.
+ * Returns 'ok' if the profile is ready to connect, 'cancelled' if the user
+ * dismissed the prompt, or 'no-key' if the vault key could not be loaded.
+ */
+export async function _resolvePassphrase(profile: SSHProfile): Promise<'ok' | 'cancelled' | 'no-key'> {
+  // Load key data from vault if not already present
+  if (profile.authType === 'key' && profile.keyVaultId && !profile.privateKey) {
+    const keyCreds = await vaultLoad(profile.keyVaultId);
+    if (keyCreds?.data) {
+      profile.privateKey = keyCreds.data as string;
+    } else {
+      return 'no-key';
+    }
+  }
+
+  // If the key is encrypted and no passphrase is set, check cache or prompt
+  if (profile.authType === 'key' && profile.privateKey && _isKeyEncrypted(profile.privateKey) && !profile.passphrase) {
+    const cacheKey = profile.keyVaultId ?? '';
+    const cached = cacheKey ? _keyPassphraseCache.get(cacheKey) : undefined;
+    if (cached !== undefined) {
+      profile.passphrase = cached;
+    } else {
+      const passphrase = await _promptPassphrase();
+      if (passphrase === null) {
+        return 'cancelled';
+      }
+      profile.passphrase = passphrase;
+      if (cacheKey) _keyPassphraseCache.set(cacheKey, passphrase);
+    }
+  }
+
+  return 'ok';
+}
+
 // ── WebSocket / SSH connection ────────────────────────────────────────────────
 
 // Max consecutive pre-open WS close events before halting the reconnect loop.
@@ -433,32 +469,15 @@ function _getWsToken(): string {
 }
 
 export async function connect(profile: SSHProfile): Promise<void> {
-  // If the profile references a stored key, load the key data from vault
-  if (profile.authType === 'key' && profile.keyVaultId && !profile.privateKey) {
-    const keyCreds = await vaultLoad(profile.keyVaultId);
-    if (keyCreds?.data) {
-      profile.privateKey = keyCreds.data as string;
-    } else {
-      _toast('Could not load stored key from vault.');
-      return;
-    }
+  // Resolve key data and passphrase (vault load + cache + prompt)
+  const result = await _resolvePassphrase(profile);
+  if (result === 'no-key') {
+    _toast('Could not load stored key from vault.');
+    return;
   }
-
-  // If the key is encrypted and no passphrase is set, check cache or prompt
-  if (profile.authType === 'key' && profile.privateKey && _isKeyEncrypted(profile.privateKey) && !profile.passphrase) {
-    const cacheKey = profile.keyVaultId ?? '';
-    const cached = cacheKey ? _keyPassphraseCache.get(cacheKey) : undefined;
-    if (cached !== undefined) {
-      profile.passphrase = cached;
-    } else {
-      const passphrase = await _promptPassphrase();
-      if (passphrase === null) {
-        _toast('Connection cancelled.');
-        return;
-      }
-      profile.passphrase = passphrase;
-      if (cacheKey) _keyPassphraseCache.set(cacheKey, passphrase);
-    }
+  if (result === 'cancelled') {
+    _toast('Connection cancelled.');
+    return;
   }
 
   // Don't cancel other sessions' reconnect timers when creating a new session
@@ -615,23 +634,37 @@ function _openWebSocket(options?: { silent?: boolean; sessionId?: string }): voi
     startKeepAlive(sessionId);
     const profile = session?.profile;
     if (!profile) return;
-    const authMsg: ConnectMessage = {
-      type: 'connect',
-      host: profile.host,
-      port: profile.port || 22,
-      username: profile.username,
-    };
-    if (profile.authType === 'key' && profile.privateKey) {
-      authMsg.privateKey = profile.privateKey;
-      if (profile.passphrase) authMsg.passphrase = profile.passphrase;
-    } else {
-      authMsg.password = profile.password ?? '';
-    }
-    if (profile.initialCommand) authMsg.initialCommand = profile.initialCommand;
-    if (localStorage.getItem('allowPrivateHosts') === 'true') authMsg.allowPrivate = true;
-    newWs.send(JSON.stringify(authMsg));
-    // Status overlay only shows if the 5s timeout already fired
-    if (!silent && _currentOverlay) _showConnectionStatus(`SSH → ${profile.username}@${profile.host}:${String(profile.port || 22)}…`);
+
+    // Resolve passphrase before building auth message (#418).
+    // On reconnect, the in-memory cache may be empty (e.g. after page reload),
+    // so we must re-resolve from vault/cache/prompt before sending credentials.
+    void _resolvePassphrase(profile).then((result) => {
+      if (result !== 'ok') {
+        // User cancelled or vault unavailable — close WS, don't send credentials
+        newWs.close();
+        if (result === 'cancelled') _toast('Reconnect cancelled — passphrase required.');
+        else _toast('Could not load stored key from vault.');
+        return;
+      }
+
+      const authMsg: ConnectMessage = {
+        type: 'connect',
+        host: profile.host,
+        port: profile.port || 22,
+        username: profile.username,
+      };
+      if (profile.authType === 'key' && profile.privateKey) {
+        authMsg.privateKey = profile.privateKey;
+        if (profile.passphrase) authMsg.passphrase = profile.passphrase;
+      } else {
+        authMsg.password = profile.password ?? '';
+      }
+      if (profile.initialCommand) authMsg.initialCommand = profile.initialCommand;
+      if (localStorage.getItem('allowPrivateHosts') === 'true') authMsg.allowPrivate = true;
+      newWs.send(JSON.stringify(authMsg));
+      // Status overlay only shows if the 5s timeout already fired
+      if (!silent && _currentOverlay) _showConnectionStatus(`SSH → ${profile.username}@${profile.host}:${String(profile.port || 22)}…`);
+    });
   }, signal ? { signal } : undefined);
 
   newWs.addEventListener('message', (event: MessageEvent) => {


### PR DESCRIPTION
## Summary
- Extract passphrase resolution logic (vault load + cache check + user prompt) from `connect()` into a shared `_resolvePassphrase(profile)` helper
- Call `_resolvePassphrase` from the `_openWebSocket` open handler so reconnects (including after page reload) re-resolve the passphrase before sending the auth message
- If the user cancels the prompt or the vault key is unavailable, the WS is closed gracefully with a toast message

## TDD Analysis
- Type: bug fix
- Behavior change: no (restoring expected behavior on reconnect)
- TDD approach: full

## Test coverage
- **Existing tests updated**: none needed (existing cache + encryption tests still pass)
- **New tests added (fail->pass)**:
  - `returns ok immediately for password auth profiles`
  - `returns ok for key auth with unencrypted key`
  - `resolves passphrase from cache for encrypted key`
  - `loads key from vault when privateKey is missing`
  - `returns no-key when vault load fails`
  - `prompts user when encrypted key has no cached passphrase`
  - `returns cancelled when user dismisses passphrase prompt`
  - `skips resolution when passphrase is already set on profile`
- **Smoketest**: `_resolvePassphrase` is exported and directly testable; exercises all three resolution paths (cache, prompt, vault)

## Test results
- tsc: PASS
- eslint: SKIP (pre-existing config issue)
- vitest: PASS (connection.test.ts: 17 tests, 8 new)

## Diff stats
- Files changed: 2
- Lines: +171 / -36

Closes #418

## Cycles used
1/3