### PR TITLE
fix: move #enablePinchZoom into Advanced section (#367)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -553,17 +553,6 @@
           <span class="toggle-slider toggle-slider-accent"></span>
         </label>
       </div>
-      <div class="setting-row">
-        <div class="setting-row-info">
-          <span class="setting-row-label">Pinch-to-zoom</span>
-          <p class="hint">Two-finger pinch changes terminal font size.</p>
-        </div>
-        <label class="toggle" aria-label="Enable pinch-to-zoom">
-          <input type="checkbox" id="enablePinchZoom" />
-          <span class="toggle-slider toggle-slider-accent"></span>
-        </label>
-      </div>
-
       <h3>Notifications</h3>
       <div class="setting-row">
         <div class="setting-row-info">
@@ -624,6 +613,17 @@
 
       <div class="advanced-section">
         <h3 class="advanced-section-title">Advanced</h3>
+
+        <div class="danger-zone-item">
+          <div class="danger-zone-item-info">
+            <span class="danger-zone-item-label">Pinch-to-zoom</span>
+            <p class="hint">Two-finger pinch changes terminal font size.</p>
+          </div>
+          <label class="toggle" aria-label="Enable pinch-to-zoom">
+            <input type="checkbox" id="enablePinchZoom" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
 
         <div class="danger-zone-item">
           <div class="danger-zone-item-info">


### PR DESCRIPTION
## Summary
- Moved `#enablePinchZoom` setting from the main settings area into `.advanced-section`, completing the partial implementation from #145
- Adopted `danger-zone-item` class pattern to match existing items in the Advanced section

## TDD Analysis
- Type: bug fix (incomplete implementation)
- Behavior change: no — completing intended layout
- TDD approach: smoketest-only (existing Appium test covers this)

## Test coverage
- **Existing tests updated**: none needed
- **New tests added (fail→pass)**: none — existing test `tests/appium/integrate-145-settings-layout.spec.js:35` already asserts `#enablePinchZoom` is inside `.advanced-section`
- **Smoketest**: Appium test verifies both `#debugOverlay` and `#enablePinchZoom` are children of `.advanced-section`

## Test results
- tsc: PASS
- eslint: pre-existing config issue (unrelated)
- vitest: pre-existing failures in sftp-preview and session-ui-state (unrelated)

## Diff stats
- Files changed: 1
- Lines: +11 / -11

Closes #367

## Cycles used
1/3