### PR TITLE
feat: export/import buttons and Connect panel navbar

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1475,6 +1475,36 @@ hr {
   cursor: pointer;
 }
 
+/* Connect panel bottom navbar (#419) */
+.connect-navbar {
+  display: flex;
+  gap: 8px;
+  margin-top: auto;
+  padding: 10px 0;
+  flex-shrink: 0;
+  position: sticky;
+  bottom: 0;
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border);
+}
+
+.connect-nav-btn {
+  flex: 1;
+  min-height: 44px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.connect-nav-btn:active {
+  background: var(--accent-dim);
+}
+
 /* Compact form: labels to left of inputs */
 .compact-form {
   display: grid;

--- a/public/index.html
+++ b/public/index.html
@@ -416,6 +416,13 @@
       </div>
 
       <button type="button" id="newConnBtn" class="secondary-btn" hidden>+ New connection</button>
+
+      <nav id="connectNavbar" class="connect-navbar">
+        <button type="button" class="connect-nav-btn" data-action="new">New</button>
+        <button type="button" class="connect-nav-btn" data-action="import">Import</button>
+        <button type="button" class="connect-nav-btn" data-action="export">Export</button>
+        <button type="button" class="connect-nav-btn" data-action="keys">Keys</button>
+      </nav>
     </div>
 
     <!-- Keys panel -->

--- a/src/modules/__tests__/profile-export-import.test.ts
+++ b/src/modules/__tests__/profile-export-import.test.ts
@@ -1,0 +1,211 @@
+/**
+ * profile-export-import.test.ts — Tests for #419: export/import profiles
+ *
+ * Verifies:
+ * 1. SECURITY: export excludes all sensitive fields
+ * 2. Export includes only safe metadata fields
+ * 3. Import validates and deduplicates profiles
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Mock globals before imports ────────────────────────────────────────────
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+});
+
+vi.stubGlobal('location', { hostname: 'localhost', host: 'localhost:8081', protocol: 'http:', pathname: '/' });
+
+vi.stubGlobal('document', {
+  getElementById: () => null,
+  querySelector: () => null,
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  documentElement: {
+    style: { setProperty: vi.fn() },
+    dataset: {},
+    classList: { toggle: vi.fn(), add: vi.fn(), remove: vi.fn() },
+  },
+  createElement: vi.fn(() => ({
+    href: '', download: '', click: vi.fn(), style: {},
+    appendChild: vi.fn(), setAttribute: vi.fn(),
+  })),
+  body: { appendChild: vi.fn(), removeChild: vi.fn() },
+});
+
+class MockURL { constructor(public href: string) {} }
+Object.assign(MockURL, { createObjectURL: vi.fn(() => 'blob:mock'), revokeObjectURL: vi.fn() });
+vi.stubGlobal('URL', MockURL);
+vi.stubGlobal('crypto', { randomUUID: () => 'uuid-mock' });
+vi.stubGlobal('navigator', { serviceWorker: undefined, wakeLock: undefined });
+vi.stubGlobal('WebSocket', class { url = ''; readyState = 3; static OPEN = 1; static CLOSED = 3; close = vi.fn(); send = vi.fn(); addEventListener = vi.fn(); });
+vi.stubGlobal('Worker', class { onmessage = null; postMessage = vi.fn(); terminate = vi.fn(); });
+vi.stubGlobal('window', { addEventListener: vi.fn(), location: { protocol: 'http:', host: 'localhost:8081', pathname: '/' } });
+vi.stubGlobal('CSS', { escape: (s: string) => s });
+vi.stubGlobal('confirm', () => true);
+vi.stubGlobal('requestAnimationFrame', (cb: () => void) => { cb(); return 0; });
+vi.stubGlobal('Blob', class { constructor(public parts: string[], public options: { type: string }) {} });
+
+const { getProfiles, exportProfilesJSON, importProfilesFromJSON } = await import('../profiles.js');
+
+/** Seed localStorage with profiles that have sensitive fields. */
+function seedProfiles(): void {
+  storage.set('sshProfiles', JSON.stringify([
+    {
+      title: 'Dev Server',
+      host: 'dev.example.com',
+      port: 22,
+      username: 'admin',
+      authType: 'password',
+      initialCommand: '',
+      vaultId: 'vault-secret-123',
+      hasVaultCreds: true,
+      keyVaultId: 'key-vault-456',
+      theme: 'dark',
+    },
+    {
+      title: 'Prod Server',
+      host: 'prod.example.com',
+      port: 2222,
+      username: 'deploy',
+      authType: 'key',
+      initialCommand: 'tmux attach',
+      vaultId: 'vault-secret-789',
+      hasVaultCreds: true,
+      theme: 'nord',
+    },
+  ]));
+}
+
+describe('#419: export profiles — security boundary', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  it('SECURITY: export does NOT include password, privateKey, passphrase, vaultId, keyVaultId, or hasVaultCreds', () => {
+    seedProfiles();
+    const json = exportProfilesJSON();
+    const parsed = JSON.parse(json);
+
+    const SENSITIVE_FIELDS = ['password', 'privateKey', 'passphrase', 'vaultId', 'keyVaultId', 'hasVaultCreds'];
+
+    for (const profile of parsed) {
+      for (const field of SENSITIVE_FIELDS) {
+        expect(profile).not.toHaveProperty(field);
+      }
+    }
+  });
+
+  it('export includes only safe metadata: title, host, port, username, authType', () => {
+    seedProfiles();
+    const json = exportProfilesJSON();
+    const parsed = JSON.parse(json);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toEqual({
+      title: 'Dev Server',
+      host: 'dev.example.com',
+      port: 22,
+      username: 'admin',
+      authType: 'password',
+    });
+    expect(parsed[1]).toEqual({
+      title: 'Prod Server',
+      host: 'prod.example.com',
+      port: 2222,
+      username: 'deploy',
+      authType: 'key',
+    });
+  });
+
+  it('export returns empty array JSON when no profiles exist', () => {
+    const json = exportProfilesJSON();
+    expect(JSON.parse(json)).toEqual([]);
+  });
+});
+
+describe('#419: import profiles', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  it('imports valid profiles into storage', () => {
+    const input = JSON.stringify([
+      { title: 'New Server', host: 'new.example.com', port: 22, username: 'user', authType: 'password' },
+    ]);
+
+    const result = importProfilesFromJSON(input);
+    expect(result.added).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+
+    const profiles = getProfiles();
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]!.title).toBe('New Server');
+  });
+
+  it('deduplicates by host+port+username — skips existing profiles', () => {
+    // Seed an existing profile
+    storage.set('sshProfiles', JSON.stringify([
+      { title: 'Existing', host: 'dev.example.com', port: 22, username: 'admin', authType: 'password', vaultId: 'v1', initialCommand: '' },
+    ]));
+
+    const input = JSON.stringify([
+      { title: 'Duplicate', host: 'dev.example.com', port: 22, username: 'admin', authType: 'password' },
+      { title: 'New One', host: 'other.com', port: 22, username: 'root', authType: 'key' },
+    ]);
+
+    const result = importProfilesFromJSON(input);
+    expect(result.added).toBe(1);
+    expect(result.skipped).toBe(1);
+
+    const profiles = getProfiles();
+    expect(profiles).toHaveLength(2);
+    // The existing profile keeps its original title
+    expect(profiles[0]!.title).toBe('Existing');
+    expect(profiles[1]!.title).toBe('New One');
+  });
+
+  it('rejects invalid JSON', () => {
+    const result = importProfilesFromJSON('not json');
+    expect(result.added).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/invalid/i);
+  });
+
+  it('rejects entries missing required fields', () => {
+    const input = JSON.stringify([
+      { title: 'No Host', port: 22, username: 'user', authType: 'password' },
+      { title: 'Valid', host: 'ok.com', port: 22, username: 'user', authType: 'password' },
+    ]);
+
+    const result = importProfilesFromJSON(input);
+    expect(result.added).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/host/i);
+  });
+
+  it('strips any sensitive fields from import data', () => {
+    const input = JSON.stringify([
+      {
+        title: 'Sneaky', host: 'evil.com', port: 22, username: 'hacker', authType: 'password',
+        password: 'secret', privateKey: 'PRIVATE', passphrase: 'pass', vaultId: 'steal-me',
+      },
+    ]);
+
+    const result = importProfilesFromJSON(input);
+    expect(result.added).toBe(1);
+
+    const profiles = getProfiles();
+    const imported = profiles[0]!;
+    expect(imported).not.toHaveProperty('password');
+    expect(imported).not.toHaveProperty('privateKey');
+    expect(imported).not.toHaveProperty('passphrase');
+    // vaultId is generated fresh, not taken from import
+    expect(imported.vaultId).not.toBe('steal-me');
+  });
+});

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -521,3 +521,133 @@ export function deleteKey(idx: number): void {
   loadKeys();
   populateKeyDropdown();
 }
+
+// ── Export / Import (#419) ─────────────────────────────────────────────────
+
+/** Safe metadata fields included in export. Everything else is stripped. */
+const EXPORT_FIELDS = ['title', 'host', 'port', 'username', 'authType'] as const;
+
+/** Serialize saved profiles to JSON string containing ONLY non-sensitive metadata. */
+export function exportProfilesJSON(): string {
+  const profiles = getProfiles();
+  const safe = profiles.map((p) => {
+    const out: Record<string, unknown> = {};
+    for (const field of EXPORT_FIELDS) {
+      out[field] = p[field];
+    }
+    return out;
+  });
+  return JSON.stringify(safe, null, 2);
+}
+
+/** Trigger a browser download of exported profiles. */
+export function downloadProfilesExport(): void {
+  const json = exportProfilesJSON();
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'mobissh-profiles.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+interface ImportResult {
+  added: number;
+  skipped: number;
+  errors: string[];
+}
+
+/** Parse and import profiles from JSON string. Deduplicates by host+port+username. */
+export function importProfilesFromJSON(json: string): ImportResult {
+  const result: ImportResult = { added: 0, skipped: 0, errors: [] };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    result.errors.push('Invalid JSON format');
+    return result;
+  }
+
+  if (!Array.isArray(parsed)) {
+    result.errors.push('Invalid format: expected an array of profiles');
+    return result;
+  }
+
+  const existing = getProfiles();
+
+  for (const entry of parsed) {
+    if (typeof entry !== 'object' || entry === null) {
+      result.errors.push('Invalid entry: not an object');
+      continue;
+    }
+    const rec = entry as Record<string, unknown>;
+
+    // Validate required fields
+    if (!rec.host || typeof rec.host !== 'string') {
+      result.errors.push('Invalid entry: missing or invalid host');
+      continue;
+    }
+    if (!rec.username || typeof rec.username !== 'string') {
+      result.errors.push('Invalid entry: missing or invalid username');
+      continue;
+    }
+
+    const port = typeof rec.port === 'number' ? rec.port : 22;
+    const host = rec.host;
+    const username = rec.username;
+
+    // Dedup: skip if host+port+username already exists
+    const isDup = existing.some(
+      (p) => p.host === host && (p.port || 22) === port && p.username === username
+    );
+    if (isDup) {
+      result.skipped++;
+      continue;
+    }
+
+    // Build a clean profile with only safe fields + fresh vaultId
+    const imported: StoredProfile = {
+      title: typeof rec.title === 'string' ? rec.title : `${username}@${host}`,
+      host,
+      port,
+      username,
+      authType: rec.authType === 'key' ? 'key' : 'password',
+      initialCommand: '',
+      vaultId: _generateId(),
+    };
+
+    existing.push(imported);
+    result.added++;
+  }
+
+  localStorage.setItem('sshProfiles', JSON.stringify(existing));
+  loadProfiles();
+  return result;
+}
+
+/** Open a file picker and import profiles from the selected JSON file. */
+export function triggerProfileImport(): void {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.json,application/json';
+  input.addEventListener('change', () => {
+    const file = input.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result as string;
+      const result = importProfilesFromJSON(text);
+      if (result.errors.length > 0) {
+        _toast(`Import: ${String(result.added)} added, ${String(result.skipped)} skipped, ${String(result.errors.length)} errors`);
+      } else {
+        _toast(`Imported ${String(result.added)} profile${result.added !== 1 ? 's' : ''}${result.skipped > 0 ? `, ${String(result.skipped)} skipped (duplicates)` : ''}`);
+      }
+    };
+    reader.readAsText(file);
+  });
+  input.click();
+}

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -11,7 +11,7 @@ import { appState, currentSession, isSessionConnected, onStateChange, transition
 import { applyTheme, _addNotification, fireNotification } from './terminal.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- backward compat: sendSftpUpload kept for legacy callers
 import { sendSSHInput, sendSSHInputToAll, disconnect, reconnect, probeSession, cancelReconnect, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath, uploadFileChunked, sendSftpUploadCancel, getSessionHandle, removeSessionHandle } from './connection.js';
-import { saveProfile, connectFromProfile, newConnection, loadProfiles, removeRecentSession, getRecentSessions } from './profiles.js';
+import { saveProfile, connectFromProfile, newConnection, loadProfiles, removeRecentSession, getRecentSessions, downloadProfilesExport, triggerProfileImport } from './profiles.js';
 import { clearIMEPreview, restoreIMEOverlay } from './ime.js';
 import { isPreviewable, createPreviewPanel } from './sftp-preview.js';
 
@@ -746,6 +746,17 @@ export function initConnectForm(): void {
 
   document.getElementById('newConnBtn')!.addEventListener('click', () => {
     newConnection();
+  });
+
+  // Connect panel bottom navbar (#419)
+  document.getElementById('connectNavbar')?.addEventListener('click', (e) => {
+    const target = (e.target as HTMLElement).closest<HTMLElement>('[data-action]');
+    if (!target) return;
+    const action = target.dataset.action;
+    if (action === 'new') newConnection();
+    else if (action === 'import') triggerProfileImport();
+    else if (action === 'export') downloadProfilesExport();
+    else if (action === 'keys') navigateToPanel('keys', { pushHistory: true });
   });
 
   document.getElementById('profileList')!.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- Add persistent bottom navbar to Connect panel with 4 buttons: New, Import, Export, Keys
- Export serializes saved profiles to JSON with ONLY non-sensitive metadata (title, host, port, username, authType) — no passwords, keys, vault references
- Import parses JSON, validates fields, deduplicates by host+port+username, strips any sensitive data from input
- Keys button navigates to #keys panel, fixing #427 (keys inaccessible without terminal session)

## TDD Analysis
- Type: feature
- Behavior change: yes — new UI and functionality
- TDD approach: full (tests written first, confirmed red, then implemented to green)

## Test coverage
- **Existing tests updated**: none needed
- **New tests added (fail-to-pass)**: `profile-export-import.test.ts` — 8 tests
  - SECURITY: export excludes password, privateKey, passphrase, vaultId, keyVaultId, hasVaultCreds
  - Export includes only safe metadata fields
  - Export returns empty array when no profiles
  - Import adds valid profiles
  - Import deduplicates by host+port+username
  - Import rejects invalid JSON
  - Import rejects entries missing required fields
  - Import strips sensitive fields from input data
- **Smoketest**: export/import functions callable, navbar markup present

## Test results
- tsc: PASS
- eslint: PASS (0 new errors, pre-existing warnings only)
- vitest: PASS (8 new tests, 706 total passing)

## Diff stats
- Files changed: 5
- Lines: +390 / -1

Closes #419

## Cycles used
1/3