### PR TITLE
Keys panel UX: Done button, Edit with passphrase, lock indicator

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1437,6 +1437,59 @@ hr {
 
 .item-btn.danger { color: var(--danger); }
 
+/* Panel header with Done/back button (#432) */
+.panel-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+.panel-header-row h2 { margin: 0; }
+.panel-done-btn {
+  padding: 6px 16px;
+  font-size: 14px;
+}
+
+/* Key info row: date + passphrase indicator (#432) */
+.key-info-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.key-passphrase-badge {
+  font-size: 12px;
+  color: var(--accent);
+}
+
+/* Inline key edit form (#432) */
+.key-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 8px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.key-edit-form label {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.key-edit-form input {
+  padding: 6px 8px;
+  background: var(--bg-input);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 14px;
+}
+.key-edit-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
 /* Connecting animation on profile Connect button (#318) */
 .item-btn.connecting {
   background: linear-gradient(90deg, var(--bg-input) 0%, var(--accent) 50%, var(--bg-input) 100%);

--- a/public/index.html
+++ b/public/index.html
@@ -427,7 +427,10 @@
 
     <!-- Keys panel -->
     <div id="panel-keys" class="panel">
-      <h2>SSH Keys</h2>
+      <div class="panel-header-row">
+        <h2>SSH Keys</h2>
+        <button id="keysDoneBtn" class="secondary-btn panel-done-btn">Done</button>
+      </div>
       <p class="hint">Import your private keys here. They are stored in your browser's localStorage.
          Do not use this on a shared device.</p>
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,7 @@ import { initVaultUI, promptVaultSetupOnStartup } from './modules/vault-ui.js';
 import {
   initProfiles, getProfiles, loadProfiles,
   loadProfileIntoForm, deleteProfile,
-  loadKeys, importKey, useKey, deleteKey, renameKey, populateKeyDropdown,
+  loadKeys, importKey, useKey, deleteKey, renameKey, editKey, saveKeyEdit, cancelKeyEdit, populateKeyDropdown,
 } from './modules/profiles.js';
 import { initSettings, initSettingsPanel, registerServiceWorker, migrateSettings, connectSSE } from './modules/settings.js';
 import { initConnection } from './modules/connection.js';
@@ -141,11 +141,14 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
       const idx = parseInt(btn.dataset.idx ?? '0');
       if (btn.dataset.action === 'use') useKey(idx);
       else if (btn.dataset.action === 'delete') deleteKey(idx);
-      else if (btn.dataset.action === 'rename') {
-        const currentName = btn.closest('.key-item')?.querySelector('.key-name')?.textContent ?? '';
-        const newName = prompt('Rename key to:', currentName);
-        if (newName !== null) renameKey(idx, newName);
-      }
+      else if (btn.dataset.action === 'edit') void editKey(idx);
+      else if (btn.dataset.action === 'save-edit') void saveKeyEdit(idx);
+      else if (btn.dataset.action === 'cancel-edit') cancelKeyEdit(idx);
+    });
+
+    // Done button on keys panel (#432)
+    document.getElementById('keysDoneBtn')!.addEventListener('click', () => {
+      navigateToPanel('connect', { pushHistory: true });
     });
 
     // Import key button

--- a/src/modules/__tests__/keys-panel-ux.test.ts
+++ b/src/modules/__tests__/keys-panel-ux.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for keys panel UX improvements (#432)
+ *
+ * Verifies:
+ * 1. Done/back button exists in keys panel HTML
+ * 2. loadKeys() renders "Edit" button (not "Rename")
+ * 3. loadKeys() renders passphrase badge placeholder
+ * 4. editKey() function exists and handles vault passphrase read
+ * 5. saveKeyEdit() function exists and writes passphrase to vault
+ * 6. cancelKeyEdit() function exists
+ * 7. app.ts wires edit/save-edit/cancel-edit actions
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const profilesSrc = readFileSync(resolve(__dirname, '../profiles.ts'), 'utf-8');
+const appSrc = readFileSync(resolve(__dirname, '../../app.ts'), 'utf-8');
+const indexHtml = readFileSync(resolve(__dirname, '../../../public/index.html'), 'utf-8');
+
+describe('Keys panel UX (#432)', () => {
+
+  describe('Done/back button', () => {
+    it('keys panel contains a Done button in HTML', () => {
+      expect(indexHtml).toContain('id="keysDoneBtn"');
+      expect(indexHtml).toContain('panel-done-btn');
+    });
+
+    it('app.ts wires keysDoneBtn to navigateToPanel connect', () => {
+      expect(appSrc).toContain('keysDoneBtn');
+      expect(appSrc).toContain("navigateToPanel('connect'");
+    });
+  });
+
+  describe('Edit button replaces Rename', () => {
+    it('loadKeys renders Edit button instead of Rename', () => {
+      // The loadKeys function should produce buttons with data-action="edit"
+      expect(profilesSrc).toContain('data-action="edit"');
+      // Should NOT contain data-action="rename" in the loadKeys HTML template
+      const loadKeysStart = profilesSrc.indexOf('export function loadKeys');
+      const loadKeysEnd = profilesSrc.indexOf('\n}', loadKeysStart + 10);
+      const loadKeysBody = profilesSrc.slice(loadKeysStart, loadKeysEnd);
+      expect(loadKeysBody).not.toContain('data-action="rename"');
+      expect(loadKeysBody).toContain('data-action="edit"');
+      expect(loadKeysBody).toContain('>Edit<');
+    });
+  });
+
+  describe('Passphrase indicator', () => {
+    it('loadKeys renders passphrase badge placeholder', () => {
+      expect(profilesSrc).toContain('key-passphrase-badge');
+    });
+
+    it('_updatePassphraseBadges checks vault for passphrase', () => {
+      expect(profilesSrc).toContain('_updatePassphraseBadges');
+      expect(profilesSrc).toContain('vaultLoad');
+      expect(profilesSrc).toContain('Passphrase set');
+    });
+  });
+
+  describe('editKey function', () => {
+    it('editKey is exported and async', () => {
+      expect(profilesSrc).toContain('export async function editKey');
+    });
+
+    it('editKey loads passphrase from vault', () => {
+      const fnStart = profilesSrc.indexOf('export async function editKey');
+      const fnSlice = profilesSrc.slice(fnStart, fnStart + 800);
+      expect(fnSlice).toContain('vaultLoad');
+      expect(fnSlice).toContain('passphrase');
+    });
+
+    it('editKey creates an inline edit form', () => {
+      const fnStart = profilesSrc.indexOf('export async function editKey');
+      const fnSlice = profilesSrc.slice(fnStart, fnStart + 1500);
+      expect(fnSlice).toContain('key-edit-form');
+      expect(fnSlice).toContain('editKeyName');
+      expect(fnSlice).toContain('editKeyPass');
+    });
+  });
+
+  describe('saveKeyEdit function', () => {
+    it('saveKeyEdit is exported and async', () => {
+      expect(profilesSrc).toContain('export async function saveKeyEdit');
+    });
+
+    it('saveKeyEdit writes passphrase to vault', () => {
+      const fnStart = profilesSrc.indexOf('export async function saveKeyEdit');
+      const fnSlice = profilesSrc.slice(fnStart, fnStart + 1000);
+      expect(fnSlice).toContain('vaultLoad');
+      expect(fnSlice).toContain('vaultStore');
+      expect(fnSlice).toContain('passphrase');
+    });
+  });
+
+  describe('cancelKeyEdit function', () => {
+    it('cancelKeyEdit is exported', () => {
+      expect(profilesSrc).toContain('export function cancelKeyEdit');
+    });
+  });
+
+  describe('app.ts wiring', () => {
+    it('imports editKey, saveKeyEdit, cancelKeyEdit', () => {
+      expect(appSrc).toContain('editKey');
+      expect(appSrc).toContain('saveKeyEdit');
+      expect(appSrc).toContain('cancelKeyEdit');
+    });
+
+    it('handles edit, save-edit, cancel-edit actions in keyList handler', () => {
+      expect(appSrc).toContain("'edit'");
+      expect(appSrc).toContain("'save-edit'");
+      expect(appSrc).toContain("'cancel-edit'");
+    });
+  });
+});

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -457,16 +457,114 @@ export function loadKeys(): void {
   }
 
   list.innerHTML = keys.map((k, i) => `
-    <div class="key-item">
+    <div class="key-item" data-key-idx="${String(i)}">
       <span class="key-name">${escHtml(k.name)}</span>
-      <span class="key-created">Added ${new Date(k.created).toLocaleDateString()}</span>
+      <div class="key-info-row">
+        <span class="key-created">Added ${new Date(k.created).toLocaleDateString()}</span>
+        <span class="key-passphrase-badge" data-vault-id="${escHtml(k.vaultId)}"></span>
+      </div>
       <div class="item-actions">
-        <button class="item-btn" data-action="rename" data-idx="${String(i)}">Rename</button>
+        <button class="item-btn" data-action="edit" data-idx="${String(i)}">Edit</button>
         <button class="item-btn" data-action="use" data-idx="${String(i)}">Use in form</button>
         <button class="item-btn danger" data-action="delete" data-idx="${String(i)}">Delete</button>
       </div>
     </div>
   `).join('');
+
+  // Async: check vault for passphrase badges
+  void _updatePassphraseBadges(keys);
+}
+
+async function _updatePassphraseBadges(keys: StoredKey[]): Promise<void> {
+  for (const k of keys) {
+    try {
+      const record = await vaultLoad(k.vaultId) as Record<string, unknown> | null;
+      const badge = document.querySelector(`.key-passphrase-badge[data-vault-id="${CSS.escape(k.vaultId)}"]`);
+      if (badge && record && typeof record.passphrase === 'string' && record.passphrase.length > 0) {
+        badge.textContent = '\u{1F512} Passphrase set';
+      }
+    } catch { /* vault locked or missing — skip badge */ }
+  }
+}
+
+export async function editKey(idx: number): Promise<void> {
+  const keys = getKeys();
+  const key = keys[idx];
+  if (!key) return;
+
+  const item = document.querySelector(`.key-item[data-key-idx="${String(idx)}"]`);
+  if (!item) return;
+
+  // Don't open a second edit form
+  if (item.querySelector('.key-edit-form')) return;
+
+  // Hide action buttons while editing
+  const actions = item.querySelector('.item-actions') as HTMLElement | null;
+  if (actions) actions.style.display = 'none';
+
+  // Load existing passphrase from vault
+  let existingPassphrase = '';
+  try {
+    const record = await vaultLoad(key.vaultId) as Record<string, unknown> | null;
+    if (record && typeof record.passphrase === 'string') {
+      existingPassphrase = record.passphrase;
+    }
+  } catch { /* vault locked — leave empty */ }
+
+  const form = document.createElement('div');
+  form.className = 'key-edit-form';
+  form.innerHTML = `
+    <label for="editKeyName-${String(idx)}">Name</label>
+    <input type="text" id="editKeyName-${String(idx)}" value="${escHtml(key.name)}" />
+    <label for="editKeyPass-${String(idx)}">Passphrase</label>
+    <input type="password" id="editKeyPass-${String(idx)}" value="${escHtml(existingPassphrase)}" placeholder="(none)" autocomplete="off" />
+    <div class="key-edit-actions">
+      <button class="item-btn accent" data-action="save-edit" data-idx="${String(idx)}">Save</button>
+      <button class="item-btn" data-action="cancel-edit" data-idx="${String(idx)}">Cancel</button>
+    </div>
+  `;
+  item.appendChild(form);
+}
+
+export async function saveKeyEdit(idx: number): Promise<void> {
+  const nameInput = document.getElementById(`editKeyName-${String(idx)}`) as HTMLInputElement | null;
+  const passInput = document.getElementById(`editKeyPass-${String(idx)}`) as HTMLInputElement | null;
+  if (!nameInput || !passInput) return;
+
+  const newName = nameInput.value.trim();
+  if (!newName) { _toast('Key name cannot be empty.'); return; }
+
+  const keys = getKeys();
+  const key = keys[idx];
+  if (!key) return;
+
+  // Update name
+  key.name = newName;
+  localStorage.setItem('sshKeys', JSON.stringify(keys));
+
+  // Update passphrase in vault
+  try {
+    const record = await vaultLoad(key.vaultId) as Record<string, unknown> | null;
+    if (record) {
+      record.passphrase = passInput.value;
+      await vaultStore(key.vaultId, record);
+    }
+  } catch { _toast('Could not save passphrase — vault may be locked.'); }
+
+  loadKeys();
+  populateKeyDropdown();
+  _toast(`Key "${key.name}" updated.`);
+}
+
+export function cancelKeyEdit(idx: number): void {
+  const item = document.querySelector(`.key-item[data-key-idx="${String(idx)}"]`);
+  if (!item) return;
+
+  const form = item.querySelector('.key-edit-form');
+  if (form) form.remove();
+
+  const actions = item.querySelector('.item-actions') as HTMLElement | null;
+  if (actions) actions.style.display = '';
 }
 
 export async function importKey(name: string, data: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Add "Done" button to keys panel header for back navigation to Connect panel
- Rename "Rename" button to "Edit" — opens inline form with name and passphrase fields, saves passphrase to vault
- Show passphrase-protected indicator (lock icon badge) on each key item via async vault check

## TDD Analysis
- Type: feature
- Behavior change: yes — new UI elements and edit functionality
- TDD approach: smoketest-only (structural source tests)

## Test coverage
- **Existing tests updated**: none needed (no existing key panel tests)
- **New tests added (fail->pass)**: `keys-panel-ux.test.ts` — 13 structural tests verifying Done button HTML/wiring, Edit button replaces Rename, passphrase badge, editKey/saveKeyEdit/cancelKeyEdit function shapes and vault usage, app.ts action wiring
- **Smoketest**: Done button exists in HTML with correct ID, app.ts wires it to navigateToPanel('connect')

## Test results
- tsc: PASS
- eslint: pre-existing config issue (src/ ignored by default)
- vitest: PASS (13 new tests, all passing)

## Diff stats
- Files changed: 5
- Lines: +282 / -10

Closes #432

## Cycles used
1/3