### PR TITLE
fix: scroll edit forms into view on mobile (#434)

### DIFF
--- a/src/modules/__tests__/scroll-into-view.test.ts
+++ b/src/modules/__tests__/scroll-into-view.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for scrollIntoView on inline edit forms (#434)
+ *
+ * Verifies:
+ * 1. editKey() calls scrollIntoView after appending the form
+ * 2. revealConnectForm() calls scrollIntoView on the form section
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const profilesSrc = readFileSync(resolve(__dirname, '../profiles.ts'), 'utf-8');
+
+describe('scrollIntoView on form expand (#434)', () => {
+
+  describe('editKey inline form', () => {
+    it('calls scrollIntoView after appendChild(form)', () => {
+      const fnStart = profilesSrc.indexOf('export async function editKey');
+      const fnEnd = profilesSrc.indexOf('\n}', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+
+      const appendIdx = fnBody.indexOf('item.appendChild(form)');
+      const scrollIdx = fnBody.indexOf('form.scrollIntoView(');
+      expect(appendIdx).toBeGreaterThan(-1);
+      expect(scrollIdx).toBeGreaterThan(-1);
+      expect(scrollIdx).toBeGreaterThan(appendIdx);
+    });
+
+    it('uses smooth behavior and nearest block', () => {
+      const fnStart = profilesSrc.indexOf('export async function editKey');
+      const fnEnd = profilesSrc.indexOf('\n}', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain("behavior: 'smooth'");
+      expect(fnBody).toContain("block: 'nearest'");
+    });
+  });
+
+  describe('revealConnectForm', () => {
+    it('calls scrollIntoView on the form section', () => {
+      const fnStart = profilesSrc.indexOf('export function revealConnectForm');
+      const fnEnd = profilesSrc.indexOf('\n}', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+
+      expect(fnBody).toContain('scrollIntoView(');
+      expect(fnBody).toContain("behavior: 'smooth'");
+      expect(fnBody).toContain("block: 'nearest'");
+    });
+  });
+});

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -266,7 +266,9 @@ export function loadProfiles(): void {
 
 /** Reveal the connect form section. */
 export function revealConnectForm(): void {
-  document.getElementById('connect-form-section')?.classList.remove('connect-form-hidden');
+  const section = document.getElementById('connect-form-section');
+  section?.classList.remove('connect-form-hidden');
+  section?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   const newConnBtn = document.getElementById('newConnBtn') as HTMLButtonElement | null;
   if (newConnBtn) newConnBtn.hidden = true;
 }
@@ -524,6 +526,7 @@ export async function editKey(idx: number): Promise<void> {
     </div>
   `;
   item.appendChild(form);
+  form.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 }
 
 export async function saveKeyEdit(idx: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Add `scrollIntoView({ behavior: 'smooth', block: 'nearest' })` after `editKey()` appends the inline edit form to the DOM
- Add the same scroll call in `revealConnectForm()` so the connect form section scrolls into view on expand
- Both fixes ensure expanded forms are visible on mobile without manual scrolling

## TDD Analysis
- Type: bug fix
- Behavior change: no
- TDD approach: smoketest-only (source grep)

## Test coverage
- **Existing tests updated**: none needed
- **New tests added (fail→pass)**: `scroll-into-view.test.ts` — 3 tests verifying scrollIntoView is called after appendChild in editKey, uses smooth/nearest options, and revealConnectForm also scrolls
- **Smoketest**: source-level verification that scrollIntoView calls exist in the right locations with correct options

## Test results
- tsc: PASS
- eslint: PASS (pre-existing warnings only)
- vitest: PASS (3 new tests)

## Diff stats
- Files changed: 1 (+ 1 new test file)
- Lines: +4 / -1 (source), +52 (test)

Closes #434

## Cycles used
1/3