### PR TITLE
Compact profile edit form (#439)

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1585,34 +1585,33 @@ hr {
   margin-top: 8px;
 }
 
-#connectAdvanced {
-  margin-top: 4px;
+/* Form row: side-by-side fields (e.g. host + port) */
+.form-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
 }
 
-#connectAdvanced summary {
-  cursor: pointer;
-  color: var(--accent);
-  font-size: 0.9em;
-  padding: 4px 0;
-  user-select: none;
-}
-
-.compact-form-advanced {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 8px 12px;
-  align-items: center;
-  margin-top: 8px;
-}
-
-.compact-form-advanced label {
-  margin: 0;
-  text-align: right;
+.form-field label {
+  display: block;
+  margin-bottom: 4px;
+  text-align: left;
   white-space: nowrap;
 }
 
-.compact-form-advanced input {
-  margin: 0;
+.form-field input,
+.form-field select {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.form-field-grow {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.form-field-port {
+  flex: 0 0 5em;
 }
 
 /* Advanced section */

--- a/public/index.html
+++ b/public/index.html
@@ -335,8 +335,19 @@
 
       <div id="connect-form-section">
         <form id="connectForm" class="compact-form" autocomplete="off">
-          <label for="host">Host</label>
-          <input type="text" id="host" placeholder="192.168.1.100" required inputmode="url" />
+          <label for="profileName">Name</label>
+          <input type="text" id="profileName" placeholder="Auto: user@host" />
+
+          <div class="compact-form-span form-row">
+            <div class="form-field form-field-grow">
+              <label for="host">Host</label>
+              <input type="text" id="host" placeholder="192.168.1.100" required inputmode="url" />
+            </div>
+            <div class="form-field form-field-port">
+              <label for="port">Port</label>
+              <input type="number" id="port" value="22" min="1" max="65535" inputmode="numeric" />
+            </div>
+          </div>
 
           <label for="remote_a">User</label>
           <input type="text" id="remote_a" placeholder="root" required autocapitalize="none"
@@ -345,8 +356,7 @@
             data-1p-ignore="true"
             data-form-type="other" />
 
-          <label for="authType">Auth</label>
-          <select id="authType">
+          <select id="authType" class="compact-form-span">
             <option value="password">Password</option>
             <option value="key">Private key</option>
           </select>
@@ -384,30 +394,19 @@
             </div>
           </div>
 
-          <details id="connectAdvanced" class="compact-form-span">
-            <summary>Advanced</summary>
-            <div class="compact-form-advanced">
-              <label for="profileName">Name</label>
-              <input type="text" id="profileName" placeholder="Auto: user@host" />
+          <label for="initialCommand">Command</label>
+          <input type="text" id="initialCommand"
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="none"
+            spellcheck="false"
+            placeholder="Optional initial command" />
 
-              <label for="port">Port</label>
-              <input type="number" id="port" value="22" min="1" max="65535" inputmode="numeric" />
-
-              <label for="initialCommand">Command</label>
-              <input type="text" id="initialCommand"
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="none"
-                spellcheck="false"
-                placeholder="Optional initial command" />
-
-              <label for="profileTheme">Session theme</label>
-              <select id="profileTheme">
-                <option value="">Use default</option>
-                <!-- Populated dynamically from THEME_ORDER in profiles.ts -->
-              </select>
-            </div>
-          </details>
+          <label for="profileTheme">Session theme</label>
+          <select id="profileTheme">
+            <option value="">Use default</option>
+            <!-- Populated dynamically from THEME_ORDER in profiles.ts -->
+          </select>
 
           <div class="compact-form-span">
             <button type="submit" class="primary-btn">Save</button>

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -41,17 +41,9 @@ async function waitForAppReady(page, timeout = 8000) {
   ]);
 }
 
-/** Open the Advanced section in the connect form (port, name, command are inside <details>). */
-async function openConnectAdvanced(page) {
-  const details = page.locator('#connectAdvanced');
-  if (await details.count() > 0) {
-    // Use el.open (boolean property) not getAttribute('open') -- getAttribute returns ''
-    // (falsy) for an open <details>, causing the check to incorrectly click again and close it.
-    const isOpen = await details.evaluate(el => el.open);
-    if (!isOpen) {
-      await details.locator('summary').click();
-    }
-  }
+/** No-op: Advanced section was removed in #439. Fields are always visible. Kept for call-site compat. */
+async function openConnectAdvanced(_page) {
+  // All fields are now inline in the main form — nothing to expand.
 }
 
 /** Return the active IME input element ID based on current mode. */

--- a/tests/layout.spec.js
+++ b/tests/layout.spec.js
@@ -187,14 +187,44 @@ test.describe('Connect form', { tag: '@headless-adequate' }, () => {
     await expect(page.locator('#host')).toBeVisible();
     await expect(page.locator('#remote_a')).toBeVisible();
     await expect(page.locator('#authType')).toBeVisible();
-    // Port is inside collapsed Advanced section
-    await openConnectAdvanced(page);
     await expect(page.locator('#port')).toBeVisible();
   });
 
   test('port field defaults to 22', async ({ page }) => {
-    await openConnectAdvanced(page);
     await expect(page.locator('#port')).toHaveValue('22');
+  });
+
+  test('host and port are on the same row (#439)', async ({ page }) => {
+    const hostBox = await page.locator('#host').boundingBox();
+    const portBox = await page.locator('#port').boundingBox();
+    expect(hostBox).toBeTruthy();
+    expect(portBox).toBeTruthy();
+    // Same vertical position (within 5px tolerance for label alignment)
+    expect(Math.abs(hostBox.y - portBox.y)).toBeLessThan(5);
+    // Host is wider than port
+    expect(hostBox.width).toBeGreaterThan(portBox.width);
+  });
+
+  test('form fields are in compact order (#439)', async ({ page }) => {
+    const nameBox = await page.locator('#profileName').boundingBox();
+    const hostBox = await page.locator('#host').boundingBox();
+    const userBox = await page.locator('#remote_a').boundingBox();
+    const authBox = await page.locator('#authType').boundingBox();
+    const pwBox = await page.locator('#remote_c').boundingBox();
+    expect(nameBox.y).toBeLessThan(hostBox.y);
+    expect(hostBox.y).toBeLessThan(userBox.y);
+    expect(userBox.y).toBeLessThan(authBox.y);
+    expect(authBox.y).toBeLessThan(pwBox.y);
+  });
+
+  test('no Advanced details section in form (#439)', async ({ page }) => {
+    await expect(page.locator('#connectAdvanced')).toHaveCount(0);
+  });
+
+  test('auth type has no label (#439)', async ({ page }) => {
+    // The authType select should not have a preceding label element
+    const labelCount = await page.locator('label[for="authType"]').count();
+    expect(labelCount).toBe(0);
   });
 
   test('auth type selector has password and key options', async ({ page }) => {
@@ -251,7 +281,6 @@ test.describe('Connect form', { tag: '@headless-adequate' }, () => {
       await createVault('test', false);
     });
 
-    await openConnectAdvanced(page);
     await page.locator('#profileName').fill('Test Server');
     await page.locator('#host').fill('192.168.1.100');
     await page.locator('#remote_a').fill('admin');

--- a/tests/profiles.spec.js
+++ b/tests/profiles.spec.js
@@ -25,7 +25,6 @@ async function revealConnectForm(page) {
   if (await btn.isVisible({ timeout: 500 }).catch(() => false)) {
     await btn.click();
   }
-  await openConnectAdvanced(page);
 }
 
 // Inject mock PasswordCredential so vault operations work in headless Chromium


### PR DESCRIPTION
## Summary
- Removed `<details id="connectAdvanced">` wrapper; all fields are now inline in the main form
- Combined host and port inputs on one row using CSS flexbox (host ~75%, port ~25%)
- Removed redundant "Auth" label — the dropdown options are self-explanatory
- Reordered fields: Name, Host+Port, User, Auth type, Password/Key, Command, Session theme, Save

## TDD Analysis
- Type: feature (UI restructure)
- Behavior change: yes (layout only, no functional changes)
- TDD approach: smoketest-only (CSS/layout changes)

## Test coverage
- **Existing tests updated**: `tests/fixtures.js` (openConnectAdvanced is now a no-op), `tests/layout.spec.js` (removed openConnectAdvanced calls, updated comments), `tests/profiles.spec.js` (removed openConnectAdvanced call)
- **New tests added (fail->pass)**: 4 new tests in layout.spec.js:
  - `host and port are on the same row` — verifies side-by-side layout via bounding box
  - `form fields are in compact order` — verifies Name > Host > User > Auth > Password vertical order
  - `no Advanced details section in form` — verifies `#connectAdvanced` element is removed
  - `auth type has no label` — verifies no `label[for="authType"]` exists
- **Smoketest**: form fields visible without expanding anything, correct order

## Test results
- tsc: PASS
- eslint: PASS (pre-existing warnings only)
- vitest: PASS (pre-existing failures only)
- headless Playwright: PASS (0 new failures; 138 pre-existing flaky failures)

## Diff stats
- Files changed: 5
- Lines: +82 / -64

Closes #439

## Cycles used
1/3