### PR TITLE
Eliminate keys panel — fold key management into Connect panel

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1098,7 +1098,6 @@ html, body {
 
 /* Scrollable panels */
 #panel-connect,
-#panel-keys,
 #panel-settings {
   padding: 16px;
   gap: 12px;
@@ -1526,6 +1525,40 @@ hr {
   padding: 10px;
   font-size: 14px;
   cursor: pointer;
+}
+
+/* Inline keys section in Connect panel (#441) */
+.connect-keys-section {
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0;
+}
+
+.connect-keys-section summary {
+  padding: 10px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-dim);
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.connect-keys-section[open] > summary {
+  border-bottom: 1px solid var(--border);
+}
+
+.connect-keys-section .item-list,
+.connect-keys-section .key-add-form {
+  padding: 10px 14px;
+}
+
+.connect-keys-section .key-add-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px solid var(--border);
 }
 
 /* Connect panel bottom navbar (#419) */

--- a/public/index.html
+++ b/public/index.html
@@ -200,10 +200,6 @@
         <span class="tab-icon">⚡</span>
         <span class="tab-label">Connect</span>
       </button>
-      <button class="tab" data-panel="keys" aria-label="Keys">
-        <span class="tab-icon">🔑</span>
-        <span class="tab-label">Keys</span>
-      </button>
       <button class="tab" data-panel="settings" aria-label="Settings">
         <span class="tab-icon">⚙</span>
         <span class="tab-label">Settings</span>
@@ -416,37 +412,25 @@
 
       <button type="button" id="newConnBtn" class="secondary-btn" hidden>+ New connection</button>
 
+      <details id="keysSection" class="connect-keys-section">
+        <summary>Stored Keys</summary>
+        <div id="keyList" class="item-list">
+          <p class="empty-hint">No keys stored.</p>
+        </div>
+        <div class="key-add-form">
+          <label for="keyName">Key name</label>
+          <input type="text" id="keyName" placeholder="my-key" />
+          <label for="keyData">Private key (PEM)</label>
+          <textarea id="keyData" rows="4" placeholder="-----BEGIN OPENSSH PRIVATE KEY-----" spellcheck="false"></textarea>
+          <button id="importKeyBtn" class="primary-btn">Save key</button>
+        </div>
+      </details>
+
       <nav id="connectNavbar" class="connect-navbar">
         <button type="button" class="connect-nav-btn" data-action="new">New</button>
         <button type="button" class="connect-nav-btn" data-action="import">Import</button>
         <button type="button" class="connect-nav-btn" data-action="export">Export</button>
-        <button type="button" class="connect-nav-btn" data-action="keys">Keys</button>
       </nav>
-    </div>
-
-    <!-- Keys panel -->
-    <div id="panel-keys" class="panel">
-      <div class="panel-header-row">
-        <h2>SSH Keys</h2>
-        <button id="keysDoneBtn" class="secondary-btn panel-done-btn">Done</button>
-      </div>
-      <p class="hint">Import your private keys here. They are stored in your browser's localStorage.
-         Do not use this on a shared device.</p>
-
-      <div class="form-section">
-        <label for="keyName">Key name</label>
-        <input type="text" id="keyName" placeholder="my-key" />
-
-        <label for="keyData">Private key (PEM)</label>
-        <textarea id="keyData" rows="6" placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;...&#10;-----END OPENSSH PRIVATE KEY-----" spellcheck="false"></textarea>
-
-        <button id="importKeyBtn" class="primary-btn">Save key</button>
-      </div>
-
-      <h3>Stored keys</h3>
-      <div id="keyList" class="item-list">
-        <p class="empty-hint">No keys stored.</p>
-      </div>
     </div>
 
     <!-- Settings panel -->

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,7 @@ import { initVaultUI, promptVaultSetupOnStartup } from './modules/vault-ui.js';
 import {
   initProfiles, getProfiles, loadProfiles,
   loadProfileIntoForm, deleteProfile,
-  loadKeys, importKey, useKey, deleteKey, renameKey, editKey, saveKeyEdit, cancelKeyEdit, populateKeyDropdown,
+  loadKeys, importKey, deleteKey, renameKey, editKey, saveKeyEdit, cancelKeyEdit, populateKeyDropdown,
 } from './modules/profiles.js';
 import { initSettings, initSettingsPanel, registerServiceWorker, migrateSettings, connectSSE } from './modules/settings.js';
 import { initConnection } from './modules/connection.js';
@@ -134,21 +134,15 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
       (e.target as HTMLElement).closest('.profile-item')?.classList.remove('tapped');
     }, { passive: true });
 
-    // Event delegation for key list
+    // Event delegation for key list (inline in Connect panel, #441)
     document.getElementById('keyList')!.addEventListener('click', (e) => {
       const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-action]');
       if (!btn) return;
       const idx = parseInt(btn.dataset.idx ?? '0');
-      if (btn.dataset.action === 'use') useKey(idx);
-      else if (btn.dataset.action === 'delete') deleteKey(idx);
+      if (btn.dataset.action === 'delete') deleteKey(idx);
       else if (btn.dataset.action === 'edit') void editKey(idx);
       else if (btn.dataset.action === 'save-edit') void saveKeyEdit(idx);
       else if (btn.dataset.action === 'cancel-edit') cancelKeyEdit(idx);
-    });
-
-    // Done button on keys panel (#432)
-    document.getElementById('keysDoneBtn')!.addEventListener('click', () => {
-      navigateToPanel('connect', { pushHistory: true });
     });
 
     // Import key button

--- a/src/modules/__tests__/keys-panel-ux.test.ts
+++ b/src/modules/__tests__/keys-panel-ux.test.ts
@@ -1,14 +1,20 @@
 /**
- * Tests for keys panel UX improvements (#432)
+ * Tests for keys section UX (#432, updated #441)
+ *
+ * After #441, key management is an inline <details> section in the Connect
+ * panel. The separate #panel-keys no longer exists.
  *
  * Verifies:
- * 1. Done/back button exists in keys panel HTML
+ * 1. Inline keysSection exists in Connect panel HTML
  * 2. loadKeys() renders "Edit" button (not "Rename")
  * 3. loadKeys() renders passphrase badge placeholder
- * 4. editKey() function exists and handles vault passphrase read
- * 5. saveKeyEdit() function exists and writes passphrase to vault
- * 6. cancelKeyEdit() function exists
- * 7. app.ts wires edit/save-edit/cancel-edit actions
+ * 4. loadKeys() does NOT render "Use in form" button (#440)
+ * 5. editKey() function exists and handles vault passphrase read
+ * 6. saveKeyEdit() function exists and writes passphrase to vault
+ * 7. cancelKeyEdit() function exists
+ * 8. app.ts wires edit/save-edit/cancel-edit actions (no "use" action)
+ * 9. #panel-keys is removed from HTML
+ * 10. #keys hash redirects to connect in routing
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -17,32 +23,64 @@ import { resolve } from 'node:path';
 const profilesSrc = readFileSync(resolve(__dirname, '../profiles.ts'), 'utf-8');
 const appSrc = readFileSync(resolve(__dirname, '../../app.ts'), 'utf-8');
 const indexHtml = readFileSync(resolve(__dirname, '../../../public/index.html'), 'utf-8');
+const uiSrc = readFileSync(resolve(__dirname, '../ui.ts'), 'utf-8');
 
-describe('Keys panel UX (#432)', () => {
+describe('Keys section UX (#441)', () => {
 
-  describe('Done/back button', () => {
-    it('keys panel contains a Done button in HTML', () => {
-      expect(indexHtml).toContain('id="keysDoneBtn"');
-      expect(indexHtml).toContain('panel-done-btn');
+  describe('Inline keys section in Connect panel', () => {
+    it('Connect panel contains a keysSection details element', () => {
+      expect(indexHtml).toContain('id="keysSection"');
+      expect(indexHtml).toContain('connect-keys-section');
     });
 
-    it('app.ts wires keysDoneBtn to navigateToPanel connect', () => {
-      expect(appSrc).toContain('keysDoneBtn');
-      expect(appSrc).toContain("navigateToPanel('connect'");
+    it('keysSection is inside panel-connect', () => {
+      const connectStart = indexHtml.indexOf('id="panel-connect"');
+      const connectEnd = indexHtml.indexOf('</div>', indexHtml.indexOf('id="connectNavbar"'));
+      const keysPos = indexHtml.indexOf('id="keysSection"');
+      expect(keysPos).toBeGreaterThan(connectStart);
+      expect(keysPos).toBeLessThan(connectEnd);
+    });
+
+    it('separate #panel-keys is removed from HTML', () => {
+      expect(indexHtml).not.toContain('id="panel-keys"');
+    });
+
+    it('Keys tab is removed from tab bar', () => {
+      expect(indexHtml).not.toContain('data-panel="keys"');
+    });
+
+    it('keysDoneBtn is removed from HTML', () => {
+      expect(indexHtml).not.toContain('id="keysDoneBtn"');
     });
   });
 
   describe('Edit button replaces Rename', () => {
     it('loadKeys renders Edit button instead of Rename', () => {
-      // The loadKeys function should produce buttons with data-action="edit"
       expect(profilesSrc).toContain('data-action="edit"');
-      // Should NOT contain data-action="rename" in the loadKeys HTML template
       const loadKeysStart = profilesSrc.indexOf('export function loadKeys');
       const loadKeysEnd = profilesSrc.indexOf('\n}', loadKeysStart + 10);
       const loadKeysBody = profilesSrc.slice(loadKeysStart, loadKeysEnd);
       expect(loadKeysBody).not.toContain('data-action="rename"');
       expect(loadKeysBody).toContain('data-action="edit"');
       expect(loadKeysBody).toContain('>Edit<');
+    });
+  });
+
+  describe('Use in form button removed (#440)', () => {
+    it('loadKeys does NOT render Use in form button', () => {
+      const loadKeysStart = profilesSrc.indexOf('export function loadKeys');
+      const loadKeysEnd = profilesSrc.indexOf('\n}', loadKeysStart + 10);
+      const loadKeysBody = profilesSrc.slice(loadKeysStart, loadKeysEnd);
+      expect(loadKeysBody).not.toContain('Use in form');
+      expect(loadKeysBody).not.toContain('data-action="use"');
+    });
+
+    it('useKey is not exported from profiles.ts', () => {
+      expect(profilesSrc).not.toContain('export function useKey');
+    });
+
+    it('app.ts does not import useKey', () => {
+      expect(appSrc).not.toContain('useKey');
     });
   });
 
@@ -110,6 +148,28 @@ describe('Keys panel UX (#432)', () => {
       expect(appSrc).toContain("'edit'");
       expect(appSrc).toContain("'save-edit'");
       expect(appSrc).toContain("'cancel-edit'");
+    });
+
+    it('does NOT handle "use" action in keyList handler', () => {
+      // Find the keyList event handler section
+      const keyListStart = appSrc.indexOf("getElementById('keyList')");
+      const keyListEnd = appSrc.indexOf('});', keyListStart);
+      const keyListHandler = appSrc.slice(keyListStart, keyListEnd);
+      expect(keyListHandler).not.toContain("'use'");
+    });
+  });
+
+  describe('Routing', () => {
+    it('#keys hash redirects to connect in ui.ts', () => {
+      expect(uiSrc).toContain("raw === 'keys'");
+      expect(uiSrc).toContain("return 'connect'");
+    });
+
+    it('keys is not in VALID_PANELS', () => {
+      // The PanelName type should not include 'keys'
+      const panelLine = uiSrc.match(/type PanelName = .+/);
+      expect(panelLine).toBeTruthy();
+      expect(panelLine![0]).not.toContain("'keys'");
     });
   });
 });

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -471,7 +471,6 @@ export function loadKeys(): void {
       </div>
       <div class="item-actions">
         <button class="item-btn" data-action="edit" data-idx="${String(i)}">Edit</button>
-        <button class="item-btn" data-action="use" data-idx="${String(i)}">Use in form</button>
         <button class="item-btn danger" data-action="delete" data-idx="${String(i)}">Delete</button>
       </div>
     </div>
@@ -591,18 +590,6 @@ export async function importKey(name: string, data: string): Promise<boolean> {
   populateKeyDropdown();
   _toast(`Key "${name}" saved.`);
   return true;
-}
-
-export function useKey(idx: number): void {
-  const key = getKeys()[idx];
-  if (!key) return;
-  (document.getElementById('authType') as HTMLSelectElement).value = 'key';
-  (document.getElementById('authType') as HTMLSelectElement).dispatchEvent(new Event('change'));
-  const keySelect = document.getElementById('selectedKeyId') as HTMLSelectElement | null;
-  if (keySelect) {
-    keySelect.value = key.vaultId;
-  }
-  _toast(`Key "${key.name}" selected in form.`);
 }
 
 export function renameKey(idx: number, newName: string): void {

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -25,9 +25,9 @@ function _setMenuBtnText(text: string): void {
 
 // ── Hash routing (#137) ─────────────────────────────────────────────────────
 
-type PanelName = 'terminal' | 'connect' | 'files' | 'keys' | 'settings';
+type PanelName = 'terminal' | 'connect' | 'files' | 'settings';
 
-const VALID_PANELS: ReadonlySet<string> = new Set<PanelName>(['terminal', 'connect', 'files', 'keys', 'settings']);
+const VALID_PANELS: ReadonlySet<string> = new Set<PanelName>(['terminal', 'connect', 'files', 'settings']);
 
 function _isValidPanel(hash: string): hash is PanelName {
   return VALID_PANELS.has(hash);
@@ -36,6 +36,8 @@ function _isValidPanel(hash: string): hash is PanelName {
 function _panelFromHash(): PanelName | null {
   const raw = location.hash.replace(/^#/, '');
   if (raw.startsWith('files/') || raw.startsWith('files%2F') || raw === 'files') return 'files';
+  // Redirect legacy #keys to connect panel (#441)
+  if (raw === 'keys') return 'connect';
   return _isValidPanel(raw) ? raw : null;
 }
 
@@ -756,7 +758,7 @@ export function initConnectForm(): void {
     if (action === 'new') newConnection();
     else if (action === 'import') triggerProfileImport();
     else if (action === 'export') downloadProfilesExport();
-    else if (action === 'keys') navigateToPanel('keys', { pushHistory: true });
+    // Keys button removed — key management is now inline in Connect panel (#441)
   });
 
   document.getElementById('profileList')!.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- Moved key management (key list, add form, edit/delete) from separate `#panel-keys` into a collapsible `<details>` section inside the Connect panel
- Removed the Keys tab from the tab bar, the `#panel-keys` div, and the `keysDoneBtn` handler
- Removed "Use in form" button from key items (#440) and the `useKey()` function
- `#keys` hash now redirects to `#connect` for backward compatibility

## TDD Analysis
- Type: feature (UI reorganization)
- Behavior change: yes — keys panel eliminated, key management inline in Connect
- TDD approach: smoketest-only (structural source assertions)

## Test coverage
- **Existing tests updated**: `keys-panel-ux.test.ts` rewritten for new structure
- **New tests added (fail->pass)**: 22 tests covering inline keysSection presence, panel-keys removal, Keys tab removal, useKey removal, routing redirect, VALID_PANELS update
- **Smoketest**: keysSection details element exists inside panel-connect, #panel-keys absent

## Test results
- tsc: PASS
- eslint: pre-existing config issue (unrelated)
- vitest: PASS (22 new/updated tests in keys-panel-ux.test.ts)

## Diff stats
- Files changed: 6
- Lines: +132 / -72

Closes #441
Closes #440

## Cycles used
1/3