### PR TITLE
feat: convert profile form to collapsible details toggle

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1507,24 +1507,31 @@ hr {
   flex-direction: column;
 }
 
-/* Connect panel: form hidden when profiles exist */
-.connect-form-hidden {
-  display: none;
+/* Connect panel: collapsible form section */
+#connect-form-section {
+  margin-top: 12px;
 }
 
-
-#newConnBtn {
-  margin-top: 12px;
-  width: 100%;
-  position: sticky;
-  bottom: 0;
+#connect-form-section > summary {
+  cursor: pointer;
+  padding: 10px;
+  font-size: 14px;
   background: var(--bg-input);
   border: 1px solid var(--border);
   color: var(--text);
   border-radius: 4px;
-  padding: 10px;
-  font-size: 14px;
-  cursor: pointer;
+  list-style: none;
+  text-align: center;
+}
+
+#connect-form-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+#connect-form-section[open] > summary {
+  border-radius: 4px 4px 0 0;
+  margin-bottom: 0;
+  border-bottom: none;
 }
 
 /* Inline keys section in Connect panel (#441) */

--- a/public/index.html
+++ b/public/index.html
@@ -329,7 +329,8 @@
         <p class="empty-hint">No saved profiles yet.</p>
       </div>
 
-      <div id="connect-form-section">
+      <details id="connect-form-section">
+        <summary>New Connection</summary>
         <form id="connectForm" class="compact-form" autocomplete="off">
           <label for="profileName">Name</label>
           <input type="text" id="profileName" placeholder="Auto: user@host" />
@@ -408,9 +409,7 @@
             <button type="submit" class="primary-btn">Save</button>
           </div>
         </form>
-      </div>
-
-      <button type="button" id="newConnBtn" class="secondary-btn" hidden>+ New connection</button>
+      </details>
 
       <details id="keysSection" class="connect-keys-section">
         <summary>Stored Keys</summary>

--- a/src/modules/__tests__/details-toggle.test.ts
+++ b/src/modules/__tests__/details-toggle.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for details-based connect form toggle
+ *
+ * Verifies:
+ * 1. loadProfiles collapses form (details.open = false) when profiles exist
+ * 2. loadProfiles expands form (details.open = true) when no profiles
+ * 3. newConnection resets summary to "New Connection"
+ * 4. loadProfileIntoForm sets summary to "Edit Profile"
+ * 5. No references to newConnBtn or connect-form-hidden class
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const profilesSrc = readFileSync(resolve(__dirname, '../profiles.ts'), 'utf-8');
+const uiSrc = readFileSync(resolve(__dirname, '../ui.ts'), 'utf-8');
+const indexHtml = readFileSync(resolve(__dirname, '../../../public/index.html'), 'utf-8');
+
+describe('details-based connect form toggle', () => {
+
+  it('index.html uses <details> element for connect-form-section', () => {
+    expect(indexHtml).toContain('<details id="connect-form-section">');
+    expect(indexHtml).toContain('<summary>New Connection</summary>');
+  });
+
+  it('index.html does not contain newConnBtn', () => {
+    expect(indexHtml).not.toContain('id="newConnBtn"');
+  });
+
+  it('profiles.ts does not reference connect-form-hidden class', () => {
+    expect(profilesSrc).not.toContain('connect-form-hidden');
+  });
+
+  it('profiles.ts does not reference newConnBtn', () => {
+    expect(profilesSrc).not.toContain('newConnBtn');
+  });
+
+  it('ui.ts does not reference newConnBtn', () => {
+    expect(uiSrc).not.toContain('newConnBtn');
+  });
+
+  it('ui.ts does not reference connect-form-hidden', () => {
+    expect(uiSrc).not.toContain('connect-form-hidden');
+  });
+
+  describe('loadProfiles', () => {
+    it('sets details.open = false when profiles exist', () => {
+      const fnStart = profilesSrc.indexOf('export function loadProfiles');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+
+      expect(fnBody).toContain('formSection.open = false');
+    });
+
+    it('sets details.open = true when no profiles', () => {
+      const fnStart = profilesSrc.indexOf('export function loadProfiles');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+
+      expect(fnBody).toContain('formSection.open = true');
+    });
+  });
+
+  describe('newConnection', () => {
+    it('updates summary to New Connection', () => {
+      const fnStart = profilesSrc.indexOf('export function newConnection');
+      const fnEnd = profilesSrc.indexOf('\n}', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+
+      expect(fnBody).toContain("_updateFormSummary('New Connection')");
+    });
+  });
+
+  describe('loadProfileIntoForm', () => {
+    it('updates summary to Edit Profile', () => {
+      const fnStart = profilesSrc.indexOf('export async function loadProfileIntoForm');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+
+      expect(fnBody).toContain("_updateFormSummary('Edit Profile')");
+    });
+  });
+
+  describe('ui.ts save handler', () => {
+    it('collapses form after save by setting details.open = false', () => {
+      const saveIdx = uiSrc.indexOf('void saveProfile(profile)');
+      const nextHandler = uiSrc.indexOf('addEventListener', saveIdx + 10);
+      const saveBlock = uiSrc.slice(saveIdx, nextHandler);
+
+      expect(saveBlock).toContain('formSection.open = false');
+    });
+  });
+});

--- a/src/modules/__tests__/scroll-into-view.test.ts
+++ b/src/modules/__tests__/scroll-into-view.test.ts
@@ -1,9 +1,10 @@
 /**
  * Tests for scrollIntoView on inline edit forms (#434)
+ * Updated for details-based form toggle
  *
  * Verifies:
  * 1. editKey() calls scrollIntoView after appending the form
- * 2. revealConnectForm() calls scrollIntoView on the form section
+ * 2. revealConnectForm() uses details.open and calls scrollIntoView
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -36,6 +37,14 @@ describe('scrollIntoView on form expand (#434)', () => {
   });
 
   describe('revealConnectForm', () => {
+    it('sets details.open = true on the form section', () => {
+      const fnStart = profilesSrc.indexOf('export function revealConnectForm');
+      const fnEnd = profilesSrc.indexOf('\n}', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+
+      expect(fnBody).toContain('section.open = true');
+    });
+
     it('calls scrollIntoView on the form section', () => {
       const fnStart = profilesSrc.indexOf('export function revealConnectForm');
       const fnEnd = profilesSrc.indexOf('\n}', fnStart + 10);

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -176,8 +176,7 @@ export function loadProfiles(): void {
   const sessionList = document.getElementById('activeSessionList');
   if (!list) return;
 
-  const formSection = document.getElementById('connect-form-section');
-  const newConnBtn = document.getElementById('newConnBtn') as HTMLButtonElement | null;
+  const formSection = document.getElementById('connect-form-section') as HTMLDetailsElement | null;
 
   // Render active sessions section (#306)
   const allSessions = Array.from(appState.sessions.values()).filter((s) => s.profile);
@@ -232,8 +231,10 @@ export function loadProfiles(): void {
 
   if (!profiles.length) {
     list.innerHTML = '<p class="empty-hint">No saved profiles yet.</p>';
-    formSection?.classList.remove('connect-form-hidden');
-    if (newConnBtn) newConnBtn.hidden = true;
+    if (formSection) {
+      formSection.open = true;
+      _updateFormSummary('New Connection');
+    }
     return;
   }
 
@@ -260,17 +261,25 @@ export function loadProfiles(): void {
       </div>`;
     }).join('');
 
-  formSection?.classList.add('connect-form-hidden');
-  if (newConnBtn) newConnBtn.hidden = false;
+  if (formSection) {
+    formSection.open = false;
+    _updateFormSummary('New Connection');
+  }
+}
+
+/** Update the summary text of the connect form details element. */
+function _updateFormSummary(text: string): void {
+  const summary = document.querySelector('#connect-form-section > summary');
+  if (summary) summary.textContent = text;
 }
 
 /** Reveal the connect form section. */
 export function revealConnectForm(): void {
-  const section = document.getElementById('connect-form-section');
-  section?.classList.remove('connect-form-hidden');
-  section?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  const newConnBtn = document.getElementById('newConnBtn') as HTMLButtonElement | null;
-  if (newConnBtn) newConnBtn.hidden = true;
+  const section = document.getElementById('connect-form-section') as HTMLDetailsElement | null;
+  if (section) {
+    section.open = true;
+    section.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
 }
 
 /** Reset form for a brand-new connection and reveal it. */
@@ -281,6 +290,7 @@ export function newConnection(): void {
   const keySelect = document.getElementById('selectedKeyId') as HTMLSelectElement | null;
   if (keySelect) keySelect.value = '';
   document.getElementById('manualKeyGroup')?.classList.add('hidden');
+  _updateFormSummary('New Connection');
   revealConnectForm();
   (document.getElementById('host') as HTMLInputElement).focus();
 }
@@ -341,6 +351,7 @@ export async function loadProfileIntoForm(idx: number): Promise<void> {
     _toast('Enter credentials — not saved on this browser.');
   }
 
+  _updateFormSummary('Edit Profile');
   revealConnectForm();
   _navigateToConnect();
 }

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -74,9 +74,9 @@ export function navigateToPanel(
     restoreIMEOverlay();
   }
   if (panel === 'connect') {
-    // Only refresh if the form isn't already visible (avoids clobbering edit-in-progress)
-    const form = document.getElementById('connect-form-section');
-    if (form?.classList.contains('connect-form-hidden')) {
+    // Only refresh if the form isn't already open (avoids clobbering edit-in-progress)
+    const form = document.getElementById('connect-form-section') as HTMLDetailsElement | null;
+    if (!form?.open) {
       loadProfiles();
     }
   }
@@ -738,16 +738,10 @@ export function initConnectForm(): void {
     if (remotePpEl) remotePpEl.value = '';
 
     void saveProfile(profile).then(() => {
-      // Hide form after save, show profile list
-      const formSection = document.getElementById('connect-form-section');
-      if (formSection) formSection.classList.add('connect-form-hidden');
-      const newBtn = document.getElementById('newConnBtn');
-      if (newBtn) newBtn.classList.remove('hidden');
+      // Collapse form after save
+      const formSection = document.getElementById('connect-form-section') as HTMLDetailsElement | null;
+      if (formSection) formSection.open = false;
     });
-  });
-
-  document.getElementById('newConnBtn')!.addEventListener('click', () => {
-    newConnection();
   });
 
   // Connect panel bottom navbar (#419)


### PR DESCRIPTION
## Summary
- Convert #connect-form-section from div+CSS-class to native `<details>` element
- Summary shows "New Connection" or "Edit Profile" contextually
- Auto-expands when no profiles exist, collapses after save
- Remove #newConnBtn button (details summary replaces it)

## Test coverage
- 11 new tests in details-toggle.test.ts
- Updated scroll-into-view.test.ts

Closes device testing feedback (profile editor should be expand/collapse toggle)