### PR TITLE
feat: inline per-profile editing with auto-save and undo

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1489,6 +1489,85 @@ hr {
   margin-top: 4px;
 }
 
+/* Inline profile edit form (#446) */
+.profile-editing > .profile-name,
+.profile-editing > .profile-host,
+.profile-editing > .item-actions {
+  display: none;
+}
+
+.profile-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 8px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.profile-edit-form label {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.profile-edit-form input,
+.profile-edit-form select {
+  padding: 6px 8px;
+  background: var(--bg-input);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 14px;
+  min-height: 44px;
+}
+.profile-edit-form .form-row {
+  display: flex;
+  gap: 8px;
+}
+.profile-edit-form .form-field-grow { flex: 1; display: flex; flex-direction: column; gap: 4px; }
+.profile-edit-form .form-field-port { width: 80px; display: flex; flex-direction: column; gap: 4px; }
+.profile-edit-form .text-dim { font-size: 13px; color: var(--text-dim); }
+.profile-edit-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* Undo toast (#446) */
+.undo-toast {
+  position: fixed;
+  bottom: calc(var(--tab-height) + var(--keybar-height) + var(--keybar-handle-height) + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  z-index: 9999;
+  opacity: 0;
+  transition: opacity 0.3s;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.undo-toast.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+.undo-action {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 8px;
+  min-height: 44px;
+}
+
 /* Connecting animation on profile Connect button (#318) */
 .item-btn.connecting {
   background: linear-gradient(90deg, var(--bg-input) 0%, var(--accent) 50%, var(--bg-input) 100%);

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,7 @@ import { initVault } from './modules/vault.js';
 import { initVaultUI, promptVaultSetupOnStartup } from './modules/vault-ui.js';
 import {
   initProfiles, getProfiles, loadProfiles,
-  loadProfileIntoForm, deleteProfile,
+  deleteProfile, editProfile, closeProfileEdit,
   loadKeys, importKey, deleteKey, renameKey, editKey, saveKeyEdit, cancelKeyEdit, populateKeyDropdown,
 } from './modules/profiles.js';
 import { initSettings, initSettingsPanel, registerServiceWorker, migrateSettings, connectSSE } from './modules/settings.js';
@@ -120,12 +120,11 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
       if (btn) {
         e.stopPropagation();
         const idx = parseInt(btn.dataset.idx ?? '0');
-        if (btn.dataset.action === 'edit') void loadProfileIntoForm(idx);
+        if (btn.dataset.action === 'edit') editProfile(idx);
         else if (btn.dataset.action === 'delete') deleteProfile(idx);
+        else if (btn.dataset.action === 'close-edit') { closeProfileEdit(); loadProfiles(); }
         return;
       }
-      const item = target.closest<HTMLElement>('.profile-item');
-      if (item) void loadProfileIntoForm(parseInt(item.dataset.idx ?? '0'));
     });
     profileList.addEventListener('touchstart', (e) => {
       (e.target as HTMLElement).closest('.profile-item')?.classList.add('tapped');

--- a/src/modules/__tests__/inline-profile-edit.test.ts
+++ b/src/modules/__tests__/inline-profile-edit.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for inline per-profile editing (#446)
+ *
+ * Verifies:
+ * 1. editProfile function exists and is exported
+ * 2. editProfile creates .profile-edit-form inside profile item
+ * 3. autoSaveField persists changes to localStorage
+ * 4. Undo reverts the last auto-saved field
+ * 5. Only one inline edit open at a time (single-edit constraint)
+ * 6. closeProfileEdit removes the form and restores normal display
+ * 7. Profile item hides normal content when editing
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const profilesSrc = readFileSync(resolve(__dirname, '../profiles.ts'), 'utf-8');
+const appCss = readFileSync(resolve(__dirname, '../../../public/app.css'), 'utf-8');
+
+describe('inline per-profile editing (#446)', () => {
+
+  describe('editProfile function', () => {
+    it('is exported from profiles.ts', () => {
+      expect(profilesSrc).toContain('export function editProfile(');
+    });
+
+    it('creates a .profile-edit-form element', () => {
+      const fnStart = profilesSrc.indexOf('export function editProfile(');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain('profile-edit-form');
+    });
+
+    it('collapses any existing inline edit first', () => {
+      const fnStart = profilesSrc.indexOf('export function editProfile(');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain('closeProfileEdit');
+    });
+
+    it('hides normal profile content while editing', () => {
+      const fnStart = profilesSrc.indexOf('export function editProfile(');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain('profile-editing');
+    });
+
+    it('calls scrollIntoView after expanding', () => {
+      const fnStart = profilesSrc.indexOf('export function editProfile(');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain('scrollIntoView');
+    });
+  });
+
+  describe('autoSaveField function', () => {
+    it('is exported from profiles.ts', () => {
+      expect(profilesSrc).toContain('export function autoSaveField(');
+    });
+
+    it('persists to localStorage via saveProfiles pattern', () => {
+      const fnStart = profilesSrc.indexOf('export function autoSaveField(');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain('localStorage.setItem');
+    });
+
+    it('shows undo toast after saving', () => {
+      const fnStart = profilesSrc.indexOf('export function autoSaveField(');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain('Undo');
+    });
+  });
+
+  describe('closeProfileEdit function', () => {
+    it('is exported from profiles.ts', () => {
+      expect(profilesSrc).toContain('export function closeProfileEdit(');
+    });
+
+    it('removes the profile-edit-form', () => {
+      const fnStart = profilesSrc.indexOf('export function closeProfileEdit(');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain('.remove()');
+    });
+
+    it('restores normal profile display', () => {
+      const fnStart = profilesSrc.indexOf('export function closeProfileEdit(');
+      const fnEnd = profilesSrc.indexOf('\n}\n', fnStart + 10);
+      const fnBody = profilesSrc.slice(fnStart, fnEnd);
+      expect(fnBody).toContain('profile-editing');
+    });
+  });
+
+  describe('CSS styles', () => {
+    it('has .profile-edit-form styles', () => {
+      expect(appCss).toContain('.profile-edit-form');
+    });
+
+    it('has .profile-editing class to hide normal content', () => {
+      expect(appCss).toContain('.profile-editing');
+    });
+
+    it('has .undo-toast styles', () => {
+      expect(appCss).toContain('.undo-toast');
+    });
+  });
+
+  describe('app.ts wiring', () => {
+    const appSrc = readFileSync(resolve(__dirname, '../../app.ts'), 'utf-8');
+
+    it('imports editProfile from profiles', () => {
+      expect(appSrc).toContain('editProfile');
+    });
+
+    it('calls editProfile on edit action instead of loadProfileIntoForm', () => {
+      // The profileList click handler should call editProfile, not loadProfileIntoForm
+      const handlerStart = appSrc.indexOf("profileList.addEventListener('click'");
+      const handlerEnd = appSrc.indexOf('});', handlerStart + 10);
+      const handler = appSrc.slice(handlerStart, handlerEnd);
+      expect(handler).toContain('editProfile(idx)');
+      expect(handler).not.toContain('loadProfileIntoForm(idx)');
+    });
+  });
+});

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -439,6 +439,195 @@ export function deleteProfile(idx: number): void {
   loadProfiles();
 }
 
+// ── Inline per-profile editing (#446) ────────────────────────────────────────
+
+let _lastUndo: { idx: number; field: string; oldValue: string | number } | null = null;
+let _undoTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Close any open inline profile edit form. */
+export function closeProfileEdit(): void {
+  const existing = document.querySelector('.profile-edit-form');
+  if (!existing) return;
+  existing.remove();
+  const editingItem = document.querySelector('.profile-editing');
+  if (editingItem) editingItem.classList.remove('profile-editing');
+}
+
+/** Open an inline edit form inside the profile item at the given index. */
+export function editProfile(idx: number): void {
+  closeProfileEdit();
+
+  const profiles = getProfiles();
+  const profile = profiles[idx];
+  if (!profile) return;
+
+  const item = document.querySelector(`.profile-item[data-idx="${String(idx)}"]`);
+  if (!item) return;
+
+  item.classList.add('profile-editing');
+
+  const form = document.createElement('div');
+  form.className = 'profile-edit-form';
+
+  const authIsKey = profile.authType === 'key';
+  const pwGroupClass = authIsKey ? 'hidden' : '';
+  const keyGroupClass = authIsKey ? '' : 'hidden';
+
+  form.innerHTML = `
+    <label for="editTitle-${String(idx)}">Name</label>
+    <input type="text" id="editTitle-${String(idx)}" value="${escHtml(profile.title || '')}" data-field="title" placeholder="Auto: user@host" />
+    <div class="form-row">
+      <div class="form-field form-field-grow">
+        <label for="editHost-${String(idx)}">Host</label>
+        <input type="text" id="editHost-${String(idx)}" value="${escHtml(profile.host || '')}" data-field="host" inputmode="url" />
+      </div>
+      <div class="form-field form-field-port">
+        <label for="editPort-${String(idx)}">Port</label>
+        <input type="number" id="editPort-${String(idx)}" value="${String(profile.port || 22)}" data-field="port" min="1" max="65535" inputmode="numeric" />
+      </div>
+    </div>
+    <label for="editUsername-${String(idx)}">User</label>
+    <input type="text" id="editUsername-${String(idx)}" value="${escHtml(profile.username || '')}" data-field="username" autocapitalize="none" />
+    <label for="editAuthType-${String(idx)}">Auth</label>
+    <select id="editAuthType-${String(idx)}" data-field="authType">
+      <option value="password"${!authIsKey ? ' selected' : ''}>Password</option>
+      <option value="key"${authIsKey ? ' selected' : ''}>Private key</option>
+    </select>
+    <div class="edit-pw-group ${pwGroupClass}" id="editPwGroup-${String(idx)}">
+      <label for="editPassword-${String(idx)}">Password</label>
+      <input type="text" id="editPassword-${String(idx)}" data-field="password" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="(vault-encrypted)" />
+    </div>
+    <div class="edit-key-group ${keyGroupClass}" id="editKeyGroup-${String(idx)}">
+      <label>Key</label>
+      <span class="text-dim">Managed via Stored Keys section</span>
+    </div>
+    <label for="editCommand-${String(idx)}">Command</label>
+    <input type="text" id="editCommand-${String(idx)}" value="${escHtml(profile.initialCommand || '')}" data-field="initialCommand" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" placeholder="Optional initial command" />
+    <label for="editTheme-${String(idx)}">Session theme</label>
+    <select id="editTheme-${String(idx)}" data-field="theme">
+      <option value="">Use default</option>
+      ${THEME_ORDER.map((name) => `<option value="${name}"${profile.theme === name ? ' selected' : ''}>${escHtml(THEMES[name].label)}</option>`).join('')}
+    </select>
+    <div class="profile-edit-actions">
+      <button class="item-btn" data-action="close-edit">Done</button>
+    </div>
+  `;
+  item.appendChild(form);
+  form.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+  // Auth type toggle: show/hide password vs key groups
+  const authSelect = form.querySelector(`#editAuthType-${String(idx)}`) as HTMLSelectElement;
+  authSelect.addEventListener('change', () => {
+    const pwGroup = form.querySelector(`#editPwGroup-${String(idx)}`);
+    const keyGroup = form.querySelector(`#editKeyGroup-${String(idx)}`);
+    if (authSelect.value === 'key') {
+      pwGroup?.classList.add('hidden');
+      keyGroup?.classList.remove('hidden');
+    } else {
+      pwGroup?.classList.remove('hidden');
+      keyGroup?.classList.add('hidden');
+    }
+    autoSaveField(idx, 'authType', authSelect.value);
+  });
+
+  // Auto-save on change/blur for all inputs and selects (except password — handled separately)
+  const inputs = form.querySelectorAll<HTMLInputElement | HTMLSelectElement>('input[data-field], select[data-field]');
+  for (const input of inputs) {
+    const field = input.dataset.field;
+    if (!field || field === 'authType' || field === 'password') continue;
+    input.addEventListener('change', () => {
+      const value = field === 'port' ? parseInt(input.value, 10) || 22 : input.value;
+      autoSaveField(idx, field, value);
+    });
+  }
+
+  // Password field: save to vault on blur, not to localStorage
+  const pwInput = form.querySelector(`#editPassword-${String(idx)}`) as HTMLInputElement | null;
+  if (pwInput) {
+    pwInput.addEventListener('change', () => {
+      void _savePasswordToVault(idx, pwInput.value);
+    });
+  }
+
+  // Close button
+  form.querySelector('[data-action="close-edit"]')?.addEventListener('click', () => {
+    closeProfileEdit();
+    loadProfiles();
+  });
+}
+
+/** Auto-save a single profile field to localStorage and show undo toast. */
+export function autoSaveField(idx: number, field: string, value: string | number): void {
+  const profiles = getProfiles();
+  const profile = profiles[idx];
+  if (!profile) return;
+  const oldValue = (profile as unknown as Record<string, string | number>)[field] ?? '';
+  (profile as unknown as Record<string, string | number>)[field] = value;
+  localStorage.setItem('sshProfiles', JSON.stringify(profiles));
+  _showUndoToast(idx, field, oldValue);
+}
+
+/** Save password to vault (never to localStorage). */
+async function _savePasswordToVault(idx: number, password: string): Promise<void> {
+  const profiles = getProfiles();
+  const profile = profiles[idx];
+  if (!profile) return;
+
+  if (!profile.vaultId) profile.vaultId = crypto.randomUUID();
+
+  const hasVault = await ensureVaultKeyWithUI();
+  if (!hasVault) {
+    _toast('Password not saved — vault setup cancelled.');
+    return;
+  }
+
+  const creds: Record<string, string> = {};
+  if (password) creds.password = password;
+  await vaultStore(profile.vaultId, creds);
+  profile.hasVaultCreds = Object.keys(creds).length > 0;
+  localStorage.setItem('sshProfiles', JSON.stringify(profiles));
+  _toast('Password saved to vault.');
+}
+
+/** Show an undo toast with a clickable undo action. */
+function _showUndoToast(idx: number, field: string, oldValue: string | number): void {
+  _lastUndo = { idx, field, oldValue };
+  if (_undoTimer) clearTimeout(_undoTimer);
+
+  let el = document.getElementById('undoToast');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'undoToast';
+    el.className = 'undo-toast';
+    document.body.appendChild(el);
+  }
+  el.innerHTML = 'Saved. <button class="undo-action">Undo</button>';
+  el.classList.add('show');
+
+  const undoBtn = el.querySelector('.undo-action');
+  const handler = (): void => {
+    if (!_lastUndo) return;
+    const profiles = getProfiles();
+    const profile = profiles[_lastUndo.idx];
+    if (profile) {
+      (profile as unknown as Record<string, string | number>)[_lastUndo.field] = _lastUndo.oldValue;
+      localStorage.setItem('sshProfiles', JSON.stringify(profiles));
+      // Update the inline form field if still open
+      const input = document.querySelector(`[data-field="${_lastUndo.field}"]`) as HTMLInputElement | null;
+      if (input) input.value = String(_lastUndo.oldValue);
+      _toast('Undone.');
+    }
+    _lastUndo = null;
+    el!.classList.remove('show');
+  };
+  undoBtn?.addEventListener('click', handler, { once: true });
+
+  _undoTimer = setTimeout(() => {
+    el!.classList.remove('show');
+    _lastUndo = null;
+  }, 5000);
+}
+
 /** Populate the key dropdown in the connect form with current stored keys. */
 export function populateKeyDropdown(): void {
   const select = document.getElementById('selectedKeyId') as HTMLSelectElement | null;


### PR DESCRIPTION
## Summary
- Replace "Edit loads shared form at bottom" with inline editing inside each profile item
- Auto-save on field change/blur with 5-second undo toast (clickable Undo action)
- Password saved to vault (never localStorage); single-edit constraint (one form open at a time)

## TDD Analysis
- Type: feature
- Behavior change: yes — new inline edit UX
- TDD approach: smoketest + structural source verification

## Test coverage
- **Existing tests updated**: none needed (details-toggle.test.ts still passes)
- **New tests added (fail->pass)**: inline-profile-edit.test.ts (16 tests)
  - editProfile export, form creation, single-edit collapse, profile-editing class, scrollIntoView
  - autoSaveField export, localStorage persistence, undo toast
  - closeProfileEdit export, form removal, class restoration
  - CSS styles for profile-edit-form, profile-editing, undo-toast
  - app.ts wiring: imports editProfile, calls it instead of loadProfileIntoForm
- **Smoketest**: editProfile function exported, creates .profile-edit-form element

## Test results
- tsc: PASS
- eslint: PASS (no new warnings)
- vitest: PASS (49 related tests, 16 new)

## Diff stats
- Files changed: 4
- Lines: +397 / -4

Closes #446

## Cycles used
1/3