### PR TITLE
feat: simplify navbar — 3 top-level tabs, hamburger opens session menu (#449)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -188,10 +188,6 @@
     </div>
     <!-- Tab bar -->
     <nav id="tabBar">
-      <button class="tab" data-panel="files" aria-label="Files">
-        <svg class="tab-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
-        <span class="tab-label">Files</span>
-      </button>
       <button class="tab active" data-panel="terminal" aria-label="Terminal">
         <span class="tab-icon">⌨</span>
         <span class="tab-label">Terminal</span>

--- a/src/modules/__tests__/navbar-simplified.test.ts
+++ b/src/modules/__tests__/navbar-simplified.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for navbar simplification (#449).
+ *
+ * Verifies:
+ *  - Navbar has exactly 3 tabs (Terminal, Connect, Settings), no Files tab.
+ *  - Hamburger (#handleMenuBtn) opens #sessionMenu instead of toggling tabBar.
+ *  - Up-swipe on #key-bar-handle reveals the navbar when it is hidden.
+ *  - Down-swipe on #tabBar hides it.
+ *  - #sessionFilesBtn is still present in the session menu (regression guard for #409).
+ *
+ * Uses source-file string inspection (see session-menu-slim.test.ts for pattern).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const html = readFileSync(resolve(__dirname, '../../../public/index.html'), 'utf-8');
+const uiSrc = readFileSync(resolve(__dirname, '../ui.ts'), 'utf-8');
+
+/** Extract the <nav id="tabBar">…</nav> block from index.html. */
+function extractTabBar(src: string): string {
+  const start = src.indexOf('<nav id="tabBar">');
+  expect(start).toBeGreaterThan(-1);
+  const end = src.indexOf('</nav>', start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end + '</nav>'.length);
+}
+
+describe('navbar simplification (#449)', () => {
+  describe('tabBar markup', () => {
+    const tabBar = extractTabBar(html);
+
+    it('contains exactly 3 tab buttons', () => {
+      const matches = tabBar.match(/class="tab[^"]*"\s+data-panel=/g) ?? [];
+      expect(matches.length).toBe(3);
+    });
+
+    it('does not contain a Files tab (data-panel="files")', () => {
+      expect(tabBar).not.toMatch(/data-panel="files"/);
+    });
+
+    it('contains the Terminal tab', () => {
+      expect(tabBar).toMatch(/data-panel="terminal"/);
+    });
+
+    it('contains the Connect tab', () => {
+      expect(tabBar).toMatch(/data-panel="connect"/);
+    });
+
+    it('contains the Settings tab', () => {
+      expect(tabBar).toMatch(/data-panel="settings"/);
+    });
+  });
+
+  describe('hamburger opens session menu', () => {
+    it('handleMenuBtn click handler opens the session menu (no longer calls toggleTabBar)', () => {
+      // Locate the handleMenuBtn click handler block.
+      const handlerStart = uiSrc.indexOf("getElementById('handleMenuBtn')");
+      expect(handlerStart).toBeGreaterThan(-1);
+
+      // The handler body is within the next ~600 chars.
+      const handlerBlock = uiSrc.slice(handlerStart, handlerStart + 600);
+
+      // New behavior: handler toggles the 'hidden' class on the menu element.
+      // The handler works with the closed-over `menu` / `backdrop` variables
+      // from initSessionMenu, so we verify menu toggling rather than the id string.
+      expect(handlerBlock).toMatch(/menu\.classList\.toggle\(['"]hidden['"]/);
+
+      // Old behavior removed: handler no longer calls toggleTabBar().
+      expect(handlerBlock).not.toMatch(/toggleTabBar\s*\(/);
+    });
+  });
+
+  describe('swipe gestures on navbar', () => {
+    it('an upward swipe on key-bar-handle reveals the navbar when hidden', () => {
+      // The handle's touchend handler must include a branch that makes the tabBar
+      // visible when an upward swipe is detected. We verify the ui.ts source
+      // contains a path where tabBarVisible is set to true (revealing the navbar)
+      // and that it sits near the handle's touchend listener.
+      expect(uiSrc).toMatch(/tabBarVisible\s*=\s*true/);
+
+      // And that the revealing happens in the same lexical neighborhood as the
+      // key-bar-handle touchend handler (i.e. swipe-driven).
+      const handleSwipeStart = uiSrc.indexOf("const handle = document.getElementById('key-bar-handle')");
+      expect(handleSwipeStart).toBeGreaterThan(-1);
+      const handleSwipeBlock = uiSrc.slice(handleSwipeStart, handleSwipeStart + 2500);
+      expect(handleSwipeBlock).toMatch(/tabBarVisible\s*=\s*true/);
+    });
+
+    it('tabBar has a downward-swipe handler that hides it', () => {
+      // A touch listener must be registered on the #tabBar element itself,
+      // and it must set tabBarVisible to false.
+      expect(uiSrc).toMatch(/const\s+tabBarEl\s*=\s*document\.getElementById\(['"]tabBar['"]\)/);
+      expect(uiSrc).toMatch(/tabBarEl\.addEventListener\(\s*['"]touch/);
+      expect(uiSrc).toMatch(/tabBarVisible\s*=\s*false/);
+    });
+  });
+
+  describe('regression guards', () => {
+    it('#sessionFilesBtn is still present in markup (#409)', () => {
+      expect(html).toContain('id="sessionFilesBtn"');
+    });
+
+    it('session menu Files button still calls navigateToPanel(\'files\')', () => {
+      // Verify the existing #409 wiring hasn't been lost.
+      const filesBtnHandler = uiSrc.indexOf("getElementById('sessionFilesBtn')");
+      expect(filesBtnHandler).toBeGreaterThan(-1);
+      const block = uiSrc.slice(filesBtnHandler, filesBtnHandler + 400);
+      expect(block).toMatch(/navigateToPanel\(['"]files['"]/);
+    });
+
+    it('MobiSSH #sessionMenuBtn still exists as an alternate menu entry', () => {
+      // The MobiSSH button should remain a menu opener.
+      expect(html).toContain('id="sessionMenuBtn"');
+    });
+  });
+});

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -520,9 +520,19 @@ export function initSessionMenu(): void {
     if ('vibrate' in navigator) navigator.vibrate(10);
   });
 
-  // Hamburger ≡ button — toggles tab bar as fallback for non-swipe users.
-  document.getElementById('handleMenuBtn')!.addEventListener('click', () => {
-    toggleTabBar();
+  // Hamburger ≡ button — opens the session menu (single entry point for
+  // per-session controls, including Files) (#449).
+  document.getElementById('handleMenuBtn')!.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const wasHidden = menu.classList.toggle('hidden');
+    backdrop.classList.toggle('hidden', wasHidden);
+    if (!wasHidden) {
+      const hb = document.getElementById('key-bar-handle');
+      if (hb) {
+        const handleTop = hb.getBoundingClientRect().top;
+        menu.style.bottom = `${String(window.innerHeight - handleTop + 4)}px`;
+      }
+    }
   });
 
   // Swipe up on handle → show tab bar; swipe down → hide tab bar (#149).
@@ -550,12 +560,42 @@ export function initSessionMenu(): void {
     if (!touch) return;
     _swipeTouchId = -1;
     const deltaY = _swipeStartY - touch.clientY;
-    if (deltaY > 30 && appState.keyBarDepth < 3) {
-      setKeyBarDepth((appState.keyBarDepth + 1) as 0 | 1 | 2 | 3);
+    // Upward swipe (deltaY > 30): reveal navbar first if hidden, else cycle depth (#449).
+    if (deltaY > 30) {
+      if (!appState.tabBarVisible) {
+        appState.tabBarVisible = true;
+        _applyTabBarVisibility();
+      } else if (appState.keyBarDepth < 3) {
+        setKeyBarDepth((appState.keyBarDepth + 1) as 0 | 1 | 2 | 3);
+      }
     } else if (deltaY < -30 && appState.keyBarDepth > 0) {
       setKeyBarDepth((appState.keyBarDepth - 1) as 0 | 1 | 2 | 3);
     }
   }, { passive: true });
+
+  // Down-swipe on the tab bar hides it (#449).
+  const tabBarEl = document.getElementById('tabBar');
+  if (tabBarEl) {
+    let _tabSwipeTouchId = -1;
+    let _tabSwipeStartY = 0;
+    tabBarEl.addEventListener('touchstart', (e) => {
+      const t = e.touches[0];
+      if (e.touches.length === 1 && t) {
+        _tabSwipeTouchId = t.identifier;
+        _tabSwipeStartY = t.clientY;
+      }
+    }, { passive: true });
+    tabBarEl.addEventListener('touchend', (e) => {
+      const touch = Array.from(e.changedTouches).find((t) => t.identifier === _tabSwipeTouchId);
+      if (!touch) return;
+      _tabSwipeTouchId = -1;
+      const deltaY = touch.clientY - _tabSwipeStartY;
+      if (deltaY > 30 && appState.tabBarVisible) {
+        appState.tabBarVisible = false;
+        _applyTabBarVisibility();
+      }
+    }, { passive: true });
+  }
 
   backdrop.addEventListener('mousedown', (e) => { if (_keyboardVisible()) e.preventDefault(); });
   backdrop.addEventListener('click', closeMenu);
@@ -2326,13 +2366,6 @@ export function initFilesPanel(): void {
   document.getElementById('transferUploadBtn')?.addEventListener('click', () => {
     const fileInput = document.querySelector<HTMLInputElement>('#filesExplore .files-upload-input');
     fileInput?.click();
-  });
-
-  // On first Files tab activation *per session*, resolve home dir via
-  // sftp_realpath then navigate (#409).
-  const filesTab = document.querySelector<HTMLElement>('[data-panel="files"]');
-  filesTab?.addEventListener('click', () => {
-    _activateFilesForCurrentSession();
   });
 
   // Session menu: Files entry — opens the files panel for the active session (#409)

--- a/tests/files.spec.js
+++ b/tests/files.spec.js
@@ -27,15 +27,15 @@ const MOCK_DOCS_ENTRIES = [
  * Show the tab bar (hidden after setupConnected) and navigate to Files tab.
  * The mock server must handle sftp_realpath and sftp_ls messages.
  */
-async function showTabBar(page) {
-  // After setupConnected, the tab bar is hidden (#36). Click the menu button to reveal it.
+async function openSessionMenu(page) {
+  // Files is now reached via the session menu (#449). Hamburger opens the menu.
   await page.locator('#handleMenuBtn').click();
-  await expect(page.locator('#tabBar')).not.toHaveClass(/hidden/, { timeout: 3000 });
+  await expect(page.locator('#sessionMenu')).not.toHaveClass(/hidden/, { timeout: 3000 });
 }
 
 async function navigateToFiles(page) {
-  await showTabBar(page);
-  await page.locator('[data-panel="files"]').click();
+  await openSessionMenu(page);
+  await page.locator('#sessionFilesBtn').click();
   await expect(page.locator('#panel-files')).toHaveClass(/active/);
   // Wait for the files panel to render breadcrumb (from sftp_ls_result)
   await expect(page.locator('.files-breadcrumb')).toBeVisible({ timeout: 5000 });
@@ -99,8 +99,8 @@ test.describe('Files panel Explore tab (#209)', () => {
     installSftpHandlers(mockSshServer);
 
     // Show tab bar (hidden after connect) and navigate to Files tab
-    await showTabBar(page);
-    await page.locator('[data-panel="files"]').click();
+    await openSessionMenu(page);
+    await page.locator('#sessionFilesBtn').click();
     await expect(page.locator('#panel-files')).toHaveClass(/active/);
 
     // Sub-tabs should be visible
@@ -238,8 +238,8 @@ test.describe('Files panel Transfer tab (#209)', () => {
     await setupConnected(page, mockSshServer);
     installSftpHandlers(mockSshServer);
 
-    await showTabBar(page);
-    await page.locator('[data-panel="files"]').click();
+    await openSessionMenu(page);
+    await page.locator('#sessionFilesBtn').click();
     await expect(page.locator('#panel-files')).toHaveClass(/active/);
 
     // Click Transfer sub-tab
@@ -258,8 +258,8 @@ test.describe('Files panel Transfer tab (#209)', () => {
     await setupConnected(page, mockSshServer);
     installSftpHandlers(mockSshServer);
 
-    await showTabBar(page);
-    await page.locator('[data-panel="files"]').click();
+    await openSessionMenu(page);
+    await page.locator('#sessionFilesBtn').click();
     await expect(page.locator('#panel-files')).toHaveClass(/active/);
 
     // Switch to Transfer tab

--- a/tests/panels.spec.js
+++ b/tests/panels.spec.js
@@ -25,6 +25,12 @@ async function showTabBar(page) {
   await page.waitForSelector('#tabBar:not(.hidden)', { timeout: 2000 });
 }
 
+// Navigate to the Files panel via the session menu (Files tab removed in #449).
+async function openFilesFromMenu(page) {
+  await page.locator('#sessionMenuBtn').click();
+  await page.locator('#sessionFilesBtn').click();
+}
+
 test.describe('Panel navigation smoke', { tag: '@headless-adequate' }, () => {
 
   test('all tabs render their panel without console errors (no connection)', async ({ page }) => {
@@ -48,12 +54,8 @@ test.describe('Panel navigation smoke', { tag: '@headless-adequate' }, () => {
     await page.locator('[data-panel="settings"]').click();
     await expect(page.locator('#panel-settings')).toHaveClass(/active/);
 
-    // Keys tab
-    await page.locator('[data-panel="keys"]').click();
-    await expect(page.locator('#panel-keys')).toHaveClass(/active/);
-
-    // Files tab — panel activates; sftp_realpath is silently dropped (not connected)
-    await page.locator('[data-panel="files"]').click();
+    // Files — reached via session menu entry (#449: no top-level Files tab)
+    await openFilesFromMenu(page);
     await expect(page.locator('#panel-files')).toHaveClass(/active/);
 
     // Terminal tab
@@ -78,7 +80,7 @@ test.describe('Files panel', { tag: '@headless-adequate' }, () => {
     await page.goto('./');
     await Promise.race([page.waitForSelector('#connectForm', { timeout: 8000 }), page.waitForSelector('.xterm-screen', { timeout: 8000 })]);
 
-    await page.locator('[data-panel="files"]').click();
+    await openFilesFromMenu(page);
     await expect(page.locator('#panel-files')).toHaveClass(/active/);
 
     // sendSftpRealpath guard returns early when not connected — no WS traffic, no errors
@@ -99,7 +101,7 @@ test.describe('Files panel', { tag: '@headless-adequate' }, () => {
     await showTabBar(page);
 
     // Navigate to Files tab
-    await page.locator('[data-panel="files"]').click();
+    await openFilesFromMenu(page);
     await expect(page.locator('#panel-files')).toHaveClass(/active/);
 
     // Wait for the app to send sftp_realpath to the mock server
@@ -162,7 +164,7 @@ test.describe('Files panel', { tag: '@headless-adequate' }, () => {
     await showTabBar(page);
 
     // Navigate to Files tab
-    await page.locator('[data-panel="files"]').click();
+    await openFilesFromMenu(page);
     await expect(page.locator('#panel-files')).toHaveClass(/active/);
 
     // Drive realpath + ls to get to a directory listing
@@ -256,7 +258,7 @@ test.describe('Files panel', { tag: '@headless-adequate' }, () => {
     await setupConnected(page, mockSshServer);
     await showTabBar(page);
 
-    await page.locator('[data-panel="files"]').click();
+    await openFilesFromMenu(page);
     await expect(page.locator('#panel-files')).toHaveClass(/active/);
 
     await page.waitForFunction(


### PR DESCRIPTION
## Summary
- Remove Files tab from navbar (now 3 tabs: Terminal, Connect, Settings)
- Rewire `#handleMenuBtn` (hamburger) to open `#sessionMenu` instead of toggle navbar
- Add up-swipe gesture on handle strip to reveal navbar
- Add down-swipe on navbar to hide it
- Files still reachable via session menu `#sessionFilesBtn` (from #409)

## TDD Analysis
- Type: feature (behavior change — navbar semantics)
- TDD approach: full
- Tests written first, confirmed red, implementation turned them green

## Test coverage
- **New tests (fail→pass)**: `src/modules/__tests__/navbar-simplified.test.ts` (11 tests)
  - Navbar has exactly 3 tabs
  - No Files tab in navbar
  - Hamburger opens session menu (not toggle navbar)
  - Up-swipe reveals navbar
  - Down-swipe hides navbar
  - Session menu still contains Files entry (regression guard from #409)

Closes #449
Builds on #409 (merged PR #450)