### PR TITLE
feat: persistent session bar via CSS overlay — no DOM moves (#452)

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -2713,6 +2713,37 @@ hr {
   display: flex;
 }
 
+/* Persistent session bar (#452): when Files is active, #panel-terminal stays
+ * structurally "active" so its chrome (handle strip + key bar) keeps rendering.
+ * The Files panel is positioned as an overlay above the terminal content area
+ * only, leaving the chrome visible at the bottom. The terminal itself is
+ * hidden with `visibility: hidden` so layout is preserved and xterm.js does
+ * not re-fit. */
+body.files-overlay #panel-files {
+  position: fixed;
+  top: env(safe-area-inset-top);
+  left: 0;
+  right: 0;
+  /* Leave room for the handle strip, key bar, and bottom nav.
+   * Values fall back if the custom properties are not yet set. */
+  bottom: calc(
+    var(--tab-height, 56px)
+    + var(--keybar-height, 0px)
+    + var(--keybar-handle-height, 22px)
+    + env(safe-area-inset-bottom)
+  );
+  z-index: 5;
+}
+
+body.files-overlay #terminal {
+  visibility: hidden;
+}
+
+/* Approval bar stays above the files overlay so it remains actionable. */
+body.files-overlay #approvalBar {
+  z-index: 6;
+}
+
 /* Panel header with back-to-terminal button (#409) */
 .panel-header {
   display: flex;

--- a/public/index.html
+++ b/public/index.html
@@ -303,11 +303,11 @@
       </div>
     </div>
 
-    <!-- Files panel -->
+    <!-- Files panel — overlays the terminal area when active (#452).
+         The session chrome (handle strip + key bar) in #panel-terminal stays
+         rendered beneath this overlay, so the ≡ session menu is always
+         reachable from Files. The back-to-terminal button was removed. -->
     <div id="panel-files" class="panel">
-      <div class="panel-header">
-        <button id="filesBackToTerminalBtn" class="panel-back-btn" aria-label="Back to terminal">← Terminal</button>
-      </div>
       <div id="filePreview" class="hidden"></div>
       <div id="filesExplore" class="files-subview active"></div>
       <div id="filesTransfer" class="files-subview hidden">

--- a/src/modules/__tests__/persistent-session-bar.test.ts
+++ b/src/modules/__tests__/persistent-session-bar.test.ts
@@ -1,0 +1,237 @@
+/**
+ * TDD tests for issue #452 (retry) — Persistent session bar via CSS overlay.
+ *
+ * Root constraint: DO NOT MOVE any DOM elements. xterm.js and the
+ * ResizeObserver are coupled to the current structure. The prior attempt
+ * moved `#key-bar-handle` out of `#panel-terminal` and broke device
+ * rendering (reverted at b552f42).
+ *
+ * The fix is CSS-only:
+ *   - `#key-bar-handle` and `#key-bar` stay children of `#panel-terminal`
+ *   - When Files is active, `#panel-terminal` stays `.active` too so chrome
+ *     keeps rendering
+ *   - `body.files-overlay` drives positioning and terminal visibility
+ *   - The obsolete "← Terminal" back button is removed from the files panel
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const indexHtml = readFileSync(
+  resolve(__dirname, '../../../public/index.html'),
+  'utf8',
+);
+
+// ── Source/HTML grep tests (no runtime needed) ────────────────────────────
+
+describe('persistent session bar (#452) — DOM structure', () => {
+  it('#key-bar-handle is still a child of #panel-terminal (regression guard)', () => {
+    // The prior attempt moved this element to a sibling layout, breaking
+    // terminal rendering on device. It MUST remain inside panel-terminal.
+    const panelStart = indexHtml.indexOf('id="panel-terminal"');
+    const panelEnd = indexHtml.indexOf('id="panel-files"');
+    const handleStart = indexHtml.indexOf('id="key-bar-handle"');
+
+    expect(panelStart).toBeGreaterThan(-1);
+    expect(panelEnd).toBeGreaterThan(panelStart);
+    expect(handleStart).toBeGreaterThan(panelStart);
+    expect(handleStart).toBeLessThan(panelEnd);
+  });
+
+  it('#key-bar is still a child of #panel-terminal (regression guard)', () => {
+    const panelStart = indexHtml.indexOf('id="panel-terminal"');
+    const panelEnd = indexHtml.indexOf('id="panel-files"');
+    const keybarStart = indexHtml.indexOf('id="key-bar"');
+
+    expect(panelStart).toBeGreaterThan(-1);
+    expect(panelEnd).toBeGreaterThan(panelStart);
+    expect(keybarStart).toBeGreaterThan(panelStart);
+    expect(keybarStart).toBeLessThan(panelEnd);
+  });
+
+  it('#filesBackToTerminalBtn is removed (hamburger replaces it)', () => {
+    // With the persistent session bar, the ≡ menu is always reachable —
+    // there is no need for a dedicated back button inside the files panel.
+    expect(indexHtml).not.toContain('id="filesBackToTerminalBtn"');
+  });
+});
+
+// ── Runtime tests for navigateToPanel body-class behavior ─────────────────
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+});
+
+vi.stubGlobal('location', { hostname: 'localhost', hash: '' });
+vi.stubGlobal('history', {
+  pushState: vi.fn(),
+  replaceState: vi.fn(),
+  back: vi.fn(),
+});
+
+type ClassListStub = {
+  classes: Set<string>;
+  add: (c: string) => void;
+  remove: (c: string) => void;
+  toggle: (c: string, force?: boolean) => void;
+  contains: (c: string) => boolean;
+};
+
+function makeClassList(): ClassListStub {
+  const classes = new Set<string>();
+  return {
+    classes,
+    add: (c: string) => { classes.add(c); },
+    remove: (c: string) => { classes.delete(c); },
+    toggle: (c: string, force?: boolean) => {
+      if (force === true) { classes.add(c); return; }
+      if (force === false) { classes.delete(c); return; }
+      if (classes.has(c)) classes.delete(c); else classes.add(c);
+    },
+    contains: (c: string) => classes.has(c),
+  };
+}
+
+const elements = new Map<string, { id: string; classList: ClassListStub; dataset: Record<string, string> }>();
+function ensureElement(id: string): { id: string; classList: ClassListStub; dataset: Record<string, string> } {
+  const existing = elements.get(id);
+  if (existing) return existing;
+  const el = { id, classList: makeClassList(), dataset: {} as Record<string, string> };
+  elements.set(id, el);
+  return el;
+}
+
+const bodyClassList = makeClassList();
+
+vi.stubGlobal('document', {
+  getElementById: vi.fn((id: string) => {
+    if (['panel-terminal', 'panel-files', 'panel-connect', 'panel-settings'].includes(id)) {
+      return ensureElement(id);
+    }
+    return null;
+  }),
+  querySelector: vi.fn((_selector: string) => null),
+  querySelectorAll: vi.fn((selector: string) => {
+    if (selector === '.panel') {
+      return ['panel-terminal', 'panel-files', 'panel-connect', 'panel-settings']
+        .map((id) => ensureElement(id));
+    }
+    if (selector === '.tab') return [];
+    if (selector === '[data-session-id]') return [];
+    return [];
+  }),
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  hasFocus: vi.fn(() => true),
+  createElement: vi.fn(() => ({
+    className: '',
+    textContent: '',
+    innerHTML: '',
+    id: '',
+    appendChild: vi.fn(),
+    addEventListener: vi.fn(),
+    querySelector: vi.fn(),
+    remove: vi.fn(),
+    classList: makeClassList(),
+    dataset: {} as Record<string, string>,
+  })),
+  body: {
+    classList: bodyClassList,
+    appendChild: vi.fn(),
+  },
+  documentElement: {
+    style: { setProperty: vi.fn() },
+    dataset: {},
+  },
+  fonts: { ready: Promise.resolve() },
+});
+
+vi.stubGlobal('WebSocket', class MockWebSocket {
+  onopen: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  readyState = 1;
+  url = 'ws://localhost:8081';
+  close = vi.fn();
+  send = vi.fn();
+  static OPEN = 1;
+});
+
+vi.stubGlobal('Worker', class { onmessage = null; postMessage = vi.fn(); terminate = vi.fn(); });
+vi.stubGlobal('navigator', { wakeLock: undefined, serviceWorker: undefined });
+vi.stubGlobal('window', { addEventListener: vi.fn(), visualViewport: null, outerHeight: 800, innerHeight: 800, innerWidth: 400 });
+vi.stubGlobal('Notification', { permission: 'default' });
+vi.stubGlobal('performance', { now: vi.fn(() => 0) });
+vi.stubGlobal('CSS', { escape: (s: string) => s });
+vi.stubGlobal('requestAnimationFrame', (cb: () => void) => { cb(); return 1; });
+vi.stubGlobal('cancelAnimationFrame', vi.fn());
+vi.stubGlobal('getComputedStyle', vi.fn(() => ({ getPropertyValue: vi.fn(() => '48px') })));
+
+vi.stubGlobal('Terminal', function TerminalMock() {
+  return {
+    open: vi.fn(), loadAddon: vi.fn(), onBell: vi.fn(), writeln: vi.fn(), write: vi.fn(),
+    parser: { registerOscHandler: vi.fn() }, options: {} as Record<string, unknown>,
+    buffer: { active: { cursorY: 0, getLine: vi.fn() } }, cols: 80, rows: 24,
+    reset: vi.fn(), scrollToBottom: vi.fn(),
+  };
+});
+vi.stubGlobal('FitAddon', { FitAddon: function FitAddonMock() { return { fit: vi.fn() }; } });
+vi.stubGlobal('ClipboardAddon', { ClipboardAddon: vi.fn() });
+
+const ui = await import('../ui.js');
+
+describe('persistent session bar (#452) — navigateToPanel behavior', () => {
+  beforeEach(() => {
+    elements.clear();
+    bodyClassList.classes.clear();
+    storage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('navigateToPanel("files") adds "files-overlay" class to body', () => {
+    ui.navigateToPanel('files');
+    expect(bodyClassList.contains('files-overlay')).toBe(true);
+  });
+
+  it('navigateToPanel("terminal") removes "files-overlay" class from body', () => {
+    ui.navigateToPanel('files');
+    expect(bodyClassList.contains('files-overlay')).toBe(true);
+    ui.navigateToPanel('terminal');
+    expect(bodyClassList.contains('files-overlay')).toBe(false);
+  });
+
+  it('navigateToPanel("connect") removes "files-overlay" class from body', () => {
+    ui.navigateToPanel('files');
+    ui.navigateToPanel('connect');
+    expect(bodyClassList.contains('files-overlay')).toBe(false);
+  });
+
+  it('#panel-terminal retains .active class after navigateToPanel("files")', () => {
+    // Chrome (handle strip + key bar) must keep rendering while files is
+    // overlayed — we achieve that by keeping panel-terminal "active".
+    ui.navigateToPanel('files');
+    const panelTerminal = ensureElement('panel-terminal');
+    expect(panelTerminal.classList.contains('active')).toBe(true);
+  });
+
+  it('#panel-files becomes .active after navigateToPanel("files")', () => {
+    ui.navigateToPanel('files');
+    const panelFiles = ensureElement('panel-files');
+    expect(panelFiles.classList.contains('active')).toBe(true);
+  });
+
+  it('#panel-terminal is not .active after navigateToPanel("connect")', () => {
+    // Connect is not a session panel — chrome should not remain.
+    ui.navigateToPanel('files');
+    ui.navigateToPanel('connect');
+    const panelTerminal = ensureElement('panel-terminal');
+    expect(panelTerminal.classList.contains('active')).toBe(false);
+  });
+});

--- a/src/modules/__tests__/session-aware-files.test.ts
+++ b/src/modules/__tests__/session-aware-files.test.ts
@@ -57,20 +57,11 @@ describe('session-aware files (#409) — HTML', () => {
     expect(btnStart).toBeGreaterThan(menuStart);
   });
 
-  it('#panel-files contains a back-to-terminal button (filesBackToTerminalBtn)', () => {
-    const panelMatch = indexHtml.match(
-      /<div\s+id="panel-files"[\s\S]*?<\/div>\s*<!--/m
-    );
-    // Fallback: just check the whole file if the regex above fails, but anchor
-    // to an id that must be inside the files panel.
-    const haystack = panelMatch ? panelMatch[0] : indexHtml;
-    expect(haystack).toContain('id="filesBackToTerminalBtn"');
-  });
-
-  it('filesBackToTerminalBtn has panel-back-btn class', () => {
-    expect(indexHtml).toMatch(
-      /id="filesBackToTerminalBtn"[^>]*class="[^"]*panel-back-btn/
-    );
+  it('#panel-files no longer has a back-to-terminal button (#452 — persistent session bar)', () => {
+    // Removed with the persistent session bar (#452): the hamburger menu
+    // is always reachable from the handle strip, so a dedicated back
+    // button inside the files panel is no longer needed.
+    expect(indexHtml).not.toContain('id="filesBackToTerminalBtn"');
   });
 });
 

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -542,7 +542,7 @@ export function editProfile(idx: number): void {
   }
 
   // Password field: save to vault on blur, not to localStorage
-  const pwInput = form.querySelector(`#editPassword-${String(idx)}`) as HTMLInputElement | null;
+  const pwInput = form.querySelector<HTMLInputElement>(`#editPassword-${String(idx)}`);
   if (pwInput) {
     pwInput.addEventListener('change', () => {
       void _savePasswordToVault(idx, pwInput.value);
@@ -613,17 +613,17 @@ function _showUndoToast(idx: number, field: string, oldValue: string | number): 
       (profile as unknown as Record<string, string | number>)[_lastUndo.field] = _lastUndo.oldValue;
       localStorage.setItem('sshProfiles', JSON.stringify(profiles));
       // Update the inline form field if still open
-      const input = document.querySelector(`[data-field="${_lastUndo.field}"]`) as HTMLInputElement | null;
+      const input = document.querySelector<HTMLInputElement>(`[data-field="${_lastUndo.field}"]`);
       if (input) input.value = String(_lastUndo.oldValue);
       _toast('Undone.');
     }
     _lastUndo = null;
-    el!.classList.remove('show');
+    el.classList.remove('show');
   };
   undoBtn?.addEventListener('click', handler, { once: true });
 
   _undoTimer = setTimeout(() => {
-    el!.classList.remove('show');
+    el.classList.remove('show');
     _lastUndo = null;
   }, 5000);
 }
@@ -686,7 +686,7 @@ export function loadKeys(): void {
 async function _updatePassphraseBadges(keys: StoredKey[]): Promise<void> {
   for (const k of keys) {
     try {
-      const record = await vaultLoad(k.vaultId) as Record<string, unknown> | null;
+      const record = await vaultLoad(k.vaultId);
       const badge = document.querySelector(`.key-passphrase-badge[data-vault-id="${CSS.escape(k.vaultId)}"]`);
       if (badge && record && typeof record.passphrase === 'string' && record.passphrase.length > 0) {
         badge.textContent = '\u{1F512} Passphrase set';
@@ -707,13 +707,13 @@ export async function editKey(idx: number): Promise<void> {
   if (item.querySelector('.key-edit-form')) return;
 
   // Hide action buttons while editing
-  const actions = item.querySelector('.item-actions') as HTMLElement | null;
+  const actions = item.querySelector<HTMLElement>('.item-actions');
   if (actions) actions.style.display = 'none';
 
   // Load existing passphrase from vault
   let existingPassphrase = '';
   try {
-    const record = await vaultLoad(key.vaultId) as Record<string, unknown> | null;
+    const record = await vaultLoad(key.vaultId);
     if (record && typeof record.passphrase === 'string') {
       existingPassphrase = record.passphrase;
     }
@@ -753,7 +753,7 @@ export async function saveKeyEdit(idx: number): Promise<void> {
 
   // Update passphrase in vault
   try {
-    const record = await vaultLoad(key.vaultId) as Record<string, unknown> | null;
+    const record = await vaultLoad(key.vaultId);
     if (record) {
       record.passphrase = passInput.value;
       await vaultStore(key.vaultId, record);
@@ -772,7 +772,7 @@ export function cancelKeyEdit(idx: number): void {
   const form = item.querySelector('.key-edit-form');
   if (form) form.remove();
 
-  const actions = item.querySelector('.item-actions') as HTMLElement | null;
+  const actions = item.querySelector<HTMLElement>('.item-actions');
   if (actions) actions.style.display = '';
 }
 

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -63,6 +63,15 @@ export function navigateToPanel(
   document.querySelector<HTMLElement>(`[data-panel="${panel}"]`)?.classList.add('active');
   document.getElementById(`panel-${panel}`)?.classList.add('active');
 
+  // Persistent session bar (#452): keep panel-terminal structurally "active"
+  // when Files is showing so the chrome (handle strip + key bar) keeps
+  // rendering beneath the overlay. DO NOT MOVE any DOM elements — xterm.js
+  // and the ResizeObserver are coupled to the current structure.
+  if (panel === 'files') {
+    document.getElementById('panel-terminal')?.classList.add('active');
+  }
+  document.body.classList.toggle('files-overlay', panel === 'files');
+
   if (panel === 'terminal') {
     // Panel just became visible — fit the active session to real dimensions
     const s = currentSession();
@@ -2375,10 +2384,8 @@ export function initFilesPanel(): void {
     navigateToPanel('files');
   });
 
-  // Back-to-terminal button inside the files panel (#409)
-  document.getElementById('filesBackToTerminalBtn')?.addEventListener('click', () => {
-    navigateToPanel('terminal');
-  });
+  // Back-to-terminal button removed with the persistent session bar (#452).
+  // The ≡ session menu in the handle strip is always reachable.
 }
 
 /** Resolve and render the files panel for the currently active session,


### PR DESCRIPTION
## Summary (retry after revert)

Previous attempt (PR #453, reverted at b552f42) moved `#key-bar-handle` out of `#panel-terminal`. This broke terminal rendering on device even though headless tests passed. Rolled back.

**This PR keeps the DOM structure identical** and uses a CSS-only overlay:
- `navigateToPanel('files')` keeps `#panel-terminal` active so chrome (`#key-bar-handle`, `#key-bar`) keeps rendering
- Body gets `.files-overlay` class
- CSS: `body.files-overlay #panel-files` becomes `position: absolute` overlay above terminal content; `#terminal` gets `visibility: hidden` (not display:none, to avoid xterm size thrash)
- `#filesBackToTerminalBtn` removed (chrome is always visible now)

Also fixes 3 pre-existing eslint errors in `profiles.ts` (unsafe Element access — added HTMLInputElement/HTMLElement generics) to unblock the gate.

## TDD Analysis
- Type: feature (behavior change — chrome visibility on Files)
- TDD approach: full
- Tests written first, implementation turned them green

## Test coverage
- **New tests (fail→pass)**: `src/modules/__tests__/persistent-session-bar.test.ts` (9 tests)
  - `#key-bar-handle` stays inside `#panel-terminal` (regression guard for the revert)
  - `#key-bar` stays inside `#panel-terminal`
  - `navigateToPanel('files')` adds `files-overlay` body class
  - `navigateToPanel('terminal')` removes `files-overlay`
  - `#panel-terminal` keeps `.active` class when on files
  - `#filesBackToTerminalBtn` does NOT exist
- **Updated**: `session-aware-files.test.ts` — inverted back-button assertion

## Test results
- tsc: PASS
- eslint: PASS (0 errors)
- vitest: 19/19 pass on new + updated tests. Pre-existing failures on main (session-ui-state, session-handle-wiring, ime-action-bar) unchanged.

Closes #452