### PR TITLE
feat: pinch-zoom and pan for image/SVG previews (#456)

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -3071,3 +3071,25 @@ body.files-overlay #approvalBar {
   font-size: 13px;
   line-height: 1.6;
 }
+
+/* Pinch-zoom image preview (#456) */
+.preview-zoom-viewport {
+  max-width: 100%;
+  max-height: 80vh;
+  overflow: hidden;
+  touch-action: none;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.preview-zoom-target {
+  transform-origin: center center;
+  transform: translate(0, 0) scale(1);
+  transition: none;
+  max-width: 100%;
+  max-height: 80vh;
+  user-select: none;
+  pointer-events: none;
+}

--- a/src/modules/__tests__/pinch-zoom.test.ts
+++ b/src/modules/__tests__/pinch-zoom.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+/**
+ * Tests for pinch-zoom controller (#456).
+ *
+ * The controller manages scale/tx/ty state for a target element inside a viewport.
+ * Pinch gestures zoom; single-finger gestures pan (only when zoomed).
+ *
+ * vitest/JSDOM does not support real TouchEvent dispatch, so these tests focus on
+ * structural invariants: initial state, bounds clamping, reset, destroy idempotency,
+ * and pinch math verified through a testable seam.
+ */
+
+import { attachPinchZoom } from '../pinch-zoom.js';
+
+/**
+ * Build a minimal element pair that exposes just enough surface for the controller.
+ * We use a lightweight stub rather than JSDOM to keep these tests fast and isolated.
+ */
+interface StubListener {
+  type: string;
+  handler: EventListenerOrEventListenerObject;
+  options?: AddEventListenerOptions | boolean;
+}
+
+interface StubElement {
+  style: Record<string, string>;
+  _listeners: StubListener[];
+  addEventListener(
+    type: string,
+    handler: EventListenerOrEventListenerObject,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  removeEventListener(
+    type: string,
+    handler: EventListenerOrEventListenerObject,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  getBoundingClientRect(): { left: number; top: number; width: number; height: number; right: number; bottom: number };
+  clientWidth: number;
+  clientHeight: number;
+  offsetWidth: number;
+  offsetHeight: number;
+}
+
+function makeStub(w = 400, h = 300): StubElement {
+  const el: StubElement = {
+    style: {},
+    _listeners: [],
+    addEventListener(type, handler, options): void {
+      el._listeners.push({ type, handler, options });
+    },
+    removeEventListener(type, handler): void {
+      const idx = el._listeners.findIndex(l => l.type === type && l.handler === handler);
+      if (idx >= 0) el._listeners.splice(idx, 1);
+    },
+    getBoundingClientRect(): { left: number; top: number; width: number; height: number; right: number; bottom: number } {
+      return { left: 0, top: 0, width: w, height: h, right: w, bottom: h };
+    },
+    clientWidth: w,
+    clientHeight: h,
+    offsetWidth: w,
+    offsetHeight: h,
+  };
+  return el;
+}
+
+describe('attachPinchZoom — initial state', () => {
+  let viewport: StubElement;
+  let target: StubElement;
+
+  beforeEach(() => {
+    viewport = makeStub(400, 300);
+    target = makeStub(400, 300);
+  });
+
+  it('applies initial transform with scale=1 and tx=0, ty=0', () => {
+    attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+    expect(target.style['transform']).toBe('translate(0px, 0px) scale(1)');
+  });
+
+  it('registers touch event listeners on viewport', () => {
+    attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+    const types = viewport._listeners.map(l => l.type);
+    expect(types).toContain('touchstart');
+    expect(types).toContain('touchmove');
+    expect(types).toContain('touchend');
+  });
+
+  it('returns an object with destroy and reset methods', () => {
+    const ctrl = attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+    expect(typeof ctrl.destroy).toBe('function');
+    expect(typeof ctrl.reset).toBe('function');
+  });
+});
+
+describe('attachPinchZoom — reset', () => {
+  it('reset returns transform to scale=1 and tx=0, ty=0', () => {
+    const viewport = makeStub();
+    const target = makeStub();
+    const ctrl = attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+    // Simulate external state mutation via internal reset path
+    ctrl.reset();
+    expect(target.style['transform']).toBe('translate(0px, 0px) scale(1)');
+  });
+});
+
+describe('attachPinchZoom — destroy', () => {
+  it('destroy removes all registered listeners', () => {
+    const viewport = makeStub();
+    const target = makeStub();
+    const ctrl = attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+    const listenersBefore = viewport._listeners.length;
+    expect(listenersBefore).toBeGreaterThan(0);
+    ctrl.destroy();
+    expect(viewport._listeners.length).toBe(0);
+  });
+
+  it('destroy is idempotent — calling twice does not throw', () => {
+    const viewport = makeStub();
+    const target = makeStub();
+    const ctrl = attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+    ctrl.destroy();
+    expect(() => ctrl.destroy()).not.toThrow();
+  });
+});
+
+describe('attachPinchZoom — pinch math', () => {
+  /**
+   * Simulate a touch event by directly invoking the registered handler with a synthetic
+   * object shaped like a TouchEvent. This tests the internal scale calculation without
+   * relying on JSDOM TouchEvent support (which JSDOM lacks).
+   */
+  interface FakeTouch { clientX: number; clientY: number; identifier: number }
+  function fakeTouchEvent(type: string, touches: FakeTouch[]): Event {
+    return {
+      type,
+      touches,
+      targetTouches: touches,
+      changedTouches: touches,
+      preventDefault(): void {},
+      stopPropagation(): void {},
+    } as unknown as Event;
+  }
+
+  function findHandler(el: StubElement, type: string): EventListenerOrEventListenerObject | undefined {
+    const entry = el._listeners.find(l => l.type === type);
+    return entry?.handler;
+  }
+
+  function invoke(h: EventListenerOrEventListenerObject | undefined, ev: Event): void {
+    if (!h) return;
+    if (typeof h === 'function') h(ev);
+    else h.handleEvent(ev);
+  }
+
+  it('two-finger pinch doubles the scale when distance doubles', () => {
+    const viewport = makeStub(400, 300);
+    const target = makeStub(400, 300);
+    attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+
+    const ts = findHandler(viewport, 'touchstart');
+    const tm = findHandler(viewport, 'touchmove');
+
+    // Start pinch with touches 100px apart (horizontal)
+    invoke(ts, fakeTouchEvent('touchstart', [
+      { clientX: 150, clientY: 150, identifier: 0 },
+      { clientX: 250, clientY: 150, identifier: 1 },
+    ]));
+    // Move to 200px apart (double distance)
+    invoke(tm, fakeTouchEvent('touchmove', [
+      { clientX: 100, clientY: 150, identifier: 0 },
+      { clientX: 300, clientY: 150, identifier: 1 },
+    ]));
+
+    const tr = target.style['transform'] ?? '';
+    // scale should be ~2
+    const m = tr.match(/scale\(([\d.]+)\)/);
+    expect(m).toBeTruthy();
+    const scale = m ? parseFloat(m[1] ?? '0') : 0;
+    expect(scale).toBeGreaterThan(1.9);
+    expect(scale).toBeLessThan(2.1);
+  });
+
+  it('scale is clamped to maximum of 8', () => {
+    const viewport = makeStub(400, 300);
+    const target = makeStub(400, 300);
+    attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+
+    const ts = findHandler(viewport, 'touchstart');
+    const tm = findHandler(viewport, 'touchmove');
+
+    // Start 10px apart
+    invoke(ts, fakeTouchEvent('touchstart', [
+      { clientX: 195, clientY: 150, identifier: 0 },
+      { clientX: 205, clientY: 150, identifier: 1 },
+    ]));
+    // Move to 300px apart — raw ratio is 30, but clamp to 8
+    invoke(tm, fakeTouchEvent('touchmove', [
+      { clientX: 50, clientY: 150, identifier: 0 },
+      { clientX: 350, clientY: 150, identifier: 1 },
+    ]));
+
+    const tr = target.style['transform'] ?? '';
+    const m = tr.match(/scale\(([\d.]+)\)/);
+    const scale = m ? parseFloat(m[1] ?? '0') : 0;
+    expect(scale).toBeLessThanOrEqual(8);
+    expect(scale).toBeGreaterThan(7);
+  });
+
+  it('scale is clamped to minimum of 1', () => {
+    const viewport = makeStub(400, 300);
+    const target = makeStub(400, 300);
+    attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+
+    const ts = findHandler(viewport, 'touchstart');
+    const tm = findHandler(viewport, 'touchmove');
+
+    // Start 200px apart
+    invoke(ts, fakeTouchEvent('touchstart', [
+      { clientX: 100, clientY: 150, identifier: 0 },
+      { clientX: 300, clientY: 150, identifier: 1 },
+    ]));
+    // Move to 20px apart — raw ratio is 0.1, clamp to 1
+    invoke(tm, fakeTouchEvent('touchmove', [
+      { clientX: 190, clientY: 150, identifier: 0 },
+      { clientX: 210, clientY: 150, identifier: 1 },
+    ]));
+
+    const tr = target.style['transform'] ?? '';
+    const m = tr.match(/scale\(([\d.]+)\)/);
+    const scale = m ? parseFloat(m[1] ?? '0') : 0;
+    expect(scale).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('attachPinchZoom — single-touch pan at scale=1', () => {
+  interface FakeTouch { clientX: number; clientY: number; identifier: number }
+  function fakeTouchEvent(type: string, touches: FakeTouch[]): Event {
+    return {
+      type,
+      touches,
+      targetTouches: touches,
+      changedTouches: touches,
+      preventDefault(): void {},
+      stopPropagation(): void {},
+    } as unknown as Event;
+  }
+  function findHandler(el: StubElement, type: string): EventListenerOrEventListenerObject | undefined {
+    const entry = el._listeners.find(l => l.type === type);
+    return entry?.handler;
+  }
+  function invoke(h: EventListenerOrEventListenerObject | undefined, ev: Event): void {
+    if (!h) return;
+    if (typeof h === 'function') h(ev);
+    else h.handleEvent(ev);
+  }
+
+  it('single-finger move at scale=1 does NOT pan (tx,ty stay 0)', () => {
+    const viewport = makeStub(400, 300);
+    const target = makeStub(400, 300);
+    attachPinchZoom(viewport as unknown as HTMLElement, target as unknown as HTMLElement);
+
+    const ts = findHandler(viewport, 'touchstart');
+    const tm = findHandler(viewport, 'touchmove');
+
+    invoke(ts, fakeTouchEvent('touchstart', [{ clientX: 100, clientY: 100, identifier: 0 }]));
+    invoke(tm, fakeTouchEvent('touchmove', [{ clientX: 200, clientY: 200, identifier: 0 }]));
+
+    const tr = target.style['transform'] ?? '';
+    expect(tr).toMatch(/translate\(0px,\s*0px\)/);
+  });
+});

--- a/src/modules/__tests__/sftp-preview.test.ts
+++ b/src/modules/__tests__/sftp-preview.test.ts
@@ -130,6 +130,20 @@ describe('renderPreview', () => {
     expect(html).toContain('blob:');
   });
 
+  it('wraps image in .preview-zoom-viewport and uses .preview-zoom-target class on <img>', () => {
+    const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const html = renderPreview('photo.png', data);
+    expect(html).toContain('preview-zoom-viewport');
+    expect(html).toContain('preview-zoom-target');
+  });
+
+  it('wraps SVG image in zoom viewport (same image path)', () => {
+    const data = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    const html = renderPreview('icon.svg', data);
+    expect(html).toContain('preview-zoom-viewport');
+    expect(html).toContain('preview-zoom-target');
+  });
+
   it('returns rendered HTML for markdown files (headers)', () => {
     const md = new TextEncoder().encode('# Hello World\n\nSome text');
     const html = renderPreview('README.md', md);

--- a/src/modules/pinch-zoom.ts
+++ b/src/modules/pinch-zoom.ts
@@ -1,0 +1,321 @@
+/**
+ * Pinch-zoom and pan controller for image/SVG previews (#456).
+ *
+ * Pure module: no imports from other project modules. Attaches Touch Event
+ * listeners to a viewport element and transforms a target element within it.
+ *
+ * Behavior:
+ *  - Two-finger pinch: zoom around midpoint of the two touches.
+ *  - Single-finger drag: pan, only when scale > 1.
+ *  - Double-tap: toggle 1x <-> 2x around tap point.
+ *  - Momentum: after a pan, decay velocity with 0.92 per frame.
+ *  - Scale clamped [1, 8]; translation clamped so image stays >=50% within viewport.
+ */
+
+export interface PinchZoomController {
+  destroy(): void;
+  reset(): void;
+}
+
+interface Disposable {
+  type: string;
+  handler: EventListener;
+  options?: AddEventListenerOptions | boolean;
+}
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 8;
+const DOUBLE_TAP_MS = 300;
+const DOUBLE_TAP_DIST = 30;
+const MOMENTUM_DECAY = 0.92;
+const MOMENTUM_MIN_VELOCITY = 0.5;
+const VELOCITY_WINDOW_MS = 100;
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+function dist(ax: number, ay: number, bx: number, by: number): number {
+  const dx = bx - ax;
+  const dy = by - ay;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function attachPinchZoom(viewport: HTMLElement, target: HTMLElement): PinchZoomController {
+  // Transform state
+  let scale = 1;
+  let tx = 0;
+  let ty = 0;
+
+  // Pinch state
+  let pinchActive = false;
+  let initialPinchDist = 0;
+  let initialScale = 1;
+  let pinchMidX = 0;
+  let pinchMidY = 0;
+  let initialTx = 0;
+  let initialTy = 0;
+
+  // Pan state
+  let panActive = false;
+  let panStartX = 0;
+  let panStartY = 0;
+  let panStartTx = 0;
+  let panStartTy = 0;
+  const velSamples: { t: number; x: number; y: number }[] = [];
+
+  // Double-tap state
+  let lastTapTime = 0;
+  let lastTapX = 0;
+  let lastTapY = 0;
+
+  // Momentum animation handle
+  let momentumRaf = 0;
+
+  // Disposable listeners
+  const disposables: Disposable[] = [];
+
+  function addListener(type: string, handler: EventListener, options?: AddEventListenerOptions | boolean): void {
+    viewport.addEventListener(type, handler, options);
+    disposables.push({ type, handler, options });
+  }
+
+  function applyTransform(): void {
+    target.style.transform = `translate(${String(tx)}px, ${String(ty)}px) scale(${String(scale)})`;
+  }
+
+  function getBounds(): { maxTx: number; maxTy: number } {
+    // Allow the scaled image to pan until at most half of it is off-screen.
+    const vw = viewport.clientWidth || viewport.getBoundingClientRect().width || 0;
+    const vh = viewport.clientHeight || viewport.getBoundingClientRect().height || 0;
+    const tw = (target.offsetWidth || target.getBoundingClientRect().width || vw) * scale;
+    const th = (target.offsetHeight || target.getBoundingClientRect().height || vh) * scale;
+    const maxTx = Math.max(0, (tw - vw) / 2 + vw / 2);
+    const maxTy = Math.max(0, (th - vh) / 2 + vh / 2);
+    return { maxTx, maxTy };
+  }
+
+  function clampTranslate(): void {
+    const { maxTx, maxTy } = getBounds();
+    tx = clamp(tx, -maxTx, maxTx);
+    ty = clamp(ty, -maxTy, maxTy);
+  }
+
+  function cancelMomentum(): void {
+    if (momentumRaf) {
+      const raf = typeof cancelAnimationFrame === 'function' ? cancelAnimationFrame : null;
+      if (raf) raf(momentumRaf);
+      momentumRaf = 0;
+    }
+  }
+
+  function startMomentum(vx: number, vy: number): void {
+    cancelMomentum();
+    const raf = typeof requestAnimationFrame === 'function' ? requestAnimationFrame : null;
+    if (!raf) return;
+    let velX = vx;
+    let velY = vy;
+    const step = (): void => {
+      velX *= MOMENTUM_DECAY;
+      velY *= MOMENTUM_DECAY;
+      tx += velX;
+      ty += velY;
+      const beforeTx = tx;
+      const beforeTy = ty;
+      clampTranslate();
+      const hitBoundsX = beforeTx !== tx;
+      const hitBoundsY = beforeTy !== ty;
+      if (hitBoundsX) velX = 0;
+      if (hitBoundsY) velY = 0;
+      applyTransform();
+      const speed = Math.sqrt(velX * velX + velY * velY);
+      if (speed >= MOMENTUM_MIN_VELOCITY) {
+        momentumRaf = raf(step);
+      } else {
+        momentumRaf = 0;
+      }
+    };
+    momentumRaf = raf(step);
+  }
+
+  function recordVelocitySample(x: number, y: number): void {
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    velSamples.push({ t: now, x, y });
+    // Keep only recent samples
+    const cutoff = now - VELOCITY_WINDOW_MS;
+    while (velSamples.length > 0 && velSamples[0]!.t < cutoff) {
+      velSamples.shift();
+    }
+  }
+
+  function computeVelocity(): { vx: number; vy: number } {
+    if (velSamples.length < 2) return { vx: 0, vy: 0 };
+    const first = velSamples[0]!;
+    const last = velSamples[velSamples.length - 1]!;
+    const dt = last.t - first.t;
+    if (dt <= 0) return { vx: 0, vy: 0 };
+    // px per frame, assuming ~16ms/frame
+    const frameMs = 16;
+    return {
+      vx: ((last.x - first.x) / dt) * frameMs,
+      vy: ((last.y - first.y) / dt) * frameMs,
+    };
+  }
+
+  function onTouchStart(ev: Event): void {
+    const e = ev as TouchEvent;
+    cancelMomentum();
+    if (e.touches.length === 2) {
+      const t0 = e.touches[0]!;
+      const t1 = e.touches[1]!;
+      pinchActive = true;
+      panActive = false;
+      initialPinchDist = dist(t0.clientX, t0.clientY, t1.clientX, t1.clientY);
+      initialScale = scale;
+      pinchMidX = (t0.clientX + t1.clientX) / 2;
+      pinchMidY = (t0.clientY + t1.clientY) / 2;
+      initialTx = tx;
+      initialTy = ty;
+      if (typeof e.preventDefault === 'function') e.preventDefault();
+    } else if (e.touches.length === 1) {
+      const t0 = e.touches[0]!;
+      // Double-tap detection
+      const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      const dtTap = now - lastTapTime;
+      const distTap = dist(lastTapX, lastTapY, t0.clientX, t0.clientY);
+      if (dtTap < DOUBLE_TAP_MS && distTap < DOUBLE_TAP_DIST) {
+        // Double-tap fires: handle on touchend for accuracy — but mark for processing
+        lastTapTime = 0;
+        handleDoubleTap(t0.clientX, t0.clientY);
+        return;
+      }
+      lastTapTime = now;
+      lastTapX = t0.clientX;
+      lastTapY = t0.clientY;
+
+      // Start pan only if zoomed in
+      if (scale > 1) {
+        panActive = true;
+        panStartX = t0.clientX;
+        panStartY = t0.clientY;
+        panStartTx = tx;
+        panStartTy = ty;
+        velSamples.length = 0;
+        recordVelocitySample(t0.clientX, t0.clientY);
+        if (typeof e.preventDefault === 'function') e.preventDefault();
+      }
+    }
+  }
+
+  function handleDoubleTap(cx: number, cy: number): void {
+    if (scale > 1.01) {
+      // Reset
+      scale = 1;
+      tx = 0;
+      ty = 0;
+    } else {
+      // Zoom to 2x around tap point
+      const rect = viewport.getBoundingClientRect();
+      const vx = cx - rect.left;
+      const vy = cy - rect.top;
+      const newScale = 2;
+      // Keep tap point anchored: new_t = v - (v - old_t) * (newScale/oldScale)
+      tx = vx - (vx - tx) * (newScale / scale);
+      ty = vy - (vy - ty) * (newScale / scale);
+      scale = newScale;
+      clampTranslate();
+    }
+    applyTransform();
+  }
+
+  function onTouchMove(ev: Event): void {
+    const e = ev as TouchEvent;
+    if (pinchActive && e.touches.length === 2) {
+      const t0 = e.touches[0]!;
+      const t1 = e.touches[1]!;
+      const currentDist = dist(t0.clientX, t0.clientY, t1.clientX, t1.clientY);
+      const ratio = initialPinchDist > 0 ? currentDist / initialPinchDist : 1;
+      const newScale = clamp(initialScale * ratio, MIN_SCALE, MAX_SCALE);
+      // Zoom around initial midpoint: keep that point anchored in target coords
+      const rect = viewport.getBoundingClientRect();
+      const vmx = pinchMidX - rect.left;
+      const vmy = pinchMidY - rect.top;
+      const ratioApplied = newScale / initialScale;
+      tx = vmx - (vmx - initialTx) * ratioApplied;
+      ty = vmy - (vmy - initialTy) * ratioApplied;
+      scale = newScale;
+      clampTranslate();
+      applyTransform();
+      if (typeof e.preventDefault === 'function') e.preventDefault();
+      return;
+    }
+
+    if (panActive && e.touches.length === 1 && scale > 1) {
+      const t0 = e.touches[0]!;
+      const dx = t0.clientX - panStartX;
+      const dy = t0.clientY - panStartY;
+      tx = panStartTx + dx;
+      ty = panStartTy + dy;
+      clampTranslate();
+      applyTransform();
+      recordVelocitySample(t0.clientX, t0.clientY);
+      if (typeof e.preventDefault === 'function') e.preventDefault();
+    }
+  }
+
+  function onTouchEnd(ev: Event): void {
+    const e = ev as TouchEvent;
+    if (pinchActive) {
+      // Pinch ends when fewer than 2 touches remain
+      if (e.touches.length < 2) {
+        pinchActive = false;
+        // If one finger remains and we're zoomed in, transition to pan
+        if (e.touches.length === 1 && scale > 1) {
+          const t0 = e.touches[0]!;
+          panActive = true;
+          panStartX = t0.clientX;
+          panStartY = t0.clientY;
+          panStartTx = tx;
+          panStartTy = ty;
+          velSamples.length = 0;
+        }
+      }
+      return;
+    }
+
+    if (panActive && e.touches.length === 0) {
+      panActive = false;
+      const { vx, vy } = computeVelocity();
+      if (Math.abs(vx) >= MOMENTUM_MIN_VELOCITY || Math.abs(vy) >= MOMENTUM_MIN_VELOCITY) {
+        startMomentum(vx, vy);
+      }
+    }
+  }
+
+  // Register listeners
+  addListener('touchstart', onTouchStart as EventListener, { passive: false });
+  addListener('touchmove', onTouchMove as EventListener, { passive: false });
+  addListener('touchend', onTouchEnd as EventListener);
+  addListener('touchcancel', onTouchEnd as EventListener);
+
+  // Initial transform
+  applyTransform();
+
+  return {
+    destroy(): void {
+      cancelMomentum();
+      while (disposables.length > 0) {
+        const d = disposables.pop();
+        if (!d) break;
+        viewport.removeEventListener(d.type, d.handler, d.options);
+      }
+    },
+    reset(): void {
+      cancelMomentum();
+      scale = 1;
+      tx = 0;
+      ty = 0;
+      applyTransform();
+    },
+  };
+}

--- a/src/modules/sftp-preview.ts
+++ b/src/modules/sftp-preview.ts
@@ -221,7 +221,7 @@ export function renderPreview(filename: string, data: Uint8Array | string): stri
       const blob = new Blob([bytes as BlobPart], { type: mime });
       const url = URL.createObjectURL(blob);
       _lastBlobUrls.push(url);
-      return `<img src="${url}" alt="${escapeHtml(filename)}" style="max-width:100%;max-height:80vh;">`;
+      return `<div class="preview-zoom-viewport"><img class="preview-zoom-target" src="${url}" alt="${escapeHtml(filename)}"></div>`;
     }
     case 'video': {
       const ext = extOf(filename);

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -14,6 +14,7 @@ import { sendSSHInput, sendSSHInputToAll, disconnect, reconnect, probeSession, c
 import { saveProfile, connectFromProfile, newConnection, loadProfiles, removeRecentSession, getRecentSessions, downloadProfilesExport, triggerProfileImport } from './profiles.js';
 import { clearIMEPreview, restoreIMEOverlay } from './ime.js';
 import { isPreviewable, createPreviewPanel } from './sftp-preview.js';
+import { attachPinchZoom, type PinchZoomController } from './pinch-zoom.js';
 
 /** Update session menu button text without clobbering child elements like badges (#355). */
 function _setMenuBtnText(text: string): void {
@@ -1832,9 +1833,23 @@ function _showFilePreview(filename: string, data: Uint8Array): void {
 
   history.pushState({ type: 'preview' }, '');
 
-  _activePreviewCleanup = (): void => { panel.cleanup(); };
+  // Attach pinch-zoom to any image preview viewports inside the panel
+  const zoomControllers: PinchZoomController[] = [];
+  const viewports = panel.querySelectorAll<HTMLElement>('.preview-zoom-viewport');
+  viewports.forEach((vp) => {
+    const tgt = vp.querySelector<HTMLElement>('.preview-zoom-target');
+    if (tgt) {
+      zoomControllers.push(attachPinchZoom(vp, tgt));
+    }
+  });
+
+  _activePreviewCleanup = (): void => {
+    for (const c of zoomControllers) c.destroy();
+    panel.cleanup();
+  };
 
   function closePreview(): void {
+    for (const c of zoomControllers) c.destroy();
     panel.cleanup();
     _activePreviewCleanup = null;
     container.classList.add('hidden');


### PR DESCRIPTION
## Summary
- New `src/modules/pinch-zoom.ts` — reusable zero-dep pinch/pan/momentum controller.
- Image case in `sftp-preview.ts` now wraps `<img>` in `.preview-zoom-viewport`.
- `ui.ts` attaches the controller at the `renderPreview` call site and destroys it on close.

## TDD Analysis
- Type: feature
- Behavior change: yes — new interactive gesture on image/SVG previews
- TDD approach: full (pinch math, bounds, state) + smoketest (DOM wrapper classes present)

## Test coverage
- **Existing tests updated**: `src/modules/__tests__/sftp-preview.test.ts` — added 2 tests (viewport wrapper + SVG path).
- **New tests added (fail→pass)**: `src/modules/__tests__/pinch-zoom.test.ts` — 10 tests:
  - initial transform `translate(0px, 0px) scale(1)`
  - registers touchstart/touchmove/touchend listeners on viewport
  - exposes `destroy()` and `reset()`
  - `reset()` returns to identity transform
  - `destroy()` removes listeners; idempotent
  - pinch distance doubling → scale ~2
  - scale clamped to max 8
  - scale clamped to min 1
  - single-finger move at scale=1 does NOT pan
- **Smoketest**: sftp-preview tests assert `.preview-zoom-viewport` + `.preview-zoom-target` classes present for PNG and SVG.

## Test results
- tsc: PASS
- eslint: PASS (0 errors in changed files; warnings are pre-existing no-non-null-assertion pattern)
- vitest: 10/10 new pinch-zoom tests PASS. Pre-existing sftp-preview failures (video.mp4 previewable by design, source-view line numbers not implemented) exist on main.

## Diff stats
- Files changed: 6 (2 new, 4 modified)
- Lines: +647 / -2

Closes #456

## Cycles used
1/3