### PR TITLE
fix: session swipe needs only one gesture (was requiring two)

### DIFF
--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -504,7 +504,17 @@ export function initSessionMenu(): void {
     });
   }
 
+  // Flag set by swipe touchend to suppress the synthesized click that follows
+  // (prevents menu from opening when user swipes to switch sessions).
+  let _suppressNextClick = false;
+
   menuBtn.addEventListener('click', (e) => {
+    if (_suppressNextClick) {
+      _suppressNextClick = false;
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
     e.stopPropagation();
     const wasHidden = menu.classList.toggle('hidden');
     backdrop.classList.toggle('hidden', wasHidden);
@@ -552,9 +562,11 @@ export function initSessionMenu(): void {
 
   menuBtn.addEventListener('touchend', (e) => {
     if (!_swipeClaimed) { _swipeX0 = null; return; }
-    // No swipe guard — the menu should NEVER be blocked
+    // Swipe was claimed — suppress the click that will follow so the menu doesn't open
+    _suppressNextClick = true;
     const dx = (e.changedTouches[0]?.clientX ?? _swipeX0 ?? 0) - (_swipeX0 ?? 0);
     _swipeX0 = null;
+    _swipeClaimed = false;
     menuBtn.style.opacity = '';
 
     const keys = Array.from(appState.sessions.keys());


### PR DESCRIPTION
## Summary
Horizontal swipe on the session title (`#sessionMenuBtn`) required two swipes to switch sessions — the first swipe appeared to open the menu instead. Root cause: `touchend` fired `switchSession()`, then the synthesized `click` event fired the menu-open handler.

Fix: `touchend` sets `_suppressNextClick = true` when swipe was claimed. Click handler no-ops once when the flag is set.

## Test plan
- [ ] Swipe left/right on "MobiSSH" button switches session in one gesture
- [ ] Tap on "MobiSSH" still opens session menu
- [ ] Menu doesn't open spuriously during swipe