### PR TITLE
feat: files panel — docs menu, close X, breadcrumb bookmark, favorites submenu

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -2900,6 +2900,143 @@ hr {
   opacity: 0.8;
 }
 
+/* Files panel chrome (#470) — close X, docs menu, bookmark */
+.files-chrome {
+  position: relative;
+  height: 0;
+  z-index: 2;
+}
+
+.files-close-btn,
+.files-docs-menu-btn {
+  position: absolute;
+  top: 4px;
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 22px;
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  touch-action: manipulation;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.files-close-btn {
+  left: 8px;
+}
+
+.files-docs-menu-btn {
+  right: 8px;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.files-close-btn:active,
+.files-docs-menu-btn:active {
+  opacity: 0.7;
+}
+
+.files-docs-menu {
+  position: absolute;
+  top: 52px;
+  right: 8px;
+  min-width: 140px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  z-index: 10;
+}
+
+.files-docs-menu-item {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.files-docs-menu-item:active {
+  background: var(--bg-input);
+}
+
+/* Push the breadcrumb in from under the chrome buttons (44px + margins) */
+#panel-files > .files-subview > .files-breadcrumb:first-child,
+#panel-files > #filesExplore > .files-breadcrumb {
+  padding-left: 60px;
+  padding-right: 60px;
+}
+
+.files-breadcrumb {
+  position: relative;
+}
+
+.files-breadcrumb-crumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.files-bookmark-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 18px;
+  line-height: 1;
+  padding: 4px 8px;
+  cursor: pointer;
+  touch-action: manipulation;
+  flex-shrink: 0;
+  opacity: 0.5;
+}
+
+.files-bookmark-btn.filled {
+  color: var(--accent);
+  opacity: 1;
+}
+
+.files-bookmark-btn:active {
+  opacity: 0.7;
+}
+
+/* Favorites submenu (#470) — re-uses .ctx-menu positioning */
+.files-fav-menu {
+  max-height: 60vh;
+  overflow-y: auto;
+  min-width: 200px;
+}
+
+.files-fav-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.files-fav-icon {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  width: 16px;
+  flex-shrink: 0;
+}
 
 #panel-files {
   display: none;

--- a/public/index.html
+++ b/public/index.html
@@ -328,6 +328,13 @@
          rendered beneath this overlay, so the ≡ session menu is always
          reachable from Files. The back-to-terminal button was removed. -->
     <div id="panel-files" class="panel">
+      <div class="files-chrome">
+        <button id="filesCloseBtn" class="files-close-btn" aria-label="Close files" title="Close">✕</button>
+        <button id="filesDocsMenuBtn" class="files-docs-menu-btn" aria-label="Files actions" title="More actions" aria-haspopup="true" aria-expanded="false">⋯</button>
+        <div id="filesDocsMenu" class="files-docs-menu hidden" role="menu" aria-label="Files actions">
+          <button class="files-docs-menu-item" data-action="upload" role="menuitem">Upload</button>
+        </div>
+      </div>
       <div id="filePreview" class="hidden"></div>
       <div id="filesExplore" class="files-subview active"></div>
       <div id="filesTransfer" class="files-subview hidden">

--- a/src/modules/__tests__/favorites.test.ts
+++ b/src/modules/__tests__/favorites.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for files favorites storage (#470).
+ *
+ * Verifies the `favorites.ts` module:
+ * 1. Stores favorites per-profile under the single localStorage key `filesFavorites`.
+ * 2. `listFavorites(profileId)` returns [] for unknown / corrupt / missing data.
+ * 3. `toggleFavorite(profileId, fav)` flips state and returns the NEW isFavorited boolean.
+ * 4. `isFavorited(profileId, path)` reflects current state.
+ * 5. Multiple profiles are isolated.
+ *
+ * Also includes structural tests (smoketests) for the files panel chrome DOM
+ * additions (docs menu, close X, bookmark slot).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+});
+
+const FAVORITES_KEY = 'filesFavorites';
+
+const { listFavorites, toggleFavorite, isFavorited, profileIdOf } = await import('../favorites.js');
+
+describe('favorites module (#470)', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  describe('profileIdOf', () => {
+    it('returns "host:port:username" for a profile', () => {
+      expect(profileIdOf({ host: 'ex.com', port: 22, username: 'alice' })).toBe('ex.com:22:alice');
+    });
+
+    it('handles non-default ports', () => {
+      expect(profileIdOf({ host: '10.0.0.1', port: 2222, username: 'root' })).toBe('10.0.0.1:2222:root');
+    });
+  });
+
+  describe('listFavorites', () => {
+    it('returns [] when no favorites are stored', () => {
+      expect(listFavorites('host:22:user')).toEqual([]);
+    });
+
+    it('returns [] when the stored value is corrupt JSON', () => {
+      storage.set(FAVORITES_KEY, '{not valid json');
+      expect(listFavorites('host:22:user')).toEqual([]);
+    });
+
+    it('returns [] when the stored value is the wrong shape', () => {
+      storage.set(FAVORITES_KEY, JSON.stringify('a string, not an object'));
+      expect(listFavorites('host:22:user')).toEqual([]);
+    });
+
+    it('returns [] for a profile that has no entry in the map', () => {
+      storage.set(FAVORITES_KEY, JSON.stringify({
+        'other:22:bob': [{ path: '/tmp', isFile: false }],
+      }));
+      expect(listFavorites('host:22:user')).toEqual([]);
+    });
+
+    it('returns the entries for the requested profile only', () => {
+      storage.set(FAVORITES_KEY, JSON.stringify({
+        'host:22:user': [
+          { path: '/home/user', isFile: false },
+          { path: '/etc/hosts', isFile: true },
+        ],
+        'other:22:bob': [{ path: '/tmp', isFile: false }],
+      }));
+      const favs = listFavorites('host:22:user');
+      expect(favs).toHaveLength(2);
+      expect(favs[0]?.path).toBe('/home/user');
+      expect(favs[1]?.isFile).toBe(true);
+    });
+  });
+
+  describe('isFavorited', () => {
+    it('returns false when nothing is stored', () => {
+      expect(isFavorited('host:22:user', '/tmp')).toBe(false);
+    });
+
+    it('returns true when the path is in the profile\'s list', () => {
+      storage.set(FAVORITES_KEY, JSON.stringify({
+        'host:22:user': [{ path: '/tmp', isFile: false }],
+      }));
+      expect(isFavorited('host:22:user', '/tmp')).toBe(true);
+    });
+
+    it('returns false when the path is in a different profile\'s list', () => {
+      storage.set(FAVORITES_KEY, JSON.stringify({
+        'other:22:bob': [{ path: '/tmp', isFile: false }],
+      }));
+      expect(isFavorited('host:22:user', '/tmp')).toBe(false);
+    });
+  });
+
+  describe('toggleFavorite', () => {
+    it('adds a favorite and returns true', () => {
+      const result = toggleFavorite('host:22:user', { path: '/tmp', isFile: false });
+      expect(result).toBe(true);
+      expect(isFavorited('host:22:user', '/tmp')).toBe(true);
+    });
+
+    it('removes an existing favorite and returns false', () => {
+      toggleFavorite('host:22:user', { path: '/tmp', isFile: false });
+      const result = toggleFavorite('host:22:user', { path: '/tmp', isFile: false });
+      expect(result).toBe(false);
+      expect(isFavorited('host:22:user', '/tmp')).toBe(false);
+    });
+
+    it('persists the single key `filesFavorites`', () => {
+      toggleFavorite('host:22:user', { path: '/tmp', isFile: false });
+      const raw = storage.get(FAVORITES_KEY);
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!);
+      expect(parsed['host:22:user']).toBeDefined();
+      expect(parsed['host:22:user'][0].path).toBe('/tmp');
+    });
+
+    it('keeps profiles isolated when toggling', () => {
+      toggleFavorite('host:22:user', { path: '/tmp', isFile: false });
+      toggleFavorite('other:22:bob', { path: '/tmp', isFile: false });
+      expect(listFavorites('host:22:user')).toHaveLength(1);
+      expect(listFavorites('other:22:bob')).toHaveLength(1);
+      // Remove from one profile; other should be unaffected
+      toggleFavorite('host:22:user', { path: '/tmp', isFile: false });
+      expect(listFavorites('host:22:user')).toEqual([]);
+      expect(isFavorited('other:22:bob', '/tmp')).toBe(true);
+    });
+
+    it('survives corrupt existing data (overwrites with fresh map)', () => {
+      storage.set(FAVORITES_KEY, '{not valid json');
+      const result = toggleFavorite('host:22:user', { path: '/tmp', isFile: false });
+      expect(result).toBe(true);
+      expect(isFavorited('host:22:user', '/tmp')).toBe(true);
+    });
+
+    it('stores isFile flag correctly', () => {
+      toggleFavorite('host:22:user', { path: '/etc/hosts', isFile: true });
+      const favs = listFavorites('host:22:user');
+      expect(favs[0]?.isFile).toBe(true);
+      expect(favs[0]?.path).toBe('/etc/hosts');
+    });
+
+    it('preserves label when provided', () => {
+      toggleFavorite('host:22:user', { path: '/', isFile: false, label: 'root' });
+      const favs = listFavorites('host:22:user');
+      expect(favs[0]?.label).toBe('root');
+    });
+  });
+});
+
+// ── Structural tests for files panel chrome (#470) ──────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const indexHtml = readFileSync(resolve(__dirname, '../../../public/index.html'), 'utf-8');
+const uiSrc = readFileSync(resolve(__dirname, '../ui.ts'), 'utf-8');
+
+describe('files panel chrome DOM (#470)', () => {
+  it('#panel-files contains a close X button (#filesCloseBtn)', () => {
+    expect(indexHtml).toContain('id="filesCloseBtn"');
+  });
+
+  it('#panel-files contains a docs menu button (#filesDocsMenuBtn)', () => {
+    expect(indexHtml).toContain('id="filesDocsMenuBtn"');
+  });
+
+  it('#panel-files contains the docs menu dropdown (#filesDocsMenu)', () => {
+    expect(indexHtml).toContain('id="filesDocsMenu"');
+  });
+
+  it('docs menu dropdown contains an Upload action', () => {
+    const menuStart = indexHtml.indexOf('id="filesDocsMenu"');
+    expect(menuStart).toBeGreaterThan(-1);
+    const block = indexHtml.slice(menuStart, menuStart + 500);
+    expect(block).toMatch(/data-action="upload"/);
+  });
+
+  it('#filesCloseBtn handler calls navigateToPanel(\'terminal\')', () => {
+    const start = uiSrc.indexOf("getElementById('filesCloseBtn')");
+    expect(start).toBeGreaterThan(-1);
+    const block = uiSrc.slice(start, start + 200);
+    expect(block).toMatch(/navigateToPanel\(['"]terminal['"]/);
+  });
+
+  it('ui.ts imports favorites helpers from ./favorites.js', () => {
+    expect(uiSrc).toMatch(/from '\.\/favorites\.js'/);
+    expect(uiSrc).toContain('listFavorites');
+    expect(uiSrc).toContain('toggleFavorite');
+    expect(uiSrc).toContain('isFavorited');
+  });
+
+  it('ui.ts renders a bookmark button in .files-breadcrumb', () => {
+    expect(uiSrc).toContain('files-bookmark-btn');
+  });
+
+  it('ui.ts wires a long-press on sessionFilesBtn that shows favorites', () => {
+    expect(uiSrc).toContain('_showFavoritesSubmenu');
+    expect(uiSrc).toMatch(/sessionFilesBtn\?\.addEventListener\(['"]touchstart['"]/);
+  });
+});

--- a/src/modules/favorites.ts
+++ b/src/modules/favorites.ts
@@ -1,0 +1,65 @@
+/**
+ * modules/favorites.ts — Files panel favorites (#470)
+ *
+ * Per-profile bookmarks for SFTP paths. Single localStorage key `filesFavorites`
+ * holds a map of `"host:port:username"` → `Favorite[]`. All reads guard against
+ * corrupt / malformed data and fall back to an empty list.
+ */
+
+import type { Favorite } from './types.js';
+
+const FAVORITES_KEY = 'filesFavorites';
+
+type FavoritesMap = Record<string, Favorite[]>;
+
+/** Canonical profile identity for favorites keying. */
+export function profileIdOf(profile: { host: string; port: number; username: string }): string {
+  return `${profile.host}:${String(profile.port)}:${profile.username}`;
+}
+
+/** Read the whole favorites map from localStorage. Returns {} on any failure. */
+function _readMap(): FavoritesMap {
+  try {
+    const raw = localStorage.getItem(FAVORITES_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as FavoritesMap;
+  } catch {
+    return {};
+  }
+}
+
+function _writeMap(map: FavoritesMap): void {
+  localStorage.setItem(FAVORITES_KEY, JSON.stringify(map));
+}
+
+/** List favorites for a given profile id. Empty list for unknown profile. */
+export function listFavorites(profileId: string): Favorite[] {
+  const map = _readMap();
+  const entries = map[profileId];
+  if (!Array.isArray(entries)) return [];
+  return entries.filter((e) => e && typeof e.path === 'string' && typeof e.isFile === 'boolean');
+}
+
+/** True when the given path is favorited for the given profile. */
+export function isFavorited(profileId: string, path: string): boolean {
+  return listFavorites(profileId).some((f) => f.path === path);
+}
+
+/** Toggle favorite state. Returns the NEW isFavorited state (true = added, false = removed). */
+export function toggleFavorite(profileId: string, fav: Favorite): boolean {
+  const map = _readMap();
+  const list = Array.isArray(map[profileId]) ? map[profileId]! : [];
+  const idx = list.findIndex((f) => f.path === fav.path);
+  if (idx >= 0) {
+    list.splice(idx, 1);
+    map[profileId] = list;
+    _writeMap(map);
+    return false;
+  }
+  list.push({ path: fav.path, isFile: fav.isFile, ...(fav.label ? { label: fav.label } : {}) });
+  map[profileId] = list;
+  _writeMap(map);
+  return true;
+}

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -44,6 +44,14 @@ export interface VaultMeta {
 
 export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected';
 
+// ── Files favorites (#470) ──────────────────────────────────────────────────
+
+export interface Favorite {
+  path: string;
+  isFile: boolean;
+  label?: string;
+}
+
 export type SessionLifecycleState =
   | 'idle'
   | 'connecting'

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -14,6 +14,8 @@ import { sendSSHInput, sendSSHInputToAll, disconnect, reconnect, probeSession, c
 import { saveProfile, connectFromProfile, newConnection, loadProfiles, removeRecentSession, getRecentSessions, downloadProfilesExport, triggerProfileImport } from './profiles.js';
 import { clearIMEPreview, restoreIMEOverlay } from './ime.js';
 import { isPreviewable, createPreviewPanel, MIME_MAP, extOf, SFTP_INLINE_IMG_ATTR, SFTP_RELATIVE_LINK_ATTR } from './sftp-preview.js';
+import { listFavorites, toggleFavorite, isFavorited, profileIdOf } from './favorites.js';
+import type { Favorite } from './types.js';
 
 /** Update session menu button text without clobbering the notification badge (#458).
  * Delegates to setSessionTitleBase which preserves the current notification count. */
@@ -2075,11 +2077,16 @@ function _renderFilesPanel(path: string, bodyHtml: string): void {
   }).join('');
   const breadcrumbHtml = rootCrumb + partCrumbs;
   const statusHidden = _transferStatus ? '' : ' hidden';
+  const bookmarked = _isCurrentPathFavorited(path);
+  const bookmarkClass = bookmarked ? 'files-bookmark-btn filled' : 'files-bookmark-btn';
+  const bookmarkLabel = bookmarked ? 'Remove from favorites' : 'Add to favorites';
 
   panel.innerHTML = `
-    <div class="files-breadcrumb">${breadcrumbHtml}</div>
+    <div class="files-breadcrumb">
+      <div class="files-breadcrumb-crumbs">${breadcrumbHtml}</div>
+      <button class="${bookmarkClass}" aria-label="${bookmarkLabel}" title="${bookmarkLabel}" data-path="${escHtml(path)}">★</button>
+    </div>
     <div class="files-toolbar">
-      <button class="files-upload-btn">Upload</button>
       <button class="files-download-btn hidden">Download</button>
       <input type="file" class="files-upload-input" multiple />
       <span class="files-transfer-status${statusHidden}">${escHtml(_transferStatus)}</span>
@@ -2136,9 +2143,7 @@ function _renderFilesPanel(path: string, bodyHtml: string): void {
     });
   });
 
-  const uploadBtn = panel.querySelector<HTMLElement>('.files-upload-btn');
   const fileInput = panel.querySelector<HTMLInputElement>('.files-upload-input');
-  uploadBtn?.addEventListener('click', () => { fileInput?.click(); });
   fileInput?.addEventListener('change', () => {
     if (fileInput.files?.length) {
       void _startUpload(fileInput.files);
@@ -2149,6 +2154,30 @@ function _renderFilesPanel(path: string, bodyHtml: string): void {
   dlBtn?.addEventListener('click', () => { _downloadSelectedFiles(panel); });
   const cancelBtn = panel.querySelector<HTMLElement>('.files-upload-cancel');
   cancelBtn?.addEventListener('click', () => { _cancelActiveUpload(); });
+
+  // Bookmark star in breadcrumb (#470)
+  const bookmarkBtn = panel.querySelector<HTMLElement>('.files-bookmark-btn');
+  bookmarkBtn?.addEventListener('click', () => {
+    const profId = _activeProfileId();
+    if (!profId) { toast('Connect a session to bookmark paths'); return; }
+    const fav: Favorite = { path, isFile: false };
+    toggleFavorite(profId, fav);
+    _renderFilesPanel(path, bodyHtml);
+  });
+}
+
+/** Resolve the active session's profile id for favorites keying, or null. */
+function _activeProfileId(): string | null {
+  const session = currentSession();
+  if (!session?.profile) return null;
+  return profileIdOf(session.profile);
+}
+
+/** True if the current files path is favorited for the active profile. */
+function _isCurrentPathFavorited(path: string): boolean {
+  const profId = _activeProfileId();
+  if (!profId) return false;
+  return isFavorited(profId, path);
 }
 
 function _filesNavigateTo(path: string, options?: { fromPopstate?: boolean }): void {
@@ -2422,6 +2451,71 @@ function _showContextMenu(touchX: number, touchY: number, path: string, isDir: b
   });
 }
 
+/** Render the favorites submenu anchored near the Files menu item. (#470) */
+function _showFavoritesSubmenu(touchX: number, touchY: number): void {
+  _dismissContextMenu();
+  const profId = _activeProfileId();
+  if (!profId) return;
+  const favs = listFavorites(profId);
+  if (favs.length === 0) return;
+
+  const overlay = document.createElement('div');
+  overlay.id = 'filesFavOverlay';
+  overlay.className = 'ctx-overlay';
+
+  const menu = document.createElement('div');
+  menu.id = 'filesFavMenu';
+  menu.className = 'ctx-menu files-fav-menu';
+  menu.innerHTML = favs.map((f) => {
+    const label = f.label ?? f.path;
+    const icon = f.isFile ? 'F' : 'D';
+    return `<button class="ctx-menu-item files-fav-item" data-path="${escHtml(f.path)}" data-is-file="${String(f.isFile)}"><span class="files-fav-icon">${icon}</span>${escHtml(label)}</button>`;
+  }).join('');
+
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const menuH = Math.min(favs.length * 44, vh - 16);
+  const left = Math.max(8, Math.min(touchX, vw - 220));
+  const top = Math.max(8, Math.min(touchY, vh - menuH - 8));
+  menu.style.setProperty('--ctx-x', `${String(left)}px`);
+  menu.style.setProperty('--ctx-y', `${String(top)}px`);
+
+  document.body.appendChild(overlay);
+  document.body.appendChild(menu);
+  history.pushState({ favMenu: true }, '');
+
+  let dismissed = false;
+  function dismiss(): void {
+    if (dismissed) return;
+    dismissed = true;
+    overlay.remove();
+    menu.remove();
+    window.removeEventListener('popstate', onPopstate);
+    _ctxMenuDismiss = null;
+  }
+  function onPopstate(): void { dismiss(); }
+  _ctxMenuDismiss = dismiss;
+  overlay.addEventListener('click', () => { dismiss(); history.back(); });
+  window.addEventListener('popstate', onPopstate);
+
+  menu.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-path]');
+    if (!btn) return;
+    const favPath = btn.dataset.path ?? '';
+    const isFile = btn.dataset.isFile === 'true';
+    dismiss();
+    history.back();
+    document.getElementById('sessionMenu')?.classList.add('hidden');
+    document.getElementById('menuBackdrop')?.classList.add('hidden');
+    navigateToPanel('files');
+    if (isFile) {
+      _requestFilePreview(favPath);
+    } else {
+      _filesNavigateTo(favPath);
+    }
+  });
+}
+
 export function initFilesPanel(): void {
   setSftpHandler((msg) => {
     if (msg.type === 'sftp_ls_result') {
@@ -2565,6 +2659,33 @@ export function initFilesPanel(): void {
     navigateToPanel('terminal');
   });
 
+  // Docs menu (#470) — top-right dropdown holding actions such as Upload
+  const docsMenuBtn = document.getElementById('filesDocsMenuBtn');
+  const docsMenu = document.getElementById('filesDocsMenu');
+  docsMenuBtn?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (!docsMenu) return;
+    const willHide = docsMenu.classList.toggle('hidden');
+    docsMenuBtn.setAttribute('aria-expanded', willHide ? 'false' : 'true');
+  });
+  document.addEventListener('click', (e) => {
+    if (!docsMenu || docsMenu.classList.contains('hidden')) return;
+    if (e.target instanceof Node && (docsMenu.contains(e.target) || docsMenuBtn?.contains(e.target))) return;
+    docsMenu.classList.add('hidden');
+    docsMenuBtn?.setAttribute('aria-expanded', 'false');
+  });
+  docsMenu?.querySelectorAll<HTMLElement>('.files-docs-menu-item').forEach((item) => {
+    item.addEventListener('click', () => {
+      const action = item.dataset.action;
+      docsMenu.classList.add('hidden');
+      docsMenuBtn?.setAttribute('aria-expanded', 'false');
+      if (action === 'upload') {
+        const fileInput = document.querySelector<HTMLInputElement>('#filesExplore .files-upload-input');
+        fileInput?.click();
+      }
+    });
+  });
+
   // Sub-tab switching
   document.querySelectorAll<HTMLElement>('.files-subtab').forEach((btn) => {
     btn.addEventListener('click', () => {
@@ -2594,12 +2715,28 @@ export function initFilesPanel(): void {
     fileInput?.click();
   });
 
-  // Session menu: Files entry — opens the files panel for the active session (#409)
-  document.getElementById('sessionFilesBtn')?.addEventListener('click', () => {
+  // Session menu: Files entry — opens the files panel (#409) / favorites on long-press (#470)
+  const sessionFilesBtn = document.getElementById('sessionFilesBtn');
+  let filesLongPressFired = false;
+  let filesPressTimer: ReturnType<typeof setTimeout> | null = null;
+  sessionFilesBtn?.addEventListener('click', () => {
+    if (filesLongPressFired) { filesLongPressFired = false; return; }
+    navigateToPanel('files');
     document.getElementById('sessionMenu')?.classList.add('hidden');
     document.getElementById('menuBackdrop')?.classList.add('hidden');
-    navigateToPanel('files');
   });
+  sessionFilesBtn?.addEventListener('touchstart', (e) => {
+    filesPressTimer = setTimeout(() => {
+      filesPressTimer = null;
+      filesLongPressFired = true;
+      const touch = e.touches[0];
+      _showFavoritesSubmenu(touch ? touch.clientX : 0, touch ? touch.clientY : 0);
+    }, 500);
+  }, { passive: true });
+  const filesCancelPress = (): void => { if (filesPressTimer) { clearTimeout(filesPressTimer); filesPressTimer = null; } };
+  sessionFilesBtn?.addEventListener('touchend', filesCancelPress);
+  sessionFilesBtn?.addEventListener('touchmove', filesCancelPress);
+  sessionFilesBtn?.addEventListener('touchcancel', () => { filesCancelPress(); filesLongPressFired = false; });
 
   // Session menu: Notifications entry — opens the review modal (#458)
   document.getElementById('sessionNotifBtn')?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ⋯ docs menu top-right collapses Upload into a dropdown (more actions later); ✕ close X top-left returns to terminal (mirrors #459 handler).
- Breadcrumb gains a ★ bookmark toggle; per-profile favorites live under single localStorage key `filesFavorites` keyed by `host:port:username`.
- Long-press on Files entry in the session menu reveals a favorites submenu — tap navigates (dir) or previews (file) for the active profile.

## TDD Analysis
- Type: feature
- Behavior change: yes
- TDD approach: full for `favorites.ts` (unit tests first), smoketest for DOM wiring

## Test coverage
- **Existing tests updated**: none needed (navbar-simplified Files-button regression guard still passes — handler restructured to keep `navigateToPanel('files')` inside the 400-char window)
- **New tests added (fail→pass)**:
  - `src/modules/__tests__/favorites.test.ts` — 17 unit tests covering `profileIdOf` / `listFavorites` / `isFavorited` / `toggleFavorite` (empty, corrupt JSON, wrong shape, unknown profile, add, remove, isolation between profiles, corrupt-fallback, isFile flag, label preservation).
  - Same file — 8 structural tests covering the DOM and wiring: `#filesCloseBtn`, `#filesDocsMenuBtn`, `#filesDocsMenu` with upload action, close-btn → navigateToPanel('terminal'), favorites import path, bookmark class emission, long-press wiring on `sessionFilesBtn`.
- **Smoketest**: the 8 structural tests double as smoketests — verify every new DOM element and wiring path exists.

## Test results
- tsc: PASS
- eslint: SKIP (pre-existing config breakage on main — see `.eslintrc.json` `src/` glob issue, unrelated to this PR)
- vitest: 884 total, 843 passing + 41 pre-existing failures (unchanged set from main baseline; +17/+8 favorites tests on top).

## Diff stats
- Files changed: 6 (public/app.css, public/index.html, src/modules/favorites.ts, src/modules/types.ts, src/modules/ui.ts, src/modules/__tests__/favorites.test.ts)
- Lines: +571 / -7

## Implementation notes
- Reused existing `_showContextMenu` positioning model (`ctx-overlay` + `ctx-menu`) for the favorites submenu — no new layout system.
- Reused `_pressTimer` / `_longPressFired` long-press pattern from files-entry context menu.
- Docs menu is CSS-positioned (`.files-chrome` absolute layer, zero-height so breadcrumb layout is unchanged — padding-left/right on the breadcrumb creates the visual inset for the chrome buttons).
- All `innerHTML` path/label assignments pass through `escHtml`.
- No inline styles. No `!important`. No `force: true`.

Closes #470

## Cycles used
1/3