### PR TITLE
feat(ui): reorder profiles via tap-menu (#481)

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1704,6 +1704,67 @@ hr {
 .profile-item {
   border-left: 9px solid var(--profile-color, transparent);
   padding-left: 12px;
+  position: relative;
+}
+
+/* Drag-grip / reorder menu trigger in the upper-right corner (#481).
+ * Tap → menu (Move to top / Move to bottom). Sits inside the card border
+ * with enough tap target to comfortably hit on mobile while staying
+ * visually secondary to the connect/edit/delete buttons. */
+.profile-reorder-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 14px;
+  letter-spacing: -1px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 6px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+.profile-reorder-btn:active {
+  background: var(--bg-card);
+  color: var(--text);
+}
+
+/* Floating popup menu anchored to a profile-reorder-btn. Positioned
+ * via inline top/right by showProfileReorderMenu in profiles.ts. */
+.profile-reorder-menu {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  z-index: 9999;
+  min-width: 160px;
+  overflow: hidden;
+}
+.profile-reorder-menu-item {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 14px;
+  font-family: var(--font-ui);
+  text-align: left;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.profile-reorder-menu-item:active {
+  background: var(--bg-card);
+}
+.profile-reorder-menu-item + .profile-reorder-menu-item {
+  border-top: 1px solid var(--border);
 }
 .active-session-item,
 .recent-session-item {

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import { initVaultUI, promptVaultSetupOnStartup } from './modules/vault-ui.js';
 import {
   initProfiles, getProfiles, loadProfiles,
   deleteProfile, editProfile, closeProfileEdit,
+  showProfileReorderMenu,
   loadKeys, importKey, deleteKey, renameKey, editKey, saveKeyEdit, cancelKeyEdit, populateKeyDropdown,
 } from './modules/profiles.js';
 import { initSettings, initSettingsPanel, registerServiceWorker, migrateSettings, connectSSE, applyUiScaleFromStorage } from './modules/settings.js';
@@ -188,6 +189,7 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
         if (btn.dataset.action === 'edit') editProfile(idx);
         else if (btn.dataset.action === 'delete') deleteProfile(idx);
         else if (btn.dataset.action === 'close-edit') { closeProfileEdit(); loadProfiles(); }
+        else if (btn.dataset.action === 'reorder') showProfileReorderMenu(btn);
         return;
       }
     });

--- a/src/modules/__tests__/profile-order.test.ts
+++ b/src/modules/__tests__/profile-order.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Profile order persistence (#481): a separate localStorage array of vaultIds
+ * controls the display order of saved profiles.
+ *
+ * Contract enforced by these tests:
+ * - Round-trip: setProfileOrder/getProfileOrder preserves order.
+ * - sortProfilesByOrder: sorted profiles match the order array; profiles
+ *   missing from the order append at the end (stable insertion-order
+ *   relative to the input).
+ * - moveProfileToPosition: 0 = top, -1 = bottom, n = insert at index.
+ * - removeProfileFromOrder: cleanly drops the id from the order.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Minimal localStorage stub — profile-order.ts has no other browser deps.
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+});
+
+const {
+  getProfileOrder,
+  setProfileOrder,
+  sortProfilesByOrder,
+  moveProfileToPosition,
+  removeProfileFromOrder,
+} = await import('../profile-order.js');
+
+interface MinimalProfile {
+  vaultId: string;
+  title: string;
+  host: string;
+  port: number;
+  username: string;
+  authType: string;
+  initialCommand: string;
+}
+
+function p(vaultId: string): MinimalProfile {
+  return { vaultId, title: vaultId, host: `${vaultId}.example`, port: 22, username: 'u', authType: 'password', initialCommand: '' };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('profile order — storage round-trip', () => {
+  it('returns empty array when no order is set', () => {
+    expect(getProfileOrder()).toEqual([]);
+  });
+
+  it('round-trips a list of vaultIds', () => {
+    setProfileOrder(['a', 'b', 'c']);
+    expect(getProfileOrder()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns empty array on corrupt localStorage value', () => {
+    localStorage.setItem('profileOrder', 'not-json');
+    expect(getProfileOrder()).toEqual([]);
+  });
+
+  it('filters non-string entries defensively', () => {
+    localStorage.setItem('profileOrder', JSON.stringify(['a', 42, null, 'b']));
+    expect(getProfileOrder()).toEqual(['a', 'b']);
+  });
+});
+
+describe('sortProfilesByOrder', () => {
+  it('returns the input unchanged when no order is set', () => {
+    const profiles = [p('a'), p('b'), p('c')];
+    expect(sortProfilesByOrder(profiles).map((x) => x.vaultId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('sorts profiles to match the order array', () => {
+    setProfileOrder(['c', 'a', 'b']);
+    const profiles = [p('a'), p('b'), p('c')];
+    expect(sortProfilesByOrder(profiles).map((x) => x.vaultId)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('appends profiles missing from the order at the end (insertion order preserved)', () => {
+    setProfileOrder(['b']);
+    const profiles = [p('a'), p('b'), p('c')];
+    // 'b' first per order; 'a' and 'c' append in their original input order.
+    expect(sortProfilesByOrder(profiles).map((x) => x.vaultId)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('skips order entries that no longer exist in the profile list', () => {
+    setProfileOrder(['gone', 'a', 'also-gone', 'b']);
+    const profiles = [p('a'), p('b')];
+    expect(sortProfilesByOrder(profiles).map((x) => x.vaultId)).toEqual(['a', 'b']);
+  });
+});
+
+describe('moveProfileToPosition', () => {
+  it('writes a fresh order with the moved id at the requested position', () => {
+    setProfileOrder(['a', 'b', 'c']);
+    moveProfileToPosition('c', 0, [p('a'), p('b'), p('c')]);
+    expect(getProfileOrder()).toEqual(['c', 'a', 'b']);
+  });
+
+  it('-1 means move to bottom', () => {
+    setProfileOrder(['a', 'b', 'c']);
+    moveProfileToPosition('a', -1, [p('a'), p('b'), p('c')]);
+    expect(getProfileOrder()).toEqual(['b', 'c', 'a']);
+  });
+
+  it('seeds order from raw profiles when none was set yet (move-to-top with empty order)', () => {
+    moveProfileToPosition('b', 0, [p('a'), p('b'), p('c')]);
+    expect(getProfileOrder()).toEqual(['b', 'a', 'c']);
+  });
+
+  it('clamps overshoot to end position', () => {
+    setProfileOrder(['a', 'b', 'c']);
+    moveProfileToPosition('a', 99, [p('a'), p('b'), p('c')]);
+    expect(getProfileOrder()).toEqual(['b', 'c', 'a']);
+  });
+});
+
+describe('removeProfileFromOrder', () => {
+  it('drops the id and preserves remaining order', () => {
+    setProfileOrder(['a', 'b', 'c']);
+    removeProfileFromOrder('b');
+    expect(getProfileOrder()).toEqual(['a', 'c']);
+  });
+
+  it('is idempotent for ids not in the order', () => {
+    setProfileOrder(['a', 'b']);
+    removeProfileFromOrder('not-there');
+    expect(getProfileOrder()).toEqual(['a', 'b']);
+  });
+});

--- a/src/modules/profile-order.ts
+++ b/src/modules/profile-order.ts
@@ -1,0 +1,86 @@
+/**
+ * modules/profile-order.ts — profile display ordering (#481)
+ *
+ * Pure storage + array helpers for ordering profile cards. Kept separate from
+ * profiles.ts so the storage logic is unit-testable without pulling in the
+ * full settings/UI/connection import chain.
+ *
+ * Storage shape: a JSON array of profile vaultIds in display order, persisted
+ * at localStorage[profileOrder]. Profiles missing from the order array fall
+ * to the end (preserves "new profile appears" semantics on cold-import).
+ */
+
+const PROFILE_ORDER_KEY = 'profileOrder';
+
+interface ProfileLike {
+  vaultId: string;
+}
+
+/** Read the ordered list of profile vaultIds from localStorage. */
+export function getProfileOrder(): string[] {
+  try {
+    const raw = localStorage.getItem(PROFILE_ORDER_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
+}
+
+/** Write the ordered list of profile vaultIds to localStorage. */
+export function setProfileOrder(order: string[]): void {
+  localStorage.setItem(PROFILE_ORDER_KEY, JSON.stringify(order));
+}
+
+/** Return profiles sorted by `profileOrder`, with unordered profiles appended
+ *  at the end in their stored (insertion) order. Profiles whose vaultId no
+ *  longer exists are skipped. Idempotent: safe to call repeatedly. */
+export function sortProfilesByOrder<T extends ProfileLike>(profiles: T[]): T[] {
+  const order = getProfileOrder();
+  if (order.length === 0) return profiles;
+  const byVaultId = new Map<string, T>();
+  for (const p of profiles) {
+    if (p.vaultId) byVaultId.set(p.vaultId, p);
+  }
+  const sorted: T[] = [];
+  const seen = new Set<string>();
+  for (const id of order) {
+    const p = byVaultId.get(id);
+    if (p) {
+      sorted.push(p);
+      seen.add(id);
+    }
+  }
+  for (const p of profiles) {
+    if (!p.vaultId || !seen.has(p.vaultId)) sorted.push(p);
+  }
+  return sorted;
+}
+
+/** Move a profile (by vaultId) to a specific position in the order. Position
+ *  -1 means "to end" / "to bottom"; 0 means "to top". Other indices reorder
+ *  within the array. New positions clamp to the valid range. Pass the full
+ *  profile list so the helper can seed an order from raw insertion order
+ *  when none was set yet. */
+export function moveProfileToPosition(
+  vaultId: string,
+  position: number,
+  profiles: ProfileLike[],
+): void {
+  const allIds = profiles.map((p) => p.vaultId).filter((id): id is string => Boolean(id));
+  const current = getProfileOrder().filter((id) => allIds.includes(id) && id !== vaultId);
+  for (const id of allIds) {
+    if (id !== vaultId && !current.includes(id)) current.push(id);
+  }
+  const insertAt = position < 0 || position > current.length ? current.length : position;
+  current.splice(insertAt, 0, vaultId);
+  setProfileOrder(current);
+}
+
+/** Remove a vaultId from the order array — call when a profile is deleted. */
+export function removeProfileFromOrder(vaultId: string): void {
+  const order = getProfileOrder().filter((id) => id !== vaultId);
+  setProfileOrder(order);
+}

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -25,6 +25,86 @@ export function profileColor(profile: { color?: string; theme?: string }): strin
   return THEMES[theme].app.accent;
 }
 
+// StoredProfile shape — full definition is below; declared early so the
+// profile-order helpers compile without no-use-before-define lint errors.
+interface StoredProfile {
+  title: string;
+  host: string;
+  port: number;
+  username: string;
+  authType: string;
+  initialCommand: string;
+  vaultId: string;
+  hasVaultCreds?: boolean;
+  keyVaultId?: string;
+  theme?: string;
+  color?: string;
+}
+
+// Profile display order helpers live in their own module so the storage
+// logic is unit-testable without pulling the full UI/connection import chain.
+import {
+  getProfileOrder,
+  sortProfilesByOrder,
+  moveProfileToPosition as _moveProfileToPosition,
+  removeProfileFromOrder,
+} from './profile-order.js';
+export { getProfileOrder, sortProfilesByOrder, removeProfileFromOrder };
+export function moveProfileToPosition(vaultId: string, position: number): void {
+  _moveProfileToPosition(vaultId, position, getProfiles());
+}
+
+/** Render a small popup menu next to the profile-card reorder grip with
+ *  "Move to top" / "Move to bottom" actions. Tapping outside dismisses. */
+export function showProfileReorderMenu(anchor: HTMLElement): void {
+  // Reuse-or-replace pattern: kill any existing menu first so a second tap
+  // toggles it off rather than stacking.
+  document.getElementById('profileReorderMenu')?.remove();
+
+  const vaultId = anchor.dataset['vaultId'];
+  if (!vaultId) return;
+
+  const menu = document.createElement('div');
+  menu.id = 'profileReorderMenu';
+  menu.className = 'profile-reorder-menu';
+  menu.innerHTML = `
+    <button class="profile-reorder-menu-item" data-action="move-top">Move to top</button>
+    <button class="profile-reorder-menu-item" data-action="move-bottom">Move to bottom</button>
+  `;
+
+  // Position relative to the anchor button's bounding rect so the menu hangs
+  // below-and-to-the-left of the grip on the upper-right corner of the card.
+  const rect = anchor.getBoundingClientRect();
+  menu.style.position = 'fixed';
+  menu.style.top = `${String(rect.bottom + 4)}px`;
+  menu.style.right = `${String(window.innerWidth - rect.right)}px`;
+
+  document.body.appendChild(menu);
+
+  const dismiss = (): void => {
+    menu.remove();
+    document.removeEventListener('click', onOutside, true);
+  };
+  function onOutside(e: Event): void {
+    if (!menu.contains(e.target as Node)) dismiss();
+  }
+
+  menu.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-action]');
+    if (!btn) return;
+    const act = btn.dataset['action'];
+    if (act === 'move-top') moveProfileToPosition(vaultId, 0);
+    else if (act === 'move-bottom') moveProfileToPosition(vaultId, -1);
+    dismiss();
+    loadProfiles();
+  });
+
+  // Defer outside-click registration one tick so the originating click
+  // doesn't immediately dismiss the menu we just opened.
+  setTimeout(() => { document.addEventListener('click', onOutside, true); }, 0);
+}
+
 // ── Recent sessions persistence (#385) ──────────────────────────────────────
 
 const RECENT_SESSIONS_KEY = 'recentSessions';
@@ -112,21 +192,9 @@ export function initProfiles({ toast, navigateToConnect }: ProfilesDeps): void {
   }
 }
 
-// Profile storage
-
-interface StoredProfile {
-  title: string;
-  host: string;
-  port: number;
-  username: string;
-  authType: string;
-  initialCommand: string;
-  vaultId: string;
-  hasVaultCreds?: boolean;
-  keyVaultId?: string;
-  theme?: string;
-  color?: string;
-}
+// Profile storage. StoredProfile interface declared earlier (above the
+// profile-order helpers) so they can reference it without
+// no-use-before-define.
 
 export function getProfiles(): StoredProfile[] {
   const raw = JSON.parse(localStorage.getItem('sshProfiles') || '[]') as StoredProfile[];
@@ -296,8 +364,13 @@ export function loadProfiles(): void {
 
   // Profiles section — only show header when active sessions exist above (#306)
   const profilesHeader = allSessions.length > 0 ? '<h3 class="section-label">Profiles</h3>' : '';
+  // Apply user-selected order (#481). Render in sorted order, but data-idx
+  // still references the original `profiles` array so click handlers that
+  // call getProfiles()[idx] keep working unchanged.
+  const sortedProfiles = sortProfilesByOrder(profiles);
   list.innerHTML = profilesHeader
-    + profiles.map((p, i) => {
+    + sortedProfiles.map((p) => {
+      const i = profiles.indexOf(p);
       const matchingSessions = allSessions.filter(
         (s) => s.profile!.host === p.host && (s.profile!.port || 22) === (p.port || 22) && s.profile!.username === p.username
       );
@@ -307,7 +380,8 @@ export function loadProfiles(): void {
       const connectBtnClass = isConnecting ? 'item-btn connecting' : 'item-btn';
       const connectBtnText = isConnecting ? 'Connecting…' : 'Connect';
       const color = profileColor(p);
-      return `<div class="profile-item${connClass}" data-idx="${String(i)}" style="--profile-color:${escHtml(color)}">
+      return `<div class="profile-item${connClass}" data-idx="${String(i)}" data-vault-id="${escHtml(p.vaultId)}" style="--profile-color:${escHtml(color)}">
+        <button class="profile-reorder-btn" data-action="reorder" data-vault-id="${escHtml(p.vaultId)}" aria-label="Reorder profile" title="Drag to reorder, tap for menu">⋮⋮</button>
         <span class="profile-name">${escHtml(p.title || `${p.username}@${p.host}`)}</span>
         <span class="profile-host">${escHtml(p.username)}@${escHtml(p.host)}:${String(p.port || 22)}</span>
         <div class="item-actions">
@@ -506,7 +580,10 @@ export async function connectFromProfile(idx: number): Promise<boolean> {
 export function deleteProfile(idx: number): void {
   const profiles = getProfiles();
   const p = profiles[idx];
-  if (p?.vaultId) vaultDelete(p.vaultId);
+  if (p?.vaultId) {
+    vaultDelete(p.vaultId);
+    removeProfileFromOrder(p.vaultId);
+  }
   profiles.splice(idx, 1);
   localStorage.setItem('sshProfiles', JSON.stringify(profiles));
   loadProfiles();


### PR DESCRIPTION
Implements #481 — drag-to-reorder profiles + reorder menu.

## What's in this PR (MVP)

- Profile cards on the Connect panel show a small drag-grip glyph (⋮⋮) in the upper-right.
- Tapping the glyph opens a popup menu with **Move to top** and **Move to bottom**.
- Order persists across reloads via a separate `profileOrder` array of vaultIds in localStorage.
- Profiles missing from the order array fall to the end (preserves "new profile appears" semantics on cold-import).
- Deleting a profile removes its vaultId from the order array.

## What's NOT in this PR (follow-up)

- **Touch-and-hold + drag** to directly reorder. The MVP ships tap-menu only; drag is more involved on mobile (custom touch handling, drop-target detection, auto-scroll) and shouldn't block this. File a follow-up if the menu isn't enough.

## Implementation notes

Storage layer extracted to `src/modules/profile-order.ts` so the helpers are unit-testable without pulling in the full UI/connection import chain. `profiles.ts` wraps `moveProfileToPosition` to seed from `getProfiles()` at the call site.

## Tests

14 new unit tests:
- Storage round-trip (set/get, corrupt-value defensive parsing, non-string filtering)
- `sortProfilesByOrder` (no-order, partial-order, missing-ids, full-order)
- `moveProfileToPosition` (top/bottom/clamp/seed-from-empty)
- `removeProfileFromOrder` (idempotent for unknown ids)

`scripts/test-fast-gate.sh` passes.

## Acceptance per issue

- [x] Profile cards display a small drag/menu glyph in the upper-right.
- [x] Tap on the glyph shows menu with "Move to top" and "Move to bottom".
- [x] Order persists across reloads.
- [x] New profiles append at the end.
- [x] Deleted profiles remove cleanly.
- [x] Recent sessions list unaffected.
- [x] Existing tap-to-connect on the card body unchanged.
- [ ] Touch-and-hold on the glyph initiates drag mode — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)