### PR TITLE
feat(ui): quick-response chips — saved phrases sendable with one tap (#480)

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -935,6 +935,113 @@ html, body {
   border-color: #d32f2f;
 }
 
+/* Quick-response floating chip strip (#480). Sits above the keybar handle.
+ * Horizontally scrollable when overflowing; chips are individually tappable. */
+.quick-response-strip {
+  position: absolute;
+  bottom: calc(var(--keybar-height) + var(--keybar-handle-height) + 4px);
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  padding: 4px 8px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  z-index: 10;
+  pointer-events: auto;
+}
+.quick-response-strip::-webkit-scrollbar { display: none; }
+.quick-response-chip {
+  flex: 0 0 auto;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 14px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  white-space: nowrap;
+}
+.quick-response-chip:active {
+  background: var(--accent);
+  color: #000;
+  border-color: var(--accent);
+}
+
+/* Settings: quick-response list editor (#480) */
+.settings-subsection {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.settings-subsection-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  color: var(--text);
+}
+.quick-response-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.quick-response-row:last-child { border-bottom: none; }
+.quick-response-row input[type="text"] {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--font-ui);
+}
+.quick-response-row .qr-label-input { flex: 0 0 30%; }
+.quick-response-row-actions {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+.quick-response-row-actions button {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.quick-response-add {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 12px 0 0;
+  align-items: center;
+}
+.quick-response-add input[type="text"] {
+  flex: 1;
+  min-width: 100px;
+  padding: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--font-ui);
+}
+.quick-response-add-enter {
+  font-size: 12px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+.quick-response-add .primary-btn { flex: 0 0 100%; }
+
 /* Copy and paste buttons in handle bar — shared layout (#55, #197) */
 .handle-copy-btn,
 .handle-paste-btn {

--- a/public/index.html
+++ b/public/index.html
@@ -260,6 +260,10 @@
         <button id="selectionDismissBtn" class="selection-chip-btn selection-chip-dismiss" aria-label="Dismiss">✕</button>
       </div>
       <!-- IME preview element removed — actions are now on #imeContainer (#106) -->
+      <!-- Quick-response floating chips (#480). Anchored above the handle bar.
+           Hidden when no entries exist or no terminal session is active.
+           Populated dynamically by initQuickResponses in ui.ts. -->
+      <div id="quickResponseStrip" class="quick-response-strip hidden" role="toolbar" aria-label="Quick responses"></div>
       <!-- Handle strip: session identity (center, swipe up/down toggles tab bar) | ▾ key bar toggle -->
       <div id="key-bar-handle" aria-label="Terminal controls">
         <button id="handleMenuBtn" class="handle-btn handle-menu-btn" title="Show tabs" aria-label="Show tabs" data-tooltip="Show tabs">≡</button>
@@ -648,6 +652,22 @@
             <option value="2000">2s</option>
             <option value="3000">3s</option>
           </select>
+        </div>
+
+        <!-- Quick responses (#480) — saved phrases sendable with one tap from
+             a floating chip strip on the terminal panel. -->
+        <div class="settings-subsection">
+          <h3 class="settings-subsection-title">Quick responses</h3>
+          <p class="hint">Saved phrases that appear as floating chips above the keybar. Tap a chip to send the phrase to the active terminal.</p>
+          <div id="quickResponseList"></div>
+          <div class="quick-response-add">
+            <input type="text" id="quickResponseAddLabel" placeholder="Label (chip text)" />
+            <input type="text" id="quickResponseAddText" placeholder="Text to send" />
+            <label class="quick-response-add-enter">
+              <input type="checkbox" id="quickResponseAddAppendEnter" checked /> append Enter
+            </label>
+            <button id="quickResponseAddBtn" class="primary-btn">Add quick response</button>
+          </div>
         </div>
         </div>
       </section>

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,8 @@ import { refreshKeepAliveNotification, dismissKeepAliveNotification } from './mo
 import { disconnect } from './modules/connection.js';
 import { initIME, initIMEInput } from './modules/ime.js';
 import { initSelection } from './modules/selection.js';
+import { initQuickResponses } from './modules/quick-responses-ui.js';
+import { sendSSHInput } from './modules/connection.js';
 import {
   initUI, toast, setStatus, focusIME,
   _applyTabBarVisibility, initSessionMenu, initTabBar,
@@ -68,6 +70,7 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
     initConnection({ toast, setStatus, focusIME, applyTabBarVisibility: _applyTabBarVisibility });
     initSessionMenu();
     initSettingsPanel();
+    initQuickResponses({ sendInput: sendSSHInput, toast });
     loadProfiles();
     loadKeys();
     populateKeyDropdown();

--- a/src/modules/__tests__/quick-responses.test.ts
+++ b/src/modules/__tests__/quick-responses.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Quick-response storage helpers (#480).
+ *
+ * Contract:
+ * - Add/update/delete/reorder operate on the same persisted JSON array.
+ * - Schema version lives INSIDE the value (per project rule), not in the key.
+ * - Bare-array values from older exports are tolerated and re-wrapped.
+ * - getEnabledQuickResponses filters disabled entries.
+ * - sanitize drops malformed records (missing label/text) without throwing.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+});
+
+const {
+  getQuickResponses,
+  getEnabledQuickResponses,
+  addQuickResponse,
+  updateQuickResponse,
+  deleteQuickResponse,
+  reorderQuickResponse,
+  setQuickResponses,
+} = await import('../quick-responses.js');
+
+beforeEach(() => {
+  storage.clear();
+});
+
+describe('quick responses — storage round-trip', () => {
+  it('returns empty array when nothing is saved', () => {
+    expect(getQuickResponses()).toEqual([]);
+  });
+
+  it('add + get round-trips an entry with default flags', () => {
+    const id = addQuickResponse('Go', 'go');
+    const all = getQuickResponses();
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({ id, label: 'Go', text: 'go', appendEnter: true, enabled: true });
+  });
+
+  it('appendEnter=false is honored', () => {
+    addQuickResponse('No Enter', 'set foo=bar', false);
+    expect(getQuickResponses()[0]?.appendEnter).toBe(false);
+  });
+
+  it('persists across re-reads (storage round-trip)', () => {
+    addQuickResponse('A', 'a');
+    addQuickResponse('B', 'b');
+    expect(getQuickResponses().map((q) => q.label)).toEqual(['A', 'B']);
+  });
+});
+
+describe('quick responses — enabled filter', () => {
+  it('hides disabled entries from the enabled-only list', () => {
+    const a = addQuickResponse('A', 'a');
+    addQuickResponse('B', 'b');
+    updateQuickResponse(a, { enabled: false });
+    const enabled = getEnabledQuickResponses();
+    expect(enabled.map((q) => q.label)).toEqual(['B']);
+    // Full list still includes both.
+    expect(getQuickResponses()).toHaveLength(2);
+  });
+});
+
+describe('quick responses — update / delete', () => {
+  it('updateQuickResponse patches fields', () => {
+    const id = addQuickResponse('Old', 'old text');
+    updateQuickResponse(id, { label: 'New', text: 'new text', appendEnter: false });
+    const entry = getQuickResponses()[0]!;
+    expect(entry.label).toBe('New');
+    expect(entry.text).toBe('new text');
+    expect(entry.appendEnter).toBe(false);
+  });
+
+  it('updateQuickResponse for unknown id is a no-op', () => {
+    addQuickResponse('A', 'a');
+    updateQuickResponse('not-real', { label: 'X' });
+    expect(getQuickResponses()[0]?.label).toBe('A');
+  });
+
+  it('deleteQuickResponse removes by id and is idempotent', () => {
+    const id = addQuickResponse('A', 'a');
+    deleteQuickResponse(id);
+    expect(getQuickResponses()).toEqual([]);
+    deleteQuickResponse(id); // no throw
+    expect(getQuickResponses()).toEqual([]);
+  });
+});
+
+describe('quick responses — reorder', () => {
+  it('moves an entry from one position to another', () => {
+    addQuickResponse('A', 'a');
+    addQuickResponse('B', 'b');
+    addQuickResponse('C', 'c');
+    reorderQuickResponse(2, 0); // move C to top
+    expect(getQuickResponses().map((q) => q.label)).toEqual(['C', 'A', 'B']);
+  });
+
+  it('clamps overshoot to last index', () => {
+    addQuickResponse('A', 'a');
+    addQuickResponse('B', 'b');
+    reorderQuickResponse(0, 99);
+    expect(getQuickResponses().map((q) => q.label)).toEqual(['B', 'A']);
+  });
+
+  it('no-ops when from === to', () => {
+    addQuickResponse('A', 'a');
+    addQuickResponse('B', 'b');
+    reorderQuickResponse(1, 1);
+    expect(getQuickResponses().map((q) => q.label)).toEqual(['A', 'B']);
+  });
+});
+
+describe('quick responses — schema tolerance', () => {
+  it('reads a bare-array value (older export) and re-wraps on next write', () => {
+    storage.set('quickResponses', JSON.stringify([
+      { id: 'x', label: 'A', text: 'a', appendEnter: true, enabled: true },
+    ]));
+    expect(getQuickResponses().map((q) => q.label)).toEqual(['A']);
+    addQuickResponse('B', 'b');
+    // After a write, value is the schema-wrapped shape.
+    const stored = JSON.parse(storage.get('quickResponses') ?? '{}') as { version: number; entries: unknown[] };
+    expect(stored.version).toBe(1);
+    expect(stored.entries).toHaveLength(2);
+  });
+
+  it('drops malformed records without throwing', () => {
+    storage.set('quickResponses', JSON.stringify({
+      version: 1,
+      entries: [
+        { id: '1', label: 'OK', text: 'ok', appendEnter: true, enabled: true },
+        { id: '2', label: 'no text here' }, // missing text
+        { id: '3', text: 'no label' }, // missing label
+        null,
+        'not-an-object',
+      ],
+    }));
+    expect(getQuickResponses().map((q) => q.label)).toEqual(['OK']);
+  });
+
+  it('returns empty array on JSON parse failure', () => {
+    storage.set('quickResponses', '{not valid json');
+    expect(getQuickResponses()).toEqual([]);
+  });
+});
+
+describe('setQuickResponses', () => {
+  it('replaces the full list and re-sanitizes', () => {
+    addQuickResponse('A', 'a');
+    setQuickResponses([
+      { id: '1', label: 'New', text: 'new', appendEnter: true, enabled: true },
+      { id: '2', label: '', text: 'no label' } as unknown as never, // dropped
+    ]);
+    expect(getQuickResponses().map((q) => q.label)).toEqual(['New']);
+  });
+});

--- a/src/modules/quick-responses-ui.ts
+++ b/src/modules/quick-responses-ui.ts
@@ -1,0 +1,149 @@
+/**
+ * modules/quick-responses-ui.ts — DOM bindings for #480 quick responses.
+ *
+ * Two surfaces:
+ *  1. #quickResponseStrip — floating chip strip on the terminal panel. Tap
+ *     a chip to send its stored text (and optionally `\r`) to the active
+ *     session.
+ *  2. The settings panel "Quick responses" subsection — list with inline
+ *     edit + add form.
+ *
+ * The storage layer is in ./quick-responses.ts (pure helpers); this module
+ * just renders + wires events.
+ */
+
+import { escHtml } from './constants.js';
+import {
+  getQuickResponses,
+  getEnabledQuickResponses,
+  addQuickResponse,
+  updateQuickResponse,
+  deleteQuickResponse,
+  type QuickResponse,
+} from './quick-responses.js';
+
+/** Re-render the floating chip strip on the terminal panel. Hidden when
+ *  there are no enabled entries. */
+export function renderQuickResponseStrip(): void {
+  const strip = document.getElementById('quickResponseStrip');
+  if (!strip) return;
+  const entries = getEnabledQuickResponses();
+  if (entries.length === 0) {
+    strip.classList.add('hidden');
+    strip.innerHTML = '';
+    return;
+  }
+  strip.classList.remove('hidden');
+  strip.innerHTML = entries.map((q) => (
+    `<button class="quick-response-chip" data-qr-id="${escHtml(q.id)}" type="button">${escHtml(q.label)}</button>`
+  )).join('');
+}
+
+/** Re-render the settings-section list of all entries (enabled and disabled). */
+function renderSettingsList(): void {
+  const list = document.getElementById('quickResponseList');
+  if (!list) return;
+  const entries = getQuickResponses();
+  if (entries.length === 0) {
+    list.innerHTML = '<p class="hint">No quick responses yet. Add one below.</p>';
+    return;
+  }
+  list.innerHTML = entries.map((q) => renderRow(q)).join('');
+}
+
+function renderRow(q: QuickResponse): string {
+  return `<div class="quick-response-row" data-qr-id="${escHtml(q.id)}">
+    <input class="qr-label-input" type="text" value="${escHtml(q.label)}" placeholder="Label" data-field="label" />
+    <input class="qr-text-input" type="text" value="${escHtml(q.text)}" placeholder="Text to send" data-field="text" />
+    <div class="quick-response-row-actions">
+      <label class="quick-response-add-enter" title="Append Enter when sent">
+        <input type="checkbox" data-field="appendEnter"${q.appendEnter ? ' checked' : ''} /> ↵
+      </label>
+      <label class="quick-response-add-enter" title="Enabled">
+        <input type="checkbox" data-field="enabled"${q.enabled ? ' checked' : ''} /> on
+      </label>
+      <button class="item-btn danger" data-action="qr-delete" type="button">Delete</button>
+    </div>
+  </div>`;
+}
+
+interface QuickResponseDeps {
+  /** Send text to the active terminal — typically connection.sendSSHInput. */
+  sendInput: (text: string) => void;
+  toast: (msg: string) => void;
+}
+
+export function initQuickResponses({ sendInput, toast }: QuickResponseDeps): void {
+  // ── Chip strip: tap → send ──
+  const strip = document.getElementById('quickResponseStrip');
+  if (strip) {
+    strip.addEventListener('click', (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-qr-id]');
+      if (!btn) return;
+      const id = btn.dataset['qrId'];
+      if (!id) return;
+      const entry = getQuickResponses().find((q) => q.id === id);
+      if (!entry || !entry.enabled) return;
+      const payload = entry.appendEnter ? entry.text + '\r' : entry.text;
+      sendInput(payload);
+    });
+  }
+
+  // ── Settings list: edit / delete / toggle ──
+  const list = document.getElementById('quickResponseList');
+  if (list) {
+    // Inline edits commit on `change` (text inputs blur or Enter; checkboxes click).
+    list.addEventListener('change', (e) => {
+      const input = e.target as HTMLInputElement;
+      const row = input.closest<HTMLElement>('[data-qr-id]');
+      if (!row) return;
+      const id = row.dataset['qrId'];
+      if (!id) return;
+      const field = input.dataset['field'];
+      if (field === 'label' || field === 'text') {
+        updateQuickResponse(id, { [field]: input.value });
+      } else if (field === 'appendEnter' || field === 'enabled') {
+        updateQuickResponse(id, { [field]: input.checked });
+      }
+      renderQuickResponseStrip();
+    });
+
+    list.addEventListener('click', (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-action="qr-delete"]');
+      if (!btn) return;
+      const row = btn.closest<HTMLElement>('[data-qr-id]');
+      const id = row?.dataset['qrId'];
+      if (!id) return;
+      deleteQuickResponse(id);
+      renderSettingsList();
+      renderQuickResponseStrip();
+      toast('Quick response deleted');
+    });
+  }
+
+  // ── Add form ──
+  const addBtn = document.getElementById('quickResponseAddBtn');
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      const labelEl = document.getElementById('quickResponseAddLabel') as HTMLInputElement | null;
+      const textEl = document.getElementById('quickResponseAddText') as HTMLInputElement | null;
+      const enterEl = document.getElementById('quickResponseAddAppendEnter') as HTMLInputElement | null;
+      const label = labelEl?.value.trim() ?? '';
+      const text = textEl?.value ?? '';
+      if (!label || !text) {
+        toast('Both label and text are required');
+        return;
+      }
+      addQuickResponse(label, text, enterEl?.checked ?? true);
+      if (labelEl) labelEl.value = '';
+      if (textEl) textEl.value = '';
+      if (enterEl) enterEl.checked = true;
+      renderSettingsList();
+      renderQuickResponseStrip();
+    });
+  }
+
+  // Initial paint.
+  renderSettingsList();
+  renderQuickResponseStrip();
+}

--- a/src/modules/quick-responses.ts
+++ b/src/modules/quick-responses.ts
@@ -1,0 +1,133 @@
+/**
+ * modules/quick-responses.ts — User-defined one-tap response buttons (#480)
+ *
+ * The user can save short phrases (e.g., "go", "status versus goal") that
+ * become floating chips above the keybar. Tap a chip → send the stored text
+ * (and optionally `\r`) to the active terminal.
+ *
+ * Storage: localStorage('quickResponses') — JSON array, schema versioned in
+ * the value (per the project's "no key bumping for migration" rule). The
+ * helpers here only know about storage + the data model. Render and send
+ * are wired up in ui.ts where the active session and the input pipeline
+ * are reachable.
+ */
+
+const STORAGE_KEY = 'quickResponses';
+const SCHEMA_VERSION = 1;
+
+export interface QuickResponse {
+  /** Stable id used for edit/delete/reorder operations. */
+  id: string;
+  /** Short text shown on the chip. */
+  label: string;
+  /** Text sent when the chip is tapped. */
+  text: string;
+  /** Append `\r` after the text on send. Defaults to true. */
+  appendEnter: boolean;
+  /** When false, the entry is hidden from the chip strip but kept in storage
+   *  (so the user can toggle without losing the phrase). */
+  enabled: boolean;
+}
+
+interface StorageShape {
+  version: number;
+  entries: QuickResponse[];
+}
+
+function _read(): StorageShape {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { version: SCHEMA_VERSION, entries: [] };
+    const parsed = JSON.parse(raw) as unknown;
+    // Tolerate a bare array (older personal exports / hand-written localStorage)
+    // by wrapping it in the current schema shape.
+    if (Array.isArray(parsed)) {
+      return { version: SCHEMA_VERSION, entries: _sanitize(parsed as unknown[]) };
+    }
+    if (parsed && typeof parsed === 'object' && Array.isArray((parsed as StorageShape).entries)) {
+      return { version: SCHEMA_VERSION, entries: _sanitize((parsed as StorageShape).entries as unknown[]) };
+    }
+  } catch {
+    // fall through
+  }
+  return { version: SCHEMA_VERSION, entries: [] };
+}
+
+function _sanitize(raw: unknown[]): QuickResponse[] {
+  const out: QuickResponse[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    // Require non-empty label and text — entries with only one of the two,
+    // or empty strings, are partial drafts and shouldn't render as chips.
+    if (typeof r.label !== 'string' || r.label === '') continue;
+    if (typeof r.text !== 'string' || r.text === '') continue;
+    out.push({
+      id: typeof r.id === 'string' && r.id ? r.id : _newId(),
+      label: r.label,
+      text: r.text,
+      appendEnter: r.appendEnter !== false,
+      enabled: r.enabled !== false,
+    });
+  }
+  return out;
+}
+
+function _newId(): string {
+  return `qr_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function _write(entries: QuickResponse[]): void {
+  const data: StorageShape = { version: SCHEMA_VERSION, entries };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+/** All saved quick-responses, including disabled ones. */
+export function getQuickResponses(): QuickResponse[] {
+  return _read().entries;
+}
+
+/** Only entries that should currently render as chips. */
+export function getEnabledQuickResponses(): QuickResponse[] {
+  return getQuickResponses().filter((q) => q.enabled);
+}
+
+/** Add a new entry to the end of the list. Returns the assigned id. */
+export function addQuickResponse(label: string, text: string, appendEnter = true): string {
+  const entries = getQuickResponses();
+  const id = _newId();
+  entries.push({ id, label, text, appendEnter, enabled: true });
+  _write(entries);
+  return id;
+}
+
+/** Update an existing entry. Pass only the fields you want to change. */
+export function updateQuickResponse(id: string, patch: Partial<Omit<QuickResponse, 'id'>>): void {
+  const entries = getQuickResponses();
+  const idx = entries.findIndex((q) => q.id === id);
+  if (idx < 0) return;
+  entries[idx] = { ...entries[idx]!, ...patch };
+  _write(entries);
+}
+
+/** Delete an entry by id. Idempotent. */
+export function deleteQuickResponse(id: string): void {
+  const entries = getQuickResponses().filter((q) => q.id !== id);
+  _write(entries);
+}
+
+/** Reorder by moving the entry at `fromIdx` to `toIdx`. Indices clamp. */
+export function reorderQuickResponse(fromIdx: number, toIdx: number): void {
+  const entries = getQuickResponses();
+  if (fromIdx < 0 || fromIdx >= entries.length) return;
+  const clamped = Math.max(0, Math.min(toIdx, entries.length - 1));
+  if (clamped === fromIdx) return;
+  const [moved] = entries.splice(fromIdx, 1);
+  if (moved) entries.splice(clamped, 0, moved);
+  _write(entries);
+}
+
+/** Replace the full list — used by settings UI batch-save flows. */
+export function setQuickResponses(entries: QuickResponse[]): void {
+  _write(_sanitize(entries));
+}


### PR DESCRIPTION
Implements #480 — configurable quick-response buttons.

## What's in this PR

- **Floating chip strip** above the keybar on the terminal panel. Tap a chip to send its saved phrase (and optionally `\r`) to the active session. Hidden when no enabled entries exist.
- **Settings panel "Quick responses" subsection** (under Input) — list with inline edit (label, text, append-Enter toggle, enabled toggle, delete) + add form.
- **Storage** in `localStorage('quickResponses')`, JSON shape `{ version, entries[] }` with schema version in the value (per project's "no key bumping for migration" rule).

## UI placement decision

Picked **option #2 from the issue** (floating chip strip) instead of key-bar integration (#1). Rationale:
- User's own framing was "floating chips" when describing this feature.
- Key-bar is already crowded; chip strip reads as a natural peer without reflowing existing layout.

If chip strip turns out to be visually noisy, can move to key-bar integration in a follow-up.

## Out of scope (file follow-up if wanted)

- **Drag-to-reorder** of entries in the settings list.
- **Bracketed-paste wrapping** (`\x1b[200~...\x1b[201~`) when active session has it on. Detecting bracketed-paste mode reliably needs more work; raw send is fine for the common phrases the issue cited (`go`, `status versus goal`).
- **Per-host or per-profile** responses.

## Tests

15 new unit tests in `src/modules/__tests__/quick-responses.test.ts`:
- Storage round-trip (empty, set/get, persistence across re-reads)
- `getEnabledQuickResponses` filter
- update/delete (incl. no-op for unknown id, idempotent delete)
- reorder (move, clamp overshoot, no-op identity)
- Schema tolerance: bare-array (older export), malformed records, JSON parse failure
- `setQuickResponses` batch replace + re-sanitize

`scripts/test-fast-gate.sh` passes.

## Acceptance per issue

- [x] User can add a quick response in Settings (label + text + enabled toggle).
- [x] New entries appear as buttons (floating chip strip on terminal panel).
- [x] Tapping the button sends `text` + (if `appendEnter`) `\r` to the active terminal.
- [x] Entries can be edited, disabled, deleted.
- [ ] Reorder by drag — deferred.
- [x] Persists across reloads.
- [x] Quick-responses are global (same set across sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)