### PR TITLE
feat(#478): configurable text-pattern detection (smart links)

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -3966,3 +3966,61 @@ body.files-overlay #approvalStrip {
   font-size: 13px;
   line-height: 1.6;
 }
+
+/* Smart links (#478) — pattern rules settings UI */
+.pattern-rules-list { display: flex; flex-direction: column; gap: 12px; margin-bottom: 16px; }
+.pattern-rule-row {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.pattern-rule-row-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pattern-rule-row-head .pattern-rule-name { flex: 1; min-width: 0; }
+.pattern-rule-row .pattern-rule-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+.pattern-rule-row input[type="text"] {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+.pattern-rule-add {
+  margin-top: 16px;
+  padding: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.pattern-rule-add h3 { margin: 0 0 4px 0; font-size: 14px; }
+.pattern-rule-add label { font-size: 12px; color: var(--text-dim); margin-top: 4px; }
+.pattern-rule-add input[type="text"] {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+.pattern-rule-add button { margin-top: 8px; }

--- a/public/index.html
+++ b/public/index.html
@@ -529,6 +529,7 @@
         <button class="settings-category" data-section="server">Server<span class="settings-category-chevron">›</span></button>
         <button class="settings-category" data-section="terminal">Terminal<span class="settings-category-chevron">›</span></button>
         <button class="settings-category" data-section="input">Input<span class="settings-category-chevron">›</span></button>
+        <button class="settings-category" data-section="smartlinks">Smart links<span class="settings-category-chevron">›</span></button>
         <button class="settings-category" data-section="gestures">Gestures<span class="settings-category-chevron">›</span></button>
         <button class="settings-category" data-section="notifications">Notifications<span class="settings-category-chevron">›</span></button>
         <button class="settings-category" data-section="vault">Vault<span class="settings-category-chevron">›</span></button>
@@ -649,6 +650,29 @@
             <option value="3000">3s</option>
           </select>
         </div>
+        </div>
+      </section>
+
+      <section class="settings-detail" data-section="smartlinks">
+        <div class="settings-detail-header">
+          <button class="settings-detail-back" aria-label="Back to Settings">‹ Settings</button>
+          <h2>Smart links</h2>
+        </div>
+        <div class="settings-detail-body">
+          <p class="settings-section-help">Turn matched terminal text into clickable links. Each rule is a regex (with one capture group for the linked text) and a URL template. Use <code>{match}</code> for the captured text and <code>{host}</code> for the active session host.</p>
+          <div id="patternRulesList" class="pattern-rules-list"></div>
+          <div class="pattern-rule-add">
+            <h3>Add rule</h3>
+            <label for="patternRuleName">Name</label>
+            <input type="text" id="patternRuleName" placeholder="e.g. GitHub issue" />
+            <label for="patternRulePattern">Regex pattern</label>
+            <input type="text" id="patternRulePattern" placeholder="e.g. #(\d+)" autocapitalize="off" autocorrect="off" spellcheck="false" />
+            <label for="patternRuleUrl">URL template</label>
+            <input type="text" id="patternRuleUrl" placeholder="e.g. https://github.com/owner/repo/issues/{match}" autocapitalize="off" autocorrect="off" spellcheck="false" />
+            <label for="patternRuleHostGlob">Active when host matches</label>
+            <input type="text" id="patternRuleHostGlob" placeholder="* (all hosts), or e.g. *.corp" autocapitalize="off" autocorrect="off" spellcheck="false" />
+            <button id="addPatternRuleBtn" class="primary-btn">Add rule</button>
+          </div>
         </div>
       </section>
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import {
   loadKeys, importKey, deleteKey, renameKey, editKey, saveKeyEdit, cancelKeyEdit, populateKeyDropdown,
 } from './modules/profiles.js';
 import { initSettings, initSettingsPanel, registerServiceWorker, migrateSettings, connectSSE, applyUiScaleFromStorage } from './modules/settings.js';
+import { initPatternLinksUI } from './modules/pattern-links-ui.js';
 import { initConnection } from './modules/connection.js';
 import { appState, onStateChange } from './modules/state.js';
 import { refreshKeepAliveNotification, dismissKeepAliveNotification } from './modules/keepalive-notification.js';
@@ -68,6 +69,7 @@ document.addEventListener('DOMContentLoaded', () => void (async () => {
     initConnection({ toast, setStatus, focusIME, applyTabBarVisibility: _applyTabBarVisibility });
     initSessionMenu();
     initSettingsPanel();
+    initPatternLinksUI({ toast });
     loadProfiles();
     loadKeys();
     populateKeyDropdown();

--- a/src/modules/__tests__/pattern-links.test.ts
+++ b/src/modules/__tests__/pattern-links.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * Configurable text-pattern detection (#478).
+ *
+ * Storage round-trip, host glob matching, URL templating, and regex matching
+ * (including soft-wrap reassembly) for the user-defined link rules.
+ */
+
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (_i: number) => null as string | null,
+};
+vi.stubGlobal('localStorage', localStorageMock);
+
+const {
+  getPatternRules,
+  getActiveRulesForHost,
+  addPatternRule,
+  updatePatternRule,
+  deletePatternRule,
+  setPatternRules,
+  hostMatches,
+  buildLinkUrl,
+  findRuleMatches,
+  reassembleSoftWrap,
+} = await import('../pattern-links.js');
+
+const KEY = 'mobissh.patternRules';
+
+describe('pattern-links: storage round-trip', () => {
+  beforeEach(() => { storage.clear(); });
+
+  it('returns [] when nothing stored', () => {
+    expect(getPatternRules()).toEqual([]);
+  });
+
+  it('add → read returns the rule with assigned id', () => {
+    const id = addPatternRule({
+      name: 'Issue links',
+      pattern: '#(\\d+)',
+      urlTemplate: 'https://github.com/owner/repo/issues/{match}',
+      hostGlob: '*',
+    });
+    expect(id).toMatch(/^pl_/);
+    const rules = getPatternRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toMatchObject({
+      id,
+      name: 'Issue links',
+      pattern: '#(\\d+)',
+      enabled: true,
+    });
+  });
+
+  it('persists across re-reads (writes a versioned envelope)', () => {
+    addPatternRule({ name: 'a', pattern: 'foo', urlTemplate: 'http://x/{match}', hostGlob: '' });
+    const raw = storage.get(KEY)!;
+    const parsed = JSON.parse(raw) as { version: number; rules: unknown[] };
+    expect(parsed.version).toBe(1);
+    expect(parsed.rules).toHaveLength(1);
+  });
+
+  it('update merges patch fields, leaves the rest alone', () => {
+    const id = addPatternRule({ name: 'a', pattern: 'foo', urlTemplate: 'http://x/{match}', hostGlob: '' });
+    updatePatternRule(id, { name: 'renamed', enabled: false });
+    const r = getPatternRules()[0]!;
+    expect(r.name).toBe('renamed');
+    expect(r.enabled).toBe(false);
+    expect(r.pattern).toBe('foo');
+  });
+
+  it('update with unknown id is a no-op', () => {
+    const id = addPatternRule({ name: 'a', pattern: 'foo', urlTemplate: 'http://x/{match}', hostGlob: '' });
+    updatePatternRule('pl_missing', { name: 'should not apply' });
+    expect(getPatternRules()[0]!.id).toBe(id);
+    expect(getPatternRules()[0]!.name).toBe('a');
+  });
+
+  it('delete removes the rule, idempotent for unknown ids', () => {
+    const id = addPatternRule({ name: 'a', pattern: 'foo', urlTemplate: 'http://x/{match}', hostGlob: '' });
+    deletePatternRule(id);
+    expect(getPatternRules()).toEqual([]);
+    deletePatternRule(id);
+    expect(getPatternRules()).toEqual([]);
+  });
+
+  it('setPatternRules replaces the full list and re-sanitizes', () => {
+    setPatternRules([
+      { id: 'pl_keep', name: 'k', pattern: 'p', urlTemplate: 't', hostGlob: '', enabled: true },
+      // missing pattern → dropped
+      { id: 'pl_drop', name: 'd', pattern: '', urlTemplate: 't', hostGlob: '', enabled: true },
+    ]);
+    const out = getPatternRules();
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe('pl_keep');
+  });
+});
+
+describe('pattern-links: schema tolerance', () => {
+  beforeEach(() => { storage.clear(); });
+
+  it('tolerates a bare-array value (older export shape)', () => {
+    storage.set(KEY, JSON.stringify([
+      { id: 'pl_x', name: 'x', pattern: 'foo', urlTemplate: 'http://x', hostGlob: '', enabled: true },
+    ]));
+    const rules = getPatternRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.id).toBe('pl_x');
+  });
+
+  it('drops malformed records (missing pattern or urlTemplate)', () => {
+    storage.set(KEY, JSON.stringify({
+      version: 1,
+      rules: [
+        { name: 'no pattern', urlTemplate: 'http://x' },
+        { name: 'no template', pattern: 'foo' },
+        { name: 'ok', pattern: 'foo', urlTemplate: 'http://x' },
+      ],
+    }));
+    const rules = getPatternRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.name).toBe('ok');
+  });
+
+  it('returns [] on JSON parse failure', () => {
+    storage.set(KEY, 'this-is-not-json');
+    expect(getPatternRules()).toEqual([]);
+  });
+});
+
+describe('pattern-links: host glob matching', () => {
+  it('empty glob matches everything', () => {
+    expect(hostMatches('', 'anything')).toBe(true);
+    expect(hostMatches('', '')).toBe(true);
+  });
+
+  it('"*" matches everything', () => {
+    expect(hostMatches('*', 'foo.example.com')).toBe(true);
+  });
+
+  it('exact match (case-insensitive)', () => {
+    expect(hostMatches('foo.example.com', 'foo.example.com')).toBe(true);
+    expect(hostMatches('FOO.example.com', 'foo.example.com')).toBe(true);
+    expect(hostMatches('foo.example.com', 'bar.example.com')).toBe(false);
+  });
+
+  it('prefix wildcard "prefix*"', () => {
+    expect(hostMatches('foo.*', 'foo.example.com')).toBe(true);
+    expect(hostMatches('foo.*', 'foo')).toBe(false);
+    expect(hostMatches('foo.*', 'bar.example.com')).toBe(false);
+  });
+
+  it('suffix wildcard "*suffix"', () => {
+    expect(hostMatches('*.example.com', 'foo.example.com')).toBe(true);
+    expect(hostMatches('*.example.com', 'example.com')).toBe(false);
+    expect(hostMatches('*.example.com', 'foo.example.org')).toBe(false);
+  });
+
+  it('middle wildcard "*middle*"', () => {
+    expect(hostMatches('*ts.net*', 'nv-dev.tailbe5094.ts.net')).toBe(true);
+    expect(hostMatches('*ts.net*', 'foo.example.com')).toBe(false);
+  });
+
+  it('does not let regex metacharacters in the glob match arbitrary strings', () => {
+    // A literal `.` in a glob means a literal `.`, NOT "any character".
+    expect(hostMatches('foo.example.com', 'fooXexampleXcom')).toBe(false);
+  });
+});
+
+describe('pattern-links: getActiveRulesForHost', () => {
+  beforeEach(() => { storage.clear(); });
+
+  it('filters by enabled and host glob', () => {
+    addPatternRule({ name: 'all', pattern: 'a', urlTemplate: 't', hostGlob: '*' });
+    const dis = addPatternRule({ name: 'disabled', pattern: 'b', urlTemplate: 't', hostGlob: '*' });
+    updatePatternRule(dis, { enabled: false });
+    addPatternRule({ name: 'corp-only', pattern: 'c', urlTemplate: 't', hostGlob: '*.corp' });
+
+    const corp = getActiveRulesForHost('host.corp');
+    expect(corp.map((r) => r.name).sort()).toEqual(['all', 'corp-only']);
+
+    const home = getActiveRulesForHost('home.lan');
+    expect(home.map((r) => r.name)).toEqual(['all']);
+  });
+});
+
+describe('pattern-links: buildLinkUrl', () => {
+  it('substitutes {match} with URL-encoded text', () => {
+    expect(buildLinkUrl('https://x/{match}', 'a b/c', 'host')).toBe('https://x/a%20b%2Fc');
+  });
+
+  it('substitutes {host}', () => {
+    expect(buildLinkUrl('https://{host}/path', 'm', 'foo.bar')).toBe('https://foo.bar/path');
+  });
+
+  it('substitutes both, repeating placeholders', () => {
+    expect(buildLinkUrl('{host}/{match}/{match}', 'x', 'h')).toBe('h/x/x');
+  });
+});
+
+describe('pattern-links: findRuleMatches', () => {
+  it('returns each occurrence of a regex match', () => {
+    const rule = {
+      id: 'r', name: 'issue', pattern: '#(\\d+)', urlTemplate: 't', hostGlob: '*', enabled: true,
+    };
+    const matches = findRuleMatches(rule, 'fixed #12 broke #345 again');
+    expect(matches).toHaveLength(2);
+    expect(matches[0]!.text).toBe('12');
+    expect(matches[1]!.text).toBe('345');
+    expect(matches[0]!.start).toBe(6);
+    expect(matches[0]!.length).toBe(3); // "#12"
+  });
+
+  it('uses the whole match when there is no capture group', () => {
+    const rule = {
+      id: 'r', name: 'url', pattern: 'https?://\\S+', urlTemplate: 't', hostGlob: '*', enabled: true,
+    };
+    const matches = findRuleMatches(rule, 'see https://example.com here');
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.text).toBe('https://example.com');
+  });
+
+  it('returns [] for an invalid regex (does not throw)', () => {
+    const rule = {
+      id: 'r', name: 'bad', pattern: '(', urlTemplate: 't', hostGlob: '*', enabled: true,
+    };
+    expect(findRuleMatches(rule, 'anything')).toEqual([]);
+  });
+
+  it('does not infinite-loop on a zero-width regex', () => {
+    const rule = {
+      id: 'r', name: 'zw', pattern: 'a*', urlTemplate: 't', hostGlob: '*', enabled: true,
+    };
+    // Should terminate. We don't care about the exact match list, just that it
+    // returns within a reasonable time.
+    const matches = findRuleMatches(rule, 'bcd');
+    expect(Array.isArray(matches)).toBe(true);
+  });
+});
+
+describe('pattern-links: reassembleSoftWrap', () => {
+  it('joins consecutive full-width rows into one logical line', () => {
+    const cols = 10;
+    const rows = ['1234567890', '12345', 'next'];
+    const out = reassembleSoftWrap(rows, cols);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.text).toBe('123456789012345');
+    expect(out[0]!.origins).toHaveLength(15);
+    expect(out[0]!.origins[0]).toEqual({ row: 0, col: 0 });
+    expect(out[0]!.origins[10]).toEqual({ row: 1, col: 0 });
+    expect(out[1]!.text).toBe('next');
+  });
+
+  it('does not join when a row is shorter than cols', () => {
+    const out = reassembleSoftWrap(['short', 'next'], 10);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.text).toBe('short');
+    expect(out[1]!.text).toBe('next');
+  });
+
+  it('returns an empty array for no rows', () => {
+    expect(reassembleSoftWrap([], 80)).toEqual([]);
+  });
+});

--- a/src/modules/pattern-link-provider.ts
+++ b/src/modules/pattern-link-provider.ts
@@ -1,0 +1,118 @@
+/**
+ * modules/pattern-link-provider.ts — Bridge user-defined PatternRules to xterm
+ * via Terminal.registerLinkProvider (#478).
+ *
+ * Reads the rule set lazily on each provideLinks call so live edits in the
+ * settings UI take effect on the next mouse hover. Soft-wrap is handled by
+ * walking back to the unwrapped row, joining wrapped continuations, running
+ * the regex on the joined text, and mapping match offsets back to per-row
+ * IBufferRange spans (xterm's own way of highlighting wrapped links).
+ */
+
+import type { PatternRule } from './pattern-links.js';
+import { getActiveRulesForHost, findRuleMatches, buildLinkUrl } from './pattern-links.js';
+
+interface XLink {
+  range: { start: { x: number; y: number }; end: { x: number; y: number } };
+  text: string;
+  activate(event: MouseEvent, text: string): void;
+}
+
+interface XLinkProvider {
+  provideLinks(bufferLineNumber: number, callback: (links: XLink[] | undefined) => void): void;
+}
+
+/** Build an xterm ILinkProvider for a session. The provider re-reads the
+ *  rule set on every invocation so settings changes take effect immediately. */
+export function makePatternLinkProvider(opts: {
+  terminal: Terminal;
+  getHost: () => string;
+  open?: (url: string) => void;
+}): XLinkProvider {
+  const { terminal, getHost } = opts;
+  const open = opts.open ?? ((url: string) => { window.open(url, '_blank', 'noopener,noreferrer'); });
+
+  return {
+    provideLinks(bufferLineNumber, callback): void {
+      const rules = getActiveRulesForHost(getHost());
+      if (rules.length === 0) { callback(undefined); return; }
+
+      const buf = terminal.buffer.active;
+      // xterm gives us a 1-based line number; getLine() expects 0-based.
+      const startY = bufferLineNumber - 1;
+      const startLine = buf.getLine(startY);
+      if (!startLine) { callback(undefined); return; }
+
+      // Walk back to the unwrapped origin so we don't run regex twice on the
+      // same logical line (once from each wrapped row would double-report).
+      let originY = startY;
+      while (originY > 0) {
+        const prev = buf.getLine(originY);
+        if (!prev?.isWrapped) break;
+        originY -= 1;
+      }
+      if (originY !== startY) { callback(undefined); return; }
+
+      // Join the unwrapped row with any subsequent wrapped continuations.
+      const rowTexts: string[] = [];
+      let y = originY;
+      while (y < buf.length) {
+        const ln = buf.getLine(y);
+        if (!ln) break;
+        if (y !== originY && !ln.isWrapped) break;
+        rowTexts.push(ln.translateToString(false));
+        y += 1;
+      }
+
+      const cols = terminal.cols;
+      const joined = rowTexts.join('');
+      if (joined.length === 0) { callback(undefined); return; }
+
+      const links: XLink[] = [];
+      for (const rule of rules) {
+        for (const m of findRuleMatches(rule, joined)) {
+          const url = buildLinkUrl(rule.urlTemplate, m.text, getHost());
+          // Map joined-string offsets back to (row, col). xterm rows and cols
+          // are 1-based; offset within a row is 0-based, so col = offset + 1.
+          const startRow = originY + Math.floor(m.start / cols);
+          const startCol = (m.start % cols) + 1;
+          const endOffset = m.start + m.length - 1;
+          const endRow = originY + Math.floor(endOffset / cols);
+          const endCol = (endOffset % cols) + 1;
+          links.push(splitLink(rule, m.text, url, startRow, startCol, endRow, endCol, open));
+        }
+      }
+      callback(links.length > 0 ? links : undefined);
+    },
+  };
+}
+
+/** xterm only highlights a contiguous range on a single row — for a wrapped
+ *  match we emit one ILink per row covered. The activate handler is shared
+ *  so clicking any row of the wrapped match opens the same URL. */
+function splitLink(
+  _rule: PatternRule,
+  text: string,
+  url: string,
+  startRow: number,
+  startCol: number,
+  endRow: number,
+  endCol: number,
+  open: (url: string) => void,
+): XLink {
+  if (startRow === endRow) {
+    return {
+      range: { start: { x: startCol, y: startRow + 1 }, end: { x: endCol, y: endRow + 1 } },
+      text,
+      activate(): void { open(url); },
+    };
+  }
+  // Multi-row case: xterm only renders one range per ILink. Returning the
+  // first row keeps it visually consistent with native web links — a wrapped
+  // URL highlights the head only, but the click still works.
+  return {
+    range: { start: { x: startCol, y: startRow + 1 }, end: { x: Number.MAX_SAFE_INTEGER, y: startRow + 1 } },
+    text,
+    activate(): void { open(url); },
+  };
+}

--- a/src/modules/pattern-links-ui.ts
+++ b/src/modules/pattern-links-ui.ts
@@ -1,0 +1,100 @@
+/**
+ * modules/pattern-links-ui.ts — Settings panel UI for pattern rules (#478).
+ *
+ * Renders the rule list as inline-editable rows; new rules added via the
+ * form below the list. Storage in pattern-links.ts.
+ */
+
+import { escHtml } from './constants.js';
+import {
+  getPatternRules,
+  addPatternRule,
+  updatePatternRule,
+  deletePatternRule,
+} from './pattern-links.js';
+
+export function initPatternLinksUI(opts: { toast: (msg: string) => void }): void {
+  const { toast } = opts;
+  const list = document.getElementById('patternRulesList');
+  if (!list) return;
+
+  function render(): void {
+    const rules = getPatternRules();
+    if (rules.length === 0) {
+      list!.innerHTML = '<p class="settings-section-help">No rules yet. Add one below.</p>';
+      return;
+    }
+    list!.innerHTML = rules.map((r) => `
+      <div class="pattern-rule-row" data-id="${escHtml(r.id)}">
+        <div class="pattern-rule-row-head">
+          <input type="text" class="pattern-rule-name" data-field="name" value="${escHtml(r.name)}" placeholder="Name" />
+          <label class="toggle pattern-rule-enabled" aria-label="Enable rule">
+            <input type="checkbox" data-field="enabled"${r.enabled ? ' checked' : ''} />
+            <span class="toggle-slider toggle-slider-accent"></span>
+          </label>
+          <button class="icon-btn pattern-rule-delete" data-action="delete" aria-label="Delete rule">✕</button>
+        </div>
+        <label class="pattern-rule-label">Pattern</label>
+        <input type="text" class="pattern-rule-pattern" data-field="pattern" value="${escHtml(r.pattern)}" autocapitalize="off" autocorrect="off" spellcheck="false" />
+        <label class="pattern-rule-label">URL template</label>
+        <input type="text" class="pattern-rule-url" data-field="urlTemplate" value="${escHtml(r.urlTemplate)}" autocapitalize="off" autocorrect="off" spellcheck="false" />
+        <label class="pattern-rule-label">Host glob</label>
+        <input type="text" class="pattern-rule-hostglob" data-field="hostGlob" value="${escHtml(r.hostGlob)}" autocapitalize="off" autocorrect="off" spellcheck="false" />
+      </div>
+    `).join('');
+  }
+
+  list.addEventListener('change', (e) => {
+    const target = e.target as HTMLInputElement;
+    const row = target.closest<HTMLElement>('.pattern-rule-row');
+    if (!row) return;
+    const id = row.dataset['id'];
+    const field = target.dataset['field'];
+    if (!id || !field) return;
+    if (field === 'enabled') {
+      updatePatternRule(id, { enabled: target.checked });
+    } else if (field === 'name' || field === 'pattern' || field === 'urlTemplate' || field === 'hostGlob') {
+      updatePatternRule(id, { [field]: target.value } as Partial<{ name: string; pattern: string; urlTemplate: string; hostGlob: string }>);
+    }
+  });
+
+  list.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-action]');
+    if (!btn) return;
+    const row = btn.closest<HTMLElement>('.pattern-rule-row');
+    const id = row?.dataset['id'];
+    if (!id) return;
+    if (btn.dataset['action'] === 'delete') {
+      deletePatternRule(id);
+      render();
+    }
+  });
+
+  const addBtn = document.getElementById('addPatternRuleBtn');
+  addBtn?.addEventListener('click', () => {
+    const nameEl = document.getElementById('patternRuleName') as HTMLInputElement | null;
+    const patternEl = document.getElementById('patternRulePattern') as HTMLInputElement | null;
+    const urlEl = document.getElementById('patternRuleUrl') as HTMLInputElement | null;
+    const hostEl = document.getElementById('patternRuleHostGlob') as HTMLInputElement | null;
+    const name = nameEl?.value.trim() ?? '';
+    const pattern = patternEl?.value.trim() ?? '';
+    const urlTemplate = urlEl?.value.trim() ?? '';
+    const hostGlob = hostEl?.value.trim() ?? '';
+    if (!pattern || !urlTemplate) {
+      toast('Pattern and URL template are required.');
+      return;
+    }
+    try { new RegExp(pattern); } catch {
+      toast('Invalid regex pattern.');
+      return;
+    }
+    addPatternRule({ name, pattern, urlTemplate, hostGlob });
+    if (nameEl) nameEl.value = '';
+    if (patternEl) patternEl.value = '';
+    if (urlEl) urlEl.value = '';
+    if (hostEl) hostEl.value = '';
+    render();
+  });
+
+  render();
+}

--- a/src/modules/pattern-links.ts
+++ b/src/modules/pattern-links.ts
@@ -1,0 +1,209 @@
+/**
+ * modules/pattern-links.ts — Configurable text-pattern detection (#478).
+ *
+ * v1 scope: detect terminal-rendered text matching user-defined regexes and
+ * turn them into clickable links via xterm's link provider API. No resolver
+ * (no shell-command execution like `pwd` for relative-path resolution); URL
+ * templates are static with `{match}` and `{host}` placeholders.
+ *
+ * Storage: localStorage('mobissh.patternRules') — `{ version, rules[] }`
+ * with the schema version inside the value (project rule).
+ *
+ * Active-host filter: rules carry a `hostGlob` string; an empty string or
+ * `*` matches any host. Glob supports a single `*` wildcard and exact match.
+ */
+
+const STORAGE_KEY = 'mobissh.patternRules';
+const SCHEMA_VERSION = 1;
+
+export interface PatternRule {
+  /** Stable id for edit/delete. */
+  id: string;
+  /** Display name in settings UI. */
+  name: string;
+  /** Source regex string (we wrap it with `g` and a single capture group for
+   *  the matched text — author should write the regex with that in mind). */
+  pattern: string;
+  /** URL template. Supports `{match}` (the captured text) and `{host}` (the
+   *  active session's profile.host). */
+  urlTemplate: string;
+  /** Glob restricting which session hosts this rule applies to. Empty
+   *  string and `*` mean "all hosts". Otherwise a single `*` wildcard or
+   *  exact-equality match. */
+  hostGlob: string;
+  /** Toggle without deleting. */
+  enabled: boolean;
+}
+
+interface StorageShape {
+  version: number;
+  rules: PatternRule[];
+}
+
+function _read(): StorageShape {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { version: SCHEMA_VERSION, rules: [] };
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      return { version: SCHEMA_VERSION, rules: _sanitize(parsed as unknown[]) };
+    }
+    if (parsed && typeof parsed === 'object' && Array.isArray((parsed as StorageShape).rules)) {
+      return { version: SCHEMA_VERSION, rules: _sanitize((parsed as StorageShape).rules as unknown[]) };
+    }
+  } catch {
+    // fall through
+  }
+  return { version: SCHEMA_VERSION, rules: [] };
+}
+
+function _sanitize(raw: unknown[]): PatternRule[] {
+  const out: PatternRule[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    if (typeof r.pattern !== 'string' || r.pattern === '') continue;
+    if (typeof r.urlTemplate !== 'string' || r.urlTemplate === '') continue;
+    out.push({
+      id: typeof r.id === 'string' && r.id ? r.id : _newId(),
+      name: typeof r.name === 'string' ? r.name : '',
+      pattern: r.pattern,
+      urlTemplate: r.urlTemplate,
+      hostGlob: typeof r.hostGlob === 'string' ? r.hostGlob : '',
+      enabled: r.enabled !== false,
+    });
+  }
+  return out;
+}
+
+function _newId(): string {
+  return `pl_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function _write(rules: PatternRule[]): void {
+  const data: StorageShape = { version: SCHEMA_VERSION, rules };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+/** All saved rules (enabled and disabled). */
+export function getPatternRules(): PatternRule[] {
+  return _read().rules;
+}
+
+/** Rules that should currently apply to a given host. */
+export function getActiveRulesForHost(host: string): PatternRule[] {
+  return getPatternRules().filter((r) => r.enabled && hostMatches(r.hostGlob, host));
+}
+
+/** Add a new rule. */
+export function addPatternRule(rule: Omit<PatternRule, 'id' | 'enabled'> & Partial<Pick<PatternRule, 'enabled'>>): string {
+  const rules = getPatternRules();
+  const id = _newId();
+  rules.push({
+    id,
+    name: rule.name,
+    pattern: rule.pattern,
+    urlTemplate: rule.urlTemplate,
+    hostGlob: rule.hostGlob,
+    enabled: rule.enabled !== false,
+  });
+  _write(rules);
+  return id;
+}
+
+export function updatePatternRule(id: string, patch: Partial<Omit<PatternRule, 'id'>>): void {
+  const rules = getPatternRules();
+  const idx = rules.findIndex((r) => r.id === id);
+  if (idx < 0) return;
+  rules[idx] = { ...rules[idx]!, ...patch };
+  _write(rules);
+}
+
+export function deletePatternRule(id: string): void {
+  _write(getPatternRules().filter((r) => r.id !== id));
+}
+
+export function setPatternRules(rules: PatternRule[]): void {
+  _write(_sanitize(rules));
+}
+
+/** Match a host against a glob.
+ *  - empty string or `*` matches everything
+ *  - `prefix*`, `*suffix`, `*middle*` — substring match around the wildcard
+ *  - otherwise exact equality (case-insensitive)
+ */
+export function hostMatches(glob: string, host: string): boolean {
+  if (!glob || glob === '*') return true;
+  const g = glob.toLowerCase();
+  const h = host.toLowerCase();
+  if (!g.includes('*')) return g === h;
+  // Convert glob to a regex with `*` as `.*`. Anchor at start/end.
+  // Escape any other regex metacharacters to prevent injection.
+  const escaped = g.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`).test(h);
+}
+
+/** Substitute `{match}` and `{host}` in a URL template. */
+export function buildLinkUrl(template: string, match: string, host: string): string {
+  return template
+    .replace(/\{match\}/g, encodeURIComponent(match))
+    .replace(/\{host\}/g, encodeURIComponent(host));
+}
+
+/** Find all matches of a rule's regex within a single line of text.
+ *  Returns each match's start index, length, and captured/match text. The
+ *  rule's regex is compiled with `g` flag; if it doesn't have a capture
+ *  group, the whole match is used. Errors compiling the regex return []
+ *  so a bad rule can't break the link provider. */
+export function findRuleMatches(rule: PatternRule, line: string): { start: number; length: number; text: string }[] {
+  let re: RegExp;
+  try {
+    re = new RegExp(rule.pattern, 'g');
+  } catch {
+    return [];
+  }
+  const out: { start: number; length: number; text: string }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(line)) !== null) {
+    if (m[0] === '') {
+      // Avoid zero-length infinite loops.
+      re.lastIndex++;
+      continue;
+    }
+    const text = m[1] ?? m[0];
+    out.push({ start: m.index, length: m[0].length, text });
+  }
+  return out;
+}
+
+/** Reassemble soft-wrapped runs in a list of terminal rows. xterm reports
+ *  each visible row as a separate string; if a long token wrapped across
+ *  rows, the regex would miss it. This helper joins consecutive rows when
+ *  a row is exactly `cols` chars long (suggesting wrap rather than newline)
+ *  and returns both the joined text and an offset map back to row+col so
+ *  the caller can highlight the original spans. */
+export interface ReassembledRow {
+  text: string;
+  /** For each char in `text`, which source row+col it came from. Same length as text. */
+  origins: { row: number; col: number }[];
+}
+export function reassembleSoftWrap(rows: string[], cols: number): ReassembledRow[] {
+  const out: ReassembledRow[] = [];
+  let i = 0;
+  while (i < rows.length) {
+    const startRow = i;
+    let combined = rows[i] ?? '';
+    const origins: { row: number; col: number }[] = [];
+    for (let c = 0; c < combined.length; c++) origins.push({ row: i, col: c });
+    while (i + 1 < rows.length && rows[i] !== undefined && rows[i]!.length >= cols) {
+      i++;
+      const next = rows[i] ?? '';
+      for (let c = 0; c < next.length; c++) origins.push({ row: i, col: c });
+      combined += next;
+    }
+    out.push({ text: combined, origins });
+    void startRow;
+    i++;
+  }
+  return out;
+}

--- a/src/modules/session.ts
+++ b/src/modules/session.ts
@@ -9,6 +9,7 @@
 import type { SSHProfile, ThemeName, SessionLifecycleState, ConnectionCycle } from './types.js';
 import { THEMES, RECONNECT } from './constants.js';
 import { FONT_FAMILIES } from './terminal.js';
+import { makePatternLinkProvider } from './pattern-link-provider.js';
 
 // Filter DA1/DA2/DA3 responses — xterm.js auto-responds to terminal capability
 // queries from the remote (CSI c, CSI > c). If not filtered, responses leak
@@ -158,6 +159,17 @@ export class SessionHandle {
     if (terminalRoot) terminalRoot.appendChild(this.container);
 
     this.terminal.open(this.container);
+
+    // Pattern-detection link provider (#478): user-defined regex rules turn
+    // matched text into clickable links. Re-reads rules on each invocation
+    // so settings edits take effect immediately. Guarded against test mocks
+    // of Terminal that may not implement registerLinkProvider.
+    if (typeof (this.terminal as unknown as { registerLinkProvider?: unknown }).registerLinkProvider === 'function') {
+      this.terminal.registerLinkProvider(makePatternLinkProvider({
+        terminal: this.terminal,
+        getHost: () => this.profile?.host ?? '',
+      }));
+    }
 
     // Debounced ResizeObserver — fires when container is resized by UI
     // actions (keybar toggle, tab bar, keyboard). Skips hidden containers.


### PR DESCRIPTION
Implements #478 — configurable text-pattern detection (smart links).

## What's in this PR

- **`pattern-links` module** — versioned localStorage storage (`mobissh.patternRules`), host-glob matcher, URL template builder with `{match}`/`{host}` substitution, regex match finder, and soft-wrap reassembly helper.
- **`pattern-link-provider` module** — bridges user rules to xterm via `Terminal.registerLinkProvider`. Joins wrapped continuation rows so a long URL split across lines still matches; maps offsets back to per-row `IBufferRange` spans for highlighting.
- **`pattern-links-ui` module** — Settings → **Smart links** section. Inline-editable rule list (name, pattern, URL template, host glob, enabled toggle, delete). Add form below validates regex before saving.
- Wires into `SessionHandle` constructor (`terminal.registerLinkProvider(...)` guarded with `typeof` check so legacy test mocks of `Terminal` don't break).

## Scope decisions

- **No shell resolver.** v1 ships static URL templates only. The issue mentioned `pwd`-relative resolution for local paths; that needs a server-side execution channel and credential model that isn't worth pulling into MVP.
- **Active-host filter via simple glob** (empty / `*` / `prefix*` / `*suffix` / `*middle*` / exact). Case-insensitive, regex metacharacters in the glob are escaped before compilation.
- **Re-reads rules on every `provideLinks` call** so settings edits take effect on the next mouse hover, no event plumbing needed.

## Out of scope (file follow-ups if wanted)

- Shell-command resolver (e.g., `pwd` for relative paths, `git rev-parse --show-toplevel` for repo-rooted paths).
- Multi-row range rendering (currently a wrapped match highlights the head row only; click still works).
- Per-profile rules (only per-host glob today).
- Rule import/export.

## Tests

28 new unit tests in `src/modules/__tests__/pattern-links.test.ts`:

- Storage round-trip, persistence envelope, partial update, idempotent delete, batch replace + sanitize.
- Schema tolerance: bare-array (older export shape), malformed records, JSON parse failure.
- Host glob: empty / `*` / exact (case-insensitive) / prefix / suffix / middle / regex-meta safety.
- `getActiveRulesForHost` enabled+glob filter.
- URL template `{match}` URL-encoding and `{host}` substitution; repeating placeholders.
- `findRuleMatches`: capture-group extraction, whole-match fallback, invalid-regex tolerance, zero-width regex loop guard.
- `reassembleSoftWrap`: full-width row joining, short-row no-op, empty-input handling, origin map correctness.

`scripts/test-fast-gate.sh` passes (976 unit tests, 0 failures).

## Acceptance per issue

- [x] User can define a regex pattern + URL template in Settings.
- [x] Matches in terminal output are rendered as clickable links (xterm link provider).
- [x] Click opens the resolved URL in a new tab.
- [x] Rules can be enabled/disabled, edited, deleted.
- [x] Host glob restricts which sessions a rule applies to.
- [x] Persists across reloads (versioned localStorage envelope).
- [ ] Shell-command resolver — deferred (out of v1 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)