### PR TITLE
feat(#502): diagnostic telemetry for focus/IME interactions during gestures

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -740,6 +740,63 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // POST /api/gesture-telemetry — auto-upload of gesture-anomaly telemetry
+  // (#502 diagnostic). Fires when selection.ts detects a focus/IME anomaly
+  // during a gesture window. Independent throttle from drop-telemetry.
+  // Lands in test-results/uploads/ with prefix gesture-telemetry.
+  if (req.method === 'POST' && req.url === '/api/gesture-telemetry') {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        const { kind, reason, eventCount, ts, userAgent, url, version, log } = data;
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        const reportDir = path.join(__dirname, '..', 'test-results', 'uploads');
+        fs.mkdirSync(reportDir, { recursive: true });
+
+        let logFile = '';
+        if (Array.isArray(log) && log.length > 0) {
+          logFile = `${stamp}-gesture-telemetry.gesture-log.json`;
+          const logPath = path.join(reportDir, logFile);
+          const logBody = JSON.stringify(log, null, 2);
+          // Cap individual log files at ~1MB to bound disk usage.
+          const MAX_LOG_BYTES = 1024 * 1024;
+          const safeBody = Buffer.byteLength(logBody, 'utf8') > MAX_LOG_BYTES
+            ? JSON.stringify(log.slice(-Math.floor(log.length / 2)), null, 2)
+            : logBody;
+          fs.writeFileSync(logPath, safeBody);
+        }
+
+        const meta = {
+          kind: kind || 'gesture-anomaly',
+          reason: reason || '',
+          eventCount: typeof eventCount === 'number' ? eventCount : 0,
+          ts: ts || Date.now(),
+          stamp,
+          userAgent: userAgent || '',
+          url: url || '',
+          version: version || '',
+          logFile,
+          logEventCount: Array.isArray(log) ? log.length : 0,
+        };
+        fs.writeFileSync(
+          path.join(reportDir, `${stamp}-gesture-telemetry.json`),
+          JSON.stringify(meta, null, 2),
+        );
+        console.log(`[gesture-telemetry] ${stamp} reason="${meta.reason}" events=${meta.eventCount} logEvents=${meta.logEventCount}`);
+        sseBroadcast('gesture-telemetry', { reason: meta.reason, eventCount: meta.eventCount, stamp });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, stamp }));
+      } catch (err) {
+        console.error('[gesture-telemetry] parse error:', err.message);
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end('{"error":"invalid json"}');
+      }
+    });
+    return;
+  }
+
   // POST /api/bug-report — receive screenshot + logs from client, save to disk.
   if (req.method === 'POST' && req.url === '/api/bug-report') {
     let body = '';

--- a/src/modules/__tests__/gesture-window-telemetry.test.ts
+++ b/src/modules/__tests__/gesture-window-telemetry.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Unit tests for the gesture-window diagnostic telemetry (#502).
+ *
+ * Scope: passive observation only. Verifies that
+ *   - touchstart on #terminal opens a gesture window
+ *   - focusin on .xterm-helper-textarea during the window logs
+ *     `gesture_focusin` with isHelper:true and a non-empty stack
+ *   - visualViewport.resize during the window logs `gesture_viewport_resize`
+ *     with the correct deltaH
+ *   - at window close, anomaly conditions trigger uploadGestureAnomaly()
+ *   - the gesture-upload throttle (10 min) prevents a second upload within
+ *     the window
+ *
+ * These tests do NOT exercise focus mutation. They only assert that the
+ * diagnostic listeners capture what they're supposed to capture.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// ── Test DOM bootstrap ───────────────────────────────────────────────────────
+
+function buildDom(): JSDOM {
+  // Minimal DOM: just the terminal element + a helper textarea (mimicking
+  // xterm.js's hidden helper) and our imeInput. The gesture-window code reads
+  // `document.activeElement`, queries for `.xterm-helper-textarea`, and binds
+  // to `document` + `window.visualViewport`.
+  const html = `<!doctype html><html><body>
+    <div id="terminal"></div>
+    <button id="handleCopyBtn" class="hidden"></button>
+    <textarea id="imeInput"></textarea>
+    <textarea class="xterm-helper-textarea"></textarea>
+  </body></html>`;
+  return new JSDOM(html, { url: 'http://localhost:8081/', pretendToBeVisual: true });
+}
+
+let dom: JSDOM;
+let storage: Map<string, string>;
+const performanceNow = { value: 0 };
+
+beforeEach(() => {
+  dom = buildDom();
+  vi.stubGlobal('document', dom.window.document);
+  vi.stubGlobal('window', dom.window);
+  vi.stubGlobal('navigator', dom.window.navigator);
+  vi.stubGlobal('location', dom.window.location);
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true })));
+  // JSDOM-provided constructors that the diagnostic code uses via
+  // `instanceof Element` and so on. Vitest's node env doesn't supply these.
+  vi.stubGlobal('Element', dom.window.Element);
+  vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+  vi.stubGlobal('HTMLTextAreaElement', dom.window.HTMLTextAreaElement);
+  vi.stubGlobal('FocusEvent', dom.window.FocusEvent);
+  vi.stubGlobal('Event', dom.window.Event);
+
+  // visualViewport: jsdom doesn't supply one. Build a fake with
+  // dispatch hooks the gesture-window listener can subscribe to.
+  const vvListeners = new Set<EventListenerOrEventListenerObject>();
+  const fakeVV = {
+    height: 800,
+    width: 400,
+    scale: 1,
+    offsetTop: 0,
+    addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'resize') vvListeners.add(listener);
+    },
+    removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'resize') vvListeners.delete(listener);
+    },
+    /** Test hook — fire a synthetic resize. */
+    __fire(newHeight: number): void {
+      this.height = newHeight;
+      for (const l of vvListeners) {
+        try {
+          if (typeof l === 'function') l(new dom.window.Event('resize'));
+          else (l as EventListenerObject).handleEvent(new dom.window.Event('resize'));
+        } catch { /* */ }
+      }
+    },
+  };
+  Object.defineProperty(dom.window, 'visualViewport', {
+    configurable: true,
+    get: () => fakeVV,
+  });
+  vi.stubGlobal('visualViewport', fakeVV);
+
+  // performance.now() — deterministic clock for delta assertions.
+  performanceNow.value = 0;
+  vi.stubGlobal('performance', {
+    now: () => performanceNow.value,
+  });
+
+  // localStorage backing the throttle key.
+  storage = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => storage.get(k) ?? null,
+    setItem: (k: string, v: string) => { storage.set(k, v); },
+    removeItem: (k: string) => { storage.delete(k); },
+    clear: () => { storage.clear(); },
+    length: 0,
+    key: () => null,
+  });
+
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Step the fake performance clock forward. */
+function advanceTime(ms: number): void {
+  performanceNow.value += ms;
+}
+
+/** Dispatch a synthetic focusin from the given element so it bubbles up
+ *  through the real DOM tree to capturing listeners on document. JSDOM
+ *  ignores a manually-set `target` on a fresh Event, so we dispatch directly
+ *  from the desired source. */
+function fireFocusInOn(el: Element): void {
+  el.dispatchEvent(new dom.window.FocusEvent('focusin', { bubbles: true }));
+}
+
+/** Dispatch a synthetic focusout via the element so it bubbles to document. */
+function fireFocusOutOn(el: Element): void {
+  el.dispatchEvent(new dom.window.FocusEvent('focusout', { bubbles: true }));
+}
+
+/** Build a gesture-log reader fresh from the just-imported module. */
+async function loadModulesFresh(): Promise<{
+  gestureLog: typeof import('../gesture-log.js');
+  selection: typeof import('../selection.js');
+  dropTelemetry: typeof import('../drop-telemetry.js');
+}> {
+  // Stub the modules selection.ts depends on but doesn't need for these tests.
+  // ime.js: must export getIMEState; provide a minimal stub.
+  vi.doMock('../ime.js', () => ({
+    getIMEState: () => 'idle',
+  }));
+  vi.doMock('../state.js', () => ({
+    currentSession: () => null,
+  }));
+  vi.doMock('../ui.js', () => ({
+    toast: () => { /* */ },
+    focusIME: () => { /* */ },
+  }));
+  vi.doMock('../terminal.js', () => ({
+    getKeyboardVisible: () => false,
+  }));
+  vi.doMock('../ime-fixup.js', () => ({
+    reconstructFromBuffer: () => '',
+  }));
+
+  const gestureLog = await import('../gesture-log.js');
+  gestureLog.clearGestureLog();
+  const selection = await import('../selection.js');
+  const dropTelemetry = await import('../drop-telemetry.js');
+  return { gestureLog, selection, dropTelemetry };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('gesture-window telemetry (#502)', () => {
+  it('logs gesture_focusin with isHelper:true and a non-empty stack', async () => {
+    const { gestureLog, selection } = await loadModulesFresh();
+
+    selection._testOpenGestureWindow();
+
+    advanceTime(120);
+    const helper = dom.window.document.querySelector('.xterm-helper-textarea');
+    expect(helper).toBeTruthy();
+    fireFocusInOn(helper!);
+
+    const log = gestureLog.getGestureLog();
+    const focusin = log.find((e) => e.e === 'gesture_focusin');
+    expect(focusin, 'gesture_focusin should be logged').toBeTruthy();
+    const d = focusin!.d as Record<string, unknown>;
+    expect(d.isHelper).toBe(true);
+    expect(d.t).toBe(120);
+    expect(typeof d.stack === 'string' && (d.stack as string).length > 0).toBe(true);
+    expect(d.targetClass).toContain('xterm-helper-textarea');
+  });
+
+  it('logs gesture_viewport_resize with correct deltaH', async () => {
+    const { gestureLog, selection } = await loadModulesFresh();
+
+    selection._testOpenGestureWindow();
+    advanceTime(50);
+    // Synthetic resize from 800 → 430 (370px shrink, matching the bug trace).
+    const vv = (dom.window as unknown as { visualViewport: { __fire: (h: number) => void } }).visualViewport;
+    vv.__fire(430);
+
+    const log = gestureLog.getGestureLog();
+    const resize = log.find((e) => e.e === 'gesture_viewport_resize');
+    expect(resize, 'gesture_viewport_resize should be logged').toBeTruthy();
+    const d = resize!.d as Record<string, unknown>;
+    expect(d.h).toBe(430);
+    expect(d.deltaH).toBe(-370);
+    expect(d.t).toBe(50);
+  });
+
+  it('triggers uploadGestureAnomaly when helper textarea gains focus during window', async () => {
+    const { gestureLog, selection } = await loadModulesFresh();
+
+    selection._testOpenGestureWindow();
+    advanceTime(60);
+    fireFocusInOn(dom.window.document.querySelector('.xterm-helper-textarea')!);
+
+    // Close the gesture window — this is what evaluates anomaly conditions.
+    selection._testCloseGestureWindow();
+
+    // The anomaly_uploaded log entry tells us whether upload fired.
+    const log = gestureLog.getGestureLog();
+    const uploaded = log.find((e) => e.e === 'gesture_anomaly_uploaded');
+    expect(uploaded, 'gesture_anomaly_uploaded must be logged when helper focuses during gesture').toBeTruthy();
+    const d = uploaded!.d as Record<string, unknown>;
+    expect(d.status).toBe('sent');
+    expect(d.reason).toBe('focus_during_long_press');
+
+    // And the upload itself must hit the gesture-telemetry endpoint.
+    const fetchSpy = (globalThis as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+    expect(fetchSpy).toHaveBeenCalled();
+    const calls = fetchSpy.mock.calls;
+    const url = calls[0]?.[0];
+    expect(url).toBe('api/gesture-telemetry');
+  });
+
+  it('throttles a second upload within 10 minutes', async () => {
+    const { gestureLog, selection } = await loadModulesFresh();
+
+    // First gesture — fires anomaly.
+    selection._testOpenGestureWindow();
+    advanceTime(60);
+    fireFocusInOn(dom.window.document.querySelector('.xterm-helper-textarea')!);
+    selection._testCloseGestureWindow();
+
+    const fetchSpy = (globalThis as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Second gesture — within 10min throttle window. Should NOT upload again.
+    selection._testOpenGestureWindow();
+    advanceTime(60);
+    fireFocusInOn(dom.window.document.querySelector('.xterm-helper-textarea')!);
+    selection._testCloseGestureWindow();
+
+    // Only the first call should have hit fetch.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // But the second anomaly should still be logged as "throttled".
+    const log = gestureLog.getGestureLog();
+    const uploads = log.filter((e) => e.e === 'gesture_anomaly_uploaded');
+    expect(uploads.length).toBeGreaterThanOrEqual(2);
+    const throttled = uploads.find((u) => (u.d as Record<string, unknown>).status === 'throttled');
+    expect(throttled, 'second upload within window must be logged as throttled').toBeTruthy();
+  });
+
+  it('does NOT trigger an anomaly when only #imeInput receives focus', async () => {
+    const { gestureLog, selection } = await loadModulesFresh();
+
+    selection._testOpenGestureWindow();
+    advanceTime(30);
+    fireFocusInOn(dom.window.document.getElementById('imeInput')!);
+    selection._testCloseGestureWindow();
+
+    // gesture_focusin should be logged, but isHelper:false, and no
+    // gesture_anomaly_uploaded with status:sent should appear.
+    const log = gestureLog.getGestureLog();
+    const focusin = log.find((e) => e.e === 'gesture_focusin');
+    expect(focusin).toBeTruthy();
+    expect((focusin!.d as Record<string, unknown>).isHelper).toBe(false);
+    expect((focusin!.d as Record<string, unknown>).isOurs).toBe(true);
+
+    const uploaded = log.find(
+      (e) => e.e === 'gesture_anomaly_uploaded' &&
+             (e.d as Record<string, unknown>).status === 'sent',
+    );
+    expect(uploaded).toBeUndefined();
+
+    const fetchSpy = (globalThis as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs focusout events during the window too', async () => {
+    const { gestureLog, selection } = await loadModulesFresh();
+
+    selection._testOpenGestureWindow();
+    advanceTime(10);
+    fireFocusOutOn(dom.window.document.getElementById('imeInput')!);
+
+    const log = gestureLog.getGestureLog();
+    const focusout = log.find((e) => e.e === 'gesture_focusout');
+    expect(focusout).toBeTruthy();
+    expect((focusout!.d as Record<string, unknown>).targetId).toBe('imeInput');
+  });
+
+  it('logs an initial gesture_helper_focus_audit at gesture window open', async () => {
+    const { gestureLog, selection } = await loadModulesFresh();
+
+    selection._testOpenGestureWindow();
+
+    const log = gestureLog.getGestureLog();
+    const audit = log.find((e) => e.e === 'gesture_helper_focus_audit');
+    expect(audit, 'initial audit snapshot should be logged on window open').toBeTruthy();
+    const d = audit!.d as Record<string, unknown>;
+    expect(d.trigger).toBe('touchstart');
+    expect(d.helperPresent).toBe(true);
+  });
+
+  it('stops capturing focus events after the window closes', async () => {
+    const { gestureLog, selection } = await loadModulesFresh();
+
+    selection._testOpenGestureWindow();
+    selection._testCloseGestureWindow();
+
+    // Clear any logs from the open phase.
+    gestureLog.clearGestureLog();
+
+    // Fire a focusin AFTER window closed — must NOT be logged.
+    fireFocusInOn(dom.window.document.querySelector('.xterm-helper-textarea')!);
+
+    const log = gestureLog.getGestureLog();
+    const focusin = log.find((e) => e.e === 'gesture_focusin');
+    expect(focusin, 'focusin outside the gesture window must not be logged').toBeUndefined();
+  });
+});

--- a/src/modules/drop-telemetry.ts
+++ b/src/modules/drop-telemetry.ts
@@ -15,10 +15,16 @@
  */
 
 import { getConnectLog } from './connect-log.js';
-import { getGestureLog } from './gesture-log.js';
+import { getGestureLog, logGesture } from './gesture-log.js';
 
 const THROTTLE_KEY = 'mobissh.dropTelemetryLastUpload';
 const THROTTLE_MS = 5 * 60_000; // 5 minutes
+
+/** Independent throttle for gesture-anomaly uploads (#502 diagnostic).
+ *  Looser than drop-telemetry's 5-min window because focus/IME anomalies
+ *  during gestures are rarer and we want to catch most of them. */
+const GESTURE_THROTTLE_KEY = 'mobissh.gestureUpload.lastT';
+const GESTURE_THROTTLE_MS = 10 * 60_000; // 10 minutes
 
 function _readLast(): number {
   const raw = localStorage.getItem(THROTTLE_KEY);
@@ -29,6 +35,19 @@ function _readLast(): number {
 
 function _writeLast(t: number): void {
   try { localStorage.setItem(THROTTLE_KEY, String(t)); } catch { /* quota */ }
+}
+
+function _readGestureLast(): number {
+  try {
+    const raw = localStorage.getItem(GESTURE_THROTTLE_KEY);
+    if (!raw) return 0;
+    const n = Number(raw);
+    return isFinite(n) && n > 0 ? n : 0;
+  } catch { return 0; }
+}
+
+function _writeGestureLast(t: number): void {
+  try { localStorage.setItem(GESTURE_THROTTLE_KEY, String(t)); } catch { /* quota */ }
 }
 
 /** Fire-and-forget upload of drop telemetry. Non-blocking, throttled,
@@ -56,6 +75,69 @@ export function uploadDropTelemetry(reason: string, sessionId?: string, host?: s
   };
 
   void fetch('api/drop-telemetry', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).catch(() => { /* silent */ });
+}
+
+/**
+ * Fire-and-forget upload of gesture-anomaly telemetry (#502 diagnostic).
+ *
+ * Trigger conditions (any one of these, evaluated by selection.ts at gesture
+ * window close):
+ *   - focusin on .xterm-helper-textarea during a gesture window
+ *   - visualViewport.resize with |deltaH| > 100 during a gesture window
+ *   - IME state changed during the gesture window
+ *
+ * Throttle: 1 per `GESTURE_THROTTLE_MS` per device (localStorage-backed).
+ * Independent of the drop-telemetry throttle.
+ *
+ * Always non-blocking, silent on failure. Also logs a `gesture_anomaly_uploaded`
+ * event so the throttle behaviour is visible in the gesture log itself.
+ */
+export function uploadGestureAnomaly(reason: string, eventCount: number): void {
+  const now = Date.now();
+  const last = _readGestureLast();
+  if (now - last < GESTURE_THROTTLE_MS) {
+    // Record the throttled attempt so we can see "would have uploaded" in logs.
+    try {
+      logGesture('gesture_anomaly_uploaded', {
+        reason,
+        eventCount,
+        status: 'throttled',
+        sinceLastMs: now - last,
+      });
+    } catch { /* logging must never throw */ }
+    return;
+  }
+
+  // Mark BEFORE the fetch so concurrent fires don't all upload.
+  _writeGestureLast(now);
+
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="app-version"]');
+  const gestureLog = getGestureLog();
+  const payload = {
+    kind: 'gesture-anomaly',
+    reason,
+    eventCount,
+    ts: now,
+    userAgent: navigator.userAgent,
+    url: location.href,
+    version: meta?.content ?? 'unknown',
+    log: gestureLog,
+  };
+
+  try {
+    logGesture('gesture_anomaly_uploaded', {
+      reason,
+      eventCount,
+      status: 'sent',
+      logEventCount: gestureLog.length,
+    });
+  } catch { /* logging must never throw */ }
+
+  void fetch('api/gesture-telemetry', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),

--- a/src/modules/gesture-log.ts
+++ b/src/modules/gesture-log.ts
@@ -37,7 +37,18 @@ export type GestureLogType =
   | 'gesture_drag_select_start'
   | 'gesture_drag_select_end'
   | 'gesture_keyboard_changed'
-  | 'gesture_listener_error';
+  | 'gesture_listener_error'
+  // ── Focus/IME diagnostic instrumentation (#502 — read-only observers) ──
+  // These fire only inside a "gesture window" (touchstart on #terminal until
+  // 2s after touchend). Outside the window, focus/resize chatter is ignored
+  // so the ring buffer isn't flooded.
+  | 'gesture_focusin'
+  | 'gesture_focusout'
+  | 'gesture_viewport_resize'
+  | 'gesture_helper_focus_audit'
+  // Logged when uploadGestureAnomaly() actually fires — captures throttle
+  // behaviour in the same log as the events that triggered it.
+  | 'gesture_anomaly_uploaded';
 
 export interface GestureLogEntry {
   /** Unix ms */

--- a/src/modules/selection.ts
+++ b/src/modules/selection.ts
@@ -20,8 +20,37 @@ import { toast, focusIME } from './ui.js';
 import { getKeyboardVisible } from './terminal.js';
 import { reconstructFromBuffer } from './ime-fixup.js';
 import { logGesture } from './gesture-log.js';
+import { getIMEState } from './ime.js';
+import { uploadGestureAnomaly } from './drop-telemetry.js';
 
 // ── State ────────────────────────────────────────────────────────────────────
+
+// ── Gesture-window diagnostic state (#502) ──────────────────────────────────
+// A "gesture window" spans from touchstart on #terminal until 2s after
+// touchend. While the window is active, capturing focusin/focusout listeners
+// and a visualViewport.resize listener record events with timestamps relative
+// to gesture start. ALL listeners are passive observers — no focus state
+// mutation, no preventDefault on focus events.
+//
+// The 2s tail catches delayed IME show events that fire after touchend.
+//
+// At window close, if any anomaly condition triggers, uploadGestureAnomaly()
+// is called (throttled). Conditions:
+//   - any gesture_focusin with isHelper=true
+//   - any gesture_viewport_resize with |deltaH| > 100
+//   - imeState changed between touchstart snapshot and window close
+let _gestureWindowActive = false;
+let _gestureWindowStart = 0;
+let _gestureWindowEndTimer: ReturnType<typeof setTimeout> | null = null;
+let _gestureAuditTimer: ReturnType<typeof setInterval> | null = null;
+let _gestureFocusinListener: ((e: FocusEvent) => void) | null = null;
+let _gestureFocusoutListener: ((e: FocusEvent) => void) | null = null;
+let _gestureVVResizeListener: ((e: Event) => void) | null = null;
+let _gestureVVPrevHeight = 0;
+let _gestureImeStateAtStart: string = 'idle';
+let _gestureHelperFocusInCount = 0;
+let _gestureLargeResizeCount = 0;
+let _gestureEventCount = 0;
 
 let _selectionActive = false;
 let _longPressTimer: ReturnType<typeof setTimeout> | null = null;
@@ -46,6 +75,257 @@ export function isSelectionActive(): boolean {
   return _selectionActive;
 }
 
+// ── Gesture-window helpers (#502 diagnostic) ────────────────────────────────
+
+/** Truncate any string-coerced className to 80 chars. SVG-element className is
+ *  a `SVGAnimatedString`, not a string — so coerce defensively. */
+function _classOf(el: Element | null): string {
+  if (!el) return '';
+  try {
+    const c = (el as { className?: unknown }).className;
+    if (typeof c === 'string') return c.slice(0, 80);
+    if (c && typeof (c as { baseVal?: string }).baseVal === 'string') {
+      return (c as { baseVal: string }).baseVal.slice(0, 80);
+    }
+  } catch { /* fall through */ }
+  return '';
+}
+
+/** Capture a 6-frame stack trace at event-time. Browsers vary in how much
+ *  of the dispatcher's frames they preserve; Chrome typically keeps enough
+ *  to identify which library called .focus(). Anonymous-only frames are
+ *  dropped. */
+function _captureStack(): string | null {
+  try {
+    const e = new Error('stack-probe');
+    if (!e.stack) return null;
+    const lines = e.stack.split('\n').map((s) => s.trim());
+    // Drop the first frame ("Error: stack-probe") and our own helper frame.
+    const filtered = lines
+      .slice(1)
+      .filter((l) => l.length > 0 && !l.includes('_captureStack'))
+      .filter((l) => !/^at\s+(<anonymous>|\(<anonymous>\))$/.test(l));
+    return filtered.slice(0, 6).join('\n');
+  } catch {
+    return null;
+  }
+}
+
+function _safeGetIMEState(): string {
+  try { return getIMEState(); } catch { return 'unknown'; }
+}
+
+function _helperFocusAuditSnapshot(): Record<string, unknown> {
+  try {
+    const active = document.activeElement;
+    const helper = document.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea');
+    return {
+      activeId: active instanceof Element ? (active.id || '') : '',
+      activeClass: _classOf(active),
+      activeTag: active instanceof Element ? active.tagName.toLowerCase() : '',
+      helperTabIndex: helper ? helper.tabIndex : null,
+      helperInputMode: helper ? helper.inputMode : null,
+      helperReadOnly: helper ? helper.readOnly : null,
+      helperPresent: !!helper,
+    };
+  } catch (err) {
+    return { auditError: (err as Error).message };
+  }
+}
+
+function _openGestureWindow(): void {
+  if (_gestureWindowActive) {
+    // Already inside a window (touchstart fired again before tail expired).
+    // Cancel any pending close and refresh start time only if we'd otherwise
+    // close. Keep the original gesture-start so deltas remain meaningful.
+    if (_gestureWindowEndTimer !== null) {
+      clearTimeout(_gestureWindowEndTimer);
+      _gestureWindowEndTimer = null;
+    }
+    return;
+  }
+  _gestureWindowActive = true;
+  _gestureWindowStart = performance.now();
+  _gestureHelperFocusInCount = 0;
+  _gestureLargeResizeCount = 0;
+  _gestureEventCount = 0;
+  _gestureImeStateAtStart = _safeGetIMEState();
+  try {
+    const vv = window.visualViewport;
+    _gestureVVPrevHeight = vv?.height ?? window.innerHeight;
+  } catch { _gestureVVPrevHeight = window.innerHeight; }
+
+  // Initial audit snapshot.
+  try {
+    logGesture('gesture_helper_focus_audit', {
+      ..._helperFocusAuditSnapshot(),
+      t: 0,
+      trigger: 'touchstart',
+    });
+  } catch { /* log must not throw */ }
+
+  // Install passive observers.
+  _gestureFocusinListener = (e: FocusEvent): void => {
+    try {
+      const target = e.target as Element | null;
+      const id = target instanceof Element ? (target.id || '') : '';
+      const cls = _classOf(target);
+      const isHelper = cls.includes('xterm-helper-textarea');
+      const isOurs = id === 'imeInput' || id === 'directInput';
+      if (isHelper) _gestureHelperFocusInCount++;
+      _gestureEventCount++;
+      const vv = window.visualViewport;
+      logGesture('gesture_focusin', {
+        t: Math.round(performance.now() - _gestureWindowStart),
+        targetId: id,
+        targetClass: cls,
+        isHelper,
+        isOurs,
+        imeState: _safeGetIMEState(),
+        selectionActive: _selectionActive,
+        vvHeight: vv?.height ?? null,
+        vvScale: vv?.scale ?? null,
+        innerHeight: window.innerHeight,
+        stack: _captureStack(),
+      });
+    } catch (err) {
+      try { logGesture('gesture_listener_error', { where: 'focusin', err: (err as Error).message }); } catch { /* */ }
+    }
+  };
+
+  _gestureFocusoutListener = (e: FocusEvent): void => {
+    try {
+      const target = e.target as Element | null;
+      const id = target instanceof Element ? (target.id || '') : '';
+      const cls = _classOf(target);
+      const isHelper = cls.includes('xterm-helper-textarea');
+      const isOurs = id === 'imeInput' || id === 'directInput';
+      _gestureEventCount++;
+      const vv = window.visualViewport;
+      logGesture('gesture_focusout', {
+        t: Math.round(performance.now() - _gestureWindowStart),
+        targetId: id,
+        targetClass: cls,
+        isHelper,
+        isOurs,
+        imeState: _safeGetIMEState(),
+        selectionActive: _selectionActive,
+        vvHeight: vv?.height ?? null,
+        vvScale: vv?.scale ?? null,
+        innerHeight: window.innerHeight,
+        stack: _captureStack(),
+      });
+    } catch (err) {
+      try { logGesture('gesture_listener_error', { where: 'focusout', err: (err as Error).message }); } catch { /* */ }
+    }
+  };
+
+  _gestureVVResizeListener = (): void => {
+    try {
+      const vv = window.visualViewport;
+      if (!vv) return;
+      const h = vv.height;
+      const w = vv.width;
+      const scale = vv.scale;
+      const deltaH = h - _gestureVVPrevHeight;
+      _gestureVVPrevHeight = h;
+      if (Math.abs(deltaH) > 100) _gestureLargeResizeCount++;
+      _gestureEventCount++;
+      logGesture('gesture_viewport_resize', {
+        t: Math.round(performance.now() - _gestureWindowStart),
+        h,
+        w,
+        scale,
+        deltaH,
+      });
+    } catch (err) {
+      try { logGesture('gesture_listener_error', { where: 'vv_resize', err: (err as Error).message }); } catch { /* */ }
+    }
+  };
+
+  document.addEventListener('focusin', _gestureFocusinListener, true);
+  document.addEventListener('focusout', _gestureFocusoutListener, true);
+  try {
+    window.visualViewport?.addEventListener('resize', _gestureVVResizeListener);
+  } catch { /* visualViewport unavailable in some environments */ }
+
+  // Periodic helper-focus audit while gesture window is active.
+  _gestureAuditTimer = setInterval(() => {
+    try {
+      logGesture('gesture_helper_focus_audit', {
+        ..._helperFocusAuditSnapshot(),
+        t: Math.round(performance.now() - _gestureWindowStart),
+        trigger: 'periodic',
+      });
+    } catch { /* */ }
+  }, 5000);
+}
+
+function _scheduleGestureWindowClose(): void {
+  if (!_gestureWindowActive) return;
+  if (_gestureWindowEndTimer !== null) {
+    clearTimeout(_gestureWindowEndTimer);
+  }
+  _gestureWindowEndTimer = setTimeout(_closeGestureWindow, 2000);
+}
+
+function _closeGestureWindow(): void {
+  if (!_gestureWindowActive) return;
+  _gestureWindowActive = false;
+  _gestureWindowEndTimer = null;
+
+  if (_gestureFocusinListener) {
+    document.removeEventListener('focusin', _gestureFocusinListener, true);
+    _gestureFocusinListener = null;
+  }
+  if (_gestureFocusoutListener) {
+    document.removeEventListener('focusout', _gestureFocusoutListener, true);
+    _gestureFocusoutListener = null;
+  }
+  if (_gestureVVResizeListener) {
+    try { window.visualViewport?.removeEventListener('resize', _gestureVVResizeListener); } catch { /* */ }
+    _gestureVVResizeListener = null;
+  }
+  if (_gestureAuditTimer !== null) {
+    clearInterval(_gestureAuditTimer);
+    _gestureAuditTimer = null;
+  }
+
+  // Evaluate anomaly conditions. Pick the most-specific reason if multiple
+  // conditions fire (helper-focus is the strongest signal for #502).
+  try {
+    const imeStateAtClose = _safeGetIMEState();
+    const imeChanged = imeStateAtClose !== _gestureImeStateAtStart;
+    const helperFocused = _gestureHelperFocusInCount > 0;
+    const largeResize = _gestureLargeResizeCount > 0;
+    if (helperFocused || largeResize || imeChanged) {
+      let reason = 'unknown';
+      if (helperFocused) reason = 'focus_during_long_press';
+      else if (largeResize) reason = 'viewport_resize_during_gesture';
+      else if (imeChanged) reason = 'ime_state_changed_during_gesture';
+      uploadGestureAnomaly(reason, _gestureEventCount);
+    }
+  } catch (err) {
+    try { logGesture('gesture_listener_error', { where: 'window_close', err: (err as Error).message }); } catch { /* */ }
+  }
+}
+
+/** Test-only: force-close the gesture window immediately. Exported for
+ *  vitest. Not part of the runtime selection API. */
+export function _testCloseGestureWindow(): void {
+  if (_gestureWindowEndTimer !== null) {
+    clearTimeout(_gestureWindowEndTimer);
+    _gestureWindowEndTimer = null;
+  }
+  _closeGestureWindow();
+}
+
+/** Test-only: open a gesture window without a real touchstart. Exported for
+ *  vitest. */
+export function _testOpenGestureWindow(): void {
+  _openGestureWindow();
+}
+
 /** Call once after terminal is created and DOM is ready. */
 export function initSelection(): void {
   const termEl = document.getElementById('terminal')!;
@@ -62,6 +342,10 @@ export function initSelection(): void {
     if (e.touches.length !== 1) return;
     _touchAnchorX = e.touches[0]!.clientX;
     _touchAnchorY = e.touches[0]!.clientY;
+    // Open the gesture diagnostic window (#502 — passive observers, no
+    // focus-state mutation). Listeners gated by _gestureWindowActive close
+    // 2s after touchend so delayed IME-show events are captured.
+    try { _openGestureWindow(); } catch { /* diagnostic must not break gestures */ }
     _longPressTimer = setTimeout(() => {
       _longPressTimer = null;
       _onLongPress();
@@ -96,6 +380,9 @@ export function initSelection(): void {
     if (_dragActive) {
       _endDragSelect();
     }
+    // Schedule the gesture-window close 2s after touchend (catches delayed
+    // IME show events that fire after touchend on Android Chrome).
+    try { _scheduleGestureWindowClose(); } catch { /* */ }
   }, { passive: true });
 
   // Tap while selection active: contract unit→word, then word→dismiss

--- a/tests/keyboard-stability-selection.spec.js
+++ b/tests/keyboard-stability-selection.spec.js
@@ -339,6 +339,66 @@ test.describe('Keyboard stability across selection gesture (#502)', () => {
     ).toHaveLength(0);
   });
 
+  test('D1: gesture-log captures focusin events during the gesture (#502 telemetry)', async ({ page }) => {
+    // Confirms the production diagnostic instrumentation actually fires
+    // during a real headless gesture — not just in mocked unit tests.
+    // The gesture-log ring buffer is in localStorage under
+    // 'mobissh.gestureLog.v1'. A long-press triggers term.select() which
+    // synchronously focuses the helper textarea. The gesture-window listener
+    // installed by selection.ts should log that focusin.
+    await simulateKeyboardVisible(page);
+    await page.evaluate((sel) => { document.querySelector(sel)?.focus(); }, IME_INPUT);
+
+    // Snapshot existing gesture log so we only inspect events from THIS gesture.
+    const baselineLen = await page.evaluate(() => {
+      try {
+        const raw = localStorage.getItem('mobissh.gestureLog.v1');
+        if (!raw) return 0;
+        const arr = JSON.parse(raw);
+        return Array.isArray(arr) ? arr.length : 0;
+      } catch { return 0; }
+    });
+
+    const { x, y } = await getTerminalCenter(page);
+    await longPressDragRelease(page, { startX: x, startY: y });
+    // Wait past the 2s gesture-window tail so window close logging runs.
+    await page.waitForTimeout(2200);
+
+    const events = await page.evaluate((startIdx) => {
+      try {
+        const raw = localStorage.getItem('mobissh.gestureLog.v1');
+        if (!raw) return [];
+        const arr = JSON.parse(raw);
+        if (!Array.isArray(arr)) return [];
+        return arr.slice(startIdx);
+      } catch { return []; }
+    }, baselineLen);
+
+    // The new event types must appear after a real gesture. The "audit"
+    // snapshot is always logged on touchstart, so it's the most reliable
+    // proof the gesture window opened.
+    const auditCount = events.filter((e) => e.e === 'gesture_helper_focus_audit').length;
+    expect(
+      auditCount,
+      `gesture_helper_focus_audit must be logged on touchstart. recent events: ${JSON.stringify(events.map((e) => e.e))}`,
+    ).toBeGreaterThan(0);
+
+    // If the headless gesture caused any focusin (it normally does because
+    // xterm.js's term.select() focuses the helper), it must have been
+    // captured by the gesture-window listener.
+    const focusinEvents = events.filter((e) => e.e === 'gesture_focusin');
+    // We don't assert > 0 unconditionally — a degenerate selection (empty
+    // line) skips term.select() — but if the page had ANY focusin event
+    // visible to installFocusTraps, the gesture log must mirror it.
+    const trace = await drainTraces(page);
+    if (trace.focus.some((f) => f.phase === 'focusin')) {
+      expect(
+        focusinEvents.length,
+        `gesture-window listener should have captured focusin events: ${JSON.stringify(events.map((e) => e.e))}`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
   test('C1: visualViewport height is stable across the gesture (headless trivial pass — documents intent)', async ({ page }) => {
     await page.evaluate((sel) => { document.querySelector(sel)?.focus(); }, IME_INPUT);
 


### PR DESCRIPTION
## Summary

Section 2 of the #502 redesign: read-only diagnostic telemetry for focus/IME interactions during gestures. The next on-device reproduction produces a decisive stack trace + payload instead of more speculation.

**Hard rule:** no focus management changes. All listeners are passive observers — never mutate focus, never `preventDefault` on focus events, no `helper.blur()`, no inputmode mutation, no tabindex change. Section 3's fix candidates (F1-F4) are explicitly out of scope for this PR.

## What's instrumented

A "gesture window" spans from `touchstart` on `#terminal` until 2 s after `touchend` (the 2 s tail catches delayed IME-show events that fire after touchend on Android Chrome). Inside the window we capture:

- `gesture_focusin` / `gesture_focusout` — every focus shift with target id/class, isHelper flag, ime state, vv height, and a 6-frame stack trace via `new Error().stack`
- `gesture_viewport_resize` — every `visualViewport.resize` with `deltaH`
- `gesture_helper_focus_audit` — initial + 5 s periodic snapshot of `.xterm-helper-textarea` (tabindex, inputmode, readOnly, activeElement)
- `gesture_anomaly_uploaded` — records the upload (or its throttle) in the same log so behaviour is visible end-to-end

At window close, if any anomaly condition fires (helper focus during window, vv height delta > 100, or imeState changed), `uploadGestureAnomaly(reason, eventCount)` POSTs the recent log slice to `/api/gesture-telemetry`. Independent 10-min throttle keyed at `mobissh.gestureUpload.lastT` (looser than drop-telemetry's 5 min — gesture anomalies are rarer and we want most of them).

## Files

- `src/modules/gesture-log.ts` — 5 new `GestureLogType` values
- `src/modules/selection.ts` — gesture-window state machine + capturing listeners + audit timer; hooks `touchstart`/`touchend`
- `src/modules/drop-telemetry.ts` — `uploadGestureAnomaly(reason, eventCount)` with 10-min throttle
- `server/index.js` — new `POST /api/gesture-telemetry` endpoint, writes to `test-results/uploads/` with 1 MB cap per log file
- `src/modules/__tests__/gesture-window-telemetry.test.ts` — 8 vitest unit tests (JSDOM)
- `tests/keyboard-stability-selection.spec.js` — added one assertion (D1) that a real headless gesture produces the new event types in the gesture log

## Test plan

- [x] `scripts/test-fast-gate.sh` — tsc + eslint + vitest all pass (1014 tests)
- [x] vitest unit: 8 tests cover focusin logging, viewport delta, anomaly trigger, 10-min throttle, imeInput-only path (no false anomaly), focusout, initial audit snapshot, listener cleanup after close
- [ ] After merge + deploy: the next real-device #502 repro should auto-upload to `test-results/uploads/*-gesture-telemetry.*`. The payload's `gesture_focusin` stack trace identifies the originator (H1 vs H2 vs H4 from the redesign doc).

## Notes for reviewer

- Added a tiny exported `getIMEState()` was already present in `ime.ts` (no new API surface there).
- Two test-only exports on `selection.ts` (`_testOpenGestureWindow`, `_testCloseGestureWindow`) bypass the `termEl` touchstart wiring for unit-test isolation.
- Performance: a 3 s long-press produces ~6 focus events × ~200 bytes = ~1.2 KB / gesture. Daily usage (~20 long-presses) is ~25 KB / day. The existing 5000-entry / 24h cap on `gesture-log.ts` absorbs this comfortably; quota-exceeded path was already implemented (drop oldest half).
- Server endpoint caps single log files at 1 MB; on overflow it truncates to the most recent half before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)