### PR TITLE
feat(#501): PWA→native profile import + saved-profile UI + release APK

### DIFF
--- a/native/lib/state/profiles_providers.dart
+++ b/native/lib/state/profiles_providers.dart
@@ -1,0 +1,23 @@
+// Riverpod providers for saved-profile persistence (#501).
+//
+// `profilesStoreProvider` exposes the [ProfilesStore] singleton.
+// `savedProfilesProvider` watches the loaded list; the UI reads it via
+// `ref.watch` and refreshes via `ref.invalidate(savedProfilesProvider)`
+// after mutating operations (save / import / remove).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../storage/profiles_store.dart';
+
+/// Singleton [ProfilesStore]. Override in tests via
+/// `profilesStoreProvider.overrideWithValue(myStore)`.
+final profilesStoreProvider = Provider<ProfilesStore>((ref) {
+  return ProfilesStore();
+});
+
+/// Async-loaded list of saved profiles. UI watches this; invalidate after
+/// mutating operations so the watcher re-fetches.
+final savedProfilesProvider = FutureProvider<List<SavedProfile>>((ref) async {
+  final store = ref.watch(profilesStoreProvider);
+  return store.load();
+});

--- a/native/lib/storage/profiles_store.dart
+++ b/native/lib/storage/profiles_store.dart
@@ -1,0 +1,275 @@
+// Saved-profile persistence for the native client (#501).
+//
+// Mirrors the PWA's `getProfiles` / `saveProfile` pattern: a JSON-encoded list
+// of connection metadata persisted in shared_preferences under the key
+// `mobissh.profiles.v1`. Credentials are explicitly NOT stored here — the
+// vault (Phase 3) owns secrets. This file owns identity only.
+//
+// The matching PWA export shape (see `exportProfilesJson` in
+// src/modules/profiles.ts) is `{ version: 1, exportedAt, profiles: [...] }`.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persisted profile shape. Connection metadata + optional visual identity.
+/// No credentials. No vaultId. Equality is by (host, port, username) — the
+/// natural identity used for dedupe everywhere else in the app.
+class SavedProfile {
+  SavedProfile({
+    required this.title,
+    required this.host,
+    required this.port,
+    required this.username,
+    this.theme,
+    this.color,
+  });
+
+  final String title;
+  final String host;
+  final int port;
+  final String username;
+  final String? theme;
+  final String? color;
+
+  /// Identity key for dedupe / lookup. Matches the PWA's behavior of treating
+  /// (host:port:username) as the unique constraint.
+  String get identityKey => '$host:$port:$username';
+
+  Map<String, dynamic> toJson() {
+    final out = <String, dynamic>{
+      'title': title,
+      'host': host,
+      'port': port,
+      'username': username,
+    };
+    if (theme != null) out['theme'] = theme;
+    if (color != null) out['color'] = color;
+    return out;
+  }
+
+  factory SavedProfile.fromJson(Map<String, dynamic> json) {
+    final hostRaw = json['host'];
+    final usernameRaw = json['username'];
+    if (hostRaw is! String || hostRaw.isEmpty) {
+      throw const FormatException('profile missing required field: host');
+    }
+    if (usernameRaw is! String || usernameRaw.isEmpty) {
+      throw const FormatException('profile missing required field: username');
+    }
+
+    // Port: JSON numbers parse as int OR double depending on encoder. Accept
+    // either, fall back to 22.
+    int port = 22;
+    final portRaw = json['port'];
+    if (portRaw is int) {
+      port = portRaw;
+    } else if (portRaw is double) {
+      port = portRaw.toInt();
+    } else if (portRaw is String) {
+      port = int.tryParse(portRaw) ?? 22;
+    }
+    if (port <= 0 || port > 65535) port = 22;
+
+    final titleRaw = json['title'];
+    final title = (titleRaw is String && titleRaw.isNotEmpty)
+        ? titleRaw
+        : '$usernameRaw@$hostRaw';
+
+    String? theme;
+    final themeRaw = json['theme'];
+    if (themeRaw is String && themeRaw.isNotEmpty) theme = themeRaw;
+
+    String? color;
+    final colorRaw = json['color'];
+    if (colorRaw is String && colorRaw.isNotEmpty) color = colorRaw;
+
+    return SavedProfile(
+      title: title,
+      host: hostRaw,
+      port: port,
+      username: usernameRaw,
+      theme: theme,
+      color: color,
+    );
+  }
+
+  SavedProfile copyWith({String? title}) {
+    return SavedProfile(
+      title: title ?? this.title,
+      host: host,
+      port: port,
+      username: username,
+      theme: theme,
+      color: color,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SavedProfile &&
+          other.host == host &&
+          other.port == port &&
+          other.username == username);
+
+  @override
+  int get hashCode => Object.hash(host, port, username);
+
+  @override
+  String toString() => 'SavedProfile($title, $username@$host:$port)';
+}
+
+/// Result of an import operation. Mirrors the PWA's `ImportResult` shape so
+/// the UI can show parallel toast messages.
+class ImportResult {
+  ImportResult({this.added = 0, this.skipped = 0, this.errors = const []});
+  final int added;
+  final int skipped;
+  final List<String> errors;
+}
+
+/// shared_preferences key. Versioned so a future schema change can migrate
+/// in-place without colliding with v1 data.
+const String profilesPrefsKey = 'mobissh.profiles.v1';
+
+/// Persistence layer for saved profiles. UI consumers go through
+/// `profilesStoreProvider` (state/profiles_providers.dart) so they can be
+/// observed via Riverpod; tests inject a [SharedPreferences] via
+/// [SharedPreferences.setMockInitialValues] and construct directly.
+class ProfilesStore {
+  ProfilesStore({SharedPreferences? prefs}) : _prefs = prefs;
+
+  // Cached SharedPreferences. Lazily replaced by [_ensure] on first call when
+  // the constructor wasn't given an explicit instance. Tests may pass in a
+  // pre-seeded prefs handle to skip async resolution.
+  SharedPreferences? _prefs;
+  // ignore_for_file: prefer_initializing_formals
+
+  Future<SharedPreferences> _ensure() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// Read all profiles from storage. Returns [] when nothing is stored or
+  /// the stored JSON is malformed (corrupt-resilience per .claude/rules).
+  Future<List<SavedProfile>> load() async {
+    final prefs = await _ensure();
+    final raw = prefs.getString(profilesPrefsKey);
+    if (raw == null || raw.isEmpty) return <SavedProfile>[];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return <SavedProfile>[];
+      final out = <SavedProfile>[];
+      for (final entry in decoded) {
+        if (entry is! Map) continue;
+        try {
+          out.add(SavedProfile.fromJson(Map<String, dynamic>.from(entry)));
+        } on FormatException {
+          // Skip corrupt entries silently — they would have been quarantined
+          // at write time anyway; tolerate stragglers.
+        }
+      }
+      return out;
+    } on FormatException {
+      return <SavedProfile>[];
+    }
+  }
+
+  /// Overwrite the entire profile list. The native UI calls `save(list)`
+  /// after each mutating operation; there's no incremental update API.
+  Future<void> save(List<SavedProfile> profiles) async {
+    final prefs = await _ensure();
+    final encoded = jsonEncode(profiles.map((p) => p.toJson()).toList());
+    await prefs.setString(profilesPrefsKey, encoded);
+  }
+
+  /// Import from a PWA-shaped export. Accepts:
+  ///   `{ version: 1, exportedAt: "iso-8601", profiles: [...] }`
+  /// Merges with existing storage; dedupes on (host:port:username).
+  ///
+  /// Returns an [ImportResult] enumerating added/skipped/errors. Does NOT
+  /// throw on malformed input — that's a user-recoverable error reported via
+  /// the result.
+  Future<ImportResult> importFromJson(String json) async {
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(json);
+    } on FormatException catch (e) {
+      return ImportResult(errors: ['Not valid JSON: ${e.message}']);
+    }
+
+    // Accept either:
+    //   1) The PWA's native-export envelope `{ version, profiles[] }`
+    //   2) The legacy bare-array shape (forward-compat with #419 exports).
+    List<dynamic> entries;
+    if (decoded is List) {
+      entries = decoded;
+    } else if (decoded is Map<String, dynamic>) {
+      final version = decoded['version'];
+      if (version != null && version != 1) {
+        return ImportResult(errors: [
+          'Unsupported export version: $version (this client supports v1).',
+        ]);
+      }
+      final profilesRaw = decoded['profiles'];
+      if (profilesRaw is! List) {
+        return ImportResult(errors: [
+          'Export envelope missing `profiles` array.',
+        ]);
+      }
+      entries = profilesRaw;
+    } else {
+      return ImportResult(errors: [
+        'Wrong file shape — expected an export envelope or profile array.',
+      ]);
+    }
+
+    final existing = await load();
+    final existingKeys = existing.map((p) => p.identityKey).toSet();
+    final errors = <String>[];
+    int added = 0;
+    int skipped = 0;
+
+    for (final entry in entries) {
+      if (entry is! Map) {
+        errors.add('Skipped a non-object entry.');
+        continue;
+      }
+      try {
+        final profile = SavedProfile.fromJson(Map<String, dynamic>.from(entry));
+        if (existingKeys.contains(profile.identityKey)) {
+          skipped++;
+          continue;
+        }
+        existing.add(profile);
+        existingKeys.add(profile.identityKey);
+        added++;
+      } on FormatException catch (e) {
+        errors.add(e.message);
+      }
+    }
+
+    if (added > 0) {
+      await save(existing);
+    }
+
+    return ImportResult(added: added, skipped: skipped, errors: errors);
+  }
+
+  /// Delete a single profile by identity. Persists if anything was removed.
+  Future<void> remove({
+    required String host,
+    required int port,
+    required String username,
+  }) async {
+    final list = await load();
+    final before = list.length;
+    list.removeWhere(
+      (p) => p.host == host && p.port == port && p.username == username,
+    );
+    if (list.length != before) {
+      await save(list);
+    }
+  }
+}

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -2,6 +2,9 @@
 //
 // Phase 1 (#501): no profiles, no persistence. Submit calls the SshSession
 // controller; UI mirrors lifecycle state below the form.
+//
+// Profile import (Phase 3 of #501): saved profiles rendered above the form;
+// tapping one populates host/port/username (user still types credentials).
 
 import 'dart:convert';
 import 'dart:typed_data';
@@ -12,7 +15,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../ssh/ssh_connect_params.dart';
 import '../ssh/ssh_session.dart';
 import '../state/connection_providers.dart';
+import '../storage/profiles_store.dart';
 import 'host_key_dialog.dart';
+import 'import_profiles_dialog.dart';
+import 'profile_list.dart';
 
 enum _AuthKind { password, key }
 
@@ -65,6 +71,19 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          // Saved profiles + import action. Collapsed-to-empty-hint when the
+          // user has no imported profiles yet.
+          ProfileList(onSelect: _applyProfileToForm),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              key: const Key('open-import-profiles-dialog'),
+              onPressed: _openImportDialog,
+              icon: const Icon(Icons.download_outlined),
+              label: const Text('Import from PWA'),
+            ),
+          ),
+          const SizedBox(height: 4),
           Row(
             children: [
               Expanded(
@@ -212,6 +231,28 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     } finally {
       if (mounted) setState(() => _busy = false);
     }
+  }
+
+  /// Populate the form with metadata from a saved profile. Credentials are
+  /// never auto-filled — the user types password / key per connect.
+  void _applyProfileToForm(SavedProfile profile) {
+    setState(() {
+      _hostCtrl.text = profile.host;
+      _portCtrl.text = profile.port.toString();
+      _userCtrl.text = profile.username;
+    });
+  }
+
+  Future<void> _openImportDialog() async {
+    final result = await showImportProfilesDialog(context);
+    if (!mounted || result == null) return;
+    final msg = result.added > 0
+        ? 'Imported ${result.added} profile${result.added == 1 ? '' : 's'}'
+            '${result.skipped > 0 ? ', ${result.skipped} skipped (duplicate)' : ''}'
+        : result.skipped > 0
+            ? 'No new profiles — all ${result.skipped} were already saved.'
+            : 'No profiles imported.';
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
   }
 
   Future<void> _handleHostKeyPrompt(PendingHostKey pending) async {

--- a/native/lib/ui/import_profiles_dialog.dart
+++ b/native/lib/ui/import_profiles_dialog.dart
@@ -1,0 +1,133 @@
+// "Import from PWA" dialog (#501).
+//
+// Accepts pasted JSON in the PWA export shape and merges into the store.
+// On success: returns the [ImportResult] so the caller can show a snackbar.
+// On parse failure or unknown shape: shows the error in-dialog without
+// closing, so the user can fix the paste and retry.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/profiles_providers.dart';
+import '../storage/profiles_store.dart';
+
+/// Show the import dialog. Resolves to the [ImportResult] on success, or
+/// `null` if the user cancelled. Tests can construct
+/// [ImportProfilesDialog] directly instead of going through this helper.
+Future<ImportResult?> showImportProfilesDialog(BuildContext context) {
+  return showDialog<ImportResult>(
+    context: context,
+    builder: (_) => const ImportProfilesDialog(),
+  );
+}
+
+class ImportProfilesDialog extends ConsumerStatefulWidget {
+  const ImportProfilesDialog({super.key});
+
+  @override
+  ConsumerState<ImportProfilesDialog> createState() =>
+      _ImportProfilesDialogState();
+}
+
+class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
+  final _ctrl = TextEditingController();
+  String? _error;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Rebuild on text changes so the Submit button's enabled state tracks
+    // whether the paste field is empty.
+    _ctrl.addListener(_onTextChanged);
+  }
+
+  void _onTextChanged() {
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _ctrl.removeListener(_onTextChanged);
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final store = ref.read(profilesStoreProvider);
+    final result = await store.importFromJson(_ctrl.text);
+    if (!mounted) return;
+
+    // If we got zero adds and zero skips with errors, treat as input error
+    // and leave the dialog open so the user can fix the paste.
+    if (result.added == 0 && result.skipped == 0 && result.errors.isNotEmpty) {
+      setState(() {
+        _busy = false;
+        _error = result.errors.first;
+      });
+      return;
+    }
+
+    // Invalidate the watcher so the parent list rebuilds.
+    if (result.added > 0) {
+      ref.invalidate(savedProfilesProvider);
+    }
+    Navigator.of(context).pop(result);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const Key('import-profiles-dialog'),
+      title: const Text('Import profiles from PWA'),
+      content: SizedBox(
+        width: 500,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Paste the JSON copied from the PWA "Export to native" button.',
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              key: const Key('import-profiles-input'),
+              controller: _ctrl,
+              maxLines: 8,
+              autocorrect: false,
+              enableSuggestions: false,
+              decoration: const InputDecoration(
+                hintText: '{ "version": 1, "profiles": [ ... ] }',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                _error!,
+                key: const Key('import-profiles-error'),
+                style: const TextStyle(color: Colors.redAccent),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          key: const Key('import-profiles-cancel'),
+          onPressed: _busy ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const Key('import-profiles-submit'),
+          onPressed: _busy || _ctrl.text.trim().isEmpty ? null : _submit,
+          child: Text(_busy ? 'Importing…' : 'Import'),
+        ),
+      ],
+    );
+  }
+}

--- a/native/lib/ui/profile_list.dart
+++ b/native/lib/ui/profile_list.dart
@@ -1,0 +1,120 @@
+// Saved-profile list rendered above the ConnectForm (#501).
+//
+// Empty-state hint nudges the user to import from the PWA. Each row is a tap
+// target that pre-fills the parent form via the [onSelect] callback. The
+// parent owns mutation — this widget is purely presentation + selection.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/profiles_providers.dart';
+import '../storage/profiles_store.dart';
+
+typedef ProfileSelectCallback = void Function(SavedProfile profile);
+
+class ProfileList extends ConsumerWidget {
+  const ProfileList({super.key, required this.onSelect});
+
+  /// Fired when the user taps a profile row. Parent populates ConnectForm
+  /// fields with the chosen profile's metadata (host/port/username).
+  final ProfileSelectCallback onSelect;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(savedProfilesProvider);
+
+    return async.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.symmetric(vertical: 8),
+        child: Center(child: SizedBox(
+          width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2),
+        )),
+      ),
+      error: (e, _) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Text('Profiles error: $e',
+            style: const TextStyle(color: Colors.redAccent)),
+      ),
+      data: (profiles) {
+        if (profiles.isEmpty) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 12),
+            child: Text(
+              'No saved profiles. Import from PWA to skip retyping.',
+              key: Key('profile-list-empty'),
+              style: TextStyle(color: Colors.grey),
+            ),
+          );
+        }
+        return Column(
+          key: const Key('profile-list-populated'),
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 4, bottom: 4),
+              child: Text(
+                'Saved Profiles',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+            ),
+            // Constrain so a giant list doesn't push the form off-screen.
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 220),
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: profiles.length,
+                itemBuilder: (context, i) {
+                  final p = profiles[i];
+                  return _ProfileTile(
+                    profile: p,
+                    onTap: () => onSelect(p),
+                  );
+                },
+              ),
+            ),
+            const Divider(),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ProfileTile extends StatelessWidget {
+  const _ProfileTile({required this.profile, required this.onTap});
+
+  final SavedProfile profile;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _parseColor(profile.color);
+    return ListTile(
+      key: Key('profile-tile-${profile.identityKey}'),
+      dense: true,
+      leading: CircleAvatar(
+        backgroundColor: color ?? Theme.of(context).colorScheme.primary,
+        radius: 8,
+      ),
+      title: Text(profile.title, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        '${profile.username}@${profile.host}:${profile.port}',
+        overflow: TextOverflow.ellipsis,
+      ),
+      onTap: onTap,
+    );
+  }
+}
+
+/// Parse a hex color string like "#ff8800" into a Color. Returns null when
+/// the input doesn't match — caller falls back to the theme primary.
+Color? _parseColor(String? hex) {
+  if (hex == null || hex.isEmpty) return null;
+  var raw = hex.trim();
+  if (raw.startsWith('#')) raw = raw.substring(1);
+  if (raw.length == 6) raw = 'FF$raw';
+  if (raw.length != 8) return null;
+  final v = int.tryParse(raw, radix: 16);
+  if (v == null) return null;
+  return Color(v);
+}

--- a/native/test/profiles_store_test.dart
+++ b/native/test/profiles_store_test.dart
@@ -1,0 +1,326 @@
+// Unit tests for [ProfilesStore] (#501).
+//
+// Covers:
+//   - load/save round-trip preserves identity + theme/color
+//   - importFromJson with the PWA's envelope shape
+//   - importFromJson with the legacy bare-array shape (forward-compat)
+//   - dedupe on (host:port:username)
+//   - invalid JSON / wrong shape returns ImportResult with errors, no crash
+//   - rejects unknown export version
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/storage/profiles_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    // Reset to a clean prefs map for every test. Empty initial values give
+    // every test its own SharedPreferences instance.
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('SavedProfile', () {
+    test('identityKey is host:port:username', () {
+      final p = SavedProfile(
+        title: 't', host: 'h.example', port: 2222, username: 'u',
+      );
+      expect(p.identityKey, 'h.example:2222:u');
+    });
+
+    test('toJson omits null theme/color', () {
+      final p = SavedProfile(title: 't', host: 'h', port: 22, username: 'u');
+      final json = p.toJson();
+      expect(json.containsKey('theme'), isFalse);
+      expect(json.containsKey('color'), isFalse);
+    });
+
+    test('toJson includes theme/color when present', () {
+      final p = SavedProfile(
+        title: 't', host: 'h', port: 22, username: 'u',
+        theme: 'nord', color: '#abcdef',
+      );
+      expect(p.toJson()['theme'], 'nord');
+      expect(p.toJson()['color'], '#abcdef');
+    });
+
+    test('fromJson throws FormatException for missing host', () {
+      expect(
+        () => SavedProfile.fromJson(<String, dynamic>{'username': 'u'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('fromJson throws FormatException for missing username', () {
+      expect(
+        () => SavedProfile.fromJson(<String, dynamic>{'host': 'h'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('fromJson defaults port to 22 when missing', () {
+      final p = SavedProfile.fromJson(<String, dynamic>{
+        'host': 'h.example', 'username': 'u',
+      });
+      expect(p.port, 22);
+    });
+
+    test('fromJson clamps invalid port to 22', () {
+      final p = SavedProfile.fromJson(<String, dynamic>{
+        'host': 'h', 'username': 'u', 'port': -1,
+      });
+      expect(p.port, 22);
+    });
+
+    test('fromJson synthesizes title from username@host when missing', () {
+      final p = SavedProfile.fromJson(<String, dynamic>{
+        'host': 'h.example', 'username': 'me', 'port': 22,
+      });
+      expect(p.title, 'me@h.example');
+    });
+
+    test('equality is by identity tuple (host, port, username)', () {
+      final a = SavedProfile(
+        title: 'A', host: 'h', port: 22, username: 'u', theme: 'dark',
+      );
+      final b = SavedProfile(
+        title: 'B (different)', host: 'h', port: 22, username: 'u',
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('ProfilesStore.load/save', () {
+    test('load returns empty list when storage is empty', () async {
+      final store = ProfilesStore();
+      final loaded = await store.load();
+      expect(loaded, isEmpty);
+    });
+
+    test('save+load round-trip preserves all fields', () async {
+      final store = ProfilesStore();
+      final original = <SavedProfile>[
+        SavedProfile(
+          title: 'Dev', host: 'dev.example', port: 22, username: 'admin',
+          theme: 'dark', color: '#ff8800',
+        ),
+        SavedProfile(
+          title: 'Prod', host: 'prod.example', port: 2222, username: 'deploy',
+        ),
+      ];
+      await store.save(original);
+
+      final loaded = await store.load();
+      expect(loaded, hasLength(2));
+      expect(loaded[0].title, 'Dev');
+      expect(loaded[0].host, 'dev.example');
+      expect(loaded[0].port, 22);
+      expect(loaded[0].username, 'admin');
+      expect(loaded[0].theme, 'dark');
+      expect(loaded[0].color, '#ff8800');
+      expect(loaded[1].theme, isNull);
+      expect(loaded[1].color, isNull);
+    });
+
+    test('load is corrupt-resilient — returns [] on malformed JSON',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        profilesPrefsKey: 'not json',
+      });
+      final store = ProfilesStore();
+      final loaded = await store.load();
+      expect(loaded, isEmpty);
+    });
+
+    test('load tolerates a corrupt entry mixed with valid ones', () async {
+      // Pre-seed prefs with one bad + one good entry. The bad entry is
+      // missing the required `host` field; the good entry should still
+      // appear in the result.
+      final raw = jsonEncode(<Map<String, dynamic>>[
+        <String, dynamic>{'username': 'u'},
+        <String, dynamic>{
+          'host': 'good.example', 'username': 'u', 'port': 22, 'title': 'OK',
+        },
+      ]);
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        profilesPrefsKey: raw,
+      });
+      final store = ProfilesStore();
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      expect(loaded[0].host, 'good.example');
+    });
+
+    test('remove deletes the matching profile', () async {
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(title: 'A', host: 'a', port: 22, username: 'u1'),
+        SavedProfile(title: 'B', host: 'b', port: 22, username: 'u2'),
+      ]);
+      await store.remove(host: 'a', port: 22, username: 'u1');
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.host, 'b');
+    });
+  });
+
+  group('ProfilesStore.importFromJson — PWA envelope shape', () {
+    // A realistic export captured from the PWA's exportProfilesJson(). The
+    // native client MUST parse this without changes; it's the contract.
+    const pwaExportFixture = '''
+{
+  "version": 1,
+  "exportedAt": "2026-05-22T13:00:00.000Z",
+  "profiles": [
+    {
+      "title": "Home NAS",
+      "host": "nas.tail123.ts.net",
+      "port": 22,
+      "username": "mfrazier",
+      "theme": "dark",
+      "color": "#88ccff"
+    },
+    {
+      "title": "Build box",
+      "host": "build.tail123.ts.net",
+      "port": 2222,
+      "username": "ci",
+      "theme": "nord"
+    }
+  ]
+}
+''';
+
+    test('imports both profiles from a fresh store', () async {
+      final store = ProfilesStore();
+      final result = await store.importFromJson(pwaExportFixture);
+      expect(result.added, 2);
+      expect(result.skipped, 0);
+      expect(result.errors, isEmpty);
+
+      final loaded = await store.load();
+      expect(loaded, hasLength(2));
+      expect(loaded[0].title, 'Home NAS');
+      expect(loaded[0].color, '#88ccff');
+      expect(loaded[1].title, 'Build box');
+      expect(loaded[1].theme, 'nord');
+    });
+
+    test('dedupes on (host:port:username) when re-importing', () async {
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Old Name', host: 'nas.tail123.ts.net',
+          port: 22, username: 'mfrazier',
+        ),
+      ]);
+      final result = await store.importFromJson(pwaExportFixture);
+      expect(result.added, 1, reason: 'only "Build box" is new');
+      expect(result.skipped, 1, reason: 'nas already exists');
+
+      final loaded = await store.load();
+      expect(loaded, hasLength(2));
+      // Existing profile keeps its original title — import does not clobber.
+      final existing = loaded.firstWhere((p) => p.host == 'nas.tail123.ts.net');
+      expect(existing.title, 'Old Name');
+    });
+
+    test('rejects unknown export version', () async {
+      final store = ProfilesStore();
+      const future = '''
+{ "version": 99, "exportedAt": "x", "profiles": [] }
+''';
+      final result = await store.importFromJson(future);
+      expect(result.added, 0);
+      expect(result.errors, hasLength(1));
+      expect(result.errors.first, contains('Unsupported export version'));
+    });
+  });
+
+  group('ProfilesStore.importFromJson — robustness', () {
+    test('accepts a bare-array (legacy #419) export shape', () async {
+      // The PWA's pre-#501 `exportProfilesJSON()` emits a bare array.
+      // Forward-compat: the native client should accept it.
+      const legacy = '''
+[
+  { "title": "X", "host": "x.example", "port": 22, "username": "u",
+    "authType": "password" }
+]
+''';
+      final store = ProfilesStore();
+      final result = await store.importFromJson(legacy);
+      expect(result.added, 1);
+      expect(result.errors, isEmpty);
+    });
+
+    test('returns errors (no throw) on invalid JSON', () async {
+      final store = ProfilesStore();
+      final result = await store.importFromJson('not json at all');
+      expect(result.added, 0);
+      expect(result.errors, hasLength(1));
+      expect(result.errors.first.toLowerCase(), contains('json'));
+      // Storage untouched.
+      expect(await store.load(), isEmpty);
+    });
+
+    test('returns errors on wrong shape (object without profiles array)',
+        () async {
+      final store = ProfilesStore();
+      const wrong = '{ "version": 1, "junk": true }';
+      final result = await store.importFromJson(wrong);
+      expect(result.added, 0);
+      expect(result.errors, hasLength(1));
+    });
+
+    test('skips entries missing required fields, collects errors', () async {
+      final store = ProfilesStore();
+      const mixed = '''
+{
+  "version": 1,
+  "profiles": [
+    { "title": "no host", "port": 22, "username": "u" },
+    { "host": "ok.example", "port": 22, "username": "u", "title": "OK" }
+  ]
+}
+''';
+      final result = await store.importFromJson(mixed);
+      expect(result.added, 1);
+      expect(result.errors, hasLength(1));
+      final loaded = await store.load();
+      expect(loaded.single.host, 'ok.example');
+    });
+
+    test('ignores credentials silently — they are not part of SavedProfile',
+        () async {
+      // Belt-and-braces: even if the PWA export had credentials, the
+      // SavedProfile.fromJson factory would not read them and they would
+      // never reach storage.
+      final store = ProfilesStore();
+      const sneaky = '''
+{
+  "version": 1,
+  "profiles": [
+    {
+      "title": "Sneaky", "host": "evil.example", "port": 22,
+      "username": "u",
+      "password": "secret", "privateKey": "PRIVATE", "vaultId": "steal"
+    }
+  ]
+}
+''';
+      final result = await store.importFromJson(sneaky);
+      expect(result.added, 1);
+      final loaded = await store.load();
+      // Serialize to JSON to inspect that credential keys are absent.
+      final stored = loaded.single.toJson();
+      expect(stored.containsKey('password'), isFalse);
+      expect(stored.containsKey('privateKey'), isFalse);
+      expect(stored.containsKey('vaultId'), isFalse);
+    });
+  });
+}

--- a/native/test/widget/import_dialog_widget_test.dart
+++ b/native/test/widget/import_dialog_widget_test.dart
@@ -1,0 +1,143 @@
+// Widget tests for [ImportProfilesDialog] (#501).
+//
+// Asserts:
+//   - valid pasted JSON triggers import (store state changes, dialog closes
+//     with non-null ImportResult)
+//   - invalid JSON keeps the dialog open and shows an inline error;
+//     store state is unchanged
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/import_profiles_dialog.dart';
+
+/// Pump a launcher that exposes a button which opens the dialog. Avoids the
+/// "guarded function conflict" trap of launching the dialog from a
+/// postFrameCallback inside the first pumpWidget call.
+Future<ImportResult?> _openDialog(
+  WidgetTester tester, {
+  required ProfilesStore store,
+  required Future<void> Function(WidgetTester) interact,
+}) async {
+  ImportResult? captured;
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        profilesStoreProvider.overrideWithValue(store),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                key: const Key('open-button'),
+                onPressed: () async {
+                  captured = await showImportProfilesDialog(context);
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  // Tap to open the dialog. pumpAndSettle lets the dialog finish its
+  // entrance animation.
+  await tester.tap(find.byKey(const Key('open-button')));
+  await tester.pumpAndSettle();
+
+  // Run the test's interaction. May tap Submit (closes dialog) or Cancel.
+  await interact(tester);
+  await tester.pumpAndSettle();
+
+  return captured;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('valid PWA-envelope JSON imports and closes the dialog',
+      (tester) async {
+    final store = ProfilesStore();
+
+    final result = await _openDialog(
+      tester,
+      store: store,
+      interact: (t) async {
+        expect(find.byKey(const Key('import-profiles-dialog')), findsOneWidget);
+
+        const validJson = '''
+{
+  "version": 1,
+  "exportedAt": "2026-05-22T13:00:00.000Z",
+  "profiles": [
+    { "title": "Home NAS", "host": "nas.example", "port": 22,
+      "username": "me", "theme": "dark" }
+  ]
+}
+''';
+        await t.enterText(
+          find.byKey(const Key('import-profiles-input')),
+          validJson,
+        );
+        await t.pump();
+        await t.tap(find.byKey(const Key('import-profiles-submit')));
+      },
+    );
+
+    // Dialog should be closed.
+    expect(find.byKey(const Key('import-profiles-dialog')), findsNothing);
+
+    expect(result, isNotNull);
+    expect(result!.added, 1);
+
+    // Store should reflect the import.
+    final loaded = await store.load();
+    expect(loaded, hasLength(1));
+    expect(loaded.single.host, 'nas.example');
+  });
+
+  testWidgets('invalid JSON shows inline error and leaves store untouched',
+      (tester) async {
+    final store = ProfilesStore();
+
+    final result = await _openDialog(
+      tester,
+      store: store,
+      interact: (t) async {
+        expect(find.byKey(const Key('import-profiles-dialog')), findsOneWidget);
+
+        await t.enterText(
+          find.byKey(const Key('import-profiles-input')),
+          'this is not json',
+        );
+        await t.pump();
+        await t.tap(find.byKey(const Key('import-profiles-submit')));
+        await t.pumpAndSettle();
+
+        // Dialog should still be open with an error message visible.
+        expect(find.byKey(const Key('import-profiles-dialog')), findsOneWidget);
+        expect(find.byKey(const Key('import-profiles-error')), findsOneWidget);
+
+        // Cancel to close so the future resolves.
+        await t.tap(find.byKey(const Key('import-profiles-cancel')));
+      },
+    );
+
+    expect(result, isNull, reason: 'cancelled dialog returns null');
+
+    final loaded = await store.load();
+    expect(loaded, isEmpty, reason: 'invalid JSON must not corrupt storage');
+  });
+}

--- a/native/test/widget/profile_list_widget_test.dart
+++ b/native/test/widget/profile_list_widget_test.dart
@@ -1,0 +1,114 @@
+// Widget tests for [ProfileList] (#501).
+//
+// Asserts:
+//   - empty-state hint renders when no profiles exist
+//   - populated list renders one tile per profile
+//   - tapping a tile fires onSelect with the correct profile
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/profile_list.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ProfileList', () {
+    testWidgets('renders empty-state hint when store has no profiles',
+        (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: ProfileList(onSelect: (_) {}),
+            ),
+          ),
+        ),
+      );
+      // Wait for the FutureProvider to resolve.
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('profile-list-empty')), findsOneWidget);
+      expect(find.byKey(const Key('profile-list-populated')), findsNothing);
+    });
+
+    testWidgets('renders one tile per saved profile', (tester) async {
+      // Seed prefs via a real ProfilesStore, then override the provider so
+      // the widget's load() goes through the same store.
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Home', host: 'home.example', port: 22, username: 'me',
+        ),
+        SavedProfile(
+          title: 'Work', host: 'work.example', port: 2222, username: 'me',
+          color: '#ff8800',
+        ),
+      ]);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            profilesStoreProvider.overrideWithValue(store),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: ProfileList(onSelect: (_) {}),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('profile-list-populated')), findsOneWidget);
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.text('Work'), findsOneWidget);
+      expect(find.text('me@home.example:22'), findsOneWidget);
+      expect(find.text('me@work.example:2222'), findsOneWidget);
+    });
+
+    testWidgets('tapping a tile fires onSelect with the correct profile',
+        (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'A', host: 'a.example', port: 22, username: 'u1',
+        ),
+        SavedProfile(
+          title: 'B', host: 'b.example', port: 22, username: 'u2',
+        ),
+      ]);
+
+      SavedProfile? selected;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            profilesStoreProvider.overrideWithValue(store),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: ProfileList(onSelect: (p) => selected = p),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the B tile.
+      await tester.tap(find.byKey(const Key('profile-tile-b.example:22:u2')));
+      await tester.pump();
+
+      expect(selected, isNotNull);
+      expect(selected!.host, 'b.example');
+      expect(selected!.username, 'u2');
+    });
+  });
+}

--- a/public/index.html
+++ b/public/index.html
@@ -529,6 +529,7 @@
         <button type="button" class="connect-nav-btn" data-action="new">New</button>
         <button type="button" class="connect-nav-btn" data-action="import">Import</button>
         <button type="button" class="connect-nav-btn" data-action="export">Export</button>
+        <button type="button" id="exportProfilesBtn" class="connect-nav-btn" data-action="export-native" title="Copy/download profiles for the native app">Export to native</button>
       </nav>
     </div>
 

--- a/src/modules/__tests__/profile-export-native.test.ts
+++ b/src/modules/__tests__/profile-export-native.test.ts
@@ -1,0 +1,229 @@
+/**
+ * profile-export-native.test.ts — Tests for #501: PWA→native profile export.
+ *
+ * Verifies the new versioned-wrapper shape consumed by the Flutter native
+ * client's `ProfilesStore.importFromJson`:
+ *   { version: 1, exportedAt: <ISO-8601>, profiles: [...] }
+ *
+ * Security boundary: NO credentials, NO vaultId/keyVaultId/hasVaultCreds.
+ * Round-trip: parsing the envelope yields the same profile metadata in.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Mock globals before imports ────────────────────────────────────────────
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => { storage.set(key, value); },
+  removeItem: (key: string) => { storage.delete(key); },
+  clear: () => { storage.clear(); },
+});
+
+vi.stubGlobal('location', { hostname: 'localhost', host: 'localhost:8081', protocol: 'http:', pathname: '/' });
+
+const clipboardWrites: string[] = [];
+const downloads: { href: string; download: string }[] = [];
+
+vi.stubGlobal('document', {
+  getElementById: () => null,
+  querySelector: () => null,
+  addEventListener: vi.fn(),
+  visibilityState: 'visible',
+  documentElement: {
+    style: { setProperty: vi.fn() },
+    dataset: {},
+    classList: { toggle: vi.fn(), add: vi.fn(), remove: vi.fn() },
+  },
+  createElement: vi.fn(() => {
+    const a: { href: string; download: string; click: () => void; style: Record<string, string> } = {
+      href: '', download: '', click() { downloads.push({ href: this.href, download: this.download }); }, style: {},
+    };
+    return a;
+  }),
+  body: { appendChild: vi.fn(), removeChild: vi.fn() },
+});
+
+class MockURL { constructor(public href: string) {} }
+Object.assign(MockURL, { createObjectURL: vi.fn(() => 'blob:mock'), revokeObjectURL: vi.fn() });
+vi.stubGlobal('URL', MockURL);
+vi.stubGlobal('crypto', { randomUUID: () => 'uuid-mock' });
+vi.stubGlobal('navigator', {
+  serviceWorker: undefined,
+  wakeLock: undefined,
+  clipboard: {
+    writeText: vi.fn((s: string) => {
+      clipboardWrites.push(s);
+      return Promise.resolve();
+    }),
+  },
+});
+vi.stubGlobal('WebSocket', class { url = ''; readyState = 3; static OPEN = 1; static CLOSED = 3; close = vi.fn(); send = vi.fn(); addEventListener = vi.fn(); });
+vi.stubGlobal('Worker', class { onmessage = null; postMessage = vi.fn(); terminate = vi.fn(); });
+vi.stubGlobal('window', { addEventListener: vi.fn(), location: { protocol: 'http:', host: 'localhost:8081', pathname: '/' } });
+vi.stubGlobal('CSS', { escape: (s: string) => s });
+vi.stubGlobal('confirm', () => true);
+vi.stubGlobal('requestAnimationFrame', (cb: () => void) => { cb(); return 0; });
+vi.stubGlobal('Blob', class { constructor(public parts: string[], public options: { type: string }) {} });
+
+const { exportProfilesJson, triggerProfilesDownload } = await import('../profiles.js');
+
+function seedProfiles(): void {
+  storage.set('sshProfiles', JSON.stringify([
+    {
+      title: 'Dev Server',
+      host: 'dev.example.com',
+      port: 22,
+      username: 'admin',
+      authType: 'password',
+      initialCommand: '',
+      vaultId: 'vault-secret-123',
+      hasVaultCreds: true,
+      keyVaultId: 'key-vault-456',
+      theme: 'dark',
+      color: '#ff8800',
+    },
+    {
+      title: 'Prod Server',
+      host: 'prod.example.com',
+      port: 2222,
+      username: 'deploy',
+      authType: 'key',
+      initialCommand: 'tmux attach',
+      vaultId: 'vault-secret-789',
+      hasVaultCreds: true,
+      theme: 'nord',
+    },
+  ]));
+}
+
+describe('#501: exportProfilesJson — versioned wrapper', () => {
+  beforeEach(() => {
+    storage.clear();
+    clipboardWrites.length = 0;
+    downloads.length = 0;
+  });
+
+  it('emits a wrapper object with version=1, ISO-8601 exportedAt, profiles array', () => {
+    seedProfiles();
+    const json = exportProfilesJson();
+    const parsed = JSON.parse(json);
+
+    expect(parsed.version).toBe(1);
+    expect(typeof parsed.exportedAt).toBe('string');
+    // ISO-8601 sanity check: YYYY-MM-DDTHH:MM:SS.sssZ
+    expect(parsed.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(Array.isArray(parsed.profiles)).toBe(true);
+    expect(parsed.profiles).toHaveLength(2);
+  });
+
+  it('SECURITY: omits credentials, vaultId, keyVaultId, hasVaultCreds, authType, initialCommand', () => {
+    seedProfiles();
+    const json = exportProfilesJson();
+    const parsed = JSON.parse(json);
+
+    const FORBIDDEN = [
+      'password', 'privateKey', 'passphrase',
+      'vaultId', 'keyVaultId', 'hasVaultCreds',
+      // The native client does not need authType (handled per-connect) and
+      // initialCommand is a PWA-only concept right now.
+      'authType', 'initialCommand',
+    ];
+    for (const profile of parsed.profiles) {
+      for (const field of FORBIDDEN) {
+        expect(profile).not.toHaveProperty(field);
+      }
+    }
+  });
+
+  it('preserves title, host, port, username, theme, color', () => {
+    seedProfiles();
+    const json = exportProfilesJson();
+    const parsed = JSON.parse(json);
+
+    expect(parsed.profiles[0]).toEqual({
+      title: 'Dev Server',
+      host: 'dev.example.com',
+      port: 22,
+      username: 'admin',
+      theme: 'dark',
+      color: '#ff8800',
+    });
+    // Second profile has no explicit color — field should be absent, not null/undefined.
+    expect(parsed.profiles[1]).toEqual({
+      title: 'Prod Server',
+      host: 'prod.example.com',
+      port: 2222,
+      username: 'deploy',
+      theme: 'nord',
+    });
+    expect(parsed.profiles[1]).not.toHaveProperty('color');
+  });
+
+  it('round-trip: parsing the export yields the same identity fields as input', () => {
+    seedProfiles();
+    const inputs = JSON.parse(localStorage.getItem('sshProfiles')!) as Array<{
+      title: string; host: string; port: number; username: string;
+      theme?: string; color?: string;
+    }>;
+    const json = exportProfilesJson();
+    const parsed = JSON.parse(json) as { profiles: Array<{ title: string; host: string; port: number; username: string }> };
+
+    expect(parsed.profiles).toHaveLength(inputs.length);
+    for (let i = 0; i < inputs.length; i++) {
+      expect(parsed.profiles[i]!.title).toBe(inputs[i]!.title);
+      expect(parsed.profiles[i]!.host).toBe(inputs[i]!.host);
+      expect(parsed.profiles[i]!.port).toBe(inputs[i]!.port);
+      expect(parsed.profiles[i]!.username).toBe(inputs[i]!.username);
+    }
+  });
+
+  it('synthesizes a title for profiles missing one', () => {
+    storage.set('sshProfiles', JSON.stringify([
+      { title: '', host: 'h.example', port: 22, username: 'me', authType: 'password', initialCommand: '', vaultId: 'v' },
+    ]));
+    const json = exportProfilesJson();
+    const parsed = JSON.parse(json);
+    expect(parsed.profiles[0]!.title).toBe('me@h.example');
+  });
+
+  it('defaults port to 22 when missing/falsy', () => {
+    storage.set('sshProfiles', JSON.stringify([
+      { title: 'Defaulty', host: 'h', port: 0, username: 'u', authType: 'password', initialCommand: '', vaultId: 'v' },
+    ]));
+    const json = exportProfilesJson();
+    const parsed = JSON.parse(json);
+    expect(parsed.profiles[0]!.port).toBe(22);
+  });
+
+  it('emits zero-profiles envelope when storage is empty', () => {
+    const json = exportProfilesJson();
+    const parsed = JSON.parse(json);
+    expect(parsed.version).toBe(1);
+    expect(parsed.profiles).toEqual([]);
+  });
+});
+
+describe('#501: triggerProfilesDownload', () => {
+  beforeEach(() => {
+    storage.clear();
+    clipboardWrites.length = 0;
+    downloads.length = 0;
+  });
+
+  it('writes the export to the clipboard AND triggers a download', () => {
+    seedProfiles();
+    triggerProfilesDownload();
+
+    // Clipboard path
+    expect(clipboardWrites).toHaveLength(1);
+    const clipParsed = JSON.parse(clipboardWrites[0]!);
+    expect(clipParsed.version).toBe(1);
+    expect(clipParsed.profiles).toHaveLength(2);
+
+    // Download path
+    expect(downloads).toHaveLength(1);
+    expect(downloads[0]!.href).toBe('blob:mock');
+    expect(downloads[0]!.download).toMatch(/^mobissh-profiles-.*\.json$/);
+  });
+});

--- a/src/modules/profiles.ts
+++ b/src/modules/profiles.ts
@@ -925,7 +925,9 @@ export function deleteKey(idx: number): void {
 /** Safe metadata fields included in export. Everything else is stripped. */
 const EXPORT_FIELDS = ['title', 'host', 'port', 'username', 'authType'] as const;
 
-/** Serialize saved profiles to JSON string containing ONLY non-sensitive metadata. */
+/** Serialize saved profiles to JSON string containing ONLY non-sensitive metadata.
+ *
+ *  Legacy bare-array shape used by #419 import. Kept for back-compat. */
 export function exportProfilesJSON(): string {
   const profiles = getProfiles();
   const safe = profiles.map((p) => {
@@ -938,7 +940,7 @@ export function exportProfilesJSON(): string {
   return JSON.stringify(safe, null, 2);
 }
 
-/** Trigger a browser download of exported profiles. */
+/** Trigger a browser download of exported profiles (legacy bare-array shape). */
 export function downloadProfilesExport(): void {
   const json = exportProfilesJSON();
   const blob = new Blob([json], { type: 'application/json' });
@@ -946,6 +948,94 @@ export function downloadProfilesExport(): void {
   const a = document.createElement('a');
   a.href = url;
   a.download = 'mobissh-profiles.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// ── Native-import export (#501) ──────────────────────────────────────────────
+//
+// The native Android client (#501) reads a versioned-wrapper shape so it can
+// validate format upfront and reject future incompatible exports cleanly:
+//   { version: 1, exportedAt: <ISO-8601>, profiles: [{ title, host, port,
+//     username, theme?, color? }] }
+// Credentials and vaultId are NEVER emitted — only connection metadata, the
+// theme name, and the per-profile color so the native app can show the same
+// visual identity as the PWA.
+
+interface NativeProfileExport {
+  title: string;
+  host: string;
+  port: number;
+  username: string;
+  theme?: string;
+  color?: string;
+}
+
+interface NativeProfilesExportEnvelope {
+  version: 1;
+  exportedAt: string;
+  profiles: NativeProfileExport[];
+}
+
+/** Serialize saved profiles to the native-client wrapped JSON shape.
+ *
+ *  Distinct from `exportProfilesJSON` (legacy bare array). This shape is what
+ *  the Flutter `ProfilesStore.importFromJson` parses. No credentials, no
+ *  vault references — purely connection metadata + visual identity. */
+export function exportProfilesJson(): string {
+  const profiles = getProfiles();
+  const envelope: NativeProfilesExportEnvelope = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    profiles: profiles.map((p) => {
+      const out: NativeProfileExport = {
+        title: p.title || `${p.username}@${p.host}`,
+        host: p.host,
+        port: p.port || 22,
+        username: p.username,
+      };
+      if (p.theme) out.theme = p.theme;
+      if (p.color) out.color = p.color;
+      return out;
+    }),
+  };
+  return JSON.stringify(envelope, null, 2);
+}
+
+/** Write the native-export JSON to the clipboard AND trigger a file download.
+ *
+ *  Both paths are attempted because mobile-browser availability varies:
+ *  - `navigator.clipboard.writeText` works on Android Chrome but may be absent
+ *    in older WebViews; failures are swallowed.
+ *  - Anchor-click download is the universal fallback.
+ *  The user can paste OR upload the resulting JSON into the native app's
+ *  "Import from PWA" dialog. */
+export function triggerProfilesDownload(): void {
+  const json = exportProfilesJson();
+
+  // 1. Clipboard write (best-effort, fire-and-forget). The Navigator type
+  // ships `clipboard: Clipboard`, but on some Android WebViews the API is
+  // absent at runtime. Probe via an `unknown` cast.
+  const clip = (navigator as unknown as { clipboard?: { writeText?: (s: string) => Promise<void> } }).clipboard;
+  const writeText = clip?.writeText?.bind(clip);
+  if (writeText) {
+    try {
+      void writeText(json).then(
+        () => { _toast('Profiles copied to clipboard and downloading…'); },
+        () => { /* swallow — download is the reliable fallback */ },
+      );
+    } catch { /* same */ }
+  }
+
+  // 2. File download with timestamped name.
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `mobissh-profiles-${ts}.json`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -12,7 +12,7 @@ import { applyTheme, _addNotification, fireNotification, setSessionTitleBase, cl
 import { showSettingsOverview, showSettingsSection } from './settings.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- backward compat: sendSftpUpload kept for legacy callers
 import { sendSSHInput, sendSSHInputToAll, disconnect, reconnect, probeSession, cancelReconnect, sendSftpLs, setSftpHandler, sendSftpDownload, sendSftpDownloadStart, sendSftpUpload, sendSftpRename, sendSftpDelete, sendSftpRealpath, uploadFileChunked, sendSftpUploadCancel, getSessionHandle, removeSessionHandle } from './connection.js';
-import { saveProfile, connectFromProfile, newConnection, loadProfiles, removeRecentSession, getRecentSessions, downloadProfilesExport, triggerProfileImport, profileColor } from './profiles.js';
+import { saveProfile, connectFromProfile, newConnection, loadProfiles, removeRecentSession, getRecentSessions, downloadProfilesExport, triggerProfileImport, triggerProfilesDownload, profileColor } from './profiles.js';
 import { clearIMEPreview, restoreIMEOverlay } from './ime.js';
 import { isPreviewable, createPreviewPanel, MIME_MAP, extOf, SFTP_INLINE_IMG_ATTR, SFTP_RELATIVE_LINK_ATTR } from './sftp-preview.js';
 import { listFavorites, toggleFavorite, isFavorited, profileIdOf, commonPathPrefix, collapsePrefix } from './favorites.js';
@@ -1155,6 +1155,7 @@ export function initConnectForm(): void {
     if (action === 'new') newConnection();
     else if (action === 'import') triggerProfileImport();
     else if (action === 'export') downloadProfilesExport();
+    else if (action === 'export-native') triggerProfilesDownload();
     // Keys button removed — key management is now inline in Connect panel (#441)
   });
 

--- a/tests/profiles.spec.js
+++ b/tests/profiles.spec.js
@@ -250,4 +250,55 @@ test.describe('Profile & key storage (#110 Phase 5)', { tag: '@headless-adequate
     await expect(hint).toHaveText('No saved profiles yet.');
   });
 
+  // #501: PWA→native export. The connect navbar has a new "Export to native"
+  // button that copies a versioned-wrapper JSON to the clipboard and downloads
+  // it. Headless test verifies the button exists and the clipboard format.
+  test('export-to-native button writes versioned wrapper to clipboard', async ({ page, mockSshServer, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await injectMockVault(page);
+    await setupConnected(page, mockSshServer);
+
+    // Save a profile so the export has content.
+    await showTabBar(page);
+    await clickConnectTab(page);
+    await revealConnectForm(page);
+    await page.locator('#profileName').fill('NativeExport');
+    await page.locator('#host').fill('native-host');
+    await page.locator('#remote_a').fill('nativeuser');
+    await page.locator('#remote_c').fill('pw');
+    await page.locator('#connectForm button[type="submit"]').click();
+    await page.waitForTimeout(500);
+
+    // Stub anchor.click() so the download doesn't actually pop a dialog —
+    // we only care about clipboard payload here.
+    await page.evaluate(() => {
+      const orig = HTMLAnchorElement.prototype.click;
+      HTMLAnchorElement.prototype.click = function () {
+        // Skip download, keep clipboard path.
+        void orig;
+      };
+    });
+
+    await showTabBar(page);
+    await clickConnectTab(page);
+
+    const exportBtn = page.locator('#exportProfilesBtn');
+    await expect(exportBtn).toBeVisible({ timeout: 3000 });
+    await exportBtn.click();
+    await page.waitForTimeout(300);
+
+    // The clipboard now holds the wrapped export.
+    const clipText = await page.evaluate(() => navigator.clipboard.readText());
+    const parsed = JSON.parse(clipText);
+    expect(parsed.version).toBe(1);
+    expect(typeof parsed.exportedAt).toBe('string');
+    expect(Array.isArray(parsed.profiles)).toBe(true);
+    const native = parsed.profiles.find((p) => p.host === 'native-host');
+    expect(native).toBeTruthy();
+    expect(native.username).toBe('nativeuser');
+    // SECURITY: no credentials in the export.
+    expect(native).not.toHaveProperty('password');
+    expect(native).not.toHaveProperty('vaultId');
+  });
+
 });


### PR DESCRIPTION
## Summary

Pipeline to import the user's existing PWA profile list into the native client, plus a release APK for live-device testing. Goal: minimize toil when sideloading the native app — no retyping host/user/port for every profile.

## What ships

### PWA side
- `src/modules/profiles.ts` — `exportProfilesJson()` returns a versioned envelope `{ version: 1, exportedAt, profiles: [...] }` with **connection metadata + visual identity only** (no credentials, no `vaultId`, no `authType`)
- `triggerProfilesDownload()` writes to clipboard AND triggers a file download for cross-mobile-browser reliability
- New `#exportProfilesBtn` ("Export to native") wired into the connect navbar
- Vitest: `src/modules/__tests__/profile-export-native.test.ts` — envelope shape, security boundary, round-trip, clipboard/download paths
- Playwright: `tests/profiles.spec.js` extension — end-to-end via the new button, asserts clipboard payload

### Native side
- `lib/storage/profiles_store.dart` — `SavedProfile` value object + `ProfilesStore` backed by `shared_preferences['mobissh.profiles.v1']`. Corrupt-resilient load. `importFromJson` accepts the PWA envelope AND the legacy bare-array shape, dedupes on `(host:port:username)`, rejects unknown versions
- `lib/state/profiles_providers.dart` — Riverpod providers (`profilesStoreProvider` + `savedProfilesProvider`)
- `lib/ui/profile_list.dart` — list above the connect form; empty-state hints at importing from PWA
- `lib/ui/import_profiles_dialog.dart` — paste-and-import with inline error reporting
- `lib/ui/connect_form.dart` — tapping a saved profile pre-fills host/port/username; credentials always typed per-connect, never stored alongside metadata

### Tests (per `docs/native-rewrite-lessons-from-pwa.md` Phase 3-style commitment — applied early)

| File | Tests |
|---|---|
| `native/test/profiles_store_test.dart` | 22 — identity, JSON round-trip, corrupt-entry tolerance, PWA envelope parsing, dedupe, version rejection, legacy-shape acceptance, credentials silently ignored |
| `native/test/widget/profile_list_widget_test.dart` | empty-state, populated rendering, onSelect callback |
| `native/test/widget/import_dialog_widget_test.dart` | valid JSON imports + closes; invalid JSON keeps dialog open, store untouched |

## Release APK delivery

Built post-commit (not committed — binary, regenerated per build):

- **`public/mobissh-native.apk`** — served via Tailscale after next `container-ctl restart`. Download URL: `https://mobissh.tailbe5094.ts.net/mobissh-native.apk`
- **`test-results/uploads/mobissh-native-2026-05-22.apk`** — timestamped archive copy

Verification:
- `apksigner verify` → signed by `CN=MobiSSH, O=flavordrake, C=US` (Phase 0 release keystore)
- Signing cert SHA-256: `f01111d967cefce5de58cbe88264539e064f2e9b8c70da133b490def28f8d2eb`
- APK content SHA-256: `70de7b94bbbbde2a23ca22e5a8ea2ed7fec52dc9cd71cf297b171a78359d97d0`
- Size: 55.3 MB

## Gates

- `scripts/test-fast-gate.sh` — tsc + eslint + vitest pass
- `scripts/native-fast-gate.sh` — analyze clean, 55 tests pass + 1 skipped (Phase 2.A's disconnect-button test, separate TODO)

## How to test on device

1. Merge this PR + run `scripts/container-ctl.sh restart` to publish the APK at `https://mobissh.tailbe5094.ts.net/mobissh-native.apk`
2. On the PWA: connect → tap "Export to native" — the JSON lands in clipboard + downloads
3. On Android: open the URL in Chrome, download the APK, install (sideloading)
4. In the native app: tap "Import from PWA" → paste the JSON → profiles appear in the list
5. Tap a profile → host/port/username pre-fill → type password → Connect

## Out of scope

- Credential migration (intentional — security boundary)
- Auto-sync between PWA and native (one-shot import only)
- iOS APK (Android-only rewrite per #501)

## Phase 1 + 2.A test-debt follow-ups

- #505 — widget tests for ConnectForm + HostKeyDialog (Phase 1 retroactive)
- Phase 2.A disconnect-button test (skipped with TODO; fix path documented in test file)