### PR TITLE
feat(#512): native foreground service keeps SSH session alive on app swap

### DIFF
--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -6,11 +6,13 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'diagnostics/crash_reporter.dart';
 import 'ssh/ssh_session.dart';
 import 'state/connection_providers.dart';
+import 'state/keepalive_providers.dart';
 import 'ui/connect_form.dart';
 import 'ui/terminal_screen.dart';
 
@@ -24,6 +26,9 @@ void main() {
     await CrashReporter.bootstrap();
     // Fire-and-forget — don't block first paint on bridge reachability.
     unawaited(CrashReporter.uploadPending());
+    // Open the isolate port so the foreground task isolate can send data
+    // back to the UI (#512). Cheap, idempotent — fine to always call.
+    FlutterForegroundTask.initCommunicationPort();
     runApp(const ProviderScope(child: MobisshApp()));
   });
 }
@@ -55,6 +60,10 @@ class RootRouter extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Touch the keepalive controller so it attaches to the SSH session
+    // controller at app start; this is what starts/stops the foreground
+    // service in response to session lifecycle changes (#512).
+    ref.watch(keepaliveControllerProvider);
     final async = ref.watch(sshSessionDataProvider);
     final data = async.valueOrNull;
     final isConnected = data?.state == SshSessionState.connected;

--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -1,0 +1,229 @@
+// Background keep-alive for SSH sessions on Android (#512).
+//
+// When a session enters the `connected` state, start a foreground service so
+// Android won't kill the process while the user swaps to another app. The
+// service is stopped as soon as no session is connected.
+//
+// Single-session for now. TODO(#511): once multi-session lands, the
+// `KeepaliveController` needs to track a *count* of connected sessions and
+// only stop the service when the count drops to zero. The plumbing here is
+// already counted-based (see `_connectedCount`) but only one session can be
+// tracked through `attach()` until the session collection refactor lands.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+
+import '../ssh/ssh_session.dart';
+
+/// Top-level entry point for the foreground task isolate. Must be
+/// `@pragma('vm:entry-point')` so the AOT compiler keeps it.
+@pragma('vm:entry-point')
+void startKeepaliveCallback() {
+  FlutterForegroundTask.setTaskHandler(KeepaliveTaskHandler());
+}
+
+/// Minimal task handler — the wake lock on the foreground task is enough to
+/// keep the Dart isolate (and the SSH socket on it) alive. We don't do any
+/// periodic work; the running socket pump is the heartbeat.
+class KeepaliveTaskHandler extends TaskHandler {
+  DateTime? startedAt;
+
+  @override
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
+    startedAt = timestamp;
+  }
+
+  @override
+  void onRepeatEvent(DateTime timestamp) {
+    // Intentionally empty. The foreground service exists only to keep the
+    // process alive; the SSH socket's own read loop handles I/O.
+  }
+
+  @override
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
+    startedAt = null;
+  }
+}
+
+/// Thin wrapper over the static `FlutterForegroundTask` API. Lets us inject a
+/// fake in tests so we don't bind to platform method channels.
+abstract class KeepaliveGateway {
+  bool get isInitialized;
+
+  Future<bool> get isRunningService;
+
+  void init();
+
+  Future<bool> startService({
+    required String notificationTitle,
+    required String notificationText,
+  });
+
+  Future<bool> stopService();
+}
+
+/// Default gateway that talks to the real `FlutterForegroundTask`.
+class FlutterForegroundTaskGateway implements KeepaliveGateway {
+  bool _initialized = false;
+
+  @override
+  bool get isInitialized => _initialized;
+
+  @override
+  Future<bool> get isRunningService => FlutterForegroundTask.isRunningService;
+
+  @override
+  void init() {
+    if (_initialized) return;
+    FlutterForegroundTask.init(
+      androidNotificationOptions: AndroidNotificationOptions(
+        channelId: 'mobissh_keepalive',
+        channelName: 'MobiSSH keep-alive',
+        channelDescription:
+            'Notification while at least one SSH session is connected.',
+        channelImportance: NotificationChannelImportance.LOW,
+        priority: NotificationPriority.LOW,
+        onlyAlertOnce: true,
+      ),
+      iosNotificationOptions: const IOSNotificationOptions(
+        showNotification: false,
+        playSound: false,
+      ),
+      foregroundTaskOptions: ForegroundTaskOptions(
+        eventAction: ForegroundTaskEventAction.nothing(),
+        autoRunOnBoot: false,
+        autoRunOnMyPackageReplaced: false,
+        allowWakeLock: true,
+        allowWifiLock: false,
+      ),
+    );
+    _initialized = true;
+  }
+
+  @override
+  Future<bool> startService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    final result = await FlutterForegroundTask.startService(
+      serviceTypes: const [ForegroundServiceTypes.dataSync],
+      notificationTitle: notificationTitle,
+      notificationText: notificationText,
+      callback: startKeepaliveCallback,
+    );
+    return result is ServiceRequestSuccess;
+  }
+
+  @override
+  Future<bool> stopService() async {
+    final result = await FlutterForegroundTask.stopService();
+    return result is ServiceRequestSuccess;
+  }
+}
+
+/// Orchestrates start/stop of the foreground service in response to SSH
+/// session lifecycle changes.
+///
+/// Tracking model (single-session for now, multi-ready):
+///   - `attach(session)` registers a session whose state will be observed.
+///   - The controller listens to that session's stream and bumps an internal
+///     "connected count" up on `connected`, back down on any terminal state.
+///   - When the count goes from 0 → ≥1 the service starts; when it returns
+///     to 0 the service stops.
+class KeepaliveController {
+  KeepaliveController({
+    KeepaliveGateway? gateway,
+    bool enabled = true,
+  }) : _gateway = gateway ?? FlutterForegroundTaskGateway() {
+    _enabled = enabled;
+  }
+
+  final KeepaliveGateway _gateway;
+  bool _enabled = true;
+  int _connectedCount = 0;
+  final Map<SshSessionController, StreamSubscription<SshSessionData>>
+      _subscriptions = {};
+
+  /// Whether the keep-alive service is allowed to run at all. Setting this
+  /// to false stops a running service immediately; setting back to true
+  /// starts it if any sessions are currently connected.
+  bool get enabled => _enabled;
+  set enabled(bool value) {
+    if (_enabled == value) return;
+    _enabled = value;
+    if (!value) {
+      // User disabled — drop the service even if sessions are still up.
+      unawaited(_stopIfRunning());
+    } else if (_connectedCount > 0) {
+      unawaited(_startIfStopped());
+    }
+  }
+
+  /// Current observed connected-session count. Visible for testing.
+  @visibleForTesting
+  int get connectedCount => _connectedCount;
+
+  /// Begin observing the given session controller. Safe to call multiple
+  /// times with the same controller.
+  void attach(SshSessionController session) {
+    if (_subscriptions.containsKey(session)) return;
+    var wasConnected = session.data.state == SshSessionState.connected;
+    if (wasConnected) {
+      _connectedCount += 1;
+      unawaited(_startIfStopped());
+    }
+    _subscriptions[session] = session.stream.listen((data) {
+      final isConnected = data.state == SshSessionState.connected;
+      if (isConnected && !wasConnected) {
+        _connectedCount += 1;
+        unawaited(_startIfStopped());
+      } else if (!isConnected && wasConnected) {
+        _connectedCount = (_connectedCount - 1).clamp(0, 1 << 30);
+        if (_connectedCount == 0) unawaited(_stopIfRunning());
+      }
+      wasConnected = isConnected;
+    });
+  }
+
+  /// Stop observing the given session controller. If it was connected, the
+  /// connected count is decremented.
+  Future<void> detach(SshSessionController session) async {
+    final sub = _subscriptions.remove(session);
+    if (sub == null) return;
+    await sub.cancel();
+    if (session.data.state == SshSessionState.connected) {
+      _connectedCount = (_connectedCount - 1).clamp(0, 1 << 30);
+      if (_connectedCount == 0) await _stopIfRunning();
+    }
+  }
+
+  /// Release all session subscriptions and stop the service if running.
+  Future<void> dispose() async {
+    for (final sub in _subscriptions.values) {
+      await sub.cancel();
+    }
+    _subscriptions.clear();
+    _connectedCount = 0;
+    await _stopIfRunning();
+  }
+
+  Future<void> _startIfStopped() async {
+    if (!_enabled) return;
+    if (!_gateway.isInitialized) _gateway.init();
+    if (await _gateway.isRunningService) return;
+    await _gateway.startService(
+      notificationTitle: 'MobiSSH',
+      notificationText: _connectedCount == 1
+          ? '1 session connected'
+          : '$_connectedCount sessions connected',
+    );
+  }
+
+  Future<void> _stopIfRunning() async {
+    if (!_gateway.isInitialized) return;
+    if (!await _gateway.isRunningService) return;
+    await _gateway.stopService();
+  }
+}

--- a/native/lib/state/keepalive_providers.dart
+++ b/native/lib/state/keepalive_providers.dart
@@ -1,0 +1,74 @@
+// Riverpod wiring for the background keep-alive service (#512).
+//
+// `keepaliveEnabledProvider` exposes the user-facing toggle (persisted via
+// SharedPreferences). `keepaliveControllerProvider` lazily constructs the
+// `KeepaliveController` and attaches it to the SSH session controller.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/keepalive_task.dart';
+import 'connection_providers.dart';
+
+/// SharedPreferences key. Matches the PWA's localStorage key naming style.
+const String keepaliveEnabledPrefKey = 'mobissh.keepalive.enabled';
+
+/// Default-on, matching the PWA where the "Keep alive in background"
+/// notification is enabled out of the box.
+const bool keepaliveEnabledDefault = true;
+
+/// User toggle for the keep-alive foreground service. Synchronous value
+/// (defaulted to [keepaliveEnabledDefault] while we load preferences) so the
+/// UI doesn't have to handle a loading state. Mutations persist via
+/// SharedPreferences and propagate to the `KeepaliveController`.
+class KeepaliveEnabledNotifier extends StateNotifier<bool> {
+  KeepaliveEnabledNotifier({Future<SharedPreferences>? prefs})
+      : _prefs = prefs ?? SharedPreferences.getInstance(),
+        super(keepaliveEnabledDefault) {
+    _hydrate();
+  }
+
+  final Future<SharedPreferences> _prefs;
+
+  Future<void> _hydrate() async {
+    try {
+      final prefs = await _prefs;
+      final stored = prefs.getBool(keepaliveEnabledPrefKey);
+      if (stored != null && stored != state) state = stored;
+    } catch (_) {
+      // SharedPreferences may be unavailable under tests without bindings;
+      // keep the default in that case.
+    }
+  }
+
+  Future<void> set(bool value) async {
+    state = value;
+    try {
+      final prefs = await _prefs;
+      await prefs.setBool(keepaliveEnabledPrefKey, value);
+    } catch (_) {
+      // best-effort persistence
+    }
+  }
+}
+
+final keepaliveEnabledProvider =
+    StateNotifierProvider<KeepaliveEnabledNotifier, bool>((ref) {
+  return KeepaliveEnabledNotifier();
+});
+
+/// Singleton KeepaliveController, attached to the singleton SSH session
+/// controller. Recreated only when the provider container is disposed.
+final keepaliveControllerProvider = Provider<KeepaliveController>((ref) {
+  final session = ref.watch(sshSessionControllerProvider);
+  final controller = KeepaliveController(
+    enabled: ref.read(keepaliveEnabledProvider),
+  );
+  controller.attach(session);
+  // Mirror toggle changes into the controller.
+  ref.listen<bool>(keepaliveEnabledProvider, (_, next) {
+    controller.enabled = next;
+  });
+  ref.onDispose(() => controller.dispose());
+  return controller;
+});

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -23,6 +23,7 @@ import 'diagnostics_section.dart';
 import 'host_key_dialog.dart';
 import 'import_profiles_dialog.dart';
 import 'profile_list.dart';
+import 'settings_panel.dart';
 
 enum _AuthKind { password, key }
 
@@ -182,6 +183,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
               label: const Text('Disconnect'),
             ),
           const SizedBox(height: 8),
+          const SettingsPanel(),
           const DiagnosticsSection(),
         ],
       ),

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -1,0 +1,41 @@
+// Settings section on the Connect form (#512).
+//
+// Currently exposes only the keep-alive-in-background toggle. Future
+// settings (theme, font, etc.) will land here too.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/keepalive_providers.dart';
+
+class SettingsPanel extends ConsumerWidget {
+  const SettingsPanel({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final keepalive = ref.watch(keepaliveEnabledProvider);
+    return ExpansionTile(
+      key: const ValueKey('settings-section'),
+      leading: const Icon(Icons.settings_outlined),
+      title: const Text('Settings'),
+      subtitle: Text(
+        keepalive
+            ? 'Keep alive in background: ON'
+            : 'Keep alive in background: OFF',
+      ),
+      children: [
+        SwitchListTile(
+          key: const ValueKey('keepalive-toggle'),
+          title: const Text('Keep alive in background'),
+          subtitle: const Text(
+            'Show an ongoing notification so Android keeps the SSH '
+            'session connected when you swap to another app.',
+          ),
+          value: keepalive,
+          onChanged: (v) =>
+              ref.read(keepaliveEnabledProvider.notifier).set(v),
+        ),
+      ],
+    );
+  }
+}

--- a/native/test/services/keepalive_task_test.dart
+++ b/native/test/services/keepalive_task_test.dart
@@ -1,0 +1,240 @@
+// Unit tests for the background keep-alive controller (#512).
+//
+// We never call the real `FlutterForegroundTask` here — instead the
+// `KeepaliveController` is given a `FakeKeepaliveGateway` and we assert that
+// start/stop are called in response to SSH session lifecycle changes and the
+// user-toggle.
+
+import 'dart:async';
+
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/keepalive_task.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+class FakeKeepaliveGateway implements KeepaliveGateway {
+  bool _initialized = false;
+  bool _running = false;
+  final List<String> calls = [];
+
+  @override
+  bool get isInitialized => _initialized;
+
+  @override
+  Future<bool> get isRunningService async => _running;
+
+  @override
+  void init() {
+    calls.add('init');
+    _initialized = true;
+  }
+
+  @override
+  Future<bool> startService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    calls.add('start:$notificationText');
+    _running = true;
+    return true;
+  }
+
+  @override
+  Future<bool> stopService() async {
+    calls.add('stop');
+    _running = false;
+    return true;
+  }
+}
+
+/// Test double for SshSessionController. We avoid spinning up a real
+/// dartssh2 client by emitting [SshSessionData] directly through the
+/// public broadcast stream.
+class StubSession implements SshSessionController {
+  final StreamController<SshSessionData> _ctrl =
+      StreamController<SshSessionData>.broadcast();
+  SshSessionData _data = const SshSessionData();
+
+  @override
+  SshSessionData get data => _data;
+
+  @override
+  Stream<SshSessionData> get stream => _ctrl.stream;
+
+  void emit(SshSessionState state) {
+    _data = _data.copyWith(state: state);
+    _ctrl.add(_data);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _ctrl.close();
+  }
+
+  // Unused members in tests; throw to catch accidental calls.
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} not stubbed');
+}
+
+Future<void> _drain() async {
+  // Let the broadcast stream + the controller's async start/stop calls
+  // resolve before assertions.
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('KeepaliveController', () {
+    test('starts service when session enters connected', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connecting);
+      await _drain();
+      expect(gateway.calls, isEmpty,
+          reason: 'no service start while still connecting');
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      expect(gateway.calls.first, 'init');
+      expect(gateway.calls.any((c) => c.startsWith('start:')), isTrue);
+      expect(await gateway.isRunningService, isTrue);
+      expect(controller.connectedCount, 1);
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('stops service when session disconnects', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+
+      session.emit(SshSessionState.disconnected);
+      await _drain();
+      expect(await gateway.isRunningService, isFalse);
+      expect(gateway.calls.last, 'stop');
+      expect(controller.connectedCount, 0);
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('failed state also stops the service', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      session.emit(SshSessionState.failed);
+      await _drain();
+
+      expect(await gateway.isRunningService, isFalse);
+      expect(controller.connectedCount, 0);
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('does not start service when disabled', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(
+        gateway: gateway,
+        enabled: false,
+      );
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      expect(gateway.calls, isEmpty);
+      expect(await gateway.isRunningService, isFalse);
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('toggle off stops a running service', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+
+      controller.enabled = false;
+      await _drain();
+      expect(await gateway.isRunningService, isFalse);
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('toggle back on starts service if a session is still connected',
+        () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller =
+          KeepaliveController(gateway: gateway, enabled: false);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isFalse);
+
+      controller.enabled = true;
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('detach decrements connected count and stops if zero', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+
+      await controller.detach(session);
+      expect(await gateway.isRunningService, isFalse);
+      expect(controller.connectedCount, 0);
+
+      await session.dispose();
+      await controller.dispose();
+    });
+  });
+
+  group('KeepaliveTaskHandler', () {
+    test('onStart records timestamp, onDestroy clears', () async {
+      final handler = KeepaliveTaskHandler();
+      expect(handler.startedAt, isNull);
+
+      final t = DateTime.utc(2026, 5, 24);
+      await handler.onStart(t, TaskStarter.developer);
+      expect(handler.startedAt, t);
+
+      handler.onRepeatEvent(t); // no-op, just don't throw
+      await handler.onDestroy(t, false);
+      expect(handler.startedAt, isNull);
+    });
+  });
+}

--- a/native/test/widget/keepalive_toggle_widget_test.dart
+++ b/native/test/widget/keepalive_toggle_widget_test.dart
@@ -1,0 +1,83 @@
+// Widget tests for the Settings panel keep-alive toggle (#512).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/keepalive_providers.dart';
+import 'package:mobissh/ui/settings_panel.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> pumpSettings(WidgetTester tester) async {
+  await tester.pumpWidget(
+    const ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(body: SettingsPanel()),
+      ),
+    ),
+  );
+  // Bounded pumps to let the hydrate Future + initial frame resolve.
+  for (var i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 10));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('toggle defaults to ON when no preference is stored',
+      (tester) async {
+    await pumpSettings(tester);
+
+    // Open the ExpansionTile so the SwitchListTile is in the tree.
+    await tester.tap(find.byKey(const ValueKey('settings-section')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final toggle = find.byKey(const ValueKey('keepalive-toggle'));
+    expect(toggle, findsOneWidget);
+    final widget = tester.widget<SwitchListTile>(toggle);
+    expect(widget.value, isTrue, reason: 'default is ON');
+  });
+
+  testWidgets('toggle reflects a stored OFF preference', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      keepaliveEnabledPrefKey: false,
+    });
+
+    await pumpSettings(tester);
+
+    await tester.tap(find.byKey(const ValueKey('settings-section')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final toggle = find.byKey(const ValueKey('keepalive-toggle'));
+    final widget = tester.widget<SwitchListTile>(toggle);
+    expect(widget.value, isFalse);
+  });
+
+  testWidgets('tapping toggle persists the new value', (tester) async {
+    await pumpSettings(tester);
+
+    // Open the ExpansionTile and wait for its expand animation to settle so
+    // the inner SwitchListTile is hit-testable.
+    await tester.tap(find.byKey(const ValueKey('settings-section')));
+    for (var i = 0; i < 30; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+
+    await tester.tap(find.byKey(const ValueKey('keepalive-toggle')));
+    // Settle the StateNotifier emission and SharedPreferences write.
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool(keepaliveEnabledPrefKey), isFalse);
+
+    final toggle = find.byKey(const ValueKey('keepalive-toggle'));
+    final widget = tester.widget<SwitchListTile>(toggle);
+    expect(widget.value, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- Wire `flutter_foreground_task` so a connected SSH session survives Android
  swapping the app away. The foreground service is started when at least one
  session enters `connected` and stopped when none are.
- Settings toggle ("Keep alive in background") persists via SharedPreferences,
  defaulting ON (matches the PWA UX). Disabling stops a running service
  immediately; enabling re-arms it if any session is still connected.
- Counted internal model is multi-session-ready (#511 plugs in by calling
  `attach()` per session); single-session today.

## TDD Analysis
- Type: feature
- Behavior change: yes
- TDD approach: full for the controller (deterministic state machine);
  smoketest level for the UI toggle

## Test coverage
- **Existing tests updated**: none (the new code is isolated)
- **New tests added (fail→pass)**:
  - `native/test/services/keepalive_task_test.dart` — 8 tests:
    - starts service when session enters `connected`
    - stops service when session disconnects
    - `failed` state also stops the service
    - does not start when `enabled` is false
    - toggle off stops a running service
    - toggle back on starts service if a session is still connected
    - `detach` decrements count and stops if zero
    - `KeepaliveTaskHandler.onStart` / `onDestroy` lifecycle
  - `native/test/widget/keepalive_toggle_widget_test.dart` — 3 tests:
    - toggle defaults to ON when no preference is stored
    - toggle reflects a stored OFF preference
    - tapping toggle persists the new value
- **Smoketest**: the settings section renders on the Connect form
  (verified by the widget tests rendering `SettingsPanel` and finding the
  toggle key). The controller provider is touched by `RootRouter.build`
  so the listener attaches at app start.

## Test results
- `scripts/native-fast-gate.sh`: PASS (analyze + 80 tests; 11 new)
- Acceptance gate (`--with-acceptance`): not run — issue says default
  gate is the required bar and acceptance only meaningful with rebuilt
  APK + online emulator.

## Diff stats
- Files changed: 7 (2 modified, 5 new)
- Lines: +678 / -0

## Notes
- Manifest permissions (`FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`,
  `WAKE_LOCK`, `POST_NOTIFICATIONS`) were already in place — no
  AndroidManifest.xml changes needed.
- `KeepaliveTaskHandler` is registered behind a top-level
  `@pragma('vm:entry-point') startKeepaliveCallback()` function so AOT
  keeps it; the gateway passes it as `callback:` to `startService`.
- Gateway abstraction (`KeepaliveGateway`) lets unit tests use a
  `FakeKeepaliveGateway` rather than touching real platform channels.

## TODO (out of scope)
- Multi-session handover (#511) — controller's connected-count model is
  ready; only needs the session collection to land before we call
  `attach()` per session.
- OS-killed restart UX — service `autoRunOnMyPackageReplaced` is false;
  manual reconnect is the intent per issue acceptance ("do NOT
  auto-reconnect; user choice").

Closes #512

## Cycles used
1/3