### PR TITLE
feat(#510): native vault — decrypt PWA backup envelope + secure-storage secrets

### DIFF
--- a/native/lib/state/profiles_providers.dart
+++ b/native/lib/state/profiles_providers.dart
@@ -4,15 +4,26 @@
 // `savedProfilesProvider` watches the loaded list; the UI reads it via
 // `ref.watch` and refreshes via `ref.invalidate(savedProfilesProvider)`
 // after mutating operations (save / import / remove).
+//
+// `secretsStoreProvider` exposes the [SecretsStore] singleton (#510). The
+// production backing is Android-Keystore via flutter_secure_storage; tests
+// override with an in-memory backend.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../storage/profiles_store.dart';
+import '../storage/secrets_store.dart';
 
 /// Singleton [ProfilesStore]. Override in tests via
 /// `profilesStoreProvider.overrideWithValue(myStore)`.
 final profilesStoreProvider = Provider<ProfilesStore>((ref) {
   return ProfilesStore();
+});
+
+/// Singleton [SecretsStore] (#510). Override in tests with an
+/// `InMemorySecretsBackend`-backed instance.
+final secretsStoreProvider = Provider<SecretsStore>((ref) {
+  return SecretsStore();
 });
 
 /// Async-loaded list of saved profiles. UI watches this; invalidate after

--- a/native/lib/storage/profiles_store.dart
+++ b/native/lib/storage/profiles_store.dart
@@ -2,19 +2,26 @@
 //
 // Mirrors the PWA's `getProfiles` / `saveProfile` pattern: a JSON-encoded list
 // of connection metadata persisted in shared_preferences under the key
-// `mobissh.profiles.v1`. Credentials are explicitly NOT stored here — the
-// vault (Phase 3) owns secrets. This file owns identity only.
+// `mobissh.profiles.v1`. Identity-only fields plus optional vault references
+// (vaultId / keyVaultId / authType / initialCommand) introduced for #510 so
+// the native connect path can look up secrets by vaultId. Credentials
+// themselves live in `flutter_secure_storage` (see `secrets_store.dart`).
 //
 // The matching PWA export shape (see `exportProfilesJson` in
 // src/modules/profiles.ts) is `{ version: 1, exportedAt, profiles: [...] }`.
+// The richer backup-envelope shape additionally carries a `vault` field with
+// PBKDF2+AES-GCM encrypted secrets; see `parseBackupEnvelope` / `applyBackup`.
 
 import 'dart:async';
 import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Persisted profile shape. Connection metadata + optional visual identity.
-/// No credentials. No vaultId. Equality is by (host, port, username) — the
+import 'secrets_store.dart';
+import 'vault.dart';
+
+/// Persisted profile shape. Connection metadata + optional visual identity +
+/// optional vault references. Equality is by (host, port, username) — the
 /// natural identity used for dedupe everywhere else in the app.
 class SavedProfile {
   SavedProfile({
@@ -24,6 +31,10 @@ class SavedProfile {
     required this.username,
     this.theme,
     this.color,
+    this.authType,
+    this.vaultId,
+    this.keyVaultId,
+    this.initialCommand,
   });
 
   final String title;
@@ -32,6 +43,21 @@ class SavedProfile {
   final String username;
   final String? theme;
   final String? color;
+
+  /// 'password' or 'key'. Optional — older saved profiles omit it.
+  final String? authType;
+
+  /// Reference to a secret in `SecretsStore`. Populated when the profile
+  /// came from a backup-envelope import and its credentials were decrypted
+  /// + persisted. When null, the connect path falls back to prompting.
+  final String? vaultId;
+
+  /// Separate reference for a key's secret material when both a password and
+  /// a key are stored. Mirrors the PWA field of the same name.
+  final String? keyVaultId;
+
+  /// Optional command to send after auth — preserved verbatim from the PWA.
+  final String? initialCommand;
 
   /// Identity key for dedupe / lookup. Matches the PWA's behavior of treating
   /// (host:port:username) as the unique constraint.
@@ -46,6 +72,12 @@ class SavedProfile {
     };
     if (theme != null) out['theme'] = theme;
     if (color != null) out['color'] = color;
+    if (authType != null) out['authType'] = authType;
+    if (vaultId != null) out['vaultId'] = vaultId;
+    if (keyVaultId != null) out['keyVaultId'] = keyVaultId;
+    if (initialCommand != null && initialCommand!.isNotEmpty) {
+      out['initialCommand'] = initialCommand;
+    }
     return out;
   }
 
@@ -85,6 +117,29 @@ class SavedProfile {
     final colorRaw = json['color'];
     if (colorRaw is String && colorRaw.isNotEmpty) color = colorRaw;
 
+    String? authType;
+    final authTypeRaw = json['authType'];
+    if (authTypeRaw is String &&
+        (authTypeRaw == 'password' || authTypeRaw == 'key')) {
+      authType = authTypeRaw;
+    }
+
+    String? vaultId;
+    final vaultIdRaw = json['vaultId'];
+    if (vaultIdRaw is String && vaultIdRaw.isNotEmpty) vaultId = vaultIdRaw;
+
+    String? keyVaultId;
+    final keyVaultIdRaw = json['keyVaultId'];
+    if (keyVaultIdRaw is String && keyVaultIdRaw.isNotEmpty) {
+      keyVaultId = keyVaultIdRaw;
+    }
+
+    String? initialCommand;
+    final initialCommandRaw = json['initialCommand'];
+    if (initialCommandRaw is String && initialCommandRaw.isNotEmpty) {
+      initialCommand = initialCommandRaw;
+    }
+
     return SavedProfile(
       title: title,
       host: hostRaw,
@@ -92,10 +147,18 @@ class SavedProfile {
       username: usernameRaw,
       theme: theme,
       color: color,
+      authType: authType,
+      vaultId: vaultId,
+      keyVaultId: keyVaultId,
+      initialCommand: initialCommand,
     );
   }
 
-  SavedProfile copyWith({String? title}) {
+  SavedProfile copyWith({
+    String? title,
+    String? vaultId,
+    String? keyVaultId,
+  }) {
     return SavedProfile(
       title: title ?? this.title,
       host: host,
@@ -103,6 +166,10 @@ class SavedProfile {
       username: username,
       theme: theme,
       color: color,
+      authType: authType,
+      vaultId: vaultId ?? this.vaultId,
+      keyVaultId: keyVaultId ?? this.keyVaultId,
+      initialCommand: initialCommand,
     );
   }
 
@@ -128,6 +195,36 @@ class ImportResult {
   final int added;
   final int skipped;
   final List<String> errors;
+}
+
+/// Outcome of a sync envelope-shape scan. The UI uses this to decide whether
+/// to render a master-password prompt before committing the import.
+class ParsedImport {
+  ParsedImport({
+    required this.profileEntries,
+    this.vaultEncryptedJson,
+    this.vaultMetaJson,
+    this.errors = const [],
+  });
+
+  /// Raw profile maps as decoded from the envelope. Validation happens at
+  /// apply-time, not parse-time, so the user sees one set of errors.
+  final List<Map<String, dynamic>> profileEntries;
+
+  /// `vault.encrypted` field if the envelope contained one. Null otherwise.
+  final String? vaultEncryptedJson;
+
+  /// `vault.meta` field if the envelope contained one. Null otherwise.
+  final String? vaultMetaJson;
+
+  /// Parse-time errors (non-JSON, wrong shape). When non-empty and there are
+  /// no profiles either, the UI surfaces these in an inline error.
+  final List<String> errors;
+
+  /// True when this envelope carries an encrypted vault — caller must prompt
+  /// for the master password before [ProfilesStore.applyParsedImport].
+  bool get hasVault =>
+      vaultEncryptedJson != null && vaultMetaJson != null;
 }
 
 /// shared_preferences key. Versioned so a future schema change can migrate
@@ -184,60 +281,132 @@ class ProfilesStore {
     await prefs.setString(profilesPrefsKey, encoded);
   }
 
-  /// Import from a PWA-shaped export. Accepts:
-  ///   `{ version: 1, exportedAt: "iso-8601", profiles: [...] }`
-  /// Merges with existing storage; dedupes on (host:port:username).
+  /// Side-effect-free first stage of import. Detects envelope shape, extracts
+  /// profile entries, and surfaces vault material for the UI to prompt-on.
   ///
-  /// Returns an [ImportResult] enumerating added/skipped/errors. Does NOT
-  /// throw on malformed input — that's a user-recoverable error reported via
-  /// the result.
-  Future<ImportResult> importFromJson(String json) async {
+  /// Returns a [ParsedImport] with either populated profile entries + vault
+  /// fields, or a non-empty `errors` list explaining why the input was
+  /// unusable. Never throws on bad input — the UI relies on the errors list.
+  static ParsedImport parseImport(String json) {
     final dynamic decoded;
     try {
       decoded = jsonDecode(json);
     } on FormatException catch (e) {
-      return ImportResult(errors: ['Not valid JSON: ${e.message}']);
+      return ParsedImport(
+        profileEntries: const [],
+        errors: ['Not valid JSON: ${e.message}'],
+      );
     }
 
-    // Accept either:
-    //   1) The PWA's native-export envelope `{ version, profiles[] }`
-    //   2) The legacy bare-array shape (forward-compat with #419 exports).
-    List<dynamic> entries;
     if (decoded is List) {
-      entries = decoded;
-    } else if (decoded is Map<String, dynamic>) {
-      final version = decoded['version'];
-      if (version != null && version != 1) {
-        return ImportResult(errors: [
-          'Unsupported export version: $version (this client supports v1).',
-        ]);
+      return ParsedImport(
+        profileEntries: _coerceEntries(decoded),
+      );
+    }
+
+    if (decoded is! Map) {
+      return ParsedImport(
+        profileEntries: const [],
+        errors: ['Wrong file shape — expected an export envelope or profile array.'],
+      );
+    }
+
+    final version = decoded['version'];
+    if (version != null && version != 1) {
+      return ParsedImport(
+        profileEntries: const [],
+        errors: ['Unsupported export version: $version (this client supports v1).'],
+      );
+    }
+
+    final profilesRaw = decoded['profiles'];
+    if (profilesRaw is! List) {
+      return ParsedImport(
+        profileEntries: const [],
+        errors: ['Export envelope missing `profiles` array.'],
+      );
+    }
+
+    String? vaultEncryptedJson;
+    String? vaultMetaJson;
+    final vaultRaw = decoded['vault'];
+    if (vaultRaw is Map) {
+      final enc = vaultRaw['encrypted'];
+      final meta = vaultRaw['meta'];
+      // Both fields must be strings for the envelope to be useful; if either
+      // is missing we treat the envelope as "metadata-only" and fall through.
+      if (enc is String && enc.isNotEmpty && meta is String && meta.isNotEmpty) {
+        vaultEncryptedJson = enc;
+        vaultMetaJson = meta;
       }
-      final profilesRaw = decoded['profiles'];
-      if (profilesRaw is! List) {
-        return ImportResult(errors: [
-          'Export envelope missing `profiles` array.',
-        ]);
+    }
+
+    return ParsedImport(
+      profileEntries: _coerceEntries(profilesRaw),
+      vaultEncryptedJson: vaultEncryptedJson,
+      vaultMetaJson: vaultMetaJson,
+    );
+  }
+
+  static List<Map<String, dynamic>> _coerceEntries(List<dynamic> raw) {
+    final out = <Map<String, dynamic>>[];
+    for (final entry in raw) {
+      if (entry is Map) {
+        out.add(Map<String, dynamic>.from(entry));
       }
-      entries = profilesRaw;
-    } else {
-      return ImportResult(errors: [
-        'Wrong file shape — expected an export envelope or profile array.',
-      ]);
+    }
+    return out;
+  }
+
+  /// Apply a parsed import. When [parsed.hasVault] is true, [password] is
+  /// required and the vault is decrypted before any persistence happens —
+  /// the wrong password aborts cleanly with no partial state.
+  ///
+  /// [secrets] is required when persisting decrypted secrets; tests pass an
+  /// [InMemorySecretsBackend]-backed store.
+  Future<ImportResult> applyParsedImport(
+    ParsedImport parsed, {
+    String? password,
+    SecretsStore? secrets,
+    VaultDecryptor? decryptor,
+  }) async {
+    if (parsed.errors.isNotEmpty && parsed.profileEntries.isEmpty) {
+      return ImportResult(errors: parsed.errors);
+    }
+
+    // If the envelope carries a vault, decrypt it BEFORE writing anything.
+    // A failed decrypt must leave the store untouched.
+    Map<String, Map<String, Object?>> decryptedVault =
+        <String, Map<String, Object?>>{};
+    if (parsed.hasVault) {
+      if (password == null || password.isEmpty) {
+        return ImportResult(errors: ['Master password required to decrypt vault.']);
+      }
+      if (secrets == null) {
+        return ImportResult(errors: ['Secrets store unavailable.']);
+      }
+      try {
+        decryptedVault = await (decryptor ?? VaultDecryptor()).decryptEnvelope(
+          encryptedJson: parsed.vaultEncryptedJson!,
+          metaJson: parsed.vaultMetaJson!,
+          password: password,
+        );
+      } on VaultDecryptException catch (e) {
+        return ImportResult(errors: [e.message]);
+      } on VaultEnvelopeException catch (e) {
+        return ImportResult(errors: ['Vault envelope is malformed: ${e.message}']);
+      }
     }
 
     final existing = await load();
     final existingKeys = existing.map((p) => p.identityKey).toSet();
-    final errors = <String>[];
+    final errors = <String>[...parsed.errors];
     int added = 0;
     int skipped = 0;
 
-    for (final entry in entries) {
-      if (entry is! Map) {
-        errors.add('Skipped a non-object entry.');
-        continue;
-      }
+    for (final entry in parsed.profileEntries) {
       try {
-        final profile = SavedProfile.fromJson(Map<String, dynamic>.from(entry));
+        final profile = SavedProfile.fromJson(entry);
         if (existingKeys.contains(profile.identityKey)) {
           skipped++;
           continue;
@@ -250,11 +419,43 @@ class ProfilesStore {
       }
     }
 
+    // Persist secrets before profiles. If profile save fails (it shouldn't),
+    // we'd rather leak an extra secret blob than have a profile without its
+    // secret. Either way, the same vaultId would just be overwritten on a
+    // re-import.
+    if (secrets != null) {
+      for (final entry in decryptedVault.entries) {
+        await secrets.write(entry.key, entry.value);
+      }
+    }
+
     if (added > 0) {
       await save(existing);
     }
 
     return ImportResult(added: added, skipped: skipped, errors: errors);
+  }
+
+  /// Backwards-compatible single-shot importer. Accepts the
+  /// `{ version, profiles[] }` envelope or a legacy bare array, ignores
+  /// any vault payload (for that, the UI calls [parseImport] +
+  /// [applyParsedImport] with a password).
+  ///
+  /// Returns an [ImportResult] enumerating added/skipped/errors. Does NOT
+  /// throw on malformed input — that's a user-recoverable error reported via
+  /// the result.
+  Future<ImportResult> importFromJson(String json) async {
+    final parsed = parseImport(json);
+    if (parsed.errors.isNotEmpty && parsed.profileEntries.isEmpty) {
+      return ImportResult(errors: parsed.errors);
+    }
+    // Without a password we cannot decrypt; the UI is expected to use the
+    // two-stage path for vault envelopes. Re-emit a non-vault parsed import
+    // so the existing call sites keep their behavior.
+    return applyParsedImport(ParsedImport(
+      profileEntries: parsed.profileEntries,
+      errors: parsed.errors,
+    ));
   }
 
   /// Delete a single profile by identity. Persists if anything was removed.

--- a/native/lib/storage/secrets_store.dart
+++ b/native/lib/storage/secrets_store.dart
@@ -1,0 +1,123 @@
+// Native secrets store (#510).
+//
+// Wraps `flutter_secure_storage` for per-vaultId secret persistence.
+// The PWA's `vault.encrypted[vaultId]` map is decrypted on import and the
+// plaintext per-vault JSON gets written here, keyed by vaultId. Storage is
+// Android-Keystore-backed at rest; the platform handles re-encryption.
+//
+// Tests inject a [SecretsBackend] fake — `flutter_secure_storage` itself
+// uses a platform channel that is not available in `flutter_test`.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Storage namespace prefix. Bumping this string forces all callers to
+/// re-import their vault; do NOT bump to fix cache issues (per CLAUDE.md
+/// localStorage policy).
+const String kSecretsKeyPrefix = 'mobissh.secret.v1.';
+
+/// Pluggable backing store. The production implementation forwards to
+/// [FlutterSecureStorage]; tests inject [InMemorySecretsBackend].
+abstract class SecretsBackend {
+  Future<String?> read(String key);
+  Future<void> write(String key, String value);
+  Future<void> delete(String key);
+  Future<Map<String, String>> readAll();
+}
+
+/// Production backend: Android Keystore-backed via flutter_secure_storage.
+class FlutterSecureStorageBackend implements SecretsBackend {
+  FlutterSecureStorageBackend({FlutterSecureStorage? storage})
+      : _storage = storage ??
+            const FlutterSecureStorage(
+              aOptions: AndroidOptions(
+                encryptedSharedPreferences: true,
+              ),
+            );
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<String?> read(String key) => _storage.read(key: key);
+
+  @override
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete(String key) => _storage.delete(key: key);
+
+  @override
+  Future<Map<String, String>> readAll() => _storage.readAll();
+}
+
+/// In-memory backend for tests + flutter_test widget runs (no platform
+/// channel).
+class InMemorySecretsBackend implements SecretsBackend {
+  final Map<String, String> _store = <String, String>{};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<Map<String, String>> readAll() async =>
+      Map<String, String>.from(_store);
+}
+
+/// Per-vaultId secrets persistence.
+///
+/// The secret payload is the same shape the PWA writes: usually
+/// `{password, privateKey?, passphrase?}` JSON-encoded. This class does not
+/// inspect the shape — callers know their own schema.
+class SecretsStore {
+  SecretsStore({SecretsBackend? backend})
+      : _backend = backend ?? FlutterSecureStorageBackend();
+
+  final SecretsBackend _backend;
+
+  String _keyFor(String vaultId) => '$kSecretsKeyPrefix$vaultId';
+
+  /// Persist a secret payload under [vaultId]. Overwrites any existing value.
+  Future<void> write(String vaultId, Map<String, Object?> secret) {
+    return _backend.write(_keyFor(vaultId), jsonEncode(secret));
+  }
+
+  /// Read the secret payload for [vaultId], or null if not stored.
+  Future<Map<String, Object?>?> read(String vaultId) async {
+    final raw = await _backend.read(_keyFor(vaultId));
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) {
+        return Map<String, Object?>.from(decoded);
+      }
+      return null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// Delete the secret for [vaultId]. No-op if not present.
+  Future<void> delete(String vaultId) => _backend.delete(_keyFor(vaultId));
+
+  /// List all currently-stored vaultIds. Used by the biometric gate to know
+  /// whether any unlock is required at app start.
+  Future<Set<String>> listVaultIds() async {
+    final all = await _backend.readAll();
+    final out = <String>{};
+    for (final key in all.keys) {
+      if (key.startsWith(kSecretsKeyPrefix)) {
+        out.add(key.substring(kSecretsKeyPrefix.length));
+      }
+    }
+    return out;
+  }
+}

--- a/native/lib/storage/vault.dart
+++ b/native/lib/storage/vault.dart
@@ -1,0 +1,277 @@
+// Native-side vault decryptor (#510).
+//
+// Mirrors the PWA's `src/modules/vault.ts` crypto contract for the purpose of
+// importing a backup-envelope export. Native does NOT re-implement the full
+// vault lifecycle (create/rotate/biometric-enroll) — once decrypted, secrets
+// are persisted via `flutter_secure_storage` and the platform vault takes
+// over.
+//
+// Crypto contract (must match PWA exactly):
+//   - PBKDF2-HMAC-SHA256, 600_000 iterations, 256-bit key.
+//   - 32-byte random salt; base64 encoded in `meta.salt`.
+//   - AES-GCM-256 with 12-byte IV everywhere (DEK wrap + per-entry encrypt).
+//   - WebCrypto encodes the AES-GCM tag as the LAST 16 bytes of the ciphertext.
+//
+// Envelope shape (`vault` field of a backup-export):
+//   {
+//     "encrypted": "<json string of { vaultId: {iv, ct} }>",
+//     "meta":      "<json string of { salt, dekPw, dekBio? }>",
+//   }
+//
+// `dekBio` (biometric DEK wrap) is silently ignored — it is bound to the
+// source device's WebAuthn credential and cannot be unwrapped here. This
+// mirrors the PWA's behavior in `profiles.ts:1144-1156`.
+//
+// Throws [VaultDecryptException] on wrong password (AES-GCM auth-tag
+// mismatch). Throws [VaultEnvelopeException] on malformed envelope/meta.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+
+/// Iteration count for PBKDF2-HMAC-SHA256. MUST match
+/// `PBKDF2_ITERATIONS` in `src/modules/vault.ts`. Reducing this breaks
+/// decryption of envelopes produced by the PWA.
+const int kVaultPbkdf2Iterations = 600000;
+
+/// Key length in bytes (32 = 256 bits, for AES-256-GCM).
+const int kVaultKeyLengthBytes = 32;
+
+/// AES-GCM IV length in bytes (12 = 96 bits, WebCrypto standard).
+const int kAesGcmIvLengthBytes = 12;
+
+/// AES-GCM auth tag length in bytes (16 = 128 bits, WebCrypto default).
+const int kAesGcmTagLengthBytes = 16;
+
+/// Raised when AES-GCM authentication fails — typically a wrong password
+/// (KEK doesn't unwrap the DEK) but also covers tampered ciphertext.
+class VaultDecryptException implements Exception {
+  VaultDecryptException(this.message);
+  final String message;
+  @override
+  String toString() => 'VaultDecryptException: $message';
+}
+
+/// Raised when the envelope's `meta` or `encrypted` strings cannot be parsed,
+/// or when required fields are missing. Distinguishes user-correctable
+/// envelope errors (paste-wrong-file) from password errors.
+class VaultEnvelopeException implements Exception {
+  VaultEnvelopeException(this.message);
+  final String message;
+  @override
+  String toString() => 'VaultEnvelopeException: $message';
+}
+
+/// One AES-GCM-wrapped value: `iv` (12 bytes) + `ct` (ciphertext with the
+/// 16-byte tag appended, per WebCrypto convention). Both base64-encoded in
+/// the envelope.
+class WrappedBlob {
+  WrappedBlob({required this.iv, required this.ct});
+  final Uint8List iv;
+  final Uint8List ct;
+
+  factory WrappedBlob.fromJson(Object? raw, {required String field}) {
+    if (raw is! Map) {
+      throw VaultEnvelopeException(
+        'meta.$field is not an object (got ${raw.runtimeType})',
+      );
+    }
+    final ivB64 = raw['iv'];
+    final ctB64 = raw['ct'];
+    if (ivB64 is! String || ctB64 is! String) {
+      throw VaultEnvelopeException(
+        'meta.$field is missing iv/ct fields',
+      );
+    }
+    try {
+      final iv = base64Decode(ivB64);
+      final ct = base64Decode(ctB64);
+      if (iv.length != kAesGcmIvLengthBytes) {
+        throw VaultEnvelopeException(
+          'meta.$field.iv has wrong length: ${iv.length} (expected '
+          '$kAesGcmIvLengthBytes)',
+        );
+      }
+      if (ct.length < kAesGcmTagLengthBytes) {
+        throw VaultEnvelopeException(
+          'meta.$field.ct is too short to contain a GCM tag '
+          '(${ct.length} < $kAesGcmTagLengthBytes)',
+        );
+      }
+      return WrappedBlob(iv: iv, ct: ct);
+    } on FormatException catch (e) {
+      throw VaultEnvelopeException(
+        'meta.$field has invalid base64: ${e.message}',
+      );
+    }
+  }
+}
+
+/// Parsed envelope metadata. `salt`, `dekPw` are required; `dekBio` is
+/// stripped on import.
+class VaultEnvelopeMeta {
+  VaultEnvelopeMeta({
+    required this.salt,
+    required this.dekPw,
+  });
+
+  final Uint8List salt;
+  final WrappedBlob dekPw;
+
+  /// Parse `vault.meta` (which is itself a JSON-stringified object) into a
+  /// [VaultEnvelopeMeta]. Strips `dekBio` per the PWA contract.
+  factory VaultEnvelopeMeta.parse(String metaJson) {
+    final Object? parsed;
+    try {
+      parsed = jsonDecode(metaJson);
+    } on FormatException catch (e) {
+      throw VaultEnvelopeException('vault.meta is not valid JSON: ${e.message}');
+    }
+    if (parsed is! Map) {
+      throw VaultEnvelopeException(
+        'vault.meta is not a JSON object (got ${parsed.runtimeType})',
+      );
+    }
+    final saltB64 = parsed['salt'];
+    if (saltB64 is! String || saltB64.isEmpty) {
+      throw VaultEnvelopeException('vault.meta missing salt');
+    }
+    final Uint8List salt;
+    try {
+      salt = base64Decode(saltB64);
+    } on FormatException catch (e) {
+      throw VaultEnvelopeException('vault.meta salt is not valid base64: ${e.message}');
+    }
+    final dekPw = WrappedBlob.fromJson(parsed['dekPw'], field: 'dekPw');
+    // dekBio is intentionally NOT read — biometric wraps are device-specific
+    // and won't decrypt on another device. See PWA's profiles.ts:1144-1156.
+    return VaultEnvelopeMeta(salt: salt, dekPw: dekPw);
+  }
+}
+
+/// The decrypted contents of a vault envelope: `vaultId -> secret JSON map`.
+typedef DecryptedVault = Map<String, Map<String, Object?>>;
+
+/// Stateless decryptor. Construct once; call [decryptEnvelope] per import.
+///
+/// The constructor takes optional overrides for the underlying cryptography
+/// primitives so tests can inject a faster `_TestPbkdf2` if 600k iterations
+/// is too slow to run in CI (it is not — PBKDF2 in Dart at 600k is sub-second
+/// on modern hardware, but the override keeps the door open).
+class VaultDecryptor {
+  VaultDecryptor({
+    Pbkdf2? pbkdf2,
+    AesGcm? aesGcm,
+  })  : _pbkdf2 = pbkdf2 ?? _defaultPbkdf2(),
+        _aesGcm = aesGcm ?? AesGcm.with256bits();
+
+  final Pbkdf2 _pbkdf2;
+  final AesGcm _aesGcm;
+
+  static Pbkdf2 _defaultPbkdf2() => Pbkdf2(
+        macAlgorithm: Hmac.sha256(),
+        iterations: kVaultPbkdf2Iterations,
+        bits: kVaultKeyLengthBytes * 8,
+      );
+
+  /// Derive the KEK (key-encryption key) from a master password + salt using
+  /// PBKDF2-HMAC-SHA256. Internal — exposed via [decryptEnvelope].
+  Future<SecretKey> deriveKek(String password, Uint8List salt) async {
+    return _pbkdf2.deriveKey(
+      secretKey: SecretKey(utf8.encode(password)),
+      nonce: salt,
+    );
+  }
+
+  /// Unwrap the DEK using the KEK. Throws [VaultDecryptException] on
+  /// auth-tag mismatch (wrong password).
+  Future<SecretKey> _unwrapDek(SecretKey kek, WrappedBlob dekPw) async {
+    return SecretKey(await _aesGcmDecrypt(kek, dekPw));
+  }
+
+  /// AES-GCM decrypt with the WebCrypto layout: `ct[:-16] || tag[16]`. The
+  /// `cryptography` package splits these into [SecretBox.cipherText] and
+  /// [SecretBox.mac].
+  Future<Uint8List> _aesGcmDecrypt(SecretKey key, WrappedBlob blob) async {
+    final ctLen = blob.ct.length;
+    final cipherText = Uint8List.sublistView(blob.ct, 0, ctLen - kAesGcmTagLengthBytes);
+    final macBytes = Uint8List.sublistView(blob.ct, ctLen - kAesGcmTagLengthBytes);
+    final secretBox = SecretBox(
+      cipherText,
+      nonce: blob.iv,
+      mac: Mac(macBytes),
+    );
+    try {
+      final plain = await _aesGcm.decrypt(secretBox, secretKey: key);
+      return Uint8List.fromList(plain);
+    } on SecretBoxAuthenticationError catch (_) {
+      throw VaultDecryptException(
+        'Decryption failed — wrong password or tampered data.',
+      );
+    }
+  }
+
+  /// Decrypt every entry in a backup envelope.
+  ///
+  /// Returns a map from `vaultId` to the decoded secret JSON object.
+  ///
+  /// Throws [VaultEnvelopeException] when the envelope is malformed
+  /// (user pasted the wrong file). Throws [VaultDecryptException] when
+  /// the master password fails to unwrap the DEK or any entry fails
+  /// AES-GCM authentication.
+  Future<DecryptedVault> decryptEnvelope({
+    required String encryptedJson,
+    required String metaJson,
+    required String password,
+  }) async {
+    final meta = VaultEnvelopeMeta.parse(metaJson);
+
+    // Parse the encrypted-entries map.
+    final Object? entriesRaw;
+    try {
+      entriesRaw = jsonDecode(encryptedJson);
+    } on FormatException catch (e) {
+      throw VaultEnvelopeException(
+        'vault.encrypted is not valid JSON: ${e.message}',
+      );
+    }
+    if (entriesRaw is! Map) {
+      throw VaultEnvelopeException(
+        'vault.encrypted is not a JSON object (got ${entriesRaw.runtimeType})',
+      );
+    }
+
+    // Derive KEK, unwrap DEK.
+    final kek = await deriveKek(password, meta.salt);
+    final dek = await _unwrapDek(kek, meta.dekPw);
+
+    // Decrypt each per-vaultId entry.
+    final out = <String, Map<String, Object?>>{};
+    for (final entry in entriesRaw.entries) {
+      final vaultId = entry.key;
+      if (vaultId is! String || vaultId.isEmpty) continue;
+      final WrappedBlob blob;
+      try {
+        blob = WrappedBlob.fromJson(entry.value, field: 'encrypted[$vaultId]');
+      } on VaultEnvelopeException {
+        // Skip malformed individual entries — the password might still be
+        // correct, and partial recovery is better than total failure.
+        continue;
+      }
+      final plain = await _aesGcmDecrypt(dek, blob);
+      final Object? secret;
+      try {
+        secret = jsonDecode(utf8.decode(plain));
+      } on FormatException catch (_) {
+        // Skip — same logic as above.
+        continue;
+      }
+      if (secret is Map) {
+        out[vaultId] = Map<String, Object?>.from(secret);
+      }
+    }
+
+    return out;
+  }
+}

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -18,6 +18,7 @@ import '../diagnostics/crash_reporter.dart';
 import '../ssh/ssh_connect_params.dart';
 import '../ssh/ssh_session.dart';
 import '../state/connection_providers.dart';
+import '../state/profiles_providers.dart';
 import '../storage/profiles_store.dart';
 import 'diagnostics_section.dart';
 import 'host_key_dialog.dart';
@@ -243,13 +244,40 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     }
   }
 
-  /// Populate the form with metadata from a saved profile. Credentials are
-  /// never auto-filled — the user types password / key per connect.
+  /// Populate the form with metadata from a saved profile. When the
+  /// profile has a `vaultId`, look up the decrypted secret in
+  /// `flutter_secure_storage` and prefill the password / key fields. The
+  /// user can still edit them before submitting.
   void _applyProfileToForm(SavedProfile profile) {
     setState(() {
       _hostCtrl.text = profile.host;
       _portCtrl.text = profile.port.toString();
       _userCtrl.text = profile.username;
+      if (profile.authType == 'key') {
+        _authKind = _AuthKind.key;
+      } else if (profile.authType == 'password') {
+        _authKind = _AuthKind.password;
+      }
+    });
+    if (profile.vaultId != null) {
+      unawaited(_prefillFromVault(profile));
+    }
+  }
+
+  Future<void> _prefillFromVault(SavedProfile profile) async {
+    final secrets = ref.read(secretsStoreProvider);
+    final secret = await secrets.read(profile.vaultId!);
+    if (!mounted || secret == null) return;
+    setState(() {
+      final pw = secret['password'];
+      if (pw is String) _passwordCtrl.text = pw;
+      final key = secret['privateKey'];
+      if (key is String && key.isNotEmpty) {
+        _keyCtrl.text = key;
+        _authKind = _AuthKind.key;
+      }
+      final passphrase = secret['passphrase'];
+      if (passphrase is String) _passphraseCtrl.text = passphrase;
     });
   }
 

--- a/native/lib/ui/import_profiles_dialog.dart
+++ b/native/lib/ui/import_profiles_dialog.dart
@@ -1,9 +1,15 @@
-// "Import from PWA" dialog (#501).
+// "Import from PWA" dialog (#501, vault decrypt for #510).
 //
-// Accepts pasted JSON in the PWA export shape and merges into the store.
+// Two-stage flow:
+//   1. User pastes JSON. Submit triggers a sync parse.
+//   2. If the parsed envelope carries `vault.encrypted`+`vault.meta`, an
+//      additional password field appears (same dialog). Submit then
+//      decrypts + persists.
+//   3. Plain envelope (no vault) → single Submit path, same as before.
+//
 // On success: returns the [ImportResult] so the caller can show a snackbar.
-// On parse failure or unknown shape: shows the error in-dialog without
-// closing, so the user can fix the paste and retry.
+// On parse failure / wrong password / unknown shape: shows the error
+// in-dialog without closing, so the user can fix the input and retry.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -30,16 +36,20 @@ class ImportProfilesDialog extends ConsumerStatefulWidget {
 }
 
 class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
-  final _ctrl = TextEditingController();
+  final _jsonCtrl = TextEditingController();
+  final _passwordCtrl = TextEditingController();
   String? _error;
   bool _busy = false;
+
+  // Stage 2: a parsed envelope carrying a vault. When non-null, the
+  // password field is rendered and Submit applies with the password.
+  ParsedImport? _pendingVault;
 
   @override
   void initState() {
     super.initState();
-    // Rebuild on text changes so the Submit button's enabled state tracks
-    // whether the paste field is empty.
-    _ctrl.addListener(_onTextChanged);
+    _jsonCtrl.addListener(_onTextChanged);
+    _passwordCtrl.addListener(_onTextChanged);
   }
 
   void _onTextChanged() {
@@ -48,8 +58,10 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
 
   @override
   void dispose() {
-    _ctrl.removeListener(_onTextChanged);
-    _ctrl.dispose();
+    _jsonCtrl.removeListener(_onTextChanged);
+    _passwordCtrl.removeListener(_onTextChanged);
+    _jsonCtrl.dispose();
+    _passwordCtrl.dispose();
     super.dispose();
   }
 
@@ -58,12 +70,48 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
       _busy = true;
       _error = null;
     });
+
     final store = ref.read(profilesStoreProvider);
-    final result = await store.importFromJson(_ctrl.text);
+    final secrets = ref.read(secretsStoreProvider);
+
+    // Stage 2: already have a vault parse; this submit carries the password.
+    if (_pendingVault != null) {
+      final result = await store.applyParsedImport(
+        _pendingVault!,
+        password: _passwordCtrl.text,
+        secrets: secrets,
+      );
+      if (!mounted) return;
+
+      if (result.added == 0 && result.skipped == 0 && result.errors.isNotEmpty) {
+        setState(() {
+          _busy = false;
+          _error = result.errors.first;
+        });
+        return;
+      }
+      if (result.added > 0) {
+        ref.invalidate(savedProfilesProvider);
+      }
+      Navigator.of(context).pop(result);
+      return;
+    }
+
+    // Stage 1: parse the pasted JSON. If it carries a vault, switch the
+    // dialog into stage 2 (password prompt) without persisting anything.
+    final parsed = ProfilesStore.parseImport(_jsonCtrl.text);
+    if (parsed.hasVault) {
+      setState(() {
+        _busy = false;
+        _pendingVault = parsed;
+      });
+      return;
+    }
+
+    // No vault: persist directly.
+    final result = await store.applyParsedImport(parsed);
     if (!mounted) return;
 
-    // If we got zero adds and zero skips with errors, treat as input error
-    // and leave the dialog open so the user can fix the paste.
     if (result.added == 0 && result.skipped == 0 && result.errors.isNotEmpty) {
       setState(() {
         _busy = false;
@@ -71,40 +119,71 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
       });
       return;
     }
-
-    // Invalidate the watcher so the parent list rebuilds.
     if (result.added > 0) {
       ref.invalidate(savedProfilesProvider);
     }
     Navigator.of(context).pop(result);
   }
 
+  bool _canSubmit() {
+    if (_busy) return false;
+    if (_pendingVault != null) {
+      return _passwordCtrl.text.isNotEmpty;
+    }
+    return _jsonCtrl.text.trim().isNotEmpty;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final inVaultStage = _pendingVault != null;
     return AlertDialog(
       key: const Key('import-profiles-dialog'),
-      title: const Text('Import profiles from PWA'),
+      title: Text(inVaultStage
+          ? 'Unlock encrypted vault'
+          : 'Import profiles from PWA'),
       content: SizedBox(
         width: 500,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Paste the JSON copied from the PWA "Export to native" button.',
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              key: const Key('import-profiles-input'),
-              controller: _ctrl,
-              maxLines: 8,
-              autocorrect: false,
-              enableSuggestions: false,
-              decoration: const InputDecoration(
-                hintText: '{ "version": 1, "profiles": [ ... ] }',
-                border: OutlineInputBorder(),
+            if (!inVaultStage) ...[
+              const Text(
+                'Paste the JSON copied from the PWA "Export to native" button.',
               ),
-            ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('import-profiles-input'),
+                controller: _jsonCtrl,
+                maxLines: 8,
+                autocorrect: false,
+                enableSuggestions: false,
+                decoration: const InputDecoration(
+                  hintText: '{ "version": 1, "profiles": [ ... ] }',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ] else ...[
+              const Text(
+                'This backup is encrypted. Enter the master password you set '
+                'in the PWA to decrypt the saved credentials.',
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('import-profiles-password'),
+                controller: _passwordCtrl,
+                obscureText: true,
+                autocorrect: false,
+                enableSuggestions: false,
+                onSubmitted: (_) {
+                  if (_canSubmit()) _submit();
+                },
+                decoration: const InputDecoration(
+                  labelText: 'Master password',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
             if (_error != null) ...[
               const SizedBox(height: 8),
               Text(
@@ -124,8 +203,10 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
         ),
         FilledButton(
           key: const Key('import-profiles-submit'),
-          onPressed: _busy || _ctrl.text.trim().isEmpty ? null : _submit,
-          child: Text(_busy ? 'Importing…' : 'Import'),
+          onPressed: _canSubmit() ? _submit : null,
+          child: Text(_busy
+              ? 'Importing…'
+              : (inVaultStage ? 'Unlock & import' : 'Import')),
         ),
       ],
     );

--- a/native/pubspec.lock
+++ b/native/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -55,6 +55,11 @@ dependencies:
   # Persist profile list, settings; small JSON blobs only
   shared_preferences: ^2.3.5
 
+  # PBKDF2-HMAC-SHA256 + AES-GCM-256 for vault decryption parity with the
+  # PWA's WebCrypto vault (#510). Pure-Dart; no platform channel; runs in
+  # flutter_test without a device.
+  cryptography: ^2.7.0
+
   # Crash telemetry pipeline (#501 crash-on-launch).
   # http: bridge upload. path_provider: app-docs dir shared with the Kotlin
   # crash writer. device_info_plus + package_info_plus: enrich crash JSON.

--- a/native/test/profiles_store_test.dart
+++ b/native/test/profiles_store_test.dart
@@ -9,11 +9,16 @@
 //   - rejects unknown export version
 
 import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
 
+import 'package:cryptography/cryptography.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/storage/vault.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -295,11 +300,12 @@ void main() {
       expect(loaded.single.host, 'ok.example');
     });
 
-    test('ignores credentials silently — they are not part of SavedProfile',
+    test('ignores plaintext credentials silently — only vaultId is kept',
         () async {
       // Belt-and-braces: even if the PWA export had credentials, the
       // SavedProfile.fromJson factory would not read them and they would
-      // never reach storage.
+      // never reach storage. (vaultId IS preserved as of #510 because it's
+      // a reference, not a secret.)
       final store = ProfilesStore();
       const sneaky = '''
 {
@@ -308,7 +314,7 @@ void main() {
     {
       "title": "Sneaky", "host": "evil.example", "port": 22,
       "username": "u",
-      "password": "secret", "privateKey": "PRIVATE", "vaultId": "steal"
+      "password": "secret", "privateKey": "PRIVATE", "vaultId": "v-keep"
     }
   ]
 }
@@ -316,11 +322,220 @@ void main() {
       final result = await store.importFromJson(sneaky);
       expect(result.added, 1);
       final loaded = await store.load();
-      // Serialize to JSON to inspect that credential keys are absent.
       final stored = loaded.single.toJson();
       expect(stored.containsKey('password'), isFalse);
       expect(stored.containsKey('privateKey'), isFalse);
-      expect(stored.containsKey('vaultId'), isFalse);
+      expect(stored['vaultId'], 'v-keep');
+    });
+  });
+
+  group('ProfilesStore.parseImport — backup envelope detection', () {
+    test('detects vault field with encrypted + meta strings', () {
+      const envelope = '''
+{
+  "version": 1,
+  "exportedAt": "2026-05-22T13:00:00.000Z",
+  "profiles": [
+    { "host": "h.example", "port": 22, "username": "u", "vaultId": "v1" }
+  ],
+  "vault": {
+    "encrypted": "{\\"v1\\":{\\"iv\\":\\"aa\\",\\"ct\\":\\"bb\\"}}",
+    "meta": "{\\"salt\\":\\"cc\\"}"
+  }
+}
+''';
+      final parsed = ProfilesStore.parseImport(envelope);
+      expect(parsed.hasVault, isTrue);
+      expect(parsed.profileEntries, hasLength(1));
+      expect(parsed.profileEntries.first['vaultId'], 'v1');
+    });
+
+    test('hasVault is false when vault.encrypted is missing', () {
+      const envelope = '''
+{
+  "version": 1,
+  "profiles": [],
+  "vault": { "meta": "{}" }
+}
+''';
+      final parsed = ProfilesStore.parseImport(envelope);
+      expect(parsed.hasVault, isFalse);
+    });
+
+    test('plain envelope without vault parses to profiles only', () {
+      const envelope = '''
+{
+  "version": 1,
+  "profiles": [
+    { "host": "h.example", "port": 22, "username": "u" }
+  ]
+}
+''';
+      final parsed = ProfilesStore.parseImport(envelope);
+      expect(parsed.hasVault, isFalse);
+      expect(parsed.profileEntries, hasLength(1));
+    });
+  });
+
+  group('ProfilesStore.applyParsedImport — backup envelope round-trip', () {
+    // Build a backup-envelope-shaped string using the same crypto primitives
+    // the PWA emits. Reuses the helper pattern from vault_test.dart with a
+    // lower iteration count for speed.
+    Future<String> buildBackupEnvelope({
+      required String password,
+      required List<Map<String, dynamic>> profiles,
+      required Map<String, Map<String, Object?>> secrets,
+      required Pbkdf2 pbkdf2,
+    }) async {
+      final random = Random.secure();
+      final salt = Uint8List.fromList(
+        List<int>.generate(32, (_) => random.nextInt(256)),
+      );
+      final dekBytes = Uint8List.fromList(
+        List<int>.generate(32, (_) => random.nextInt(256)),
+      );
+      final dek = SecretKey(dekBytes);
+      final kek = await pbkdf2.deriveKey(
+        secretKey: SecretKey(utf8.encode(password)),
+        nonce: salt,
+      );
+      final aesGcm = AesGcm.with256bits();
+
+      final dekWrapIv = Uint8List.fromList(
+        List<int>.generate(12, (_) => random.nextInt(256)),
+      );
+      final dekWrapBox = await aesGcm.encrypt(
+        dekBytes,
+        secretKey: kek,
+        nonce: dekWrapIv,
+      );
+      final dekWrapCt = Uint8List.fromList([
+        ...dekWrapBox.cipherText,
+        ...dekWrapBox.mac.bytes,
+      ]);
+
+      final encrypted = <String, Map<String, String>>{};
+      for (final entry in secrets.entries) {
+        final iv = Uint8List.fromList(
+          List<int>.generate(12, (_) => random.nextInt(256)),
+        );
+        final box = await aesGcm.encrypt(
+          utf8.encode(jsonEncode(entry.value)),
+          secretKey: dek,
+          nonce: iv,
+        );
+        final ct = Uint8List.fromList([
+          ...box.cipherText,
+          ...box.mac.bytes,
+        ]);
+        encrypted[entry.key] = <String, String>{
+          'iv': base64Encode(iv),
+          'ct': base64Encode(ct),
+        };
+      }
+
+      return jsonEncode(<String, Object?>{
+        'version': 1,
+        'exportedAt': '2026-05-22T13:00:00.000Z',
+        'profiles': profiles,
+        'vault': <String, String>{
+          'encrypted': jsonEncode(encrypted),
+          'meta': jsonEncode(<String, Object?>{
+            'salt': base64Encode(salt),
+            'dekPw': <String, String>{
+              'iv': base64Encode(dekWrapIv),
+              'ct': base64Encode(dekWrapCt),
+            },
+          }),
+        },
+      });
+    }
+
+    Pbkdf2 fastPbkdf2() => Pbkdf2(
+          macAlgorithm: Hmac.sha256(),
+          iterations: 1000,
+          bits: 256,
+        );
+
+    test('applies a backup envelope with the right password', () async {
+      final pbkdf2 = fastPbkdf2();
+      final envelope = await buildBackupEnvelope(
+        password: 'master',
+        profiles: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'title': 'Home NAS',
+            'host': 'nas.example',
+            'port': 22,
+            'username': 'me',
+            'authType': 'password',
+            'vaultId': 'v-home',
+          },
+        ],
+        secrets: <String, Map<String, Object?>>{
+          'v-home': <String, Object?>{'password': 'hunter2'},
+        },
+        pbkdf2: pbkdf2,
+      );
+
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final parsed = ProfilesStore.parseImport(envelope);
+      expect(parsed.hasVault, isTrue);
+
+      final result = await store.applyParsedImport(
+        parsed,
+        password: 'master',
+        secrets: secrets,
+        decryptor: VaultDecryptor(pbkdf2: pbkdf2),
+      );
+      expect(result.errors, isEmpty);
+      expect(result.added, 1);
+
+      // Profile persisted with vaultId.
+      final loaded = await store.load();
+      expect(loaded.single.vaultId, 'v-home');
+      // Secret available in store.
+      final secret = await secrets.read('v-home');
+      expect(secret, isNotNull);
+      expect(secret!['password'], 'hunter2');
+    });
+
+    test('wrong password reports clear error and writes no state',
+        () async {
+      final pbkdf2 = fastPbkdf2();
+      final envelope = await buildBackupEnvelope(
+        password: 'master',
+        profiles: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'host': 'h.example',
+            'port': 22,
+            'username': 'u',
+            'vaultId': 'v-x',
+          },
+        ],
+        secrets: <String, Map<String, Object?>>{
+          'v-x': <String, Object?>{'password': 'secret'},
+        },
+        pbkdf2: pbkdf2,
+      );
+
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final parsed = ProfilesStore.parseImport(envelope);
+
+      final result = await store.applyParsedImport(
+        parsed,
+        password: 'wrong',
+        secrets: secrets,
+        decryptor: VaultDecryptor(pbkdf2: pbkdf2),
+      );
+
+      expect(result.added, 0);
+      expect(result.errors, isNotEmpty);
+      // No profile persisted.
+      expect(await store.load(), isEmpty);
+      // No secret persisted.
+      expect(await secrets.read('v-x'), isNull);
     });
   });
 }

--- a/native/test/storage/vault_test.dart
+++ b/native/test/storage/vault_test.dart
@@ -1,0 +1,265 @@
+// Unit tests for [VaultDecryptor] (#510).
+//
+// Round-trip strategy: we don't have an offline-generated PWA envelope
+// fixture (browsers + WebCrypto vs `cryptography` Dart package), so each
+// test builds its own envelope using the same primitives that the PWA's
+// `vault.ts` uses (PBKDF2-HMAC-SHA256 600k / AES-GCM-256 / 12-byte IV /
+// tag-appended ciphertext). This proves the parity contract:
+//   - PBKDF2 params + salt encoding produce a stable KEK.
+//   - AES-GCM IV+tag layout matches WebCrypto.
+//   - Wrong password → SecretBoxAuthenticationError → VaultDecryptException.
+//
+// Tests use a low-iteration PBKDF2 override on the decryptor — running 600k
+// iterations is ~half a second in test mode and we'd burn the wall-clock
+// budget on a noisy local loop. The crypto contract under test (HMAC-SHA256
+// + iteration count round-trip) is unchanged by the iteration count.
+
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobissh/storage/vault.dart';
+
+/// Lower-iteration PBKDF2 for fast tests. Production code uses
+/// kVaultPbkdf2Iterations (600k); we override here so test runtimes stay
+/// sub-second. Round-trip parity is independent of iteration count — the
+/// same param chain (Pbkdf2 → KEK → AES-GCM unwrap → DEK → AES-GCM decrypt)
+/// runs in both cases.
+Pbkdf2 _fastPbkdf2() => Pbkdf2(
+      macAlgorithm: Hmac.sha256(),
+      iterations: 1000,
+      bits: 256,
+    );
+
+Future<Map<String, String>> _buildEnvelope({
+  required String password,
+  required Map<String, Map<String, Object?>> secrets,
+  required Pbkdf2 pbkdf2,
+}) async {
+  final random = Random.secure();
+  final salt = Uint8List.fromList(
+    List<int>.generate(32, (_) => random.nextInt(256)),
+  );
+
+  // Generate DEK (32 bytes for AES-256-GCM).
+  final dekBytes = Uint8List.fromList(
+    List<int>.generate(32, (_) => random.nextInt(256)),
+  );
+  final dek = SecretKey(dekBytes);
+
+  // Derive KEK from password.
+  final kek = await pbkdf2.deriveKey(
+    secretKey: SecretKey(utf8.encode(password)),
+    nonce: salt,
+  );
+
+  final aesGcm = AesGcm.with256bits();
+
+  // Wrap DEK under KEK.
+  final dekWrapIv = Uint8List.fromList(
+    List<int>.generate(12, (_) => random.nextInt(256)),
+  );
+  final dekWrapBox = await aesGcm.encrypt(
+    dekBytes,
+    secretKey: kek,
+    nonce: dekWrapIv,
+  );
+  // WebCrypto layout: ciphertext + tag concatenated.
+  final dekWrapCt = Uint8List.fromList([
+    ...dekWrapBox.cipherText,
+    ...dekWrapBox.mac.bytes,
+  ]);
+
+  // Encrypt each secret under DEK.
+  final encryptedEntries = <String, Map<String, String>>{};
+  for (final entry in secrets.entries) {
+    final iv = Uint8List.fromList(
+      List<int>.generate(12, (_) => random.nextInt(256)),
+    );
+    final box = await aesGcm.encrypt(
+      utf8.encode(jsonEncode(entry.value)),
+      secretKey: dek,
+      nonce: iv,
+    );
+    final ct = Uint8List.fromList([
+      ...box.cipherText,
+      ...box.mac.bytes,
+    ]);
+    encryptedEntries[entry.key] = <String, String>{
+      'iv': base64Encode(iv),
+      'ct': base64Encode(ct),
+    };
+  }
+
+  final meta = <String, Object?>{
+    'salt': base64Encode(salt),
+    'dekPw': <String, String>{
+      'iv': base64Encode(dekWrapIv),
+      'ct': base64Encode(dekWrapCt),
+    },
+  };
+
+  return <String, String>{
+    'encrypted': jsonEncode(encryptedEntries),
+    'meta': jsonEncode(meta),
+  };
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('VaultDecryptor.decryptEnvelope', () {
+    test('round-trips a single secret with the right password', () async {
+      final pbkdf2 = _fastPbkdf2();
+      final secret = <String, Object?>{
+        'password': 'hunter2',
+        'authType': 'password',
+      };
+      final envelope = await _buildEnvelope(
+        password: 'masterpw',
+        secrets: <String, Map<String, Object?>>{'vault-1': secret},
+        pbkdf2: pbkdf2,
+      );
+
+      final decryptor = VaultDecryptor(pbkdf2: pbkdf2);
+      final out = await decryptor.decryptEnvelope(
+        encryptedJson: envelope['encrypted']!,
+        metaJson: envelope['meta']!,
+        password: 'masterpw',
+      );
+
+      expect(out, hasLength(1));
+      expect(out['vault-1'], secret);
+    });
+
+    test('round-trips multiple secrets', () async {
+      final pbkdf2 = _fastPbkdf2();
+      final envelope = await _buildEnvelope(
+        password: 'pw',
+        secrets: <String, Map<String, Object?>>{
+          'v1': <String, Object?>{'password': 'one'},
+          'v2': <String, Object?>{'password': 'two', 'passphrase': 'xyz'},
+        },
+        pbkdf2: pbkdf2,
+      );
+
+      final decryptor = VaultDecryptor(pbkdf2: pbkdf2);
+      final out = await decryptor.decryptEnvelope(
+        encryptedJson: envelope['encrypted']!,
+        metaJson: envelope['meta']!,
+        password: 'pw',
+      );
+
+      expect(out.keys.toSet(), {'v1', 'v2'});
+      expect(out['v1']!['password'], 'one');
+      expect(out['v2']!['passphrase'], 'xyz');
+    });
+
+    test('throws VaultDecryptException on wrong password', () async {
+      final pbkdf2 = _fastPbkdf2();
+      final envelope = await _buildEnvelope(
+        password: 'correct-horse',
+        secrets: <String, Map<String, Object?>>{
+          'v1': <String, Object?>{'password': 'secret'},
+        },
+        pbkdf2: pbkdf2,
+      );
+
+      final decryptor = VaultDecryptor(pbkdf2: pbkdf2);
+
+      await expectLater(
+        decryptor.decryptEnvelope(
+          encryptedJson: envelope['encrypted']!,
+          metaJson: envelope['meta']!,
+          password: 'wrong-password',
+        ),
+        throwsA(isA<VaultDecryptException>()),
+      );
+    });
+
+    test('throws VaultEnvelopeException on malformed meta', () async {
+      final decryptor = VaultDecryptor(pbkdf2: _fastPbkdf2());
+      await expectLater(
+        decryptor.decryptEnvelope(
+          encryptedJson: '{}',
+          metaJson: 'not json at all',
+          password: 'pw',
+        ),
+        throwsA(isA<VaultEnvelopeException>()),
+      );
+    });
+
+    test('throws VaultEnvelopeException on missing meta.salt', () async {
+      final decryptor = VaultDecryptor(pbkdf2: _fastPbkdf2());
+      await expectLater(
+        decryptor.decryptEnvelope(
+          encryptedJson: '{}',
+          metaJson: '{"dekPw":{"iv":"","ct":""}}',
+          password: 'pw',
+        ),
+        throwsA(isA<VaultEnvelopeException>()),
+      );
+    });
+
+    test('silently ignores dekBio in meta (device-specific wrap)', () async {
+      // PWA backups carry dekBio when the source device enrolled biometric;
+      // it's tied to the source device's WebAuthn credential and cannot
+      // decrypt here. Native must NOT crash on its presence.
+      final pbkdf2 = _fastPbkdf2();
+      final envelope = await _buildEnvelope(
+        password: 'pw',
+        secrets: <String, Map<String, Object?>>{
+          'v1': <String, Object?>{'password': 'x'},
+        },
+        pbkdf2: pbkdf2,
+      );
+
+      // Inject a bogus dekBio into the meta. The decryptor should ignore it.
+      final metaParsed = jsonDecode(envelope['meta']!) as Map<String, dynamic>;
+      metaParsed['dekBio'] = <String, String>{
+        'iv': base64Encode(Uint8List(12)),
+        'ct': base64Encode(Uint8List(32)),
+      };
+      final tamperedMeta = jsonEncode(metaParsed);
+
+      final decryptor = VaultDecryptor(pbkdf2: pbkdf2);
+      final out = await decryptor.decryptEnvelope(
+        encryptedJson: envelope['encrypted']!,
+        metaJson: tamperedMeta,
+        password: 'pw',
+      );
+
+      expect(out['v1']!['password'], 'x');
+    });
+
+    test('skips individual malformed entries but decrypts the rest',
+        () async {
+      final pbkdf2 = _fastPbkdf2();
+      final envelope = await _buildEnvelope(
+        password: 'pw',
+        secrets: <String, Map<String, Object?>>{
+          'good': <String, Object?>{'password': 'ok'},
+        },
+        pbkdf2: pbkdf2,
+      );
+
+      // Tamper: add a malformed entry to the encrypted map.
+      final entries =
+          jsonDecode(envelope['encrypted']!) as Map<String, dynamic>;
+      entries['bad'] = <String, String>{'iv': 'not base 64!@#', 'ct': 'zzz'};
+      final tamperedEncrypted = jsonEncode(entries);
+
+      final decryptor = VaultDecryptor(pbkdf2: pbkdf2);
+      final out = await decryptor.decryptEnvelope(
+        encryptedJson: tamperedEncrypted,
+        metaJson: envelope['meta']!,
+        password: 'pw',
+      );
+
+      expect(out.keys, {'good'});
+    });
+  });
+}

--- a/native/test/widget/import_dialog_widget_test.dart
+++ b/native/test/widget/import_dialog_widget_test.dart
@@ -13,6 +13,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:mobissh/state/profiles_providers.dart';
 import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
 import 'package:mobissh/ui/import_profiles_dialog.dart';
 
 /// Pump a launcher that exposes a button which opens the dialog. Avoids the
@@ -21,6 +22,7 @@ import 'package:mobissh/ui/import_profiles_dialog.dart';
 Future<ImportResult?> _openDialog(
   WidgetTester tester, {
   required ProfilesStore store,
+  SecretsStore? secrets,
   required Future<void> Function(WidgetTester) interact,
 }) async {
   ImportResult? captured;
@@ -29,6 +31,7 @@ Future<ImportResult?> _openDialog(
     ProviderScope(
       overrides: [
         profilesStoreProvider.overrideWithValue(store),
+        if (secrets != null) secretsStoreProvider.overrideWithValue(secrets),
       ],
       child: MaterialApp(
         home: Scaffold(
@@ -139,5 +142,66 @@ void main() {
 
     final loaded = await store.load();
     expect(loaded, isEmpty, reason: 'invalid JSON must not corrupt storage');
+  });
+
+  testWidgets('envelope containing a vault prompts for master password',
+      (tester) async {
+    // Smoketest: paste an envelope with a `vault` field. The dialog must
+    // switch to its stage-2 password prompt (key: import-profiles-password)
+    // WITHOUT writing any profile to storage. We don't test successful
+    // decryption here — that's covered by profiles_store_test.dart's
+    // applyParsedImport round-trip. This proves the UI is wired up to detect
+    // the envelope shape and render the prompt.
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+
+    final result = await _openDialog(
+      tester,
+      store: store,
+      secrets: secrets,
+      interact: (t) async {
+        // The vault payload here is intentionally not decryptable — we only
+        // care that detection works and the prompt appears, then we cancel.
+        const envelopeWithVault = '''
+{
+  "version": 1,
+  "exportedAt": "2026-05-22T13:00:00.000Z",
+  "profiles": [
+    { "host": "h.example", "port": 22, "username": "u", "vaultId": "v1" }
+  ],
+  "vault": {
+    "encrypted": "{\\"v1\\":{\\"iv\\":\\"aa\\",\\"ct\\":\\"bb\\"}}",
+    "meta": "{\\"salt\\":\\"cc\\"}"
+  }
+}
+''';
+        await t.enterText(
+          find.byKey(const Key('import-profiles-input')),
+          envelopeWithVault,
+        );
+        await t.pump();
+        await t.tap(find.byKey(const Key('import-profiles-submit')));
+        await t.pumpAndSettle();
+
+        // Stage 2: password input is now visible.
+        expect(
+          find.byKey(const Key('import-profiles-password')),
+          findsOneWidget,
+        );
+        // The JSON paste field is gone.
+        expect(
+          find.byKey(const Key('import-profiles-input')),
+          findsNothing,
+        );
+
+        // Cancel — we don't need a successful decrypt for this smoke.
+        await t.tap(find.byKey(const Key('import-profiles-cancel')));
+      },
+    );
+
+    expect(result, isNull,
+        reason: 'cancelled at password stage → no ImportResult');
+    // Profile store untouched.
+    expect(await store.load(), isEmpty);
   });
 }


### PR DESCRIPTION
## Summary
- Native vault: pure-Dart PBKDF2 + AES-GCM decryption of the PWA's backup-envelope shape (`vault.encrypted` + `vault.meta`), keyed by vaultId.
- Per-vaultId secrets persisted to `flutter_secure_storage` (Android Keystore-backed); connect-form auto-fills password/key fields from secure storage.
- Two-stage import dialog: master-password prompt appears only when the envelope contains a vault. Wrong password → inline error, no partial state.

## TDD Analysis
- Type: feature
- Behavior change: yes (new envelope support + secure-storage persistence + connect-path vault lookup)
- TDD approach: full for crypto + importer round-trip; smoketest for the UI password prompt

## Test coverage
- **Existing tests updated**: `native/test/profiles_store_test.dart` (added 5 tests in `parseImport` + `applyParsedImport` groups); `native/test/widget/import_dialog_widget_test.dart` (added `secretsStoreProvider` override + vault-prompt smoketest)
- **New tests added (fail→pass)**:
  - `native/test/storage/vault_test.dart` (7 tests): round-trip single/multi-secret envelopes, `VaultDecryptException` on wrong password, `VaultEnvelopeException` on malformed meta/missing salt, `dekBio` ignore parity with PWA, malformed-entry recovery.
  - `parseImport` detection (3 tests): envelope with vault, missing-encrypted, plain envelope.
  - `applyParsedImport` round-trip (2 tests): correct-password applies + persists; wrong-password aborts with empty store/secrets.
- **Smoketest**: import dialog detects vault envelope and renders `import-profiles-password` field; cancel leaves storage empty.

## Test results
- flutter analyze: PASS (`No issues found!`)
- flutter test: PASS (82 tests pass, 4 skipped integration-tag tests)
- `scripts/native-fast-gate.sh`: PASS

## Crypto contract (parity with PWA `src/modules/vault.ts`)
- PBKDF2-HMAC-SHA256, **600_000** iterations, 256-bit output
- 32-byte salt, 12-byte AES-GCM IV
- WebCrypto layout: ciphertext + 16-byte tag concatenated; split for `cryptography` Dart's `SecretBox`
- `dekBio` stripped on import (device-specific WebAuthn wrap, mirrors PWA `profiles.ts:1144-1156`)

## Diff stats
- Files changed: 11 (3 new lib, 1 new test, 1 modified test, 4 modified lib, pubspec.yaml/lock)
- Lines: +1358 / -80 (the diff is dominated by `vault_test.dart` envelope-builder fixtures and the `profiles_store_test.dart` round-trip group)

## Out of scope (deliberate, per delegation)
- Did NOT touch `ssh_session.dart` session-controller architecture (would collide with #511 multi-session work).
- Did NOT add a `local_auth` BiometricGate — `flutter_secure_storage` already requires user authentication on Keystore-backed reads when `requireUserAuthenticationToEnter` is set; deferring that toggle to a follow-up so this PR stays scoped to decrypt + persist.

Closes #510

## Cycles used
1/3