### PR TITLE
fix(#519): load key-blob credentials by keyVaultId on connect prefill

### DIFF
--- a/native/lib/storage/profiles_store.dart
+++ b/native/lib/storage/profiles_store.dart
@@ -474,3 +474,87 @@ class ProfilesStore {
     }
   }
 }
+
+/// Decrypted credentials for a saved profile, ready to drop into the connect
+/// form / dartssh2 client. All fields are optional — callers handle null.
+///
+/// `privateKey` is the PEM-encoded key bytes (string form so callers can
+/// utf8-encode it before handing to dartssh2's `SSHKeyPair.fromPem`).
+class ProfileCredentials {
+  ProfileCredentials({this.password, this.privateKey, this.passphrase});
+  final String? password;
+  final String? privateKey;
+  final String? passphrase;
+
+  bool get isEmpty =>
+      password == null && privateKey == null && passphrase == null;
+}
+
+/// Load decrypted credentials for [profile] from [secrets].
+///
+/// Resolves the bug in #519: a `key`-auth profile imported from the PWA has
+/// its private-key blob stored under `profile.keyVaultId` (NOT `vaultId`).
+/// Prior to this helper, the connect path only read `vaultId`, so the key
+/// blob sat unused in flutter_secure_storage and the user was re-prompted.
+///
+/// Shape contract (mirrors PWA `src/modules/profiles.ts:450-493`):
+///   `vault.encrypted[vaultId]`    → `{password?, privateKey?, passphrase?}`
+///   `vault.encrypted[keyVaultId]` → `{data: <PEM>, passphrase?}`
+///
+/// The keyVaultId entry's `data` field holds the PEM-encoded private key.
+/// A legacy `privateKey` field is also accepted to tolerate alternative
+/// import paths. The keyVaultId entry's passphrase takes precedence over
+/// the vaultId entry's passphrase for a `key`-auth profile.
+Future<ProfileCredentials> loadProfileCredentials(
+  SecretsStore secrets,
+  SavedProfile profile,
+) async {
+  String? password;
+  String? privateKey;
+  String? passphrase;
+
+  // Pass 1: vaultId entry (typically `{password, passphrase?}` shape for a
+  // password-auth profile; may also carry a privateKey for legacy profiles
+  // that bundled key + password into one entry).
+  final vaultId = profile.vaultId;
+  if (vaultId != null && vaultId.isNotEmpty) {
+    final entry = await secrets.read(vaultId);
+    if (entry != null) {
+      final pw = entry['password'];
+      if (pw is String && pw.isNotEmpty) password = pw;
+      final pk = entry['privateKey'];
+      if (pk is String && pk.isNotEmpty) privateKey = pk;
+      final pp = entry['passphrase'];
+      if (pp is String && pp.isNotEmpty) passphrase = pp;
+    }
+  }
+
+  // Pass 2: keyVaultId entry (PWA shape: `{data: <PEM>, passphrase?}`).
+  // Overrides any privateKey / passphrase pulled from the vaultId entry,
+  // since this is the key-specific entry by design.
+  final keyVaultId = profile.keyVaultId;
+  if (keyVaultId != null && keyVaultId.isNotEmpty) {
+    final entry = await secrets.read(keyVaultId);
+    if (entry != null) {
+      // PWA canonical key field is `data` (see profiles.ts:482). Fall back
+      // to `privateKey` for resilience against alternative import paths.
+      final data = entry['data'];
+      if (data is String && data.isNotEmpty) {
+        privateKey = data;
+      } else {
+        final legacy = entry['privateKey'];
+        if (legacy is String && legacy.isNotEmpty) {
+          privateKey = legacy;
+        }
+      }
+      final pp = entry['passphrase'];
+      if (pp is String && pp.isNotEmpty) passphrase = pp;
+    }
+  }
+
+  return ProfileCredentials(
+    password: password,
+    privateKey: privateKey,
+    passphrase: passphrase,
+  );
+}

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -257,9 +257,13 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
   }
 
   /// Populate the form with metadata from a saved profile. When the
-  /// profile has a `vaultId`, look up the decrypted secret in
-  /// `flutter_secure_storage` and prefill the password / key fields. The
-  /// user can still edit them before submitting.
+  /// profile has a `vaultId` or `keyVaultId`, look up the decrypted secret
+  /// in `flutter_secure_storage` and prefill the password / key fields.
+  /// The user can still edit them before submitting.
+  ///
+  /// Both ids are consulted because a `key`-auth profile imported from the
+  /// PWA stores the private-key blob under `keyVaultId`, not `vaultId`
+  /// (#519).
   void _applyProfileToForm(SavedProfile profile) {
     setState(() {
       _hostCtrl.text = profile.host;
@@ -271,25 +275,25 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
         _authKind = _AuthKind.password;
       }
     });
-    if (profile.vaultId != null) {
+    if (profile.vaultId != null || profile.keyVaultId != null) {
       unawaited(_prefillFromVault(profile));
     }
   }
 
   Future<void> _prefillFromVault(SavedProfile profile) async {
     final secrets = ref.read(secretsStoreProvider);
-    final secret = await secrets.read(profile.vaultId!);
-    if (!mounted || secret == null) return;
+    final creds = await loadProfileCredentials(secrets, profile);
+    if (!mounted || creds.isEmpty) return;
     setState(() {
-      final pw = secret['password'];
-      if (pw is String) _passwordCtrl.text = pw;
-      final key = secret['privateKey'];
-      if (key is String && key.isNotEmpty) {
+      final pw = creds.password;
+      if (pw != null) _passwordCtrl.text = pw;
+      final key = creds.privateKey;
+      if (key != null) {
         _keyCtrl.text = key;
         _authKind = _AuthKind.key;
       }
-      final passphrase = secret['passphrase'];
-      if (passphrase is String) _passphraseCtrl.text = passphrase;
+      final passphrase = creds.passphrase;
+      if (passphrase != null) _passphraseCtrl.text = passphrase;
     });
   }
 

--- a/native/test/storage/profile_credentials_test.dart
+++ b/native/test/storage/profile_credentials_test.dart
@@ -1,0 +1,171 @@
+// Tests for [loadProfileCredentials] (#519).
+//
+// Covers the connect-path load of decrypted secrets from a [SecretsStore]
+// for both the `password`-auth and `key`-auth profile shapes.
+//
+// Shape contract (mirrors the PWA — see src/modules/profiles.ts:450-493 and
+// src/modules/connection.ts:498-507):
+//
+//   vault.encrypted[vaultId]    → { password?, privateKey?, passphrase? }
+//   vault.encrypted[keyVaultId] → { data: <PEM>, passphrase? }
+//
+// The `data` field on a keyVaultId-keyed entry holds the PEM-encoded private
+// key. The keyVaultId entry's passphrase wins over the password entry's
+// passphrase for a `key`-auth profile (per PWA precedence).
+//
+// Why these tests exist: prior to #519 the native importer decrypted and
+// persisted ALL vault entries correctly, but the connect-form prefill only
+// loaded `profile.vaultId` and never consulted `profile.keyVaultId`. Result:
+// the key bytes were sitting in flutter_secure_storage but never reached
+// dartssh2. These tests lock the load behavior in.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('loadProfileCredentials — password auth', () {
+    test('loads password + passphrase from vaultId entry', () async {
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('v-pw', <String, Object?>{
+        'password': 'hunter2',
+        'passphrase': 'pp',
+      });
+
+      final profile = SavedProfile(
+        title: 't', host: 'h', port: 22, username: 'u',
+        authType: 'password', vaultId: 'v-pw',
+      );
+
+      final creds = await loadProfileCredentials(secrets, profile);
+
+      expect(creds.password, 'hunter2');
+      expect(creds.passphrase, 'pp');
+      expect(creds.privateKey, isNull);
+    });
+
+    test('returns empty creds when no vaultId is set', () async {
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final profile = SavedProfile(
+        title: 't', host: 'h', port: 22, username: 'u',
+        authType: 'password',
+      );
+
+      final creds = await loadProfileCredentials(secrets, profile);
+
+      expect(creds.password, isNull);
+      expect(creds.privateKey, isNull);
+      expect(creds.passphrase, isNull);
+    });
+  });
+
+  group('loadProfileCredentials — key auth', () {
+    test('loads private key bytes + passphrase from keyVaultId entry',
+        () async {
+      const pem = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n'
+          '-----END OPENSSH PRIVATE KEY-----';
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('v-key', <String, Object?>{
+        'data': pem,
+        'passphrase': 'keypass',
+      });
+
+      final profile = SavedProfile(
+        title: 't', host: 'h', port: 22, username: 'u',
+        authType: 'key', keyVaultId: 'v-key',
+      );
+
+      final creds = await loadProfileCredentials(secrets, profile);
+
+      expect(creds.privateKey, pem,
+          reason: 'PWA stores the PEM under `data` for keyVaultId entries');
+      expect(creds.passphrase, 'keypass');
+      expect(creds.password, isNull);
+    });
+
+    test('loads key even when vaultId is also present', () async {
+      // A key-auth profile may carry both a vaultId (legacy / host-shared)
+      // and a keyVaultId. The key MUST come from keyVaultId, not vaultId.
+      const pem = '-----BEGIN OPENSSH PRIVATE KEY-----\nzzz\n'
+          '-----END OPENSSH PRIVATE KEY-----';
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('v-shared', <String, Object?>{
+        'password': 'leftover-password',
+      });
+      await secrets.write('v-key', <String, Object?>{
+        'data': pem,
+        'passphrase': 'kp',
+      });
+
+      final profile = SavedProfile(
+        title: 't', host: 'h', port: 22, username: 'u',
+        authType: 'key', vaultId: 'v-shared', keyVaultId: 'v-key',
+      );
+
+      final creds = await loadProfileCredentials(secrets, profile);
+
+      expect(creds.privateKey, pem);
+      expect(creds.passphrase, 'kp',
+          reason: 'keyVaultId passphrase wins over vaultId passphrase');
+    });
+
+    test('keyVaultId passphrase wins over vaultId passphrase', () async {
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('v-shared', <String, Object?>{
+        'password': 'pw',
+        'passphrase': 'old-pp',
+      });
+      await secrets.write('v-key', <String, Object?>{
+        'data': 'PEM',
+        'passphrase': 'new-pp',
+      });
+
+      final profile = SavedProfile(
+        title: 't', host: 'h', port: 22, username: 'u',
+        authType: 'key', vaultId: 'v-shared', keyVaultId: 'v-key',
+      );
+
+      final creds = await loadProfileCredentials(secrets, profile);
+
+      expect(creds.passphrase, 'new-pp');
+    });
+
+    test('returns empty creds when keyVaultId entry is missing', () async {
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final profile = SavedProfile(
+        title: 't', host: 'h', port: 22, username: 'u',
+        authType: 'key', keyVaultId: 'v-missing',
+      );
+
+      final creds = await loadProfileCredentials(secrets, profile);
+
+      expect(creds.password, isNull);
+      expect(creds.privateKey, isNull);
+      expect(creds.passphrase, isNull);
+    });
+
+    test('falls back to legacy `privateKey` field on keyVaultId entry',
+        () async {
+      // Belt-and-braces: if someone wrote the key under `privateKey` instead
+      // of `data` (e.g. an older importer), the load path should still find
+      // it. PWA's canonical shape uses `data`, but a forgiving reader avoids
+      // breakage on the import path.
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('v-legacy', <String, Object?>{
+        'privateKey': 'legacy-pem',
+      });
+
+      final profile = SavedProfile(
+        title: 't', host: 'h', port: 22, username: 'u',
+        authType: 'key', keyVaultId: 'v-legacy',
+      );
+
+      final creds = await loadProfileCredentials(secrets, profile);
+
+      expect(creds.privateKey, 'legacy-pem');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Native importer (#510) already decrypted/persisted every `vault.encrypted` entry; the bug was on the **connect-form prefill side** — it only consulted `profile.vaultId`, never `keyVaultId`, and even when it did read, it assumed the password-entry shape (`privateKey` field) rather than the PWA's key-entry shape (`data` field).
- Extracts a pure `loadProfileCredentials(secrets, profile)` helper that reads both ids with the correct field names. ConnectForm uses it; prefill now triggers on either `vaultId` or `keyVaultId`.
- 7 new tests cover the new shape variants (password, key-only, both ids, missing entry, legacy-field fallback, passphrase precedence). All 101 existing tests still pass.

## TDD Analysis

- Type: bug fix
- Behavior change: yes — `key`-auth profiles imported from a PWA backup envelope now have their PEM and passphrase auto-populated when the profile is tapped, instead of staying empty
- TDD approach: full — wrote 7 failing tests against the (then-missing) helper, watched compilation fail, implemented, watched green

## Test coverage

- **Existing tests updated**: none needed. The old `_prefillFromVault` behavior (read `vaultId`, look for `password`/`privateKey`/`passphrase`) is a subset of the new behavior, so all existing widget + storage tests still pass unchanged.
- **New tests added (fail→pass)**: `native/test/storage/profile_credentials_test.dart` (7 tests):
  - password auth: loads `password` + `passphrase` from `vaultId` entry
  - password auth: returns empty creds when no `vaultId` is set
  - key auth: loads private key bytes + passphrase from `keyVaultId` entry (PWA's `data` field)
  - key auth: loads key even when both `vaultId` and `keyVaultId` are present
  - key auth: `keyVaultId` passphrase wins over `vaultId` passphrase
  - key auth: returns empty creds when `keyVaultId` entry is missing
  - key auth: falls back to legacy `privateKey` field on `keyVaultId` entry
- **Smoketest**: the helper is the contract — the existing widget-level prefill path (`_applyProfileToForm` → `_prefillFromVault` → `loadProfileCredentials`) is exercised end-to-end by the existing profile-list widget test paths.

## Test results

- `flutter analyze`: PASS (no issues)
- `flutter test` (fast gate, excl. integration tag): PASS (101 tests, +7 new)
- Native acceptance gate: not run (opt-in, requires emulator)

## Diff stats

- Files changed: 3
- Lines: +271 / -12 (net 259, of which 178 are the new test file)

## Device validation

Per `feedback_device_validation_before_merge.md`, this change to native vault/connect plumbing should be verified on a real device before merge:
1. Import a backup envelope containing a `key`-auth profile (with `keyVaultId` only, or both `vaultId` + `keyVaultId`).
2. Enter the master password — vault decrypts successfully.
3. Tap the imported key-auth profile — key bytes and passphrase auto-populate the form.
4. Tap Connect — dartssh2 authenticates without re-prompting for the key.

Closes #519

## Cycles used

1/3