### PR TITLE
feat(#520): file picker as primary vault/profile import affordance

### DIFF
--- a/native/lib/ui/import_profiles_dialog.dart
+++ b/native/lib/ui/import_profiles_dialog.dart
@@ -1,7 +1,14 @@
-// "Import from PWA" dialog (#501, vault decrypt for #510).
+// "Import from PWA" dialog (#501, vault decrypt for #510, file picker
+// affordance for #520).
 //
-// Two-stage flow:
-//   1. User pastes JSON. Submit triggers a sync parse.
+// Primary affordance: "Choose backup file…" → opens Android's storage
+// picker (file_picker), reads the chosen JSON's bytes, drives the same
+// parseImport/applyParsedImport pipeline as the paste path. The paste
+// textarea remains as a collapsed disclosure ("Paste JSON instead") so
+// power users and tests can still drive it directly.
+//
+// Two-stage flow (unchanged from #510):
+//   1. User selects a file OR pastes JSON. Submit triggers a sync parse.
 //   2. If the parsed envelope carries `vault.encrypted`+`vault.meta`, an
 //      additional password field appears (same dialog). Submit then
 //      decrypts + persists.
@@ -11,24 +18,76 @@
 // On parse failure / wrong password / unknown shape: shows the error
 // in-dialog without closing, so the user can fix the input and retry.
 
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../state/profiles_providers.dart';
 import '../storage/profiles_store.dart';
 
+/// Plain-data result of a file pick. Decoupled from `file_picker` so the
+/// widget test can inject a fake without binding to platform channels.
+class PickedFile {
+  PickedFile({required this.name, required this.bytes});
+
+  final String name;
+  final Uint8List bytes;
+}
+
+/// Abstraction over `file_picker` so tests can supply a fake. Production
+/// code uses [DefaultFilePickerAdapter]; widget tests construct
+/// [ImportProfilesDialog] with a custom adapter via [showImportProfilesDialog]
+/// (`pickerAdapter` parameter).
+abstract class FilePickerAdapter {
+  /// Open the storage picker filtered to JSON files. Returns the picked
+  /// file's bytes + display name, or null if the user cancelled.
+  Future<PickedFile?> pickJsonFile();
+}
+
+/// Real implementation that wraps `FilePicker.platform`.
+class DefaultFilePickerAdapter implements FilePickerAdapter {
+  const DefaultFilePickerAdapter();
+
+  @override
+  Future<PickedFile?> pickJsonFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: const ['json'],
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return null;
+    final file = result.files.first;
+    final bytes = file.bytes;
+    if (bytes == null) return null;
+    return PickedFile(name: file.name, bytes: bytes);
+  }
+}
+
 /// Show the import dialog. Resolves to the [ImportResult] on success, or
 /// `null` if the user cancelled. Tests can construct
-/// [ImportProfilesDialog] directly instead of going through this helper.
-Future<ImportResult?> showImportProfilesDialog(BuildContext context) {
+/// [ImportProfilesDialog] directly instead of going through this helper,
+/// or pass a custom [pickerAdapter] to inject a fake.
+Future<ImportResult?> showImportProfilesDialog(
+  BuildContext context, {
+  FilePickerAdapter pickerAdapter = const DefaultFilePickerAdapter(),
+}) {
   return showDialog<ImportResult>(
     context: context,
-    builder: (_) => const ImportProfilesDialog(),
+    builder: (_) => ImportProfilesDialog(pickerAdapter: pickerAdapter),
   );
 }
 
 class ImportProfilesDialog extends ConsumerStatefulWidget {
-  const ImportProfilesDialog({super.key});
+  const ImportProfilesDialog({
+    super.key,
+    this.pickerAdapter = const DefaultFilePickerAdapter(),
+  });
+
+  /// Adapter used to open the storage picker. Tests pass a fake.
+  final FilePickerAdapter pickerAdapter;
 
   @override
   ConsumerState<ImportProfilesDialog> createState() =>
@@ -40,6 +99,13 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
   final _passwordCtrl = TextEditingController();
   String? _error;
   bool _busy = false;
+  bool _pasteExpanded = false;
+
+  // Set after a successful file pick. The bytes/name drive the import and
+  // a one-line summary so the user can confirm the selection before tapping
+  // Import.
+  String? _pickedFileName;
+  String? _pickedSummary;
 
   // Stage 2: a parsed envelope carrying a vault. When non-null, the
   // password field is rendered and Submit applies with the password.
@@ -63,6 +129,66 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
     _jsonCtrl.dispose();
     _passwordCtrl.dispose();
     super.dispose();
+  }
+
+  Future<void> _pickFile() async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    PickedFile? picked;
+    try {
+      picked = await widget.pickerAdapter.pickJsonFile();
+    } on Exception catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _error = 'Could not open file picker: $e';
+      });
+      return;
+    }
+    if (!mounted) return;
+    if (picked == null) {
+      // User cancelled the picker — leave any prior selection intact.
+      setState(() {
+        _busy = false;
+      });
+      return;
+    }
+
+    String text;
+    try {
+      text = utf8.decode(picked.bytes);
+    } on FormatException catch (e) {
+      setState(() {
+        _busy = false;
+        _error = 'Could not read file as UTF-8 text: ${e.message}';
+      });
+      return;
+    }
+
+    // Drive both the underlying paste field (so Submit reuses one code path)
+    // and a user-facing summary that's correct even when paste is collapsed.
+    _jsonCtrl.text = text;
+    final summary = _summarize(text);
+    setState(() {
+      _busy = false;
+      _pickedFileName = picked!.name;
+      _pickedSummary = summary;
+    });
+  }
+
+  /// Build the one-line summary shown under `Selected: <name>`. Uses the
+  /// same envelope-shape detection as `parseImport` so the user can spot
+  /// a wrong file before tapping Import.
+  String _summarize(String text) {
+    final parsed = ProfilesStore.parseImport(text);
+    if (parsed.profileEntries.isEmpty && parsed.errors.isNotEmpty) {
+      return parsed.errors.first;
+    }
+    final n = parsed.profileEntries.length;
+    final vault = parsed.hasVault ? 'vault present' : 'no vault';
+    return '$n profile${n == 1 ? '' : 's'}, $vault';
   }
 
   Future<void> _submit() async {
@@ -97,8 +223,8 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
       return;
     }
 
-    // Stage 1: parse the pasted JSON. If it carries a vault, switch the
-    // dialog into stage 2 (password prompt) without persisting anything.
+    // Stage 1: parse the pasted/loaded JSON. If it carries a vault, switch
+    // the dialog into stage 2 (password prompt) without persisting anything.
     final parsed = ProfilesStore.parseImport(_jsonCtrl.text);
     if (parsed.hasVault) {
       setState(() {
@@ -143,24 +269,65 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
           : 'Import profiles from PWA'),
       content: SizedBox(
         width: 500,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
             if (!inVaultStage) ...[
               const Text(
-                'Paste the JSON copied from the PWA "Export to native" button.',
+                'Choose the backup file the PWA downloaded, or paste the '
+                'JSON copied from the PWA "Export to native" button.',
               ),
               const SizedBox(height: 12),
-              TextField(
-                key: const Key('import-profiles-input'),
-                controller: _jsonCtrl,
-                maxLines: 8,
-                autocorrect: false,
-                enableSuggestions: false,
-                decoration: const InputDecoration(
-                  hintText: '{ "version": 1, "profiles": [ ... ] }',
-                  border: OutlineInputBorder(),
+              FilledButton.tonalIcon(
+                key: const Key('import-profiles-pick-file'),
+                onPressed: _busy ? null : _pickFile,
+                icon: const Icon(Icons.folder_open),
+                label: const Text('Choose backup file…'),
+              ),
+              if (_pickedFileName != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  'Selected: $_pickedFileName',
+                  key: const Key('import-profiles-picked-name'),
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+                if (_pickedSummary != null)
+                  Text(
+                    _pickedSummary!,
+                    key: const Key('import-profiles-picked-summary'),
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+              ],
+              const SizedBox(height: 12),
+              // Paste textarea behind a disclosure — fallback path. Same key
+              // as before (`import-profiles-input`) so existing tests work.
+              Theme(
+                data: Theme.of(context).copyWith(
+                  dividerColor: Colors.transparent,
+                ),
+                child: ExpansionTile(
+                  key: const Key('import-profiles-paste-disclosure'),
+                  initiallyExpanded: _pasteExpanded,
+                  onExpansionChanged: (v) =>
+                      setState(() => _pasteExpanded = v),
+                  tilePadding: EdgeInsets.zero,
+                  childrenPadding: const EdgeInsets.only(top: 8),
+                  title: const Text('Paste JSON instead'),
+                  children: [
+                    TextField(
+                      key: const Key('import-profiles-input'),
+                      controller: _jsonCtrl,
+                      maxLines: 8,
+                      autocorrect: false,
+                      enableSuggestions: false,
+                      decoration: const InputDecoration(
+                        hintText: '{ "version": 1, "profiles": [ ... ] }',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ] else ...[
@@ -192,7 +359,8 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
                 style: const TextStyle(color: Colors.redAccent),
               ),
             ],
-          ],
+            ],
+          ),
         ),
       ),
       actions: [

--- a/native/pubspec.lock
+++ b/native/pubspec.lock
@@ -161,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.7"
   fixnum:
     dependency: transitive
     description:

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -70,6 +70,11 @@ dependencies:
   package_info_plus: ^8.1.2
   share_plus: ^10.1.2
 
+  # File picker for vault/profile import (#520). Replaces paste-JSON as the
+  # primary affordance — users select the backup file the PWA downloaded
+  # rather than copy-pasting hundreds of lines of envelope JSON.
+  file_picker: ^8.1.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/native/test/widget/import_dialog_widget_test.dart
+++ b/native/test/widget/import_dialog_widget_test.dart
@@ -1,10 +1,17 @@
-// Widget tests for [ImportProfilesDialog] (#501).
+// Widget tests for [ImportProfilesDialog] (#501, #510, #520).
 //
 // Asserts:
-//   - valid pasted JSON triggers import (store state changes, dialog closes
-//     with non-null ImportResult)
+//   - file picker button exists and is the primary affordance (#520)
+//   - picked file bytes drive the same parseImport/applyParsedImport path
+//     as paste (smoketest, no platform channel binding)
+//   - paste textarea is collapsed behind a disclosure but still works
+//     end-to-end (legacy + power-user path)
 //   - invalid JSON keeps the dialog open and shows an inline error;
 //     store state is unchanged
+//   - vault envelopes prompt for the master password
+
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,6 +23,17 @@ import 'package:mobissh/storage/profiles_store.dart';
 import 'package:mobissh/storage/secrets_store.dart';
 import 'package:mobissh/ui/import_profiles_dialog.dart';
 
+/// Test adapter that returns a pre-configured [PickedFile] (or null for
+/// "user cancelled"). Avoids binding to the `file_picker` platform channel,
+/// which is unavailable in `flutter_test`.
+class _FakeFilePickerAdapter implements FilePickerAdapter {
+  _FakeFilePickerAdapter({this.result});
+  final PickedFile? result;
+
+  @override
+  Future<PickedFile?> pickJsonFile() async => result;
+}
+
 /// Pump a launcher that exposes a button which opens the dialog. Avoids the
 /// "guarded function conflict" trap of launching the dialog from a
 /// postFrameCallback inside the first pumpWidget call.
@@ -23,6 +41,7 @@ Future<ImportResult?> _openDialog(
   WidgetTester tester, {
   required ProfilesStore store,
   SecretsStore? secrets,
+  FilePickerAdapter? pickerAdapter,
   required Future<void> Function(WidgetTester) interact,
 }) async {
   ImportResult? captured;
@@ -40,7 +59,11 @@ Future<ImportResult?> _openDialog(
               child: ElevatedButton(
                 key: const Key('open-button'),
                 onPressed: () async {
-                  captured = await showImportProfilesDialog(context);
+                  captured = await showImportProfilesDialog(
+                    context,
+                    pickerAdapter:
+                        pickerAdapter ?? const DefaultFilePickerAdapter(),
+                  );
                 },
                 child: const Text('Open'),
               ),
@@ -63,11 +86,100 @@ Future<ImportResult?> _openDialog(
   return captured;
 }
 
+/// Tap the paste disclosure to reveal the textarea before driving it.
+/// The two pre-#520 paste tests assume the textarea is visible; #520 moved
+/// it behind an ExpansionTile.
+Future<void> _expandPasteDisclosure(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('import-profiles-paste-disclosure')));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('file picker button is the primary affordance (#520 smoketest)',
+      (tester) async {
+    final store = ProfilesStore();
+
+    await _openDialog(
+      tester,
+      store: store,
+      interact: (t) async {
+        // The picker button is present and visible without any disclosure.
+        expect(
+          find.byKey(const Key('import-profiles-pick-file')),
+          findsOneWidget,
+        );
+
+        // The paste field, by contrast, is hidden until the disclosure
+        // is expanded — the picker is the primary path.
+        expect(
+          find.byKey(const Key('import-profiles-input')),
+          findsNothing,
+        );
+
+        await t.tap(find.byKey(const Key('import-profiles-cancel')));
+      },
+    );
+  });
+
+  testWidgets('picked file bytes drive the same import as paste (#520)',
+      (tester) async {
+    final store = ProfilesStore();
+
+    const validJson = '''
+{
+  "version": 1,
+  "exportedAt": "2026-05-22T13:00:00.000Z",
+  "profiles": [
+    { "title": "Home NAS", "host": "nas.example", "port": 22,
+      "username": "me", "theme": "dark" }
+  ]
+}
+''';
+
+    final fakePicker = _FakeFilePickerAdapter(
+      result: PickedFile(
+        name: 'mobissh-profiles-2026-05-22T13-00-00.json',
+        bytes: Uint8List.fromList(utf8.encode(validJson)),
+      ),
+    );
+
+    final result = await _openDialog(
+      tester,
+      store: store,
+      pickerAdapter: fakePicker,
+      interact: (t) async {
+        await t.tap(find.byKey(const Key('import-profiles-pick-file')));
+        await t.pumpAndSettle();
+
+        // Summary surfaces the selected file's contents.
+        expect(
+          find.byKey(const Key('import-profiles-picked-name')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('import-profiles-picked-summary')),
+          findsOneWidget,
+        );
+        expect(find.textContaining('1 profile'), findsOneWidget);
+
+        await t.tap(find.byKey(const Key('import-profiles-submit')));
+      },
+    );
+
+    // Dialog closed, result matches the paste-path outcome.
+    expect(find.byKey(const Key('import-profiles-dialog')), findsNothing);
+    expect(result, isNotNull);
+    expect(result!.added, 1);
+
+    final loaded = await store.load();
+    expect(loaded, hasLength(1));
+    expect(loaded.single.host, 'nas.example');
   });
 
   testWidgets('valid PWA-envelope JSON imports and closes the dialog',
@@ -79,6 +191,7 @@ void main() {
       store: store,
       interact: (t) async {
         expect(find.byKey(const Key('import-profiles-dialog')), findsOneWidget);
+        await _expandPasteDisclosure(t);
 
         const validJson = '''
 {
@@ -120,6 +233,7 @@ void main() {
       store: store,
       interact: (t) async {
         expect(find.byKey(const Key('import-profiles-dialog')), findsOneWidget);
+        await _expandPasteDisclosure(t);
 
         await t.enterText(
           find.byKey(const Key('import-profiles-input')),
@@ -160,6 +274,7 @@ void main() {
       store: store,
       secrets: secrets,
       interact: (t) async {
+        await _expandPasteDisclosure(t);
         // The vault payload here is intentionally not decryptable — we only
         // care that detection works and the prompt appears, then we cancel.
         const envelopeWithVault = '''


### PR DESCRIPTION
## Summary
- Adds `file_picker` (^8.1.4) and makes "Choose backup file…" the primary import affordance.
- Picked file bytes drive the same `parseImport` → `applyParsedImport` pipeline as the paste path; a one-line summary ("Selected: <name>" + "N profiles, vault present/no vault") confirms the user's selection before they tap Import.
- Paste textarea collapses behind an `ExpansionTile` ("Paste JSON instead"). Same Key so it remains an end-to-end-testable fallback.

## TDD Analysis
- Type: feature
- Behavior change: yes (new primary import path)
- TDD approach: smoketest-only — data path is already covered by `profiles_store_test.dart` (`parseImport` + `applyParsedImport` round-trips). UI gets one accessibility smoketest and one end-to-end smoke that proves picked bytes drive the same import path as paste.

## Test coverage
- **Existing tests updated**: 3 paste tests in `import_dialog_widget_test.dart` now expand the disclosure before driving the textarea (the dialog gained an `ExpansionTile` wrapper around paste).
- **New tests added (fail→pass)**:
  - "file picker button is the primary affordance (#520 smoketest)" — picker button is present; paste field is hidden behind the disclosure.
  - "picked file bytes drive the same import as paste (#520)" — inject a fake `FilePickerAdapter`, tap "Choose backup file…", verify summary appears and Submit applies the parsed envelope (store has 1 profile).
- **Smoketest**: file picker button exists with `Key('import-profiles-pick-file')`; paste textarea hidden until disclosure expanded.

## Design notes
- `FilePickerAdapter` interface lets the widget test inject a fake `PickedFile` without binding to the `file_picker` platform channel (unavailable in `flutter_test`). Production uses `DefaultFilePickerAdapter`, which wraps `FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: ['json'], withData: true)`.
- AndroidManifest unchanged. SAF on API 33+ requires no extra permission.
- Dialog content wrapped in `SingleChildScrollView` so the expanded paste textarea doesn't overflow the AlertDialog's bounded height.

## Test results
- analyze: PASS
- flutter test (excluding integration): PASS (103 tests, +2 new)

## Diff stats
- Files changed: 4
- Lines: +324 / -28 (pubspec.lock auto-generated; dialog +216, tests +123)

Closes #520

## Cycles used
1/3