### PR TITLE
feat(#525): AppLifecycleState provider for native rewrite

### DIFF
--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -13,6 +13,7 @@ import 'diagnostics/crash_reporter.dart';
 import 'ssh/ssh_session.dart';
 import 'state/connection_providers.dart';
 import 'state/keepalive_providers.dart';
+import 'state/lifecycle_providers.dart';
 import 'state/sessions.dart';
 import 'state/terminal_providers.dart';
 import 'ui/connect_form.dart';
@@ -40,16 +41,18 @@ class MobisshApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'MobiSSH',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.indigo,
-          brightness: Brightness.dark,
+    return AppLifecycleObserver(
+      child: MaterialApp(
+        title: 'MobiSSH',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.indigo,
+            brightness: Brightness.dark,
+          ),
+          useMaterial3: true,
         ),
-        useMaterial3: true,
+        home: const RootRouter(),
       ),
-      home: const RootRouter(),
     );
   }
 }

--- a/native/lib/state/lifecycle_providers.dart
+++ b/native/lib/state/lifecycle_providers.dart
@@ -1,0 +1,63 @@
+// AppLifecycleState awareness for the native rewrite (#525).
+//
+// Exposes the current Flutter `AppLifecycleState` as a Riverpod provider so
+// consumers (Phase 4 #524: SshSessionController rebind on resume) can
+// `ref.listen` for transitions. This module only makes the lifecycle event
+// addressable — it does NOT itself rebind, reconnect, or alter keepalive
+// behavior. That's the Phase 4 PR's job.
+//
+// Wiring: `AppLifecycleObserver` is mounted near the top of the widget tree
+// (see `main.dart`). It registers a `WidgetsBindingObserver` on init and
+// mirrors `didChangeAppLifecycleState` callbacks into `lifecycleProvider`.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Current Flutter app-lifecycle state. Defaults to `resumed` because the
+/// widget tree is only built while the app is in the foreground; the observer
+/// will update this as the framework dispatches lifecycle changes.
+final lifecycleProvider =
+    StateProvider<AppLifecycleState>((ref) => AppLifecycleState.resumed);
+
+/// Widget that bridges Flutter's `WidgetsBindingObserver` into Riverpod.
+///
+/// Mount once, high in the tree (above any consumer of `lifecycleProvider`).
+/// On `didChangeAppLifecycleState` it writes the new state to the provider so
+/// `ref.listen(lifecycleProvider, ...)` callbacks fire on every transition.
+///
+/// Inert by design: this widget does not itself trigger reconnects or rebinds.
+/// The Phase 4 PR (#524) wires a listener that drives those side effects.
+class AppLifecycleObserver extends ConsumerStatefulWidget {
+  const AppLifecycleObserver({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<AppLifecycleObserver> createState() =>
+      _AppLifecycleObserverState();
+}
+
+class _AppLifecycleObserverState extends ConsumerState<AppLifecycleObserver>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Guard against post-dispose dispatches.
+    if (!mounted) return;
+    ref.read(lifecycleProvider.notifier).state = state;
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/native/test/state/lifecycle_provider_test.dart
+++ b/native/test/state/lifecycle_provider_test.dart
@@ -1,0 +1,59 @@
+// Unit tests for the AppLifecycleState provider (#525).
+//
+// Verifies the provider's contract:
+//   - default state is AppLifecycleState.resumed (app is foregrounded at boot)
+//   - writing a new state updates the provider's current value
+//   - ref.listen callback fires on each transition (paused, then resumed)
+//
+// The widget-layer hook that wires WidgetsBindingObserver to this provider is
+// exercised in test/widget/app_lifecycle_test.dart. This file is pure-state.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/lifecycle_providers.dart';
+
+void main() {
+  group('lifecycleProvider', () {
+    test('default state is AppLifecycleState.resumed', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(lifecycleProvider), AppLifecycleState.resumed);
+    });
+
+    test('writing a new state updates the current value', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(lifecycleProvider.notifier).state =
+          AppLifecycleState.paused;
+      expect(container.read(lifecycleProvider), AppLifecycleState.paused);
+
+      container.read(lifecycleProvider.notifier).state =
+          AppLifecycleState.resumed;
+      expect(container.read(lifecycleProvider), AppLifecycleState.resumed);
+    });
+
+    test('ref.listen fires on each transition (paused → resumed)', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final emissions = <AppLifecycleState>[];
+      container.listen<AppLifecycleState>(
+        lifecycleProvider,
+        (prev, next) => emissions.add(next),
+      );
+
+      container.read(lifecycleProvider.notifier).state =
+          AppLifecycleState.paused;
+      container.read(lifecycleProvider.notifier).state =
+          AppLifecycleState.resumed;
+
+      expect(emissions, <AppLifecycleState>[
+        AppLifecycleState.paused,
+        AppLifecycleState.resumed,
+      ]);
+    });
+  });
+}

--- a/native/test/widget/app_lifecycle_test.dart
+++ b/native/test/widget/app_lifecycle_test.dart
@@ -1,0 +1,79 @@
+// Widget tests for the AppLifecycleState observer wiring (#525).
+//
+// Pumps a `ProviderScope`-wrapped widget that mounts the
+// `AppLifecycleObserver`, simulates a pause → resume cycle via
+// `WidgetsBinding.instance.handleAppLifecycleStateChanged`, and asserts the
+// `lifecycleProvider` reflects each transition.
+//
+// This is the integration point that the Phase 4 PR (#524) will hook into
+// for SshSessionController rebind. Here we only verify the event becomes
+// addressable.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/lifecycle_providers.dart';
+
+void main() {
+  testWidgets('AppLifecycleObserver mirrors pause/resume into the provider',
+      (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final emissions = <AppLifecycleState>[];
+    container.listen<AppLifecycleState>(
+      lifecycleProvider,
+      (prev, next) => emissions.add(next),
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const AppLifecycleObserver(child: SizedBox.shrink()),
+      ),
+    );
+
+    // Sanity: default state is resumed (app is foregrounded at boot).
+    expect(container.read(lifecycleProvider), AppLifecycleState.resumed);
+
+    // Simulate the framework dispatching a lifecycle change.
+    WidgetsBinding.instance
+        .handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    expect(container.read(lifecycleProvider), AppLifecycleState.paused);
+
+    WidgetsBinding.instance
+        .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    expect(container.read(lifecycleProvider), AppLifecycleState.resumed);
+
+    expect(emissions, <AppLifecycleState>[
+      AppLifecycleState.paused,
+      AppLifecycleState.resumed,
+    ]);
+  });
+
+  testWidgets('AppLifecycleObserver removes itself on dispose', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const AppLifecycleObserver(child: SizedBox.shrink()),
+      ),
+    );
+
+    // Replace the tree with an empty one so the observer disposes.
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    // After dispose, dispatching a lifecycle change must not touch the
+    // (now-disposed) container. We assert by verifying the provider read is
+    // safe and reflects whatever was last written before dispose.
+    final beforeDispatch = container.read(lifecycleProvider);
+    WidgetsBinding.instance
+        .handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    expect(container.read(lifecycleProvider), beforeDispatch);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `lifecycleProvider` (Riverpod `StateProvider<AppLifecycleState>`) and an `AppLifecycleObserver` ConsumerStatefulWidget that bridges Flutter's `WidgetsBindingObserver` into Riverpod.
- Wired once near the root of the widget tree (`MobisshApp` builds `AppLifecycleObserver(child: MaterialApp(...))`).
- Inert by design: no listener wired yet — Phase 4 (#524) consumes the event for SshSessionController rebind/keepalive. No reconnect logic and no `KeepaliveController` change here.

## TDD Analysis
- Type: feature (additive infrastructure)
- Behavior change: no (provider exposed; nothing reads it yet)
- TDD approach: full (provider contract + widget-level event dispatch)

## Test coverage
- **Existing tests updated**: none needed — `MaterialApp` is now nested inside `AppLifecycleObserver`, but the ancestor chain remains compatible; all 126 pre-existing tests still pass.
- **New tests added (fail→pass)**:
  - `native/test/state/lifecycle_provider_test.dart` — default is `resumed`; setter mutates value; `ref.listen` fires on each transition.
  - `native/test/widget/app_lifecycle_test.dart` — pump observer, dispatch `paused`/`resumed` via `WidgetsBinding.instance.handleAppLifecycleStateChanged`, assert provider tracks transitions and the observer cleans up on dispose.
- **Smoketest**: provider importable and resolvable from a `ProviderContainer` with `AppLifecycleState.resumed` as the default value.

## Test results
- analyze: PASS (no issues)
- test: PASS (131 tests, 5 new)
- gate: `scripts/native-fast-gate.sh` PASS

## Diff stats
- Files changed: 4 (1 modified, 3 new)
- Lines: +212 / -8 (production: ~75 lines; tests: ~138 lines)

## What this PR does NOT do
- Does NOT implement the foreground-task-isolate move (#524).
- Does NOT add rebind logic to `SshSessionController`.
- Does NOT change `KeepaliveController` behavior.

Closes #525

## Cycles used
1/3