### PR TITLE
fix(native): bump compileSdk to 36 + file_picker to 11.x for release build

### DIFF
--- a/native/android/app/build.gradle.kts
+++ b/native/android/app/build.gradle.kts
@@ -25,7 +25,11 @@ val keystoreProperties = Properties().apply {
 
 android {
     namespace = "com.flavordrake.mobissh"
-    compileSdk = flutter.compileSdkVersion
+    // Bumped to 36 because file_picker (#520) transitively pulls
+    // flutter_plugin_android_lifecycle which requires API 36+ on its current
+    // version. Bumping compileSdk only — minSdk/targetSdk stay inherited from
+    // flutter so installable surface and runtime behavior are unchanged.
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     compileOptions {

--- a/native/lib/ui/import_profiles_dialog.dart
+++ b/native/lib/ui/import_profiles_dialog.dart
@@ -47,13 +47,15 @@ abstract class FilePickerAdapter {
   Future<PickedFile?> pickJsonFile();
 }
 
-/// Real implementation that wraps `FilePicker.platform`.
+/// Real implementation that wraps the static `FilePicker.pickFiles` API.
+/// (file_picker 11.0.0 collapsed the prior `FilePicker.platform.pickFiles`
+/// instance-style call into a static method — see CHANGELOG.)
 class DefaultFilePickerAdapter implements FilePickerAdapter {
   const DefaultFilePickerAdapter();
 
   @override
   Future<PickedFile?> pickJsonFile() async {
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: const ['json'],
       withData: true,

--- a/native/pubspec.lock
+++ b/native/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.17.1"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.13"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -165,10 +173,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.7"
+    version: "11.0.2"
   fixnum:
     dependency: transitive
     description:
@@ -544,6 +552,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   pinenacl:
     dependency: transitive
     description:
@@ -837,6 +853,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   xterm:
     dependency: "direct main"
     description:

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -73,7 +73,10 @@ dependencies:
   # File picker for vault/profile import (#520). Replaces paste-JSON as the
   # primary affordance — users select the backup file the PWA downloaded
   # rather than copy-pasting hundreds of lines of envelope JSON.
-  file_picker: ^8.1.4
+  # Bumped to 11.x because 8.x is compiled against android-34 but transitively
+  # depends on flutter_plugin_android_lifecycle which now requires compileSdk 36.
+  # The 11.x release is compiled against 36 and clears the AAR-metadata check.
+  file_picker: ^11.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Build hygiene on top of #520. `flutter build apk --release` was failing post-merge with the AAR metadata check:

```
Execution failed for task ':file_picker:checkReleaseAarMetadata'.
Dependency ':flutter_plugin_android_lifecycle' requires libraries and applications
that depend on it to compile against version 36 or later of the Android APIs.
```

Three coupled fixes:

1. **`android/app/build.gradle.kts`** — `compileSdk` bumped from `flutter.compileSdkVersion` (resolves to 34) to a hard `36`. `minSdk` and `targetSdk` stay inherited from Flutter, so installable surface and runtime opt-in behavior are unchanged.
2. **`pubspec.yaml`** — `file_picker: ^11.0.2` (was `^8.1.4`). The 8.x release is compiled against android-34 and was the artifact tripping the AAR-metadata check. 11.0.2 is compiled against 36.
3. **`lib/ui/import_profiles_dialog.dart`** — file_picker 11.0.0 was a breaking change that collapsed the prior `FilePicker.platform.pickFiles` instance-style call into a static `FilePicker.pickFiles(...)`. Call site updated to the canonical API (confirmed via the package's own CHANGELOG.md and README.md).

## Verification

- `scripts/native-fast-gate.sh` → analyze clean, 140 tests pass, 5 skipped.
- `scripts/flutter-cmd.sh --in native build apk --release` now completes (was failing before).

## Why not a real issue

Pure build-fix follow-up to #520; opening a focused PR rather than landing directly on main to keep the audit trail consistent with the rest of this cycle. No behavior change.