### PR TITLE
feat(#531): physically host SSH lifecycle in foreground task isolate

### DIFF
--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -1,14 +1,13 @@
-// Background keep-alive for SSH sessions on Android (#512).
+// Background keep-alive for SSH sessions on Android (#512, #531).
 //
 // When a session enters the `connected` state, start a foreground service so
 // Android won't kill the process while the user swaps to another app. The
 // service is stopped as soon as no session is connected.
 //
-// Single-session for now. TODO(#511): once multi-session lands, the
-// `KeepaliveController` needs to track a *count* of connected sessions and
-// only stop the service when the count drops to zero. The plumbing here is
-// already counted-based (see `_connectedCount`) but only one session can be
-// tracked through `attach()` until the session collection refactor lands.
+// #531: the task handler that runs inside the foreground task's Dart isolate
+// also owns a `SessionHost` so the underlying `SSHClient` instances live in
+// the task isolate, not the UI isolate. If Android kills the UI isolate the
+// socket survives; the UI proxy rebinds on resume.
 
 import 'dart:async';
 
@@ -16,6 +15,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 import '../ssh/ssh_session.dart';
+import 'session_host.dart';
+import 'task_ssh_gateway.dart';
 
 /// Top-level entry point for the foreground task isolate. Must be
 /// `@pragma('vm:entry-point')` so the AOT compiler keeps it.
@@ -24,15 +25,46 @@ void startKeepaliveCallback() {
   FlutterForegroundTask.setTaskHandler(KeepaliveTaskHandler());
 }
 
-/// Minimal task handler — the wake lock on the foreground task is enough to
-/// keep the Dart isolate (and the SSH socket on it) alive. We don't do any
-/// periodic work; the running socket pump is the heartbeat.
+/// Task handler that runs inside the foreground task's Dart isolate (#531).
+///
+/// Hosts a [SessionHost] bound to a [TaskSideForegroundGateway]. Inbound
+/// payloads arrive via [onReceiveData] (delivered by `flutter_foreground_task`
+/// from the UI's `sendDataToTask` calls) and are routed into the gateway's
+/// transport. Outbound payloads (state, output, snapshots) flow back via
+/// `FlutterForegroundTask.sendDataToMain` inside the gateway's `send`.
 class KeepaliveTaskHandler extends TaskHandler {
   DateTime? startedAt;
+
+  /// Factory for the per-handler `SessionHost`. Production uses the default
+  /// which constructs a real host wired to FFT static methods. Tests inject
+  /// a stub host bound to a [StubFftTransport] so the wire contract can be
+  /// exercised without binding to platform channels.
+  KeepaliveTaskHandler({SessionHostBuilder? hostBuilder})
+      : _hostBuilder = hostBuilder ?? _defaultHostBuilder;
+
+  final SessionHostBuilder _hostBuilder;
+  TaskSideFftTransport? _transport;
+  SessionHost? _host;
+
+  /// Visible for testing — exposes the host owned by this handler so widget
+  /// tests can drive it through the gateway pair.
+  @visibleForTesting
+  SessionHost? get hostForTest => _host;
 
   @override
   Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
     startedAt = timestamp;
+    final transport = TaskSideFftTransport();
+    final gateway = TaskSideForegroundGateway(transport: transport);
+    _transport = transport;
+    _host = _hostBuilder(gateway);
+  }
+
+  @override
+  void onReceiveData(Object data) {
+    // Forward the UI-side payload into the gateway transport. The gateway
+    // coerces shape; the host dispatches the command.
+    _transport?.deliver(data);
   }
 
   @override
@@ -44,8 +76,25 @@ class KeepaliveTaskHandler extends TaskHandler {
   @override
   Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
     startedAt = null;
+    final host = _host;
+    _host = null;
+    _transport = null;
+    if (host != null) {
+      // Tear down all hosted sessions cleanly (closes SSHClient + cancels
+      // state subs). Errors here are swallowed — the isolate is going away.
+      try {
+        await host.dispose();
+      } catch (_) {/* ignore */}
+    }
   }
 }
+
+/// Factory injected for tests so a stub `SessionHost` can be hooked into
+/// the [KeepaliveTaskHandler] without binding to FFT statics.
+typedef SessionHostBuilder = SessionHost Function(TaskSshGateway gateway);
+
+SessionHost _defaultHostBuilder(TaskSshGateway gateway) =>
+    SessionHost(gateway: gateway);
 
 /// Thin wrapper over the static `FlutterForegroundTask` API. Lets us inject a
 /// fake in tests so we don't bind to platform method channels.

--- a/native/lib/services/task_ssh_gateway.dart
+++ b/native/lib/services/task_ssh_gateway.dart
@@ -1,16 +1,20 @@
 // ignore_for_file: prefer_initializing_formals
-// Abstraction over the UI ↔ foreground-task isolate channel (#524).
+// Abstraction over the UI ↔ foreground-task isolate channel (#524, #531).
 //
-// The real implementation forwards through `FlutterForegroundTask.sendData…`
-// / `addTaskDataCallback`. Tests use an in-memory pair of `StreamController`s
-// so the wire contract can be exercised without binding to platform method
-// channels (and without spinning up a real task isolate).
+// The production implementation forwards through
+// `FlutterForegroundTask.sendData…` / `addTaskDataCallback`
+// (see [FlutterForegroundSshGateway] + [TaskSideForegroundGateway]). Tests
+// use an in-memory pair of `StreamController`s so the wire contract can be
+// exercised without binding to platform method channels (and without
+// spinning up a real task isolate).
 //
 // Both sides see the gateway as: send a payload, listen for payloads. The
 // payload is always `Map<String, dynamic>` so the same code path can encode
 // to whatever the plugin's IPC marshaller expects.
 
 import 'dart:async';
+
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 /// One half of the UI ↔ task channel. The UI proxy holds the
 /// "ui-side" instance; the task-side session host holds the "task-side"
@@ -88,5 +92,227 @@ class _InMemoryGateway implements TaskSshGateway {
   @override
   Future<void> dispose() async {
     _disposed = true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Production gateway (#531) — `flutter_foreground_task`-backed transport.
+// ---------------------------------------------------------------------------
+
+/// Low-level transport used by the FFT-backed gateways. Production wires this
+/// to `FlutterForegroundTask` static methods; tests inject [StubFftTransport]
+/// so the gateway logic is exercised without binding to platform channels.
+///
+/// The transport is direction-aware: the UI side and the task side speak
+/// different methods (UI → task uses `sendDataToTask`, task → UI uses
+/// `sendDataToMain`). Both sides listen via callbacks (`addTaskDataCallback`
+/// on the UI side; `TaskHandler.onReceiveData` on the task side).
+abstract class FftTransport {
+  /// Push a payload toward the other end.
+  void send(Object payload);
+
+  /// Register a listener invoked when the other end sends us a payload.
+  /// Returns a cancel function the gateway will call on dispose.
+  void Function() registerReceiver(void Function(Object data) onData);
+}
+
+/// Production transport for the UI isolate. Uses
+/// `FlutterForegroundTask.sendDataToTask` to push commands toward the task,
+/// and `FlutterForegroundTask.addTaskDataCallback` to receive events from the
+/// task.
+class UiSideFftTransport implements FftTransport {
+  const UiSideFftTransport();
+
+  @override
+  void send(Object payload) {
+    FlutterForegroundTask.sendDataToTask(payload);
+  }
+
+  @override
+  void Function() registerReceiver(void Function(Object data) onData) {
+    FlutterForegroundTask.addTaskDataCallback(onData);
+    return () => FlutterForegroundTask.removeTaskDataCallback(onData);
+  }
+}
+
+/// Production transport for the task isolate. Uses
+/// `FlutterForegroundTask.sendDataToMain` to push events toward the UI, and
+/// a manual receiver register because the task isolate's inbound payloads
+/// arrive through `TaskHandler.onReceiveData` — the host wires that to the
+/// transport via [TaskSideFftTransport.deliver].
+class TaskSideFftTransport implements FftTransport {
+  TaskSideFftTransport();
+
+  void Function(Object data)? _receiver;
+
+  /// Called by [KeepaliveTaskHandler.onReceiveData] to push an incoming
+  /// payload through to whatever receiver the gateway registered.
+  void deliver(Object data) {
+    final r = _receiver;
+    if (r != null) r(data);
+  }
+
+  @override
+  void send(Object payload) {
+    FlutterForegroundTask.sendDataToMain(payload);
+  }
+
+  @override
+  void Function() registerReceiver(void Function(Object data) onData) {
+    _receiver = onData;
+    return () {
+      if (_receiver == onData) _receiver = null;
+    };
+  }
+}
+
+/// Shared encoder/decoder. The transport carries `Object` (because FFT's
+/// SendPort is `Object?`-typed); the gateway always serializes to
+/// `Map<String, dynamic>`. When the platform marshaller hands us a typed-key
+/// `Map` we coerce to `Map<String, dynamic>` so downstream `fromJson` calls
+/// see the expected type.
+Map<String, dynamic>? _coercePayload(Object? raw) {
+  if (raw is Map<String, dynamic>) return raw;
+  if (raw is Map) {
+    return raw.map((k, v) => MapEntry(k.toString(), v));
+  }
+  return null;
+}
+
+/// Production [TaskSshGateway] for the UI isolate side.
+class FlutterForegroundSshGateway implements TaskSshGateway {
+  FlutterForegroundSshGateway({FftTransport? transport})
+      : _transport = transport ?? const UiSideFftTransport() {
+    _cancel = _transport.registerReceiver(_onData);
+  }
+
+  final FftTransport _transport;
+  final StreamController<Map<String, dynamic>> _incoming =
+      StreamController<Map<String, dynamic>>.broadcast();
+  void Function()? _cancel;
+  bool _disposed = false;
+
+  @override
+  Stream<Map<String, dynamic>> get incoming => _incoming.stream;
+
+  @override
+  void send(Map<String, dynamic> payload) {
+    if (_disposed) return;
+    _transport.send(payload);
+  }
+
+  void _onData(Object data) {
+    if (_disposed) return;
+    final map = _coercePayload(data);
+    if (map == null) return;
+    if (!_incoming.isClosed) _incoming.add(map);
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _cancel?.call();
+    _cancel = null;
+    if (!_incoming.isClosed) await _incoming.close();
+  }
+}
+
+/// Production [TaskSshGateway] for the task isolate side. Built by
+/// [KeepaliveTaskHandler] inside the foreground task isolate. The transport
+/// is fed inbound payloads via `TaskHandler.onReceiveData` →
+/// [TaskSideFftTransport.deliver].
+class TaskSideForegroundGateway implements TaskSshGateway {
+  TaskSideForegroundGateway({required TaskSideFftTransport transport})
+      : _transport = transport {
+    _cancel = _transport.registerReceiver(_onData);
+  }
+
+  final TaskSideFftTransport _transport;
+  final StreamController<Map<String, dynamic>> _incoming =
+      StreamController<Map<String, dynamic>>.broadcast();
+  void Function()? _cancel;
+  bool _disposed = false;
+
+  @override
+  Stream<Map<String, dynamic>> get incoming => _incoming.stream;
+
+  @override
+  void send(Map<String, dynamic> payload) {
+    if (_disposed) return;
+    _transport.send(payload);
+  }
+
+  void _onData(Object data) {
+    if (_disposed) return;
+    final map = _coercePayload(data);
+    if (map == null) return;
+    if (!_incoming.isClosed) _incoming.add(map);
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _cancel?.call();
+    _cancel = null;
+    if (!_incoming.isClosed) await _incoming.close();
+  }
+}
+
+/// Test transport that lets a UI-side and task-side gateway share an
+/// in-process channel without binding to FFT statics. Pairs are constructed
+/// via [StubFftTransportPair].
+class StubFftTransport implements FftTransport {
+  StubFftTransport._(this._outbound, this._inbound);
+
+  /// Where this side's outbound payloads end up. The OTHER side's transport
+  /// adds them to its `_inbound` controller.
+  final StreamController<Object> _outbound;
+
+  /// What the other side has sent us. Listened to lazily on
+  /// [registerReceiver].
+  final Stream<Object> _inbound;
+
+  StreamSubscription<Object>? _sub;
+
+  @override
+  void send(Object payload) {
+    if (_outbound.isClosed) return;
+    _outbound.add(payload);
+  }
+
+  @override
+  void Function() registerReceiver(void Function(Object data) onData) {
+    _sub?.cancel();
+    _sub = _inbound.listen(onData);
+    return () {
+      _sub?.cancel();
+      _sub = null;
+    };
+  }
+}
+
+/// Pair of [StubFftTransport]s that mirror the FFT topology: UI side's
+/// outbound goes to the task side's inbound, and vice versa. Used in
+/// [task_isolate_handover_test.dart] so the gateway code is exercised
+/// end-to-end.
+class StubFftTransportPair {
+  StubFftTransportPair()
+      : _uiOutbound = StreamController<Object>.broadcast(),
+        _taskOutbound = StreamController<Object>.broadcast() {
+    uiSide = StubFftTransport._(_uiOutbound, _taskOutbound.stream);
+    taskSide = StubFftTransport._(_taskOutbound, _uiOutbound.stream);
+  }
+
+  final StreamController<Object> _uiOutbound;
+  final StreamController<Object> _taskOutbound;
+
+  late final StubFftTransport uiSide;
+  late final StubFftTransport taskSide;
+
+  Future<void> dispose() async {
+    if (!_uiOutbound.isClosed) await _uiOutbound.close();
+    if (!_taskOutbound.isClosed) await _taskOutbound.close();
   }
 }

--- a/native/lib/state/session_host_providers.dart
+++ b/native/lib/state/session_host_providers.dart
@@ -1,28 +1,51 @@
-// Wiring for the task-side session host (#524).
+// Wiring for the task-side session host (#524, #531).
 //
-// Lazily constructs the [SessionHost] + an in-memory [InMemoryGatewayPair] so
-// the IPC contract is exercised even before the controllers physically move
-// to the foreground task isolate. The host's `Map<sessionId,
-// SshSessionController>` lives in this same Dart isolate today; future work
-// relocates it to the task isolate without touching the providers below
-// (the gateway is the only seam that changes).
+// The UI-side gateway resolved here is what `SshSessionProxy` consumers talk
+// to. Two flavors exist:
+//
+//   - Production: `FlutterForegroundTaskGateway`, wired to FFT statics. The
+//     actual `SessionHost` (and the `SSHClient` instances it owns) lives in
+//     the foreground task isolate, constructed by `KeepaliveTaskHandler` so
+//     the socket survives the UI isolate being killed (#531 acceptance).
+//
+//   - Test: `InMemoryGatewayPair`, a pair of in-isolate `StreamController`s.
+//     Lets widget tests exercise the full IPC contract without binding to
+//     platform method channels.
+//
+// Tests override [taskSshGatewayProvider] directly via
+// `ProviderScope.overrides`; production code reads it through
+// `sshSessionProxyProvider` (TODO follow-up) or directly.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/session_host.dart';
 import '../services/task_ssh_gateway.dart';
 
-/// Holds the gateway pair so the host (task side) and any UI-side proxies
-/// share the same in-memory transport. Disposed when the provider container
-/// is torn down.
+/// In-memory gateway pair used by tests + by the legacy in-process host
+/// resolver below. Disposed when the provider container tears down.
 final gatewayPairProvider = Provider<InMemoryGatewayPair>((ref) {
   final pair = InMemoryGatewayPair();
   ref.onDispose(pair.dispose);
   return pair;
 });
 
-/// Task-side session host. Reads the gateway pair so each consumer of
-/// `gatewayPairProvider` sees a host bound to the same transport.
+/// UI-side gateway the proxy + UI consumers talk to. Production resolves to a
+/// [FlutterForegroundSshGateway] bound to FFT statics; tests override this
+/// provider with a [TaskSshGateway] backed by `InMemoryGatewayPair.uiSide`.
+final taskSshGatewayProvider = Provider<TaskSshGateway>((ref) {
+  final gateway = FlutterForegroundSshGateway();
+  ref.onDispose(gateway.dispose);
+  return gateway;
+});
+
+/// Legacy in-process [SessionHost] provider — kept so the widget rebind test
+/// and the existing UI scaffolding continue to resolve a host even when the
+/// production gateway hasn't been swapped in. Production callers should NOT
+/// read this provider; the task isolate constructs its own host via
+/// [KeepaliveTaskHandler].
+///
+/// Tests that want to inspect host state use this provider directly so they
+/// can call `host.ingestOutputForTest(...)` without crossing the gateway.
 final sessionHostProvider = Provider<SessionHost>((ref) {
   final pair = ref.watch(gatewayPairProvider);
   final host = SessionHost(gateway: pair.taskSide);

--- a/native/test/services/task_isolate_handover_test.dart
+++ b/native/test/services/task_isolate_handover_test.dart
@@ -1,0 +1,332 @@
+// Cross-isolate handover tests for the foreground-task SSH host (#531).
+//
+// The production gateway pair — [FlutterForegroundSshGateway] (UI) and
+// [TaskSideForegroundGateway] (task) — talks across the FFT IPC boundary. We
+// can't bind to platform channels inside `flutter test`, so the gateways
+// expose a transport seam: production transport calls
+// `FlutterForegroundTask.sendData…` statics; the [StubFftTransport] pair
+// shipped in `task_ssh_gateway.dart` mirrors that topology with in-process
+// `StreamController`s.
+//
+// The tests below construct a UI-side `FlutterForegroundSshGateway` and a
+// task-side `TaskSideForegroundGateway` connected via a stub transport pair,
+// then wire a real `SessionHost` to the task side and a real `SshSessionProxy`
+// to the UI side. The full envelope flow — encode in UI, transport, decode
+// in task, dispatch to `SshSessionController`, encode reply, transport back,
+// decode in UI — is exercised end-to-end.
+//
+// Plus: `KeepaliveTaskHandler.onStart` constructs a host bound to a
+// task-side transport that we can drive directly through `onReceiveData`.
+// That test enforces #531 acceptance bullet "the task isolate is the SSH
+// lifecycle owner" — the handler is the thing that physically holds the
+// host.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:mobissh/services/keepalive_task.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) async {
+      // Synchronous throw — controller transitions straight to `failed`,
+      // no pending timers (avoids fake-async leak detection in widget tests).
+      throw Exception('stub socket opener — bypass real connect');
+    },
+  );
+}
+
+void main() {
+  group('gateway pair via stub transport', () {
+    test(
+        'UI-side connect command flows through the transport and reaches '
+        'the task-side SessionHost', () async {
+      final pair = StubFftTransportPair();
+      addTearDown(pair.dispose);
+
+      final uiGateway = FlutterForegroundSshGateway(transport: pair.uiSide);
+      addTearDown(uiGateway.dispose);
+      // The stub transport is fed via the pair, not via the FFT
+      // transport's `deliver`. We wire it manually so the gateway sees
+      // payloads coming through the test transport.
+      final taskTransport = _PairFedTaskTransport(pair.taskSide);
+      final realTaskGateway =
+          TaskSideForegroundGateway(transport: taskTransport);
+      addTearDown(realTaskGateway.dispose);
+
+      final host = SessionHost(
+        gateway: realTaskGateway,
+        controllerFactory: _stubControllerFactory,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(host.disposeSyncForTest);
+
+      final proxy = SshSessionProxy(
+        sessionId: 'sid-handover',
+        gateway: uiGateway,
+      );
+      addTearDown(proxy.dispose);
+
+      // Issue a connect through the UI proxy. The command must travel the
+      // stub transport into the task gateway, get decoded by the host, and
+      // result in a hosted controller.
+      proxy.connect(const SshConnectParams(
+        host: 'h',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ));
+      // Drain the event loop so the controllers all register.
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(host.sessionIds, contains('sid-handover'));
+
+      // Inject task-side output and verify the UI proxy sees the snapshot
+      // through the transport.
+      host.ingestOutputForTest(
+        'sid-handover',
+        Uint8List.fromList('hello\n'.codeUnits),
+      );
+      proxy.rebind();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(proxy.snapshot.scrollbackTail, contains('hello'));
+      expect(proxy.snapshot.bytesIn, greaterThanOrEqualTo(6));
+    });
+
+    test('task-side state events flow back through the transport to the UI',
+        () async {
+      final pair = StubFftTransportPair();
+      addTearDown(pair.dispose);
+
+      final uiGateway = FlutterForegroundSshGateway(transport: pair.uiSide);
+      addTearDown(uiGateway.dispose);
+      final taskTransport = _PairFedTaskTransport(pair.taskSide);
+      final taskGateway = TaskSideForegroundGateway(transport: taskTransport);
+      addTearDown(taskGateway.dispose);
+
+      final host = SessionHost(
+        gateway: taskGateway,
+        controllerFactory: _stubControllerFactory,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(host.disposeSyncForTest);
+
+      final proxy =
+          SshSessionProxy(sessionId: 'sid-state', gateway: uiGateway);
+      addTearDown(proxy.dispose);
+
+      final seen = <SshSessionState>[];
+      final sub = proxy.stream.listen((d) => seen.add(d.state));
+      addTearDown(sub.cancel);
+
+      proxy.connect(const SshConnectParams(
+        host: 'h',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ));
+      // Stub socket opener throws synchronously → state machine emits
+      // connecting → failed. Both must reach the UI proxy.
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(seen, contains(SshSessionState.connecting));
+      expect(seen, contains(SshSessionState.failed));
+    });
+
+    test('disconnect command tears down the hosted session over the wire',
+        () async {
+      final pair = StubFftTransportPair();
+      addTearDown(pair.dispose);
+
+      final uiGateway = FlutterForegroundSshGateway(transport: pair.uiSide);
+      addTearDown(uiGateway.dispose);
+      final taskTransport = _PairFedTaskTransport(pair.taskSide);
+      final taskGateway = TaskSideForegroundGateway(transport: taskTransport);
+      addTearDown(taskGateway.dispose);
+
+      final host = SessionHost(
+        gateway: taskGateway,
+        controllerFactory: _stubControllerFactory,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(host.disposeSyncForTest);
+
+      final proxy = SshSessionProxy(
+        sessionId: 'sid-disco',
+        gateway: uiGateway,
+      );
+      addTearDown(proxy.dispose);
+
+      proxy.connect(const SshConnectParams(
+        host: 'h',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(host.sessionIds, contains('sid-disco'));
+
+      proxy.disconnect();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(host.sessionIds, isNot(contains('sid-disco')));
+    });
+
+    test('Map<dynamic, dynamic> payloads are coerced to Map<String, dynamic>',
+        () {
+      // FFT's platform marshaller can hand back loosely-typed maps; the
+      // gateway must coerce before re-dispatching so downstream `fromJson`
+      // calls don't blow up with a type error.
+      final pair = StubFftTransportPair();
+      final uiGateway = FlutterForegroundSshGateway(transport: pair.uiSide);
+      final taskTransport = _PairFedTaskTransport(pair.taskSide);
+      final taskGateway = TaskSideForegroundGateway(transport: taskTransport);
+      final received = <Map<String, dynamic>>[];
+      final sub = taskGateway.incoming.listen(received.add);
+
+      // Send a Map<dynamic, dynamic> directly through the transport.
+      final loose = <dynamic, dynamic>{
+        'kind': 'disconnect',
+        'sessionId': 'sid',
+      };
+      pair.uiSide.send(loose);
+      // The pair's stub uses synchronous broadcast streams; one microtask
+      // flush is enough for the listener to fire.
+      return Future<void>.delayed(Duration.zero).then((_) {
+        expect(received, isNotEmpty);
+        expect(received.first['kind'], 'disconnect');
+        sub.cancel();
+        uiGateway.dispose();
+        taskGateway.dispose();
+        pair.dispose();
+      });
+    });
+  });
+
+  group('KeepaliveTaskHandler hosts a SessionHost in the task isolate', () {
+    test('onStart constructs a host bound to the FFT task transport',
+        () async {
+      // We inject a builder that captures the gateway the handler hands us.
+      TaskSshGateway? capturedGateway;
+      SessionHost? capturedHost;
+      final handler = KeepaliveTaskHandler(
+        hostBuilder: (gateway) {
+          capturedGateway = gateway;
+          final host = SessionHost(
+            gateway: gateway,
+            controllerFactory: _stubControllerFactory,
+            snapshotInterval: const Duration(hours: 1),
+          );
+          capturedHost = host;
+          return host;
+        },
+      );
+
+      await handler.onStart(DateTime.now(), TaskStarter.developer);
+      expect(capturedGateway, isNotNull);
+      expect(capturedHost, isNotNull);
+      expect(handler.hostForTest, same(capturedHost));
+      expect(handler.startedAt, isNotNull);
+
+      // Tear down via onDestroy — host.dispose must be called so any
+      // SSHClient instances close cleanly.
+      capturedHost!.disposeSyncForTest();
+      await handler.onDestroy(DateTime.now(), false);
+      expect(handler.hostForTest, isNull);
+      expect(handler.startedAt, isNull);
+    });
+
+    test('onReceiveData forwards UI payloads into the host gateway',
+        () async {
+      // Build the handler with a host that we can inspect. The transport is
+      // the handler's own (private) task-side FFT transport; the only public
+      // way payloads flow in is via onReceiveData.
+      final hostInbound = <Map<String, dynamic>>[];
+      final handler = KeepaliveTaskHandler(
+        hostBuilder: (gateway) {
+          // Tap the gateway's incoming stream so we can verify payloads
+          // arriving via onReceiveData get there.
+          gateway.incoming.listen(hostInbound.add);
+          return SessionHost(
+            gateway: gateway,
+            controllerFactory: _stubControllerFactory,
+            snapshotInterval: const Duration(hours: 1),
+          );
+        },
+      );
+
+      await handler.onStart(DateTime.now(), TaskStarter.developer);
+
+      // Deliver a connect command — same wire format the UI proxy would
+      // produce. The handler routes it into the gateway via deliver.
+      const connect = SshConnectCommand(
+        sessionId: 'sid-keepalive',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        authJson: {'type': 'password', 'password': 'p'},
+      );
+      handler.onReceiveData(connect.toJson());
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(hostInbound, isNotEmpty);
+      expect(hostInbound.first['kind'], 'connect');
+      expect(handler.hostForTest!.sessionIds, contains('sid-keepalive'));
+
+      handler.hostForTest!.disposeSyncForTest();
+      await handler.onDestroy(DateTime.now(), false);
+    });
+
+    test('onDestroy disposes the hosted session and clears handler state',
+        () async {
+      final handler = KeepaliveTaskHandler(
+        hostBuilder: (gateway) => SessionHost(
+          gateway: gateway,
+          controllerFactory: _stubControllerFactory,
+          snapshotInterval: const Duration(hours: 1),
+        ),
+      );
+      await handler.onStart(DateTime.now(), TaskStarter.developer);
+      const connect = SshConnectCommand(
+        sessionId: 'sid-bye',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        authJson: {'type': 'password', 'password': 'p'},
+      );
+      handler.onReceiveData(connect.toJson());
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(handler.hostForTest!.sessionIds, contains('sid-bye'));
+
+      // Forced sync disposal so we don't leak controllers when the test
+      // host tears down via `await onDestroy`.
+      handler.hostForTest!.disposeSyncForTest();
+      await handler.onDestroy(DateTime.now(), false);
+      expect(handler.hostForTest, isNull);
+      expect(handler.startedAt, isNull);
+    });
+  });
+}
+
+/// Test helper — a [TaskSideFftTransport] whose inbound payloads come from
+/// a [StubFftTransport] pair instead of FFT's `onReceiveData`. Lets the test
+/// drive the UI ↔ task channel without binding to platform statics.
+class _PairFedTaskTransport extends TaskSideFftTransport {
+  _PairFedTaskTransport(this._pairSide) {
+    _pairSide.registerReceiver(deliver);
+  }
+
+  final StubFftTransport _pairSide;
+
+  @override
+  void send(Object payload) {
+    _pairSide.send(payload);
+  }
+}


### PR DESCRIPTION
## Summary
- Add production FFT-backed gateways (`FlutterForegroundSshGateway` UI side, `TaskSideForegroundGateway` task side) behind a thin `FftTransport` seam so the IPC seam from #524 actually crosses the isolate boundary.
- Refactor `KeepaliveTaskHandler` so `onStart` constructs a `SessionHost` inside the foreground task isolate; `onReceiveData` routes UI commands; `onDestroy` tears down all hosted `SSHClient`s before the isolate dies.
- Swap the production `taskSshGatewayProvider` to use the FFT gateway while keeping `gatewayPairProvider` / `sessionHostProvider` available for test injection.

## TDD Analysis
- Type: feature (completes the #524 → #531 sequence)
- Behavior change: yes — SSH lifecycle now physically owned by the foreground task isolate so the socket survives UI isolate death
- TDD approach: full

## Test coverage
- **Existing tests updated**: none — `multi_session_rebind_test.dart` continues to use `InMemoryGatewayPair` and still passes (500ms budget intact); `task_ipc_test.dart` envelope round-trips unchanged.
- **New tests added (fail→pass)**: `native/test/services/task_isolate_handover_test.dart` — 7 tests covering:
  - UI-side connect command flows through the transport into the task-side `SessionHost`
  - Task-side state events flow back through the transport to the UI proxy
  - Disconnect command tears down the hosted session over the wire
  - `Map<dynamic, dynamic>` payloads are coerced to `Map<String, dynamic>` (FFT marshaller robustness)
  - `KeepaliveTaskHandler.onStart` constructs a host bound to the FFT task transport
  - `KeepaliveTaskHandler.onReceiveData` forwards UI payloads into the host gateway
  - `KeepaliveTaskHandler.onDestroy` disposes the hosted session and clears handler state
- **Smoketest**: the handler `onStart` test verifies a host is constructed; `onReceiveData` verifies dispatch wiring; together they prove the task isolate is the SSH lifecycle owner.

## Test results
- `flutter analyze`: PASS (0 issues)
- `flutter test --exclude-tags integration`: PASS (161 tests, 7 new)

## Diff stats
- Files changed: 4
- Lines: +656 / -26 (under the 800-line scope cap; +286 production / +332 test)

## Architecture notes
- `FftTransport` is the new seam: production uses `UiSideFftTransport` / `TaskSideFftTransport` (FFT statics); tests use `StubFftTransport` pairs (in-process StreamControllers that mirror the FFT topology). The gateway code itself runs identically in both.
- `SessionsNotifier` consumer migration to `SshSessionProxy` is intentionally left as a follow-up — out of scope per the issue body ("UI / keybar / session menu changes — #518's work is final"). The scaffolding lets a future PR migrate consumers one at a time without re-touching this plumbing.
- Naming: existing `keepalive_task.dart` already had a `FlutterForegroundTaskGateway` for the *foreground service* abstraction; the new SSH gateway is named `FlutterForegroundSshGateway` to avoid the collision.

Closes #531

## Cycles used
1/3