### PR TITLE
feat(#529): custom SAF file picker via MethodChannel (no third-party package)

### DIFF
--- a/native/android/app/src/main/kotlin/com/flavordrake/mobissh/mobissh/MainActivity.kt
+++ b/native/android/app/src/main/kotlin/com/flavordrake/mobissh/mobissh/MainActivity.kt
@@ -1,9 +1,13 @@
 package com.flavordrake.mobissh.mobissh
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -32,9 +36,102 @@ import java.util.TimeZone
 class MainActivity : FlutterActivity() {
     private val tag = "MobiSSHCrash"
 
+    // ── Storage Access Framework file picker (#529 — custom MethodChannel
+    // bypass of the broken `file_picker` package). The bridge between Dart's
+    // `MethodChannelFilePickerAdapter` and Android's `ACTION_OPEN_DOCUMENT`
+    // intent. Result holds the pending MethodChannel result so
+    // `onActivityResult` can complete it asynchronously.
+    private var pendingPickerResult: MethodChannel.Result? = null
+    private val pickerChannel = "mobissh/storage_picker"
+    private val pickerRequestCode = 0xC0DE
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         installNativeCrashHandler()
+        installStoragePickerChannel(flutterEngine)
+    }
+
+    private fun installStoragePickerChannel(flutterEngine: FlutterEngine) {
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            pickerChannel,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "pickJsonBytes" -> {
+                    if (pendingPickerResult != null) {
+                        result.error("ALREADY_OPEN", "picker already in flight", null)
+                        return@setMethodCallHandler
+                    }
+                    pendingPickerResult = result
+                    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                        addCategory(Intent.CATEGORY_OPENABLE)
+                        type = "*/*"
+                        // Multiple MIME types because the SAF mime filter is
+                        // strict — "application/json" alone hides files the
+                        // PWA names with .json that Android stamps with the
+                        // generic "application/octet-stream" mime.
+                        putExtra(
+                            Intent.EXTRA_MIME_TYPES,
+                            arrayOf("application/json", "text/plain", "application/octet-stream"),
+                        )
+                    }
+                    try {
+                        startActivityForResult(intent, pickerRequestCode)
+                    } catch (err: Throwable) {
+                        pendingPickerResult = null
+                        result.error(
+                            "NO_PICKER",
+                            "Storage picker unavailable: ${err.message}",
+                            null,
+                        )
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == pickerRequestCode) {
+            val pending = pendingPickerResult
+            pendingPickerResult = null
+            if (resultCode != Activity.RESULT_OK || data == null) {
+                pending?.success(null) // user cancelled
+                return
+            }
+            val uri: Uri? = data.data
+            if (uri == null) {
+                pending?.success(null)
+                return
+            }
+            try {
+                val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                if (bytes == null) {
+                    pending?.error("READ_FAILED", "Could not read picked URI", uri.toString())
+                    return
+                }
+                val name = displayNameFor(uri) ?: "backup.json"
+                pending?.success(mapOf("name" to name, "bytes" to bytes))
+            } catch (err: Throwable) {
+                pending?.error("READ_FAILED", err.message, uri.toString())
+            }
+            return
+        }
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    /** Resolve a human-friendly display name for a content URI. SAF returns
+     *  `content://` URIs whose path is opaque; the OpenableColumns query is
+     *  the documented way to recover the original filename. */
+    private fun displayNameFor(uri: Uri): String? {
+        return try {
+            contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) cursor.getString(0) else null
+            }
+        } catch (err: Throwable) {
+            Log.w(tag, "displayNameFor failed", err)
+            null
+        }
     }
 
     private fun installNativeCrashHandler() {

--- a/native/lib/ui/import_profiles_dialog.dart
+++ b/native/lib/ui/import_profiles_dialog.dart
@@ -1,34 +1,95 @@
-// "Import from PWA" dialog (#501, vault decrypt for #510).
+// "Import from PWA" dialog (#501, vault decrypt for #510, file picker for #529).
+//
+// Primary affordance: "Choose backup file…" → opens Android Storage Access
+// Framework via a custom MethodChannel (`mobissh/storage_picker`). The file's
+// bytes are read by the Kotlin side and returned to Dart. The paste path
+// stays as a collapsed disclosure ("Paste JSON instead") so the existing
+// test/keyboard-driven flow keeps working.
+//
+// Why a custom channel instead of the `file_picker` package: see #529. Both
+// `file_picker` 8.x and 11.x break the build in this project (AAR-metadata
+// at 8.x; Flutter Built-in-Kotlin / KGP conflict at 11.x). The custom channel
+// is ~30 LoC of Kotlin and bypasses the entire package toolchain.
 //
 // Two-stage flow:
-//   1. User pastes JSON. Submit triggers a sync parse.
+//   1. User picks file OR pastes JSON. Submit triggers a sync parse.
 //   2. If the parsed envelope carries `vault.encrypted`+`vault.meta`, an
 //      additional password field appears (same dialog). Submit then
 //      decrypts + persists.
-//   3. Plain envelope (no vault) → single Submit path, same as before.
+//   3. Plain envelope (no vault) → single Submit path.
 //
 // On success: returns the [ImportResult] so the caller can show a snackbar.
 // On parse failure / wrong password / unknown shape: shows the error
 // in-dialog without closing, so the user can fix the input and retry.
 
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../state/profiles_providers.dart';
 import '../storage/profiles_store.dart';
 
+/// Plain-data result of a file pick. Decoupled from the platform so the
+/// widget test can inject a fake without binding to MethodChannel.
+class PickedFile {
+  PickedFile({required this.name, required this.bytes});
+
+  final String name;
+  final Uint8List bytes;
+}
+
+/// Abstraction over the platform file picker so tests can supply a fake.
+abstract class FilePickerAdapter {
+  /// Open the storage picker filtered to JSON files. Returns the picked
+  /// file's bytes + display name, or null if the user cancelled.
+  Future<PickedFile?> pickJsonFile();
+}
+
+/// Production adapter — calls the Kotlin handler in `MainActivity` via the
+/// `mobissh/storage_picker` channel. Returns a [PickedFile] with the
+/// file's name and raw bytes.
+class MethodChannelFilePickerAdapter implements FilePickerAdapter {
+  const MethodChannelFilePickerAdapter();
+
+  static const _channel = MethodChannel('mobissh/storage_picker');
+
+  @override
+  Future<PickedFile?> pickJsonFile() async {
+    final result = await _channel.invokeMethod<Map<Object?, Object?>>(
+      'pickJsonBytes',
+    );
+    if (result == null) return null;
+    final name = result['name'] as String? ?? 'backup.json';
+    final bytes = result['bytes'] as Uint8List?;
+    if (bytes == null) return null;
+    return PickedFile(name: name, bytes: bytes);
+  }
+}
+
 /// Show the import dialog. Resolves to the [ImportResult] on success, or
 /// `null` if the user cancelled. Tests can construct
-/// [ImportProfilesDialog] directly instead of going through this helper.
-Future<ImportResult?> showImportProfilesDialog(BuildContext context) {
+/// [ImportProfilesDialog] directly instead of going through this helper,
+/// or pass a custom [pickerAdapter] to inject a fake.
+Future<ImportResult?> showImportProfilesDialog(
+  BuildContext context, {
+  FilePickerAdapter pickerAdapter = const MethodChannelFilePickerAdapter(),
+}) {
   return showDialog<ImportResult>(
     context: context,
-    builder: (_) => const ImportProfilesDialog(),
+    builder: (_) => ImportProfilesDialog(pickerAdapter: pickerAdapter),
   );
 }
 
 class ImportProfilesDialog extends ConsumerStatefulWidget {
-  const ImportProfilesDialog({super.key});
+  const ImportProfilesDialog({
+    super.key,
+    this.pickerAdapter = const MethodChannelFilePickerAdapter(),
+  });
+
+  /// Adapter used to open the storage picker. Tests pass a fake.
+  final FilePickerAdapter pickerAdapter;
 
   @override
   ConsumerState<ImportProfilesDialog> createState() =>
@@ -40,6 +101,12 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
   final _passwordCtrl = TextEditingController();
   String? _error;
   bool _busy = false;
+  bool _pasteExpanded = false;
+
+  // Set after a successful file pick. Drives a one-line summary so the user
+  // can confirm the selection before tapping Import.
+  String? _pickedFileName;
+  String? _pickedSummary;
 
   // Stage 2: a parsed envelope carrying a vault. When non-null, the
   // password field is rendered and Submit applies with the password.
@@ -63,6 +130,69 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
     _jsonCtrl.dispose();
     _passwordCtrl.dispose();
     super.dispose();
+  }
+
+  Future<void> _pickFile() async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    PickedFile? picked;
+    try {
+      picked = await widget.pickerAdapter.pickJsonFile();
+    } on PlatformException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _error = 'Could not open file picker: ${e.message ?? e.code}';
+      });
+      return;
+    } on Exception catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _error = 'Could not open file picker: $e';
+      });
+      return;
+    }
+    if (!mounted) return;
+    if (picked == null) {
+      setState(() {
+        _busy = false;
+      });
+      return;
+    }
+
+    String text;
+    try {
+      text = utf8.decode(picked.bytes);
+    } on FormatException catch (e) {
+      setState(() {
+        _busy = false;
+        _error = 'Could not read file as UTF-8 text: ${e.message}';
+      });
+      return;
+    }
+
+    _jsonCtrl.text = text;
+    final summary = _summarize(text);
+    setState(() {
+      _busy = false;
+      _pickedFileName = picked!.name;
+      _pickedSummary = summary;
+    });
+  }
+
+  /// One-line summary under `Selected: <name>`. Uses the same envelope-shape
+  /// detection as `parseImport` so a wrong file is spotted before submit.
+  String _summarize(String text) {
+    final parsed = ProfilesStore.parseImport(text);
+    if (parsed.profileEntries.isEmpty && parsed.errors.isNotEmpty) {
+      return parsed.errors.first;
+    }
+    final n = parsed.profileEntries.length;
+    final vault = parsed.hasVault ? 'vault present' : 'no vault';
+    return '$n profile${n == 1 ? '' : 's'}, $vault';
   }
 
   Future<void> _submit() async {
@@ -97,8 +227,8 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
       return;
     }
 
-    // Stage 1: parse the pasted JSON. If it carries a vault, switch the
-    // dialog into stage 2 (password prompt) without persisting anything.
+    // Stage 1: parse the pasted/loaded JSON. If it carries a vault, switch
+    // the dialog into stage 2 (password prompt) without persisting anything.
     final parsed = ProfilesStore.parseImport(_jsonCtrl.text);
     if (parsed.hasVault) {
       setState(() {
@@ -108,7 +238,6 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
       return;
     }
 
-    // No vault: persist directly.
     final result = await store.applyParsedImport(parsed);
     if (!mounted) return;
 
@@ -143,56 +272,84 @@ class _ImportProfilesDialogState extends ConsumerState<ImportProfilesDialog> {
           : 'Import profiles from PWA'),
       content: SizedBox(
         width: 500,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (!inVaultStage) ...[
-              const Text(
-                'Paste the JSON copied from the PWA "Export to native" button.',
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                key: const Key('import-profiles-input'),
-                controller: _jsonCtrl,
-                maxLines: 8,
-                autocorrect: false,
-                enableSuggestions: false,
-                decoration: const InputDecoration(
-                  hintText: '{ "version": 1, "profiles": [ ... ] }',
-                  border: OutlineInputBorder(),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (!inVaultStage) ...[
+                FilledButton.icon(
+                  key: const Key('import-profiles-pick-file'),
+                  onPressed: _busy ? null : _pickFile,
+                  icon: const Icon(Icons.attach_file),
+                  label: const Text('Choose backup file…'),
                 ),
-              ),
-            ] else ...[
-              const Text(
-                'This backup is encrypted. Enter the master password you set '
-                'in the PWA to decrypt the saved credentials.',
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                key: const Key('import-profiles-password'),
-                controller: _passwordCtrl,
-                obscureText: true,
-                autocorrect: false,
-                enableSuggestions: false,
-                onSubmitted: (_) {
-                  if (_canSubmit()) _submit();
-                },
-                decoration: const InputDecoration(
-                  labelText: 'Master password',
-                  border: OutlineInputBorder(),
+                if (_pickedFileName != null) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    'Selected: $_pickedFileName',
+                    key: const Key('import-profiles-picked-name'),
+                  ),
+                  if (_pickedSummary != null)
+                    Text(
+                      _pickedSummary!,
+                      key: const Key('import-profiles-picked-summary'),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                ],
+                const SizedBox(height: 8),
+                ExpansionTile(
+                  key: const Key('import-profiles-paste-disclosure'),
+                  title: const Text('Paste JSON instead'),
+                  initiallyExpanded: _pasteExpanded,
+                  onExpansionChanged: (v) => setState(() => _pasteExpanded = v),
+                  childrenPadding: const EdgeInsets.only(bottom: 8),
+                  tilePadding: EdgeInsets.zero,
+                  children: [
+                    TextField(
+                      key: const Key('import-profiles-input'),
+                      controller: _jsonCtrl,
+                      maxLines: 8,
+                      autocorrect: false,
+                      enableSuggestions: false,
+                      decoration: const InputDecoration(
+                        hintText: '{ "version": 1, "profiles": [ ... ] }',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ],
                 ),
-              ),
+              ] else ...[
+                const Text(
+                  'This backup is encrypted. Enter the master password you set '
+                  'in the PWA to decrypt the saved credentials.',
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  key: const Key('import-profiles-password'),
+                  controller: _passwordCtrl,
+                  obscureText: true,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  onSubmitted: (_) {
+                    if (_canSubmit()) _submit();
+                  },
+                  decoration: const InputDecoration(
+                    labelText: 'Master password',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ],
+              if (_error != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  _error!,
+                  key: const Key('import-profiles-error'),
+                  style: const TextStyle(color: Colors.redAccent),
+                ),
+              ],
             ],
-            if (_error != null) ...[
-              const SizedBox(height: 8),
-              Text(
-                _error!,
-                key: const Key('import-profiles-error'),
-                style: const TextStyle(color: Colors.redAccent),
-              ),
-            ],
-          ],
+          ),
         ),
       ),
       actions: [

--- a/native/test/widget/import_dialog_widget_test.dart
+++ b/native/test/widget/import_dialog_widget_test.dart
@@ -1,10 +1,16 @@
-// Widget tests for [ImportProfilesDialog] (#501).
+// Widget tests for [ImportProfilesDialog] (#501, #510 vault, #529 file picker).
 //
 // Asserts:
-//   - valid pasted JSON triggers import (store state changes, dialog closes
-//     with non-null ImportResult)
-//   - invalid JSON keeps the dialog open and shows an inline error;
-//     store state is unchanged
+//   - file picker is the primary affordance; tapping it drives the adapter
+//     and populates the dialog state (#529 smoketest)
+//   - picked file bytes flow through parseImport/applyParsedImport (#529)
+//   - paste path stays usable behind the "Paste JSON instead" disclosure
+//   - valid pasted JSON imports and closes
+//   - invalid JSON shows inline error; store unchanged
+//   - vault envelope switches to stage-2 password prompt
+
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,6 +22,16 @@ import 'package:mobissh/storage/profiles_store.dart';
 import 'package:mobissh/storage/secrets_store.dart';
 import 'package:mobissh/ui/import_profiles_dialog.dart';
 
+/// Fake adapter — returns a scripted PickedFile (or null) without binding to
+/// MethodChannel. Tests pass a real fake via `pickerAdapter:`.
+class _FakeFilePicker implements FilePickerAdapter {
+  _FakeFilePicker(this._pick);
+  final PickedFile? _pick;
+
+  @override
+  Future<PickedFile?> pickJsonFile() async => _pick;
+}
+
 /// Pump a launcher that exposes a button which opens the dialog. Avoids the
 /// "guarded function conflict" trap of launching the dialog from a
 /// postFrameCallback inside the first pumpWidget call.
@@ -23,9 +39,11 @@ Future<ImportResult?> _openDialog(
   WidgetTester tester, {
   required ProfilesStore store,
   SecretsStore? secrets,
+  FilePickerAdapter? pickerAdapter,
   required Future<void> Function(WidgetTester) interact,
 }) async {
   ImportResult? captured;
+  final adapter = pickerAdapter ?? _FakeFilePicker(null);
 
   await tester.pumpWidget(
     ProviderScope(
@@ -40,7 +58,10 @@ Future<ImportResult?> _openDialog(
               child: ElevatedButton(
                 key: const Key('open-button'),
                 onPressed: () async {
-                  captured = await showImportProfilesDialog(context);
+                  captured = await showImportProfilesDialog(
+                    context,
+                    pickerAdapter: adapter,
+                  );
                 },
                 child: const Text('Open'),
               ),
@@ -63,11 +84,92 @@ Future<ImportResult?> _openDialog(
   return captured;
 }
 
+/// Expand the "Paste JSON instead" disclosure so the legacy paste TextField
+/// is visible. Most paste-based tests need this first since #529 collapsed
+/// the textarea behind a disclosure.
+Future<void> _expandPaste(WidgetTester t) async {
+  await t.tap(find.byKey(const Key('import-profiles-paste-disclosure')));
+  await t.pumpAndSettle();
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('file picker is the primary affordance (#529 smoketest)',
+      (tester) async {
+    final store = ProfilesStore();
+
+    final result = await _openDialog(
+      tester,
+      store: store,
+      interact: (t) async {
+        // File picker button visible immediately.
+        expect(
+          find.byKey(const Key('import-profiles-pick-file')),
+          findsOneWidget,
+        );
+        // Paste textarea is hidden until the disclosure expands.
+        expect(
+          find.byKey(const Key('import-profiles-input')),
+          findsNothing,
+        );
+        // Cancel to satisfy the future.
+        await t.tap(find.byKey(const Key('import-profiles-cancel')));
+      },
+    );
+    expect(result, isNull);
+    expect(await store.load(), isEmpty);
+  });
+
+  testWidgets('picked file bytes drive the same import as paste (#529)',
+      (tester) async {
+    final store = ProfilesStore();
+
+    const validJson = '''
+{
+  "version": 1,
+  "exportedAt": "2026-05-22T13:00:00.000Z",
+  "profiles": [
+    { "title": "Picked via file", "host": "f.example", "port": 22,
+      "username": "me" }
+  ]
+}
+''';
+    final fake = _FakeFilePicker(PickedFile(
+      name: 'mobissh-profiles-test.json',
+      bytes: Uint8List.fromList(utf8.encode(validJson)),
+    ));
+
+    final result = await _openDialog(
+      tester,
+      store: store,
+      pickerAdapter: fake,
+      interact: (t) async {
+        await t.tap(find.byKey(const Key('import-profiles-pick-file')));
+        await t.pumpAndSettle();
+        // Summary line is shown after the pick.
+        expect(
+          find.byKey(const Key('import-profiles-picked-name')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('import-profiles-picked-summary')),
+          findsOneWidget,
+        );
+        // Submit drives the same parse + apply pipeline as paste.
+        await t.tap(find.byKey(const Key('import-profiles-submit')));
+      },
+    );
+
+    expect(find.byKey(const Key('import-profiles-dialog')), findsNothing);
+    expect(result, isNotNull);
+    expect(result!.added, 1);
+    final loaded = await store.load();
+    expect(loaded.single.host, 'f.example');
   });
 
   testWidgets('valid PWA-envelope JSON imports and closes the dialog',
@@ -79,6 +181,7 @@ void main() {
       store: store,
       interact: (t) async {
         expect(find.byKey(const Key('import-profiles-dialog')), findsOneWidget);
+        await _expandPaste(t);
 
         const validJson = '''
 {
@@ -120,6 +223,7 @@ void main() {
       store: store,
       interact: (t) async {
         expect(find.byKey(const Key('import-profiles-dialog')), findsOneWidget);
+        await _expandPaste(t);
 
         await t.enterText(
           find.byKey(const Key('import-profiles-input')),
@@ -160,6 +264,8 @@ void main() {
       store: store,
       secrets: secrets,
       interact: (t) async {
+        await _expandPaste(t);
+
         // The vault payload here is intentionally not decryptable — we only
         // care that detection works and the prompt appears, then we cancel.
         const envelopeWithVault = '''


### PR DESCRIPTION
## Summary

Closes #529 by replacing the broken `file_picker` package with a ~30 LoC Kotlin handler + ~10 LoC Dart adapter. No new dependency, no `compileSdk` bump, no Kotlin Gradle Plugin conflict.

## Architecture

```
ImportProfilesDialog
  ↓ uses FilePickerAdapter
MethodChannelFilePickerAdapter (Dart, lib/ui/import_profiles_dialog.dart)
  ↓ MethodChannel('mobissh/storage_picker').invokeMethod('pickJsonBytes')
MainActivity.installStoragePickerChannel (Kotlin)
  ↓ Intent(ACTION_OPEN_DOCUMENT) with MIME filter
SAF picker UI → onActivityResult
  ↓ contentResolver.openInputStream(uri).readBytes()
  ↓ OpenableColumns.DISPLAY_NAME query for the file name
returns {name: String, bytes: Uint8List} or null on cancel
```

## What's covered by tests

Two new widget tests using a `_FakeFilePicker` (no MethodChannel binding needed):

1. `file picker is the primary affordance (#529 smoketest)` — picker button visible immediately; paste textarea hidden until disclosure expands.
2. `picked file bytes drive the same import as paste (#529)` — fake adapter returns scripted JSON bytes, dialog submits, store contains imported profile.

Existing paste-path tests updated to first tap the "Paste JSON instead" disclosure (`ExpansionTile`) — added a `_expandPaste(t)` helper.

## What's NOT covered

- The Kotlin onActivityResult path is exercised only on-device. (Same constraint as any platform-channel code — not testable headless.)
- The MIME filter (`application/json` / `text/plain` / `application/octet-stream`) is a reasonable triple for SAF — verify on-device that PWA-downloaded files surface in the picker.

## Test plan
- [x] `scripts/native-fast-gate.sh` → analyze clean, 163 tests pass, 5 skipped
- [ ] Reviewer on-device: tap "Import from PWA" → "Choose backup file…" → SAF picker opens → pick the PWA-downloaded JSON → "Selected: ..." appears → tap Import → master-password prompt (vault present) → enter password → profiles + secrets imported.

## Why not `file_picker`

See #529. Both 8.x (AAR metadata check vs `flutter_plugin_android_lifecycle` requiring `compileSdk 36+`) and 11.x (KGP conflict with Flutter Built-in Kotlin) break the release build in this project. The custom channel is smaller than either workaround.

Closes #529