### PR TITLE
feat(#536): host-key trust-on-first-use over IPC

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -100,6 +100,20 @@ class SessionHost {
       case SshRequestSnapshotCommand():
         final s = _sessions[cmd.sessionId];
         if (s != null) _emitSnapshot(cmd.sessionId, s);
+      case SshHostKeyDecisionCommand():
+        _handleHostKeyDecision(cmd);
+    }
+  }
+
+  void _handleHostKeyDecision(SshHostKeyDecisionCommand cmd) {
+    final hosted = _sessions[cmd.sessionId];
+    if (hosted == null) return;
+    // The controller owns the pending Completer + trust-on-first-use store;
+    // forward the user's decision so it can resolve `onVerifyHostKey`.
+    if (cmd.accepted) {
+      hosted.controller.acceptHostKey();
+    } else {
+      hosted.controller.rejectHostKey();
     }
   }
 
@@ -121,6 +135,7 @@ class SessionHost {
         hosted.metrics.lastReconnectAtMs =
             DateTime.now().millisecondsSinceEpoch;
       }
+      _maybeEmitHostKeyChallenge(cmd.sessionId, hosted, data);
       _emitStateData(cmd.sessionId, data);
     });
 
@@ -156,6 +171,31 @@ class SessionHost {
       await hosted.controller.dispose();
     } catch (_) {/* ignore */}
     _gateway.send(SshClosedEvent(sessionId: sessionId).toJson());
+  }
+
+  /// Emit a host-key challenge to the UI when the controller surfaces a fresh
+  /// untrusted key (#536). Deduped per pending fingerprint so a single
+  /// awaitingHostKey transition produces exactly one challenge — repeated
+  /// state emits (e.g. banner updates) don't re-prompt.
+  void _maybeEmitHostKeyChallenge(
+    String sessionId,
+    _HostedSession hosted,
+    SshSessionData data,
+  ) {
+    final pending = data.pendingHostKey;
+    if (pending == null) {
+      hosted.challengedFingerprint = null;
+      return;
+    }
+    if (hosted.challengedFingerprint == pending.fingerprint) return;
+    hosted.challengedFingerprint = pending.fingerprint;
+    _gateway.send(SshHostKeyChallengeEvent(
+      sessionId: sessionId,
+      host: pending.host,
+      port: pending.port,
+      keyType: pending.keyType,
+      fingerprint: pending.fingerprint,
+    ).toJson());
   }
 
   void _emitState(String sessionId, SshSessionController controller) {
@@ -292,6 +332,10 @@ class _HostedSession {
   final SshSessionController controller;
   StreamSubscription<SshSessionData>? stateSub;
   final SessionMetrics metrics = SessionMetrics();
+
+  /// Fingerprint of the host-key challenge already forwarded to the UI, so a
+  /// single awaitingHostKey transition emits exactly one challenge (#536).
+  String? challengedFingerprint;
   final BytesBuilder _scrollback = BytesBuilder(copy: false);
 
   /// Append raw bytes to the scrollback cache and cap the buffer at ~4KB

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -21,6 +21,7 @@ enum SshTaskCommandKind {
   input,
   resize,
   requestSnapshot,
+  hostKeyDecision,
 }
 
 /// Envelope kind discriminator for task → UI events.
@@ -30,6 +31,7 @@ enum SshTaskEventKind {
   snapshot,
   closed,
   error,
+  hostKeyChallenge,
 }
 
 /// Base for all UI → task command envelopes. Subclasses are concrete records
@@ -84,6 +86,11 @@ sealed class SshTaskCommand {
         );
       case SshTaskCommandKind.requestSnapshot:
         return SshRequestSnapshotCommand(sessionId: sessionId);
+      case SshTaskCommandKind.hostKeyDecision:
+        return SshHostKeyDecisionCommand(
+          sessionId: sessionId,
+          accepted: json['accepted'] as bool,
+        );
     }
   }
 }
@@ -195,6 +202,30 @@ class SshRequestSnapshotCommand extends SshTaskCommand {
       };
 }
 
+/// UI → task: the user's trust decision for a pending host-key challenge
+/// (#536). Routed to the task-side controller's
+/// `acceptHostKey()` / `rejectHostKey()` so trust-on-first-use can resolve the
+/// verify callback that the controller is blocked on.
+class SshHostKeyDecisionCommand extends SshTaskCommand {
+  const SshHostKeyDecisionCommand({
+    required String sessionId,
+    required this.accepted,
+  }) : super(sessionId);
+
+  /// True = trust + continue; false = reject + abort.
+  final bool accepted;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.hostKeyDecision;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'accepted': accepted,
+      };
+}
+
 // ---------------------------------------------------------------------------
 // Events (task → UI)
 // ---------------------------------------------------------------------------
@@ -252,6 +283,14 @@ sealed class SshTaskEvent {
         return SshErrorEvent(
           sessionId: sessionId,
           message: json['message'] as String,
+        );
+      case SshTaskEventKind.hostKeyChallenge:
+        return SshHostKeyChallengeEvent(
+          sessionId: sessionId,
+          host: json['host'] as String,
+          port: json['port'] as int,
+          keyType: json['keyType'] as String,
+          fingerprint: json['fingerprint'] as String,
         );
     }
   }
@@ -375,5 +414,36 @@ class SshErrorEvent extends SshTaskEvent {
         'kind': kind.name,
         'sessionId': sessionId,
         'message': message,
+      };
+}
+
+/// Task → UI: a new (untrusted) host key needs a user trust decision (#536).
+/// The UI proxy turns this into a `PendingHostKey` so the existing host-key
+/// dialog (keyed on `SshSessionData.pendingHostKey`) surfaces unchanged.
+class SshHostKeyChallengeEvent extends SshTaskEvent {
+  const SshHostKeyChallengeEvent({
+    required String sessionId,
+    required this.host,
+    required this.port,
+    required this.keyType,
+    required this.fingerprint,
+  }) : super(sessionId);
+
+  final String host;
+  final int port;
+  final String keyType;
+  final String fingerprint;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.hostKeyChallenge;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'host': host,
+        'port': port,
+        'keyType': keyType,
+        'fingerprint': fingerprint,
       };
 }

--- a/native/lib/ssh/ssh_session.dart
+++ b/native/lib/ssh/ssh_session.dart
@@ -496,6 +496,21 @@ class SshSessionController {
     ));
   }
 
+  /// Drive the host-key verification path directly, bypassing the real SSH
+  /// handshake. Returns the same `Future<bool>` the dartssh2 verify callback
+  /// awaits: it resolves once [acceptHostKey] / [rejectHostKey] is called (or
+  /// immediately `true` for an already-trusted key). Exists so the IPC
+  /// round-trip (#536) can be exercised without a live socket.
+  @visibleForTesting
+  Future<bool> verifyHostKeyForTest(
+    SshConnectParams params,
+    String type,
+    Uint8List fingerprint,
+  ) {
+    _lastParams = params;
+    return _onVerifyHostKey(params, type, fingerprint);
+  }
+
   // --- private helpers ---
 
   void _emit(SshSessionData next) {

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -134,23 +134,30 @@ class SshSessionProxy {
     gateway.send(SshDisconnectCommand(sessionId: sessionId).toJson());
   }
 
-  /// Accept a pending host-key prompt.
-  ///
-  /// No-op today (#533): the IPC envelope contract from #530 does NOT carry
-  /// `pendingHostKey` state across the gateway, so the UI never sees a
-  /// prompt and never needs to dispatch a decision. The trust-on-first-use
-  /// cache lives in the task-side controller; cached fingerprints continue
-  /// to authenticate without UI involvement. Surfacing fresh host-key
-  /// prompts to the UI is tracked as a follow-up — when the contract grows
-  /// `SshHostKeyEvent` + `SshHostKeyDecisionCommand`, this method will send
-  /// the accept envelope.
+  /// Accept a pending host-key prompt (#536). Sends a decision command to the
+  /// task side (which trusts the key + resolves the controller's verify
+  /// callback) and clears the local `pendingHostKey` so the dialog dismisses.
   void acceptHostKey() {
-    // intentional no-op pending IPC envelope extension (follow-up to #533)
+    _sendHostKeyDecision(true);
   }
 
-  /// Reject a pending host-key prompt. See [acceptHostKey] for status.
+  /// Reject a pending host-key prompt (#536). The task-side controller aborts
+  /// the connect via its existing "Host key rejected" failure path.
   void rejectHostKey() {
-    // intentional no-op pending IPC envelope extension (follow-up to #533)
+    _sendHostKeyDecision(false);
+  }
+
+  void _sendHostKeyDecision(bool accepted) {
+    if (_disposed) return;
+    if (_data.pendingHostKey == null) return;
+    gateway.send(SshHostKeyDecisionCommand(
+      sessionId: sessionId,
+      accepted: accepted,
+    ).toJson());
+    // Optimistically clear the prompt; the authoritative state (authenticating
+    // / failed) arrives as a follow-up state event from the task side.
+    _data = _data.copyWith(clearPendingHostKey: true);
+    if (!_dataCtrl.isClosed) _dataCtrl.add(_data);
   }
 
   /// Send keystroke / paste bytes to the remote PTY through the gateway.
@@ -224,6 +231,17 @@ class SshSessionProxy {
         _data = _data.copyWith(
           state: SshSessionState.failed,
           error: event.message,
+        );
+        if (!_dataCtrl.isClosed) _dataCtrl.add(_data);
+      case SshHostKeyChallengeEvent():
+        _data = _data.copyWith(
+          state: SshSessionState.awaitingHostKey,
+          pendingHostKey: PendingHostKey(
+            host: event.host,
+            port: event.port,
+            keyType: event.keyType,
+            fingerprint: event.fingerprint,
+          ),
         );
         if (!_dataCtrl.isClosed) _dataCtrl.add(_data);
     }

--- a/native/test/services/host_key_ipc_test.dart
+++ b/native/test/services/host_key_ipc_test.dart
@@ -1,0 +1,253 @@
+// Host-key trust-on-first-use over IPC (#536).
+//
+// After #533 the verify callback runs task-side. These tests prove the IPC
+// bridge restores the trust prompt for new hosts:
+//   task-side untrusted key  → SshHostKeyChallengeEvent reaches the UI proxy
+//   → proxy.pendingHostKey populated
+//   → acceptHostKey()/rejectHostKey() sends SshHostKeyDecisionCommand
+//   → task-side controller's verify Completer resolves
+//   → HostKeyStore gains (accept) / stays empty (reject).
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/host_key_store.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+
+void main() {
+  group('host-key envelope round-trip', () {
+    test('SshHostKeyChallengeEvent preserves all fields', () {
+      const ev = SshHostKeyChallengeEvent(
+        sessionId: 'sid',
+        host: 'example.com',
+        port: 2222,
+        keyType: 'ssh-ed25519',
+        fingerprint: 'abc123',
+      );
+      final restored =
+          SshTaskEvent.fromJson(ev.toJson()) as SshHostKeyChallengeEvent;
+      expect(restored.sessionId, 'sid');
+      expect(restored.host, 'example.com');
+      expect(restored.port, 2222);
+      expect(restored.keyType, 'ssh-ed25519');
+      expect(restored.fingerprint, 'abc123');
+    });
+
+    test('SshHostKeyDecisionCommand preserves accepted flag', () {
+      for (final accepted in [true, false]) {
+        final cmd =
+            SshHostKeyDecisionCommand(sessionId: 'sid', accepted: accepted);
+        final restored = SshTaskCommand.fromJson(cmd.toJson())
+            as SshHostKeyDecisionCommand;
+        expect(restored.sessionId, 'sid');
+        expect(restored.accepted, accepted);
+      }
+    });
+  });
+
+  group('host-key IPC round-trip via InMemoryGatewayPair', () {
+    /// Controllers produced by the factory, in creation order, so the test can
+    /// reach into the one a given session is bound to.
+    late List<SshSessionController> created;
+    late List<HostKeyStore> stores;
+
+    SshSessionController makeController() {
+      final store = HostKeyStore();
+      // socketOpener never resolves so connect() parks in `connecting` and we
+      // drive the host-key verify path directly via verifyHostKeyForTest —
+      // no real TCP attempt that would race the controller to `failed`.
+      final c = SshSessionController(
+        hostKeyStore: store,
+        socketOpener: (host, port, {timeout}) {
+          return Future.delayed(const Duration(days: 1), () {
+            throw Exception('socketOpener not used in host-key IPC tests');
+          });
+        },
+      );
+      created.add(c);
+      stores.add(store);
+      return c;
+    }
+
+    setUp(() {
+      created = [];
+      stores = [];
+    });
+
+    Uint8List fp(List<int> bytes) => Uint8List.fromList(bytes);
+
+    test('accept: challenge surfaces, decision trusts the key', () async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(pair.dispose);
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: makeController,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(host.disposeSyncForTest);
+      final proxy = SshSessionProxy(sessionId: 'sid-a', gateway: pair.uiSide);
+      addTearDown(proxy.dispose);
+
+      // Spin up the hosted controller (its connect socketOpener never resolves,
+      // so we drive the verify path directly via the test seam below).
+      proxy.connect(const SshConnectParams(
+        host: 'newhost',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(created, hasLength(1));
+      final controller = created.first;
+      final store = stores.first;
+
+      // Drive an untrusted host-key verification on the task side.
+      final verifyFuture = controller.verifyHostKeyForTest(
+        const SshConnectParams(
+          host: 'newhost',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+        'ssh-ed25519',
+        fp([0xDE, 0xAD, 0xBE, 0xEF]),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // The UI proxy must now see a pending host-key prompt.
+      expect(proxy.data.pendingHostKey, isNotNull);
+      expect(proxy.data.pendingHostKey!.host, 'newhost');
+      expect(proxy.data.pendingHostKey!.port, 22);
+      expect(proxy.data.pendingHostKey!.keyType, 'ssh-ed25519');
+      expect(proxy.data.pendingHostKey!.fingerprint, 'deadbeef');
+      expect(proxy.data.state, SshSessionState.awaitingHostKey);
+
+      // User accepts → decision crosses the wire → controller resolves true.
+      proxy.acceptHostKey();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(await verifyFuture, isTrue);
+      expect(store.isTrusted('newhost', 22, 'deadbeef'), isTrue);
+      // Prompt cleared on the UI side.
+      expect(proxy.data.pendingHostKey, isNull);
+    });
+
+    test('reject: decision aborts and does not trust', () async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(pair.dispose);
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: makeController,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(host.disposeSyncForTest);
+      final proxy = SshSessionProxy(sessionId: 'sid-r', gateway: pair.uiSide);
+      addTearDown(proxy.dispose);
+
+      proxy.connect(const SshConnectParams(
+        host: 'rejhost',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final controller = created.first;
+      final store = stores.first;
+
+      final verifyFuture = controller.verifyHostKeyForTest(
+        const SshConnectParams(
+          host: 'rejhost',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+        'ssh-rsa',
+        fp([0x01, 0x02, 0x03]),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(proxy.data.pendingHostKey, isNotNull);
+
+      proxy.rejectHostKey();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(await verifyFuture, isFalse);
+      expect(store.length, 0);
+      expect(controller.data.state, SshSessionState.failed);
+      expect(controller.data.error, contains('rejected'));
+    });
+
+    test('multi-session: challenges are independent', () async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(pair.dispose);
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: makeController,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(host.disposeSyncForTest);
+      final proxyA = SshSessionProxy(sessionId: 'sid-1', gateway: pair.uiSide);
+      final proxyB = SshSessionProxy(sessionId: 'sid-2', gateway: pair.uiSide);
+      addTearDown(proxyA.dispose);
+      addTearDown(proxyB.dispose);
+
+      const paramsA = SshConnectParams(
+        host: 'hostA',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      );
+      const paramsB = SshConnectParams(
+        host: 'hostB',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      );
+      proxyA.connect(paramsA);
+      proxyB.connect(paramsB);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(created, hasLength(2));
+
+      // created order follows connect order: A (sid-1) then B (sid-2).
+      final ctrlA = created[0];
+      final ctrlB = created[1];
+      final storeA = stores[0];
+      final storeB = stores[1];
+
+      final fA = ctrlA.verifyHostKeyForTest(
+          paramsA, 'ssh-ed25519', fp([0xAA, 0xAA]));
+      final fB = ctrlB.verifyHostKeyForTest(
+          paramsB, 'ssh-ed25519', fp([0xBB, 0xBB]));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(proxyA.data.pendingHostKey!.fingerprint, 'aaaa');
+      expect(proxyB.data.pendingHostKey!.fingerprint, 'bbbb');
+
+      // Accept only session 1; session 2 must remain unanswered.
+      proxyA.acceptHostKey();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(await fA, isTrue);
+      expect(storeA.isTrusted('hostA', 22, 'aaaa'), isTrue);
+      expect(proxyA.data.pendingHostKey, isNull);
+
+      // Session 2's verify Completer is still pending and its store empty.
+      expect(storeB.length, 0);
+      expect(proxyB.data.pendingHostKey, isNotNull);
+      var bResolved = false;
+      // ignore: unawaited_futures
+      fB.then((_) => bResolved = true);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(bResolved, isFalse);
+
+      // Now answer B so the pending Completer doesn't leak past teardown.
+      proxyB.rejectHostKey();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(await fB, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Restore the host-key trust-on-first-use prompt for NEW hosts, which the #533 proxy migration silently disabled (cached hosts still worked; new hosts could never complete).
- Extend the IPC envelope with `SshHostKeyChallengeEvent` (task→UI) and `SshHostKeyDecisionCommand` (UI→task). Existing envelope shapes are unchanged — additive only.
- Task side emits a challenge when the controller surfaces an untrusted key; the UI proxy populates `pendingHostKey` (so the existing `host_key_dialog.dart`, keyed off `SshSessionData.pendingHostKey` in `connect_form.dart`, surfaces with no UI changes); accept/reject send the decision back.

## Design note
The task-side `SshSessionController` already owned the full host-key flow — the per-session `Completer<bool>`, the `awaitingHostKey`/`pendingHostKey` emit, and trust persistence in `acceptHostKey`/`rejectHostKey`. This PR adds no new state machine or store; it only bridges the existing seam across the gateway. The host forwards the decision command to the controller's existing methods rather than duplicating a Completer.

## TDD Analysis
- Type: protocol/API (restore behavior lost in #533)
- Behavior change: yes (new-host prompts surface again)
- TDD approach: full — deterministic IPC round-trip via `InMemoryGatewayPair`

## Test coverage
- **Existing tests updated**: none needed (additive envelopes; `task_ipc_test.dart` unchanged and still green)
- **New tests added (fail→pass)** in `native/test/services/host_key_ipc_test.dart`:
  - envelope round-trip for both new types (`toJson`/`fromJson`)
  - accept: challenge surfaces task→UI → `proxy.pendingHostKey` populated → `acceptHostKey()` → controller Completer resolves `true` → `HostKeyStore` gains the fingerprint → prompt cleared
  - reject: decision aborts via the existing "Host key rejected" failure path; store stays empty
  - multi-session: two sessions challenged independently; accepting one does not answer the other
- **Smoketest**: round-trip tests assert the new envelope kinds are handled by `fromJson`

## Test results
- flutter analyze: PASS (No issues found)
- flutter test: PASS (172 tests, 5 new)

## Diff stats
- Files changed: 5 (4 lib + 1 test)
- Lines: +160 lib / -13, +253 test

## Device verification note
The full new-host connect flow is device-verifiable (real socket + dialog). The headless obligation — the IPC challenge→decision→trust round-trip — is covered by the new pure-Dart test.

Closes #536

## Cycles used
1/3