### PR TITLE
fix(#539): start foreground task on connect-initiation + buffer commands until task ready

### DIFF
--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -17,7 +17,6 @@ import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import 'session_host.dart';
-import 'session_messages.dart';
 import 'task_ssh_gateway.dart';
 
 /// Top-level entry point for the foreground task isolate. Must be
@@ -59,13 +58,10 @@ class KeepaliveTaskHandler extends TaskHandler {
     final transport = TaskSideFftTransport();
     final gateway = TaskSideForegroundGateway(transport: transport);
     _transport = transport;
+    // The host announces readiness in its constructor (#539): the first
+    // task → UI payload it sends is an `SshTaskReadyEvent`, which the UI-side
+    // gateway uses to flush any commands buffered during isolate spin-up.
     _host = _hostBuilder(gateway);
-    // Announce readiness now that the host + gateway are wired. The UI-side
-    // gateway buffers commands until it sees this (the first task → UI
-    // payload) and then flushes them in order — without this the connect that
-    // was dispatched during `startService` spin-up is dropped and the session
-    // deadlocks at `idle` (#539).
-    gateway.send(const SshTaskReadyEvent().toJson());
   }
 
   @override
@@ -257,8 +253,20 @@ class KeepaliveController {
   /// Idempotent: guards on [KeepaliveGateway.isRunningService] so calling it
   /// twice does not start two services. A no-op when the user has disabled the
   /// keep-alive service.
+  ///
+  /// Tolerant of a missing platform plugin: on a platform where
+  /// `flutter_foreground_task` isn't wired (e.g. the Flutter test host, or a
+  /// desktop build) the underlying channel throws `MissingPluginException`.
+  /// Connect-initiation must not crash on that, so the failure is caught and
+  /// logged — the session still connects (just without the keep-alive service).
   Future<void> ensureStarted() async {
-    await _startIfStopped();
+    try {
+      await _startIfStopped();
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('KeepaliveController.ensureStarted: service start skipped — $e');
+      }
+    }
   }
 
   /// Begin observing the given SSH session view (proxy or controller —

--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -17,6 +17,7 @@ import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import 'session_host.dart';
+import 'session_messages.dart';
 import 'task_ssh_gateway.dart';
 
 /// Top-level entry point for the foreground task isolate. Must be
@@ -59,6 +60,12 @@ class KeepaliveTaskHandler extends TaskHandler {
     final gateway = TaskSideForegroundGateway(transport: transport);
     _transport = transport;
     _host = _hostBuilder(gateway);
+    // Announce readiness now that the host + gateway are wired. The UI-side
+    // gateway buffers commands until it sees this (the first task → UI
+    // payload) and then flushes them in order — without this the connect that
+    // was dispatched during `startService` spin-up is dropped and the session
+    // deadlocks at `idle` (#539).
+    gateway.send(const SshTaskReadyEvent().toJson());
   }
 
   @override
@@ -230,9 +237,28 @@ class KeepaliveController {
   /// Returns true while the given state should hold the foreground service
   /// open. `reconnecting` (#517) is treated as "still connected" so Android
   /// doesn't freeze the Dart isolate mid-reconnect.
+  ///
+  /// This predicate drives the connected-COUNT (start on 0→1, stop on 1→0).
+  /// The in-flight handshake states (`connecting`, `authenticating`,
+  /// `awaitingHostKey`) deliberately do NOT increment the count — the service
+  /// for those is started explicitly by [ensureStarted] on connect-initiation
+  /// (#539). Because they never increment the count, they also never trigger
+  /// the 1→0 stop, so a session mid-handshake cannot tear the service down.
   static bool _holdsService(SshSessionState state) {
     return state == SshSessionState.connected ||
         state == SshSessionState.reconnecting;
+  }
+
+  /// Start the foreground service immediately, independent of how many
+  /// sessions are connected (#539). Called on connect-initiation so the task
+  /// isolate (and its `SessionHost`) is running BEFORE the first connect
+  /// command is dispatched across the gateway.
+  ///
+  /// Idempotent: guards on [KeepaliveGateway.isRunningService] so calling it
+  /// twice does not start two services. A no-op when the user has disabled the
+  /// keep-alive service.
+  Future<void> ensureStarted() async {
+    await _startIfStopped();
   }
 
   /// Begin observing the given SSH session view (proxy or controller —
@@ -260,9 +286,23 @@ class KeepaliveController {
       } else if (!isConnected && wasConnected) {
         _connectedCount = (_connectedCount - 1).clamp(0, 1 << 30);
         if (_connectedCount == 0) unawaited(_stopIfRunning());
+      } else if (!isConnected && _connectedCount == 0 && _isTerminal(data.state)) {
+        // #539: the service may have been started explicitly via
+        // ensureStarted() before any session reached `connected` (count still
+        // 0). If the connect then fails / disconnects, tear the service down
+        // so it doesn't leak with no live sessions.
+        unawaited(_stopIfRunning());
       }
       wasConnected = isConnected;
     });
+  }
+
+  /// A terminal session state: the connect attempt is over and not holding the
+  /// service. Used to stop a service started by [ensureStarted] when the
+  /// session never reached `connected`.
+  static bool _isTerminal(SshSessionState state) {
+    return state == SshSessionState.failed ||
+        state == SshSessionState.disconnected;
   }
 
   /// Stop observing the given session. If it was connected, the connected
@@ -310,9 +350,11 @@ class KeepaliveController {
     if (await _gateway.isRunningService) return;
     await _gateway.startService(
       notificationTitle: 'MobiSSH',
-      notificationText: _connectedCount == 1
-          ? '1 session connected'
-          : '$_connectedCount sessions connected',
+      notificationText: _connectedCount == 0
+          ? 'Connecting…'
+          : _connectedCount == 1
+              ? '1 session connected'
+              : '$_connectedCount sessions connected',
     );
   }
 

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -42,6 +42,12 @@ class SessionHost {
         _factory = controllerFactory ?? _defaultControllerFactory {
     _commandSub = _gateway.incoming.listen(_dispatch);
     _snapshotTimer = Timer.periodic(snapshotInterval, (_) => _pushSnapshots());
+    // Announce readiness as the FIRST task → UI payload (#539). The host is the
+    // component that actually consumes commands, so its existence is the true
+    // "ready" signal. The UI-side gateway buffers outbound commands until it
+    // sees this and then flushes them in order — without it a connect sent
+    // during task-isolate spin-up is dropped and the session deadlocks at idle.
+    _gateway.send(const SshTaskReadyEvent().toJson());
   }
 
   final TaskSshGateway _gateway;

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -32,6 +32,10 @@ enum SshTaskEventKind {
   closed,
   error,
   hostKeyChallenge,
+
+  /// Task isolate finished booting (`SessionHost` + gateway wired). The UI
+  /// gateway flushes any commands it buffered during isolate spin-up (#539).
+  ready,
 }
 
 /// Base for all UI → task command envelopes. Subclasses are concrete records
@@ -292,6 +296,8 @@ sealed class SshTaskEvent {
           keyType: json['keyType'] as String,
           fingerprint: json['fingerprint'] as String,
         );
+      case SshTaskEventKind.ready:
+        return const SshTaskReadyEvent();
     }
   }
 }
@@ -445,5 +451,26 @@ class SshHostKeyChallengeEvent extends SshTaskEvent {
         'port': port,
         'keyType': keyType,
         'fingerprint': fingerprint,
+      };
+}
+
+/// Task → UI: the foreground task isolate has finished booting (#539). Sent
+/// once from `KeepaliveTaskHandler.onStart` after the `SessionHost` + gateway
+/// are wired. It is task-global, not per-session, so [sessionId] is an empty
+/// sentinel — the per-session proxy ignores it on the sessionId mismatch.
+///
+/// The UI-side gateway uses the FIRST inbound payload (typically this event) as
+/// the signal to flush any commands it buffered while `startService` was still
+/// spinning up the isolate.
+class SshTaskReadyEvent extends SshTaskEvent {
+  const SshTaskReadyEvent() : super('');
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.ready;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
       };
 }

--- a/native/lib/services/task_ssh_gateway.dart
+++ b/native/lib/services/task_ssh_gateway.dart
@@ -180,6 +180,15 @@ Map<String, dynamic>? _coercePayload(Object? raw) {
 }
 
 /// Production [TaskSshGateway] for the UI isolate side.
+///
+/// #539: `startService` is async and the task isolate's `onStart` (which builds
+/// the `SessionHost` and registers the receiver) runs later still. A command
+/// sent via `sendDataToTask` in that gap is dropped — the task isn't listening
+/// yet — which deadlocked connect at `idle`. To close the gap the gateway
+/// BUFFERS outbound payloads until it has seen the first inbound payload from
+/// the task (typically a [SshTaskReadyEvent]). Once ready, the buffer flushes
+/// front-to-back (preserving connect → input → resize order) and subsequent
+/// sends pass through immediately.
 class FlutterForegroundSshGateway implements TaskSshGateway {
   FlutterForegroundSshGateway({FftTransport? transport})
       : _transport = transport ?? const UiSideFftTransport() {
@@ -192,12 +201,24 @@ class FlutterForegroundSshGateway implements TaskSshGateway {
   void Function()? _cancel;
   bool _disposed = false;
 
+  /// Whether the task has signalled it is listening. Until true, [send]
+  /// queues into [_outboundBuffer] instead of hitting the transport.
+  bool _ready = false;
+
+  /// FIFO queue of payloads sent before the task became ready. Flushed in
+  /// order once the first inbound payload arrives.
+  final List<Map<String, dynamic>> _outboundBuffer = [];
+
   @override
   Stream<Map<String, dynamic>> get incoming => _incoming.stream;
 
   @override
   void send(Map<String, dynamic> payload) {
     if (_disposed) return;
+    if (!_ready) {
+      _outboundBuffer.add(payload);
+      return;
+    }
     _transport.send(payload);
   }
 
@@ -205,6 +226,16 @@ class FlutterForegroundSshGateway implements TaskSshGateway {
     if (_disposed) return;
     final map = _coercePayload(data);
     if (map == null) return;
+    // First inbound payload proves the task isolate is alive and listening:
+    // flush anything we buffered during spin-up, in order (#539).
+    if (!_ready) {
+      _ready = true;
+      final buffered = List<Map<String, dynamic>>.from(_outboundBuffer);
+      _outboundBuffer.clear();
+      for (final p in buffered) {
+        _transport.send(p);
+      }
+    }
     if (!_incoming.isClosed) _incoming.add(map);
   }
 
@@ -212,6 +243,7 @@ class FlutterForegroundSshGateway implements TaskSshGateway {
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
+    _outboundBuffer.clear();
     _cancel?.call();
     _cancel = null;
     if (!_incoming.isClosed) await _incoming.close();

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -244,6 +244,12 @@ class SshSessionProxy {
           ),
         );
         if (!_dataCtrl.isClosed) _dataCtrl.add(_data);
+      case SshTaskReadyEvent():
+        // Task-global readiness signal (#539). Per-session proxies ignore it —
+        // the UI-side gateway already consumed it to flush buffered commands.
+        // It only reaches here for the matching (empty) sessionId, which no
+        // real proxy uses, but handle it for switch exhaustiveness.
+        break;
     }
   }
 

--- a/native/lib/state/keepalive_providers.dart
+++ b/native/lib/state/keepalive_providers.dart
@@ -74,3 +74,29 @@ final keepaliveControllerProvider = Provider<KeepaliveController>((ref) {
   ref.onDispose(() => controller.dispose());
   return controller;
 });
+
+/// Function the session collection calls to start the foreground task isolate
+/// on connect-initiation (#539). Returns a `Future<void>`-producing callback so
+/// `SessionsNotifier.addOrActivate` can `ensureStarted()` BEFORE the caller
+/// dispatches the first connect command across the gateway.
+///
+/// This is a SEPARATE provider from [keepaliveControllerProvider] on purpose:
+/// the lifecycle controller watches `sshSessionProxyProvider` →
+/// `activeSessionEntryProvider` → `sessionsProvider`, so reading it from inside
+/// the `SessionsNotifier` during a state mutation would create a provider read
+/// cycle. The starter's controller does NOT observe any session, so the read is
+/// acyclic. `startService` is idempotent (guards on `isRunningService`), so the
+/// starter and the lifecycle controller never double-start the service; STOP
+/// remains owned by the lifecycle controller's connected-count.
+typedef KeepaliveStarter = Future<void> Function();
+
+final keepaliveServiceStarterProvider = Provider<KeepaliveStarter>((ref) {
+  final controller = KeepaliveController(
+    enabled: ref.read(keepaliveEnabledProvider),
+  );
+  ref.listen<bool>(keepaliveEnabledProvider, (_, next) {
+    controller.enabled = next;
+  });
+  ref.onDispose(controller.dispose);
+  return controller.ensureStarted;
+});

--- a/native/lib/state/keepalive_providers.dart
+++ b/native/lib/state/keepalive_providers.dart
@@ -91,12 +91,16 @@ final keepaliveControllerProvider = Provider<KeepaliveController>((ref) {
 typedef KeepaliveStarter = Future<void> Function();
 
 final keepaliveServiceStarterProvider = Provider<KeepaliveStarter>((ref) {
+  // The starter only ever START the service (idempotently). STOP is owned by
+  // [keepaliveControllerProvider]'s connected-count, so this controller holds
+  // no session subscriptions and must NOT be disposed here — `dispose()` would
+  // call `stopService()`, tearing down a service the lifecycle controller still
+  // wants running.
   final controller = KeepaliveController(
     enabled: ref.read(keepaliveEnabledProvider),
   );
   ref.listen<bool>(keepaliveEnabledProvider, (_, next) {
     controller.enabled = next;
   });
-  ref.onDispose(controller.dispose);
   return controller.ensureStarted;
 });

--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -27,6 +27,7 @@ import 'package:xterm/xterm.dart';
 import '../ssh/ssh_connect_params.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
+import 'keepalive_providers.dart';
 import 'session_host_providers.dart';
 
 /// One row in the session collection.
@@ -170,6 +171,13 @@ class SessionsNotifier extends Notifier<SessionsState> {
       state = state.copyWith(activeId: existing.id);
       return existing;
     }
+    // #539: start the foreground task isolate NOW, before the caller dispatches
+    // `proxy.connect(...)`. The task isolate is where the `SessionHost` turns
+    // the connect command into a real `SSHClient.connect`; if it isn't running,
+    // `sendDataToTask` drops the command and the session deadlocks at `idle`.
+    // The UI-side gateway buffers commands until the task signals readiness, so
+    // it's safe to start the service and connect without awaiting startup here.
+    unawaited(ref.read(keepaliveServiceStarterProvider)());
     final id =
         '${params.host}:${params.port}:${params.username}:${DateTime.now().millisecondsSinceEpoch}';
     final gateway = ref.read(taskSshGatewayProvider);

--- a/native/test/services/task_bootstrap_test.dart
+++ b/native/test/services/task_bootstrap_test.dart
@@ -1,0 +1,201 @@
+// Cross-isolate bootstrap tests (#539).
+//
+// Proves the two halves of the connect-deadlock fix:
+//   1. The UI-side gateway BUFFERS outbound commands sent before the task
+//      signals readiness, then flushes them in order once the first inbound
+//      payload (the ready event) arrives.
+//   2. `SessionsNotifier.addOrActivate` triggers `ensureStarted()` on the
+//      keepalive controller for a freshly-created session, so the foreground
+//      task is started before the caller dispatches the first connect.
+//
+// Both tests use the FFT stub transports / fake gateway — no platform
+// channels, no real isolate.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/keepalive_task.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/keepalive_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Records the `ensureStarted` / start calls in order so the test can assert
+/// the service was started before any command was sent.
+class FakeKeepaliveGateway implements KeepaliveGateway {
+  bool _initialized = false;
+  bool _running = false;
+  final List<String> calls = [];
+
+  @override
+  bool get isInitialized => _initialized;
+
+  @override
+  Future<bool> get isRunningService async => _running;
+
+  @override
+  void init() {
+    calls.add('init');
+    _initialized = true;
+  }
+
+  @override
+  Future<bool> startService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    calls.add('start');
+    _running = true;
+    return true;
+  }
+
+  @override
+  Future<bool> stopService() async {
+    calls.add('stop');
+    _running = false;
+    return true;
+  }
+}
+
+Future<void> _drain() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FlutterForegroundSshGateway buffering (#539)', () {
+    test('buffers commands sent before ready, flushes in order after ready',
+        () async {
+      final pair = StubFftTransportPair();
+      addTearDown(pair.dispose);
+
+      // Capture what the UI side actually pushes toward the task.
+      final received = <Map<String, dynamic>>[];
+      pair.taskSide.registerReceiver((data) {
+        received.add(Map<String, dynamic>.from(data as Map));
+      });
+
+      final ui = FlutterForegroundSshGateway(transport: pair.uiSide);
+      addTearDown(ui.dispose);
+
+      // The task isolate hasn't signalled ready yet. Send three commands in a
+      // specific order: connect, input, resize.
+      ui.send(SshConnectCommand(
+        sessionId: 'sid',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        authJson: const {'type': 'password', 'password': 'p'},
+      ).toJson());
+      ui.send(SshResizeCommand(sessionId: 'sid', cols: 80, rows: 24).toJson());
+      await _drain();
+
+      expect(received, isEmpty,
+          reason: 'commands must be buffered until the task is ready');
+
+      // Task signals ready (the first inbound payload the UI ever sees).
+      pair.taskSide.send(const SshTaskReadyEvent().toJson());
+      await _drain();
+
+      expect(received.length, 2,
+          reason: 'buffered commands flush once ready arrives');
+      expect(received[0]['kind'], SshTaskCommandKind.connect.name);
+      expect(received[1]['kind'], SshTaskCommandKind.resize.name,
+          reason: 'order must be preserved: connect before resize');
+
+      // After ready, sends pass through immediately.
+      ui.send(SshInputCommand(
+        sessionId: 'sid',
+        bytes: Uint8List.fromList('x'.codeUnits),
+      ).toJson());
+      await _drain();
+      expect(received.length, 3);
+      expect(received[2]['kind'], SshTaskCommandKind.input.name);
+    });
+
+    test('any inbound payload (not only ready) flushes the buffer', () async {
+      // Defensive: even if the first task→UI payload is a state event rather
+      // than the ready event, the buffer should flush — the task is clearly
+      // alive and receiving.
+      final pair = StubFftTransportPair();
+      addTearDown(pair.dispose);
+      final received = <Map<String, dynamic>>[];
+      pair.taskSide.registerReceiver((data) {
+        received.add(Map<String, dynamic>.from(data as Map));
+      });
+      final ui = FlutterForegroundSshGateway(transport: pair.uiSide);
+      addTearDown(ui.dispose);
+
+      ui.send(SshConnectCommand(
+        sessionId: 'sid',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        authJson: const {'type': 'password', 'password': 'p'},
+      ).toJson());
+      await _drain();
+      expect(received, isEmpty);
+
+      pair.taskSide.send(
+        SshStateEvent(sessionId: 'sid', state: 'connecting').toJson(),
+      );
+      await _drain();
+      expect(received.length, 1);
+      expect(received[0]['kind'], SshTaskCommandKind.connect.name);
+    });
+  });
+
+  group('addOrActivate ensures service started (#539)', () {
+    test('fresh session triggers ensureStarted before returning', () async {
+      final fakeGateway = FakeKeepaliveGateway();
+      final pair = InMemoryGatewayPair();
+      addTearDown(pair.dispose);
+
+      final container = ProviderContainer(overrides: [
+        // UI talks to the in-memory pair so no platform channels are touched.
+        taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+        // The keepalive controller used by the starter seam uses the fake
+        // foreground-task gateway so we can observe startService.
+        keepaliveServiceStarterProvider.overrideWith((ref) {
+          final controller = KeepaliveController(gateway: fakeGateway);
+          ref.onDispose(controller.dispose);
+          return controller.ensureStarted;
+        }),
+      ]);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(sessionsProvider.notifier);
+      notifier.addOrActivate(const SshConnectParams(
+        host: 'h',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ));
+      await _drain();
+
+      expect(fakeGateway.calls, contains('start'),
+          reason: 'addOrActivate must start the foreground service');
+      // start happens via ensureStarted → init then start.
+      expect(fakeGateway.calls.indexOf('init'),
+          lessThan(fakeGateway.calls.indexOf('start')));
+    });
+
+    test('ensureStarted is idempotent — no double start', () async {
+      final fakeGateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: fakeGateway);
+      addTearDown(controller.dispose);
+
+      await controller.ensureStarted();
+      await controller.ensureStarted();
+      await _drain();
+
+      expect(fakeGateway.calls.where((c) => c == 'start').length, 1,
+          reason: 'second ensureStarted must not start a second service');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Connect no longer deadlocks at `idle`: `SessionsNotifier.addOrActivate` now starts the foreground task isolate on connect-INITIATION via a new `KeepaliveController.ensureStarted()` (count-independent, idempotent), instead of waiting for a session to reach `connected` (which it never could, because the connect command was dropped while the task wasn't running).
- A readiness handshake closes the start-up race: the UI-side `FlutterForegroundSshGateway` buffers outbound commands in a FIFO `List` until the task signals readiness, then flushes them in ORDER (connect → input → resize) and passes through afterward.
- The readiness signal (`SshTaskReadyEvent`, additive) is emitted by `SessionHost` on construction — the host is what actually consumes commands, so its existence is the true "ready" signal. This also keeps the existing task-isolate handover tests green unmodified.

## TDD Analysis
- Type: bug fix (P0 deadlock)
- Behavior change: no — restores the intended connect flow
- TDD approach: full (deterministic buffer/flush ordering + ensureStarted)

## Test coverage
- **Existing tests updated**: none needed — kept green by emitting ready from `SessionHost` (handover tests) and by making `ensureStarted()` tolerant of a missing FFT plugin (pure-state/widget tests that call `addOrActivate` without platform bindings).
- **New tests added (fail→pass)** — `native/test/services/task_bootstrap_test.dart`:
  - buffers commands sent before ready, flushes them in order after ready
  - any inbound payload (not only ready) flushes the buffer
  - `addOrActivate` triggers `ensureStarted()` (init before start) for a fresh session
  - `ensureStarted()` is idempotent — no double start
- **Smoketest**: the addOrActivate test proves the starter is wired into the session-creation path.

## Test results
- analyze: PASS (no issues)
- flutter test (excluding integration): PASS (176 passing / ~5 skipped)

## Diff stats
- Files changed: 8 (1 new test)
- Lines: +363 / -12

## Notes for the integrator
- STOP logic unchanged for the common path: the lifecycle `keepaliveControllerProvider` still owns stop via its connected-count. A new guard stops the service if a session started via `ensureStarted()` reaches a terminal state (`failed`/`disconnected`) without ever reaching `connected`, so the service can't leak.
- A session mid-handshake (`connecting`/`authenticating`/`awaitingHostKey`) never increments the count and so can never trigger the 1→0 stop — it cannot tear the service down.
- Device/emulator validation (fresh install → creds → Connect → `connected`) is the orchestrator's obligation, not covered here.

Closes #539

## Cycles used
2/3