### PR TITLE
fix(native): infer key-auth from keyVaultId + credential-presence tracing

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -298,11 +298,16 @@ class SessionHost {
   static SshAuth _decodeAuth(Map<String, dynamic> json) {
     final type = json['type'] as String?;
     if (type == 'password') {
-      return SshAuth.password(json['password'] as String);
+      final pw = json['password'] as String;
+      // Presence trace (length only — never the value): confirms the password
+      // survived the UI→task IPC. Compare against ui.form's pwLen (#542/#543).
+      ctrace('task.host', 'decodeAuth password pwLen=${pw.length}');
+      return SshAuth.password(pw);
     }
     if (type == 'key') {
       final pemB64 = json['pem'] as String;
       final pem = Uint8List.fromList(base64Decode(pemB64));
+      ctrace('task.host', 'decodeAuth key pemBytes=${pem.length}');
       return SshAuth.key(pem, passphrase: json['passphrase'] as String?);
     }
     throw FormatException('unknown auth type: $type');

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -231,6 +231,15 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       return;
     }
 
+    // Credential-presence trace (lengths only — never values). Tells us via
+    // the on-device Connect log whether the vault prefill actually populated
+    // the fields: pwLen=0 / keyLen=0 means prefill returned empty (secret not
+    // found / read failed), vs a non-zero length meaning creds are present and
+    // the server rejected them. (#542/#543 diagnosis of "all auth methods
+    // failed after import".)
+    ctrace('ui.form',
+        'auth=${_authKind.name} pwLen=${_passwordCtrl.text.length} '
+        'keyLen=${_keyCtrl.text.length} ppLen=${_passphraseCtrl.text.length}');
     final SshAuth auth;
     if (_authKind == _AuthKind.password) {
       auth = SshAuth.password(_passwordCtrl.text);
@@ -294,11 +303,25 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       _hostCtrl.text = profile.host;
       _portCtrl.text = profile.port.toString();
       _userCtrl.text = profile.username;
+      // Pick the auth mode. Prefer the explicit authType, but if it's missing
+      // or ambiguous (e.g. a profile imported by an older build that persisted
+      // before authType round-tripped), INFER from keyVaultId: a profile that
+      // carries a key-blob reference is a key-auth profile. Without this, such
+      // a profile defaults to password mode with an empty password field and
+      // every connect fails with "all authentication methods failed" against a
+      // publickey-only host.
       if (profile.authType == 'key') {
         _authKind = _AuthKind.key;
       } else if (profile.authType == 'password') {
         _authKind = _AuthKind.password;
+      } else if (profile.keyVaultId != null && profile.keyVaultId!.isNotEmpty) {
+        _authKind = _AuthKind.key;
+      } else {
+        _authKind = _AuthKind.password;
       }
+      ctrace('ui.form',
+          'applyProfile ${profile.host} authType=${profile.authType} '
+          'keyVaultId=${profile.keyVaultId != null} → mode=${_authKind.name}');
     });
     if (profile.vaultId != null || profile.keyVaultId != null) {
       unawaited(_prefillFromVault(profile));


### PR DESCRIPTION
## Summary

Device report: after import, **"all authentication methods failed"** on every profile. The on-device Connect log (#543, now in use!) showed `auth=password` for `fd-dev` — which is a **key**-auth profile. Connecting a publickey-only host in password mode with an empty password field fails every method.

## Root cause

`_applyProfileToForm` set the auth mode with `if authType=='key' … else if authType=='password' …` and **no else**. A profile whose `authType` is null/ambiguous — e.g. imported by an older build and persisted to shared_preferences (which survives reinstalls) before `authType` round-tripped — fell through and kept the form's default password mode.

## Fixes

- **Infer key-auth from `keyVaultId`** when `authType` is missing/ambiguous: a profile carrying a key-blob reference is key-auth. Explicit `authType` still wins.
- **Credential-presence tracing** (lengths only, never values): `ui.form` logs `auth=<mode> pwLen= keyLen= ppLen=` at submit and `applyProfile … → mode=` on tap — so the in-app Connect log reveals whether the prefill populated fields and which mode was chosen. `session_host._decodeAuth` adds a task-side presence trace (logcat) to confirm the auth survived the IPC.

## Test plan
- [x] `scripts/native-fast-gate.sh` → analyze clean, 187 tests pass
- [ ] Device: re-import fresh on this build (clears stale authType-less profiles), tap a key profile → Connect log shows `mode=key`, connect proceeds to host-key/auth. Paste the Connect log if it still fails — the `pwLen/keyLen` now disambiguates empty-creds vs rejected-creds.

## Note

This is partly diagnostic: the `pwLen/keyLen` trace will confirm on the next device run whether the remaining issue (if any) is empty credentials (prefill/secret-store) vs server rejection. The key-auth inference fixes the concrete `auth=password`-on-a-key-host case from the log.