### PR TITLE
fix(#547): re-import upserts existing profiles instead of skipping (key/password creds now applied)

### DIFF
--- a/native/integration_test/import_smoke_test.dart
+++ b/native/integration_test/import_smoke_test.dart
@@ -1,0 +1,249 @@
+// On-emulator import → upsert → connect-in-key-mode smoke (#547).
+//
+// Exercises the device-only failure that headless tests cannot reach: an
+// imported KEY profile whose secret was decrypted from a backup envelope and
+// stored in the REAL flutter_secure_storage (Android Keystore), then resolved
+// back out by the connect path so the session connects in key mode against the
+// test-sshd bridge.
+//
+// This is the test the #547 device-confirmed bug needed: every imported profile
+// showed `authType=null keyVaultId=false pwLen=0 keyLen=0` on hardware while
+// headless round-trips passed, because re-import was a no-op for pre-#510
+// identity-only profiles AND the secret was never reachable.
+//
+// Network: scripts/native-connect-test.sh sets up
+//   emulator 127.0.0.1:2222 → (adb reverse) → fd-dev → (socat) → test-sshd:22
+// so connecting to 127.0.0.1:2222 reaches the Alpine test sshd container, which
+// trusts docker/test-sshd/testuser_id_ed25519 for `testuser`.
+//
+// NOTE: we pump `MobisshApp` directly rather than calling `app.main()`.
+// `main()` wraps everything in `CrashReporter.runGuarded`, which overrides
+// `FlutterError.onError` and conflicts with the integration-test binding's
+// error capture. We still call `initCommunicationPort()` (which `main()` does)
+// so the FFT IPC channel is open.
+//
+// PASS = the session reaches the terminal screen (session-menu AppBar button
+// appears). MINIMUM acceptable = the profile applies in key mode with a
+// non-empty private key loaded into the form (the connect-form key field is
+// populated from the resolved secret) even if the live socket flakes.
+
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/storage/vault.dart' show kVaultPbkdf2Iterations;
+
+// The ed25519 private key test-sshd trusts for `testuser`. Mirrors
+// docker/test-sshd/testuser_id_ed25519 verbatim — keep in sync if rotated.
+const String _testPrivateKeyPem = '''
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACB85qILD6Ykve+v2FrQWtcrsjW1baL6CXJ4LD5mmiDTdgAAAJgTrJmWE6yZ
+lgAAAAtzc2gtZWQyNTUxOQAAACB85qILD6Ykve+v2FrQWtcrsjW1baL6CXJ4LD5mmiDTdg
+AAAEBbgsew/IHGlnh7mBUSl/1dndeVjG9AmMGYWl0TNGsVK3zmogsPpiS976/YWtBa1yuy
+NbVtovoJcngsPmaaINN2AAAAFXRlc3R1c2VyQG1vYmlzc2gtdGVzdA==
+-----END OPENSSH PRIVATE KEY-----
+''';
+
+/// Build a backup envelope shaped exactly like the PWA's encrypted export,
+/// using the PRODUCTION PBKDF2 iteration count so the in-app default
+/// `VaultDecryptor()` (no override) decrypts it. Slow (600k iterations) but run
+/// once per test.
+Future<String> _buildEnvelope({
+  required String password,
+  required List<Map<String, dynamic>> profiles,
+  required Map<String, Map<String, Object?>> secrets,
+}) async {
+  final pbkdf2 = Pbkdf2(
+    macAlgorithm: Hmac.sha256(),
+    iterations: kVaultPbkdf2Iterations,
+    bits: 256,
+  );
+  final random = Random.secure();
+  final salt = Uint8List.fromList(
+    List<int>.generate(32, (_) => random.nextInt(256)),
+  );
+  final dekBytes = Uint8List.fromList(
+    List<int>.generate(32, (_) => random.nextInt(256)),
+  );
+  final dek = SecretKey(dekBytes);
+  final kek = await pbkdf2.deriveKey(
+    secretKey: SecretKey(utf8.encode(password)),
+    nonce: salt,
+  );
+  final aesGcm = AesGcm.with256bits();
+
+  final dekWrapIv = Uint8List.fromList(
+    List<int>.generate(12, (_) => random.nextInt(256)),
+  );
+  final dekWrapBox = await aesGcm.encrypt(
+    dekBytes,
+    secretKey: kek,
+    nonce: dekWrapIv,
+  );
+  final dekWrapCt = Uint8List.fromList([
+    ...dekWrapBox.cipherText,
+    ...dekWrapBox.mac.bytes,
+  ]);
+
+  final encrypted = <String, Map<String, String>>{};
+  for (final entry in secrets.entries) {
+    final iv = Uint8List.fromList(
+      List<int>.generate(12, (_) => random.nextInt(256)),
+    );
+    final box = await aesGcm.encrypt(
+      utf8.encode(jsonEncode(entry.value)),
+      secretKey: dek,
+      nonce: iv,
+    );
+    final ct = Uint8List.fromList([...box.cipherText, ...box.mac.bytes]);
+    encrypted[entry.key] = <String, String>{
+      'iv': base64Encode(iv),
+      'ct': base64Encode(ct),
+    };
+  }
+
+  return jsonEncode(<String, Object?>{
+    'version': 1,
+    'exportedAt': '2026-05-26T00:00:00.000Z',
+    'profiles': profiles,
+    'vault': <String, String>{
+      'encrypted': jsonEncode(encrypted),
+      'meta': jsonEncode(<String, Object?>{
+        'salt': base64Encode(salt),
+        'dekPw': <String, String>{
+          'iv': base64Encode(dekWrapIv),
+          'ct': base64Encode(dekWrapCt),
+        },
+      }),
+    },
+  });
+}
+
+Future<bool> _pump(
+  WidgetTester tester,
+  Finder finder, {
+  int slices = 30,
+  Duration step = const Duration(milliseconds: 500),
+}) async {
+  for (var i = 0; i < slices; i++) {
+    await tester.pump(step);
+    if (finder.evaluate().isNotEmpty) return true;
+  }
+  return false;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+      'import KEY profile from backup → tap → connect in key mode (#547)',
+      (tester) async {
+    FlutterForegroundTask.initCommunicationPort();
+
+    const masterPassword = 'master';
+    const keyVaultId = 'k-testsshd';
+    final envelope = await _buildEnvelope(
+      password: masterPassword,
+      profiles: <Map<String, dynamic>>[
+        <String, dynamic>{
+          'title': 'Test SSHD',
+          'host': '127.0.0.1',
+          'port': 2222,
+          'username': 'testuser',
+          'authType': 'key',
+          'keyVaultId': keyVaultId,
+        },
+      ],
+      // PWA key-secret shape: `{data: <PEM>}` under keyVaultId.
+      secrets: <String, Map<String, Object?>>{
+        keyVaultId: <String, Object?>{'data': _testPrivateKeyPem},
+      },
+    );
+
+    await tester.pumpWidget(const ProviderScope(child: MobisshApp()));
+    await tester.pump(const Duration(seconds: 1));
+
+    // Open the import dialog. The Connect form exposes an import affordance;
+    // the dialog itself is keyed `import-profiles-dialog`.
+    final importButton = find.byKey(const Key('open-import-profiles-dialog'));
+    expect(importButton.evaluate(), isNotEmpty,
+        reason: 'no import affordance found on the connect screen');
+    await tester.tap(importButton.first);
+    expect(await _pump(tester, find.byKey(const Key('import-profiles-dialog'))),
+        isTrue,
+        reason: 'import dialog did not open');
+
+    // Expand the paste disclosure and paste the envelope JSON.
+    final disclosure = find.byKey(const Key('import-profiles-paste-disclosure'));
+    if (disclosure.evaluate().isNotEmpty) {
+      await tester.tap(disclosure);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    await tester.enterText(
+        find.byKey(const Key('import-profiles-input')), envelope);
+    await tester.pump(const Duration(milliseconds: 200));
+
+    // Stage 1 submit → vault detected → password field appears.
+    await tester.tap(find.byKey(const Key('import-profiles-submit')));
+    expect(
+        await _pump(tester, find.byKey(const Key('import-profiles-password'))),
+        isTrue,
+        reason: 'password stage did not appear for the encrypted envelope');
+
+    await tester.enterText(
+        find.byKey(const Key('import-profiles-password')), masterPassword);
+    await tester.pump(const Duration(milliseconds: 200));
+
+    // Stage 2 submit → decrypt (600k PBKDF2 on device) + persist + close.
+    await tester.tap(find.byKey(const Key('import-profiles-submit')));
+    final tile = find.byKey(const Key('profile-tile-127.0.0.1:2222:testuser'));
+    expect(await _pump(tester, tile, slices: 40),
+        isTrue,
+        reason: 'imported profile tile did not appear after import');
+
+    // Tap the saved profile → prefills the form from the resolved secret.
+    await tester.tap(tile);
+    // Give the async vault prefill time to land the private key.
+    final keyField = find.byKey(const Key('connect-key'));
+    final keyApplied = await _pump(tester, keyField, slices: 20);
+
+    // MINIMUM acceptance: profile applied in key mode with a non-empty key.
+    if (keyApplied) {
+      final widget = tester.widget<TextField>(keyField);
+      expect(widget.controller?.text ?? '', isNotEmpty,
+          reason: 'key field empty — secret not resolved (the #547 bug)');
+    }
+
+    // FULL acceptance: connect reaches the terminal screen.
+    await tester.tap(find.byKey(const Key('connect-submit')));
+    var connected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        connected = true;
+        break;
+      }
+    }
+
+    // The live socket may flake (bridge down); the key-mode application is the
+    // load-bearing #547 assertion. Connect is the stronger signal when the
+    // bridge is up.
+    expect(connected || keyApplied, isTrue,
+        reason: 'neither connected nor applied key mode — #547 regression');
+  });
+}

--- a/native/lib/storage/profiles_store.dart
+++ b/native/lib/storage/profiles_store.dart
@@ -17,6 +17,7 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../diagnostics/connect_trace.dart';
 import 'secrets_store.dart';
 import 'vault.dart';
 
@@ -190,9 +191,20 @@ class SavedProfile {
 
 /// Result of an import operation. Mirrors the PWA's `ImportResult` shape so
 /// the UI can show parallel toast messages.
+///
+/// `updated` (#547) counts existing profiles that were upserted in place — an
+/// incoming entry whose identity (host:port:username) matched a stored profile
+/// and refreshed its authType/vaultId/keyVaultId/theme/color/initialCommand.
+/// It is additive: existing callers that read [added]/[skipped] keep working.
 class ImportResult {
-  ImportResult({this.added = 0, this.skipped = 0, this.errors = const []});
+  ImportResult({
+    this.added = 0,
+    this.updated = 0,
+    this.skipped = 0,
+    this.errors = const [],
+  });
   final int added;
+  final int updated;
   final int skipped;
   final List<String> errors;
 }
@@ -399,41 +411,83 @@ class ProfilesStore {
     }
 
     final existing = await load();
-    final existingKeys = existing.map((p) => p.identityKey).toSet();
+    // Index existing profiles by identity for in-place upsert (#547).
+    final byIdentity = <String, int>{
+      for (var i = 0; i < existing.length; i++) existing[i].identityKey: i,
+    };
     final errors = <String>[...parsed.errors];
     int added = 0;
-    int skipped = 0;
+    int updated = 0;
+    int withVault = 0;
+    int withKeyVaultId = 0;
+    int withAuthType = 0;
 
     for (final entry in parsed.profileEntries) {
       try {
         final profile = SavedProfile.fromJson(entry);
-        if (existingKeys.contains(profile.identityKey)) {
-          skipped++;
+        if (profile.authType != null) withAuthType++;
+        if (profile.vaultId != null) withVault++;
+        if (profile.keyVaultId != null) withKeyVaultId++;
+
+        final existingIndex = byIdentity[profile.identityKey];
+        if (existingIndex != null) {
+          // #547: re-import over a (possibly stale identity-only) profile is an
+          // UPSERT, not a skip. Refresh the auth/vault references and visual
+          // identity so a pre-#510 profile gains the data it was missing.
+          // Preserve the user's existing title — import never clobbers it.
+          final prior = existing[existingIndex];
+          existing[existingIndex] = SavedProfile(
+            title: prior.title,
+            host: prior.host,
+            port: prior.port,
+            username: prior.username,
+            theme: profile.theme,
+            color: profile.color,
+            authType: profile.authType,
+            vaultId: profile.vaultId,
+            keyVaultId: profile.keyVaultId,
+            initialCommand: profile.initialCommand,
+          );
+          updated++;
           continue;
         }
         existing.add(profile);
-        existingKeys.add(profile.identityKey);
+        byIdentity[profile.identityKey] = existing.length - 1;
         added++;
       } on FormatException catch (e) {
         errors.add(e.message);
       }
     }
 
+    ctrace(
+      'ui.import',
+      'profiles=${parsed.profileEntries.length} added=$added '
+          'updated=$updated withVault=$withVault '
+          'withKeyVaultId=$withKeyVaultId withAuthType=$withAuthType',
+    );
+
     // Persist secrets before profiles. If profile save fails (it shouldn't),
     // we'd rather leak an extra secret blob than have a profile without its
     // secret. Either way, the same vaultId would just be overwritten on a
-    // re-import.
+    // re-import. Secrets are written for BOTH added and updated profiles —
+    // an upserted key profile that just gained its keyVaultId needs the secret
+    // re-stored, not only freshly-added ones (#547).
     if (secrets != null) {
       for (final entry in decryptedVault.entries) {
         await secrets.write(entry.key, entry.value);
       }
     }
 
-    if (added > 0) {
+    if (added > 0 || updated > 0) {
       await save(existing);
     }
 
-    return ImportResult(added: added, skipped: skipped, errors: errors);
+    return ImportResult(
+      added: added,
+      updated: updated,
+      skipped: 0,
+      errors: errors,
+    );
   }
 
   /// Backwards-compatible single-shot importer. Accepts the

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -162,6 +162,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
             )
           else ...[
             TextField(
+              key: const Key('connect-key'),
               controller: _keyCtrl,
               decoration: const InputDecoration(
                 labelText: 'Private key (PEM)',
@@ -364,12 +365,16 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
   Future<void> _openImportDialog() async {
     final result = await showImportProfilesDialog(context);
     if (!mounted || result == null) return;
-    final msg = result.added > 0
-        ? 'Imported ${result.added} profile${result.added == 1 ? '' : 's'}'
-            '${result.skipped > 0 ? ', ${result.skipped} skipped (duplicate)' : ''}'
-        : result.skipped > 0
-            ? 'No new profiles — all ${result.skipped} were already saved.'
-            : 'No profiles imported.';
+    final parts = <String>[];
+    if (result.added > 0) {
+      parts.add('${result.added} added');
+    }
+    if (result.updated > 0) {
+      parts.add('${result.updated} updated');
+    }
+    final msg = parts.isNotEmpty
+        ? 'Imported ${parts.join(', ')}'
+        : 'No profiles imported.';
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
   }
 

--- a/native/test/profiles_store_test.dart
+++ b/native/test/profiles_store_test.dart
@@ -216,7 +216,8 @@ void main() {
       expect(loaded[1].theme, 'nord');
     });
 
-    test('dedupes on (host:port:username) when re-importing', () async {
+    test('upserts existing (host:port:username) when re-importing (#547)',
+        () async {
       final store = ProfilesStore();
       await store.save(<SavedProfile>[
         SavedProfile(
@@ -226,13 +227,17 @@ void main() {
       ]);
       final result = await store.importFromJson(pwaExportFixture);
       expect(result.added, 1, reason: 'only "Build box" is new');
-      expect(result.skipped, 1, reason: 'nas already exists');
+      expect(result.updated, 1, reason: 'nas already exists → upsert, not skip');
+      expect(result.skipped, 0);
 
       final loaded = await store.load();
       expect(loaded, hasLength(2));
-      // Existing profile keeps its original title — import does not clobber.
+      // Existing profile keeps its original title — import does not clobber it.
       final existing = loaded.firstWhere((p) => p.host == 'nas.tail123.ts.net');
       expect(existing.title, 'Old Name');
+      // ...but its visual identity IS refreshed from the import.
+      expect(existing.theme, 'dark');
+      expect(existing.color, '#88ccff');
     });
 
     test('rejects unknown export version', () async {
@@ -498,6 +503,79 @@ void main() {
       final secret = await secrets.read('v-home');
       expect(secret, isNotNull);
       expect(secret!['password'], 'hunter2');
+    });
+
+    test(
+        're-import over a stale identity-only profile UPDATES authType/'
+        'vaultId/keyVaultId AND re-stores vault secrets (#547)', () async {
+      // Simulate the device-confirmed bug: a pre-#510 build persisted an
+      // identity-only profile (no authType, no vault refs). Re-importing a
+      // backup envelope that carries the same identity must upgrade it in
+      // place AND land the decrypted secret in the SecretsStore.
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'My Box',
+          host: 'box.example',
+          port: 22,
+          username: 'me',
+        ),
+      ]);
+
+      final pbkdf2 = fastPbkdf2();
+      final envelope = await buildBackupEnvelope(
+        password: 'master',
+        profiles: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'title': 'My Box (re-export)',
+            'host': 'box.example',
+            'port': 22,
+            'username': 'me',
+            'authType': 'key',
+            'vaultId': 'v-box',
+            'keyVaultId': 'k-box',
+          },
+        ],
+        secrets: <String, Map<String, Object?>>{
+          'v-box': <String, Object?>{'password': 'fallbackpw'},
+          'k-box': <String, Object?>{'data': '-----BEGIN KEY-----\\nabc\\n'},
+        },
+        pbkdf2: pbkdf2,
+      );
+
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final parsed = ProfilesStore.parseImport(envelope);
+      final result = await store.applyParsedImport(
+        parsed,
+        password: 'master',
+        secrets: secrets,
+        decryptor: VaultDecryptor(pbkdf2: pbkdf2),
+      );
+
+      expect(result.errors, isEmpty);
+      expect(result.added, 0, reason: 'identity already existed');
+      expect(result.updated, 1, reason: 'upserted in place');
+      expect(result.skipped, 0);
+
+      // Profile upgraded in place — title preserved, refs refreshed.
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      final upserted = loaded.single;
+      expect(upserted.title, 'My Box', reason: 'user title not clobbered');
+      expect(upserted.authType, 'key');
+      expect(upserted.vaultId, 'v-box');
+      expect(upserted.keyVaultId, 'k-box');
+
+      // Secrets re-stored for the matched (updated) profile, not just added.
+      final keySecret = await secrets.read('k-box');
+      expect(keySecret, isNotNull);
+      expect(keySecret!['data'], '-----BEGIN KEY-----\\nabc\\n');
+
+      // The credential loader can now resolve a non-empty private key —
+      // the connect path will run in key mode rather than re-prompting.
+      final creds = await loadProfileCredentials(secrets, upserted);
+      expect(creds.privateKey, isNotNull);
+      expect(creds.privateKey, isNotEmpty);
     });
 
     test('wrong password reports clear error and writes no state',


### PR DESCRIPTION
## Summary
- `ProfilesStore.applyParsedImport` now **upserts** on identity match instead of skipping: a re-import over a stale pre-#510 identity-only profile refreshes `authType`/`vaultId`/`keyVaultId`/`theme`/`color`/`initialCommand` in place (user-set `title` is preserved).
- Vault secrets are re-stored for **updated** profiles too (they were always written from `decryptedVault`, but the matched profile — and thus its vault references — was previously discarded, leaving the secret unreachable). Persists whenever `added > 0 || updated > 0`.
- `ImportResult.updated` added (additive — existing callers reading `added`/`skipped` unchanged). `ui.import` ctrace logs counts only. Import snackbar now reads "Imported N added, N updated".

## TDD Analysis
- Type: bug fix
- Behavior change: yes (dedup-skip → upsert)
- TDD approach: full (headless) + smoketest-only (emulator integration)

## Test coverage
- **Existing tests updated**: `profiles_store_test.dart` "dedupes on re-import" → "upserts existing (#547)" — now asserts `updated==1`, title preserved, theme/color refreshed.
- **New tests added (fail→pass)**:
  - `profiles_store_test.dart` "re-import over a stale identity-only profile UPDATES authType/vaultId/keyVaultId AND re-stores vault secrets (#547)" — full encrypted-envelope round-trip via `InMemorySecretsBackend`; asserts upsert, secret re-store, and that `loadProfileCredentials` resolves a non-empty key.
  - `integration_test/import_smoke_test.dart` (NEW) — pumps `MobisshApp`, opens the import dialog, pastes a **real encrypted backup envelope** (production 600k PBKDF2) containing a KEY profile for `127.0.0.1:2222` whose `keyVaultId` secret is the test-sshd ed25519 key, enters the master password, imports, taps the profile, and asserts connect reaches the terminal (`session-menu-button`) OR at minimum the form applies in key mode with a non-empty key.
- **Smoketest**: added `connect-key` Key to the private-key field for integration-test addressability.

## Test results
- flutter analyze: PASS (incl. `integration_test/import_smoke_test.dart`)
- headless (`scripts/native-fast-gate.sh`): PASS — 188 tests

## Emulator gate (ORCHESTRATOR runs this)
The integration test is **authored + analyzer-clean** but I cannot drive the shared emulator from the worktree. The orchestrator must run it on `emulator-5554` with the socat/adb-reverse bridge up:
```
scripts/native-connect-test.sh   # (or the import_smoke_test equivalent driver)
```
The test connects to `127.0.0.1:2222` → adb reverse → socat → `test-sshd:22` and trusts the host key on first use ("Trust + connect"). It uses production PBKDF2 (600k) once, so allow extra time on the import step.

## Diff stats
- Files changed: 4 (2 prod, 1 test, 1 new integration test)
- Lines: +404 / -18 (the new integration test is the bulk)

## Notes / scope
- `skipped` is retained on `ImportResult` for backward-compat; it is now always 0 (every identity match is an update). `importFromJson` and the widget test only read `added`, so no breakage.
- Did NOT touch envelope/IPC shapes, `ssh_session.dart`, the gateway, or the foreground service.

Closes #547

## Cycles used
1/3