### PR TITLE
feat(native): default command on connect (#558)

### DIFF
--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -84,10 +84,7 @@ class SessionEntry {
 /// Immutable snapshot of the session collection. The notifier emits a fresh
 /// copy on each mutation so Riverpod consumers re-render.
 class SessionsState {
-  const SessionsState({
-    this.entries = const [],
-    this.activeId,
-  });
+  const SessionsState({this.entries = const [], this.activeId});
 
   /// Insertion-ordered list of entries (tab strip renders in this order).
   final List<SessionEntry> entries;
@@ -218,10 +215,7 @@ class SessionsNotifier extends Notifier<SessionsState> {
         pixelHeight: pixelHeight,
       );
     };
-    state = state.copyWith(
-      entries: [...state.entries, entry],
-      activeId: id,
-    );
+    state = state.copyWith(entries: [...state.entries, entry], activeId: id);
     return entry;
   }
 
@@ -265,9 +259,92 @@ class SessionsNotifier extends Notifier<SessionsState> {
   }
 }
 
+/// Fires a profile's "initial command" (#558) exactly once per session, on the
+/// FIRST transition to `connected`.
+///
+/// The command is sent UI-side through the existing PTY input path
+/// (`proxy.sendInput(utf8.encode(cmd + "\n"))`) — deliberately NOT through
+/// `session_host.dart` / `ssh_session.dart`, which are owned by the parallel
+/// SFTP work. Sending via the proxy is equivalent to the user typing the
+/// command into the terminal and pressing Enter.
+///
+/// The once-only guard is the crux: the merged reconnect work (#551) rebinds
+/// the proxy on resume and may RE-EMIT `connected`. Without a guard the
+/// command would re-run on every background→resume. We track which session
+/// ids have already fired in [_fired]; a fired id never fires again for the
+/// life of the runner, regardless of how many `connected` events arrive.
+class InitialCommandRunner {
+  InitialCommandRunner();
+
+  /// Session ids whose initial command has already been sent. Keyed by the
+  /// full session id (`host:port:user:createdAtMs`) so two distinct connects
+  /// to the same target each get their own one-shot.
+  final Set<String> _fired = <String>{};
+
+  final List<StreamSubscription<SshSessionData>> _subs = [];
+
+  /// True once the initial command has fired for [sessionId]. Test seam.
+  bool hasFired(String sessionId) => _fired.contains(sessionId);
+
+  /// Arm a one-shot: when [proxy] first reaches `connected`, send
+  /// `command + "\n"` through its input path. No-op when [command] is empty
+  /// or the session has already fired.
+  ///
+  /// If the proxy is ALREADY `connected` at arm time (e.g. a dedup
+  /// re-activate of a live session), this does NOT fire — the command applies
+  /// to a fresh connect only, matching the PWA's "run after the shell opens"
+  /// behavior and the acceptance bullet "does not re-run on resume".
+  void arm({
+    required String sessionId,
+    required SshSessionProxy proxy,
+    required String? command,
+  }) {
+    final cmd = command?.trim() ?? '';
+    if (cmd.isEmpty) return;
+    if (_fired.contains(sessionId)) return;
+    // Already connected when armed → this is a re-activate of a live session,
+    // not a fresh connect. Don't fire (and don't arm a listener that would
+    // fire on a future reconnect's re-emit).
+    if (proxy.data.state == SshSessionState.connected) return;
+
+    late final StreamSubscription<SshSessionData> sub;
+    sub = proxy.stream.listen((data) {
+      if (data.state != SshSessionState.connected) return;
+      if (_fired.contains(sessionId)) return;
+      _fired.add(sessionId);
+      ctrace('ui.initcmd', 'firing initial command for sid=$sessionId');
+      proxy.sendInput(Uint8List.fromList(utf8.encode('$cmd\n')));
+      // One-shot: stop listening so a later rebind/reconnect re-emit of
+      // `connected` (#551) can't re-trigger.
+      sub.cancel();
+      _subs.remove(sub);
+    });
+    _subs.add(sub);
+  }
+
+  /// Cancel any still-armed listeners. Fired runners have already self-
+  /// cancelled; this cleans up sessions that never reached `connected`.
+  void dispose() {
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _subs.clear();
+  }
+}
+
+/// App-wide [InitialCommandRunner]. A single instance so the once-only guard
+/// survives form rebuilds and the "New session" push/pop lifecycle — a new
+/// `ConnectForm` state must not get a fresh guard set and re-fire.
+final initialCommandRunnerProvider = Provider<InitialCommandRunner>((ref) {
+  final runner = InitialCommandRunner();
+  ref.onDispose(runner.dispose);
+  return runner;
+});
+
 /// Top-level provider for the session collection.
-final sessionsProvider =
-    NotifierProvider<SessionsNotifier, SessionsState>(SessionsNotifier.new);
+final sessionsProvider = NotifierProvider<SessionsNotifier, SessionsState>(
+  SessionsNotifier.new,
+);
 
 /// Active session id (null when no sessions exist).
 final activeSessionIdProvider = Provider<String?>((ref) {

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -44,6 +44,9 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
   final _passwordCtrl = TextEditingController();
   final _keyCtrl = TextEditingController();
   final _passphraseCtrl = TextEditingController();
+  // Optional command run once after the session connects (#558). Prefilled
+  // from an applied profile's `initialCommand`; empty by default.
+  final _initialCommandCtrl = TextEditingController();
 
   _AuthKind _authKind = _AuthKind.password;
   bool _busy = false;
@@ -78,6 +81,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     _passwordCtrl.dispose();
     _keyCtrl.dispose();
     _passphraseCtrl.dispose();
+    _initialCommandCtrl.dispose();
     super.dispose();
   }
 
@@ -197,6 +201,17 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
               enableSuggestions: false,
             ),
           ],
+          const SizedBox(height: 12),
+          TextField(
+            key: const Key('connect-initial-command'),
+            controller: _initialCommandCtrl,
+            decoration: const InputDecoration(
+              labelText: 'Initial command (optional)',
+              hintText: 'e.g. tmux attach || tmux',
+            ),
+            autocorrect: false,
+            enableSuggestions: false,
+          ),
           const SizedBox(height: 16),
           FilledButton.icon(
             key: const Key('connect-submit'),
@@ -291,6 +306,18 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       // connecting/authenticating are no-ops inside the task-side controller
       // itself.
       ctrace('ui.form', 'entry=${entry.id} → proxy.connect()');
+      // Arm the run-on-connect command (#558) BEFORE dispatching connect, so
+      // the one-shot listener is attached before the task side can emit
+      // `connected`. The runner fires exactly once on the first `connected`
+      // transition for this session id and guards against re-fire on the
+      // #551 reconnect rebind. No-op when the field is empty.
+      ref
+          .read(initialCommandRunnerProvider)
+          .arm(
+            sessionId: entry.id,
+            proxy: entry.proxy,
+            command: _initialCommandCtrl.text,
+          );
       await entry.proxy.connect(params);
       // Once we've proven we have network reachability, fire-and-forget a
       // crash upload sweep. Tailscale being down is the common case at boot
@@ -371,6 +398,9 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       _hostCtrl.text = profile.host;
       _portCtrl.text = profile.port.toString();
       _userCtrl.text = profile.username;
+      // Prefill the optional run-on-connect command (#558). Empty when the
+      // profile carries none.
+      _initialCommandCtrl.text = profile.initialCommand ?? '';
       // Pick the auth mode. Prefer the explicit authType, but if it's missing
       // or ambiguous (e.g. a profile imported by an older build that persisted
       // before authType round-tripped), INFER from keyVaultId: a profile that

--- a/native/test/state/initial_command_runner_test.dart
+++ b/native/test/state/initial_command_runner_test.dart
@@ -1,0 +1,130 @@
+// Unit tests for the run-on-connect "initial command" once-only fire (#558).
+//
+// The runner arms a one-shot listener on a session's [SshSessionProxy]. On the
+// FIRST `connected` transition it sends `command + "\n"` through the proxy's
+// PTY input path (`sendInput`). It must NOT re-fire when the #551 reconnect
+// work rebinds and re-emits `connected` on a background→resume.
+//
+// We drive a REAL proxy via an [InMemoryGatewayPair]: state events injected
+// from the task side flip the proxy to `connected`; input commands the proxy
+// sends are observed back on the task side, so we assert on the exact wire
+// bytes (`base64(utf8(cmd + "\n"))`).
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/state/sessions.dart';
+
+void main() {
+  group('InitialCommandRunner', () {
+    late InMemoryGatewayPair pair;
+    late SshSessionProxy proxy;
+    const sid = 'h:22:u:1';
+
+    // Input commands the proxy emitted, decoded back to their UTF-8 string.
+    late List<String> sentInputs;
+    late StreamSubscription<Map<String, dynamic>> taskSub;
+
+    setUp(() {
+      pair = InMemoryGatewayPair();
+      proxy = SshSessionProxy(sessionId: sid, gateway: pair.uiSide);
+      sentInputs = [];
+      taskSub = pair.taskSide.incoming.listen((payload) {
+        if (payload['kind'] == SshTaskCommandKind.input.name &&
+            payload['sessionId'] == sid) {
+          final bytes = base64Decode(payload['bytes'] as String);
+          sentInputs.add(utf8.decode(bytes));
+        }
+      });
+    });
+
+    tearDown(() async {
+      await taskSub.cancel();
+      await proxy.dispose();
+      await pair.dispose();
+    });
+
+    // Push a state event from the task side and let the proxy's broadcast
+    // stream deliver it to the runner's listener.
+    Future<void> emitState(SshSessionState state) async {
+      pair.taskSide.send(
+        SshStateEvent(sessionId: sid, state: state.name).toJson(),
+      );
+      // Let the gateway + proxy stream microtasks settle.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    test('sends command + newline once on first connected', () async {
+      final runner = InitialCommandRunner();
+      addTearDown(runner.dispose);
+      runner.arm(sessionId: sid, proxy: proxy, command: 'tmux attach');
+
+      await emitState(SshSessionState.connecting);
+      expect(sentInputs, isEmpty, reason: 'not fired before connected');
+
+      await emitState(SshSessionState.connected);
+      expect(sentInputs, ['tmux attach\n']);
+      expect(runner.hasFired(sid), isTrue);
+    });
+
+    test(
+      'does NOT re-fire on a second connected (reconnect rebind #551)',
+      () async {
+        final runner = InitialCommandRunner();
+        addTearDown(runner.dispose);
+        runner.arm(sessionId: sid, proxy: proxy, command: 'echo hi');
+
+        await emitState(SshSessionState.connected);
+        expect(sentInputs, ['echo hi\n']);
+
+        // Simulate background→resume: soft-disconnect, reconnect, re-emit.
+        await emitState(SshSessionState.softDisconnected);
+        await emitState(SshSessionState.reconnecting);
+        await emitState(SshSessionState.connected);
+
+        expect(sentInputs, [
+          'echo hi\n',
+        ], reason: 'initial command must fire exactly once per session');
+      },
+    );
+
+    test('empty / whitespace command is a no-op', () async {
+      final runner = InitialCommandRunner();
+      addTearDown(runner.dispose);
+      runner.arm(sessionId: sid, proxy: proxy, command: '   ');
+      runner.arm(sessionId: sid, proxy: proxy, command: null);
+
+      await emitState(SshSessionState.connected);
+      expect(sentInputs, isEmpty);
+      expect(runner.hasFired(sid), isFalse);
+    });
+
+    test('trims surrounding whitespace before sending', () async {
+      final runner = InitialCommandRunner();
+      addTearDown(runner.dispose);
+      runner.arm(sessionId: sid, proxy: proxy, command: '  ls -la  ');
+
+      await emitState(SshSessionState.connected);
+      expect(sentInputs, ['ls -la\n']);
+    });
+
+    test('does not fire when armed on an already-connected proxy', () async {
+      // A dedup re-activate of a live session: proxy is already connected at
+      // arm time. The command belongs to a fresh connect only.
+      await emitState(SshSessionState.connected);
+
+      final runner = InitialCommandRunner();
+      addTearDown(runner.dispose);
+      runner.arm(sessionId: sid, proxy: proxy, command: 'whoami');
+
+      await emitState(SshSessionState.connected);
+      expect(sentInputs, isEmpty);
+    });
+  });
+}

--- a/native/test/widget/initial_command_field_test.dart
+++ b/native/test/widget/initial_command_field_test.dart
@@ -1,0 +1,99 @@
+// Widget test: the connect form's "Initial command" field (#558).
+//
+//   1. The field exists on the connect form.
+//   2. Tapping a saved profile that carries an `initialCommand` prefills it.
+//   3. A profile without an `initialCommand` leaves the field empty.
+//
+// The form's profile list reads `savedProfilesProvider`; we override it with a
+// fixed list so no real ProfilesStore IO happens. The chosen profiles have no
+// vault references, so `_prefillFromVault` never runs.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/connect_form.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _app(List<SavedProfile> profiles, InMemoryGatewayPair pair) {
+  return ProviderScope(
+    overrides: [
+      savedProfilesProvider.overrideWith((ref) async => profiles),
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+    ],
+    child: const MaterialApp(
+      home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+    ),
+  );
+}
+
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('connect form renders an initial-command field', (tester) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    await tester.pumpWidget(_app(const [], pair));
+    await _settle(tester);
+
+    expect(find.byKey(const Key('connect-initial-command')), findsOneWidget);
+  });
+
+  testWidgets('tapping a profile prefills its initialCommand', (tester) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    final profile = SavedProfile(
+      title: 'Box',
+      host: 'box.example',
+      port: 22,
+      username: 'me',
+      initialCommand: 'tmux attach || tmux new',
+    );
+    await tester.pumpWidget(_app([profile], pair));
+    await _settle(tester);
+
+    await tester.tap(find.byKey(Key('profile-tile-${profile.identityKey}')));
+    await _settle(tester);
+
+    final field = tester.widget<TextField>(
+      find.byKey(const Key('connect-initial-command')),
+    );
+    expect(field.controller?.text, 'tmux attach || tmux new');
+  });
+
+  testWidgets('profile without initialCommand leaves the field empty', (
+    tester,
+  ) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    final profile = SavedProfile(
+      title: 'Plain',
+      host: 'plain.example',
+      port: 22,
+      username: 'me',
+    );
+    await tester.pumpWidget(_app([profile], pair));
+    await _settle(tester);
+
+    await tester.tap(find.byKey(Key('profile-tile-${profile.identityKey}')));
+    await _settle(tester);
+
+    final field = tester.widget<TextField>(
+      find.byKey(const Key('connect-initial-command')),
+    );
+    expect(field.controller?.text, isEmpty);
+  });
+}


### PR DESCRIPTION
## #558 — default / run-on-connect command (native)

Adds an **Initial command** field to the native connect form, prefills it from an applied profile's `initialCommand`, and runs it **once** on the first transition to `connected` for a session.

### What changed
- **`native/lib/ui/connect_form.dart`**
  - New `connect-initial-command` `TextField` (optional, empty by default).
  - Prefilled in `_applyProfileToForm` from `profile.initialCommand` (cleared when the profile has none).
  - Armed in `_submit` (before `proxy.connect`) via the shared runner.
- **`native/lib/state/sessions.dart`**
  - New `InitialCommandRunner`: arms a one-shot listener on the session's proxy stream; on the **first** `connected` it sends `proxy.sendInput(utf8.encode(cmd + "\n"))`, then cancels its own subscription.
  - Per-session-id `_fired` guard **plus** self-cancel → the command never re-fires on the #551 reconnect rebind / background→resume re-emit of `connected`.
  - Already-connected at arm time (dedup re-activate of a live session) does **not** fire — the command applies to a fresh connect only.
  - App-wide single instance via `initialCommandRunnerProvider` so the guard survives `ConnectForm` rebuilds and the "New session" push/pop lifecycle.

### Scope discipline
Entirely UI-side via the existing PTY input path. **Does not touch** `session_host.dart` or `ssh_session.dart` (owned by the parallel SFTP agent).

### Tests
- `native/test/state/initial_command_runner_test.dart` — send-once on first `connected`, **no re-fire** on reconnect re-emit, empty/whitespace no-op, whitespace trim, no-fire when armed on an already-connected proxy. Driven against a real `SshSessionProxy` via `InMemoryGatewayPair` asserting on the exact wire bytes.
- `native/test/widget/initial_command_field_test.dart` — field exists; profile prefill; empty when profile carries none.

### Gate
`scripts/native-fast-gate.sh` green — `flutter analyze` clean, 236 tests pass.

### Device validation
Run-on-connect against a live shell should be confirmed on the emulator/device (headless gateway never emits a real `connected` shell).

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)