### PR TITLE
feat(native): SFTP file explorer foundation (#559)

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -20,9 +20,12 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 
+import 'package:dartssh2/dartssh2.dart';
+
 import '../diagnostics/connect_trace.dart';
 import '../ssh/ssh_connect_params.dart';
 import '../ssh/ssh_session.dart';
+import '../ssh/sftp_session.dart';
 import 'session_messages.dart';
 import 'task_ssh_gateway.dart';
 
@@ -38,9 +41,11 @@ class SessionHost {
   SessionHost({
     required TaskSshGateway gateway,
     SshControllerFactory? controllerFactory,
+    SftpSessionOpener? sftpOpener,
     this.snapshotInterval = const Duration(seconds: 2),
   })  : _gateway = gateway,
-        _factory = controllerFactory ?? _defaultControllerFactory {
+        _factory = controllerFactory ?? _defaultControllerFactory,
+        _sftpOpener = sftpOpener {
     _commandSub = _gateway.incoming.listen(_dispatch);
     _snapshotTimer = Timer.periodic(snapshotInterval, (_) => _pushSnapshots());
     ctrace('task.host', 'ctor: listening; sending SshTaskReadyEvent');
@@ -54,6 +59,11 @@ class SessionHost {
 
   final TaskSshGateway _gateway;
   final SshControllerFactory _factory;
+
+  /// Opens an [SftpSession] for a session id (#559). Null in production →
+  /// [_defaultSftpOpener] opens an SFTP subsystem over the live `SSHClient`.
+  /// Tests inject a fake so the handlers run without a real socket.
+  final SftpSessionOpener? _sftpOpener;
 
   /// How often a snapshot is pushed to the UI side. Tests use a short
   /// interval; production defaults to two seconds.
@@ -112,6 +122,10 @@ class SessionHost {
         if (s != null) _emitSnapshot(cmd.sessionId, s);
       case SshHostKeyDecisionCommand():
         _handleHostKeyDecision(cmd);
+      case SftpListCommand():
+        _handleSftpList(cmd);
+      case SftpDownloadCommand():
+        _handleSftpDownload(cmd);
     }
   }
 
@@ -181,10 +195,119 @@ class SessionHost {
   Future<void> _teardown(String sessionId, _HostedSession hosted) async {
     await hosted.stateSub?.cancel();
     hosted.stateSub = null;
+    final sftp = hosted.sftp;
+    hosted.sftp = null;
+    if (sftp != null) {
+      try {
+        await sftp.close();
+      } catch (_) {/* ignore */}
+    }
     try {
       await hosted.controller.dispose();
     } catch (_) {/* ignore */}
     _gateway.send(SshClosedEvent(sessionId: sessionId).toJson());
+  }
+
+  // -------------------------------------------------------------------------
+  // SFTP region (#559) — additive. Sits alongside the connect/keepalive/
+  // reconnect handlers above and never mutates the SSH lifecycle state machine.
+  // Each op opens (lazily) an [SftpSession] over the session's authenticated
+  // `SSHClient` and routes results back as request-id-scoped events so a failed
+  // list/download surfaces in the browser without disturbing the live shell.
+  // -------------------------------------------------------------------------
+
+  /// Open (or reuse) the [SftpSession] for [sessionId]. Returns null if the
+  /// session isn't hosted or has no authenticated client yet.
+  Future<SftpSession?> _ensureSftp(String sessionId) async {
+    final hosted = _sessions[sessionId];
+    if (hosted == null) return null;
+    if (hosted.sftp != null) return hosted.sftp;
+    final opener = _sftpOpener ?? _defaultSftpOpener;
+    final session = await opener(sessionId);
+    // Re-check: an interleaved open could have set it; the controller may also
+    // have been torn down while we awaited. Prefer the already-cached one.
+    if (hosted.sftp != null) {
+      if (session != null) await session.close();
+      return hosted.sftp;
+    }
+    hosted.sftp = session;
+    return session;
+  }
+
+  /// Default opener: grab the authenticated `SSHClient` from the controller and
+  /// open an SFTP subsystem channel over it. Returns null when the session
+  /// isn't connected (no client) so the caller emits a friendly error.
+  Future<SftpSession?> _defaultSftpOpener(String sessionId) async {
+    final hosted = _sessions[sessionId];
+    final client = hosted?.controller.client;
+    if (client == null) return null;
+    final SftpClient sftp = await client.sftp();
+    return DartSshSftpSession(sftp);
+  }
+
+  Future<void> _handleSftpList(SftpListCommand cmd) async {
+    try {
+      final sftp = await _ensureSftp(cmd.sessionId);
+      if (sftp == null) {
+        _emitSftpError(cmd.sessionId, cmd.requestId, 'Session not connected');
+        return;
+      }
+      final entries = await sftp.list(cmd.path);
+      if (_disposed) return;
+      _gateway.send(SftpListingEvent(
+        sessionId: cmd.sessionId,
+        requestId: cmd.requestId,
+        path: cmd.path,
+        entries: entries,
+      ).toJson());
+    } catch (e) {
+      ctrace('task.host', 'sftp ls FAILED path=${cmd.path} — $e');
+      _emitSftpError(cmd.sessionId, cmd.requestId, 'List failed: $e');
+    }
+  }
+
+  Future<void> _handleSftpDownload(SftpDownloadCommand cmd) async {
+    try {
+      final sftp = await _ensureSftp(cmd.sessionId);
+      if (sftp == null) {
+        _emitSftpError(cmd.sessionId, cmd.requestId, 'Session not connected');
+        return;
+      }
+      // Resolve the size up front so the UI can render a determinate bar; a
+      // null size just means an indeterminate spinner.
+      final totalBytes = await sftp.sizeOf(cmd.path);
+      final written = await sftp.download(
+        cmd.path,
+        onChunk: (chunk, offset) {
+          if (_disposed) return;
+          _gateway.send(SftpDownloadChunkEvent(
+            sessionId: cmd.sessionId,
+            requestId: cmd.requestId,
+            bytes: chunk,
+            offset: offset,
+            totalBytes: totalBytes,
+          ).toJson());
+        },
+      );
+      if (_disposed) return;
+      _gateway.send(SftpDownloadDoneEvent(
+        sessionId: cmd.sessionId,
+        requestId: cmd.requestId,
+        totalBytes: written,
+      ).toJson());
+    } catch (e) {
+      ctrace('task.host', 'sftp download FAILED path=${cmd.path} — $e');
+      _emitSftpError(cmd.sessionId, cmd.requestId, 'Download failed: $e');
+    }
+  }
+
+  void _emitSftpError(String sessionId, String requestId, String message) {
+    if (_disposed) return;
+    _gateway.send(SftpErrorEvent(
+      sessionId: sessionId,
+      requestId: requestId,
+      message: message,
+    ).toJson());
   }
 
   /// Emit a host-key challenge to the UI when the controller surfaces a fresh
@@ -290,9 +413,11 @@ class SessionHost {
     for (final hosted in _sessions.values) {
       hosted.stateSub?.cancel();
       hosted.stateSub = null;
-      // Don't await controller.dispose — let GC handle it. Tests that
-      // construct controllers via the stub factory have no live SSHClient
-      // anyway.
+      // Cancel the controller's own timers (ready/reconnect) so the framework's
+      // pending-timer invariant doesn't fire. `disconnect()` is sync when no
+      // live SSHClient exists (the stub factory's socket never opens), so the
+      // fire-and-forget is safe and complete by the time the test body ends.
+      unawaited(hosted.controller.disconnect());
     }
     _sessions.clear();
   }
@@ -356,6 +481,11 @@ class _HostedSession {
   final SshSessionController controller;
   StreamSubscription<SshSessionData>? stateSub;
   final SessionMetrics metrics = SessionMetrics();
+
+  /// Lazily-opened SFTP subsystem over this session's `SSHClient` (#559).
+  /// Opened on the first list/download command, reused after, closed on
+  /// teardown. Null until the first SFTP op.
+  SftpSession? sftp;
 
   /// Fingerprint of the host-key challenge already forwarded to the UI, so a
   /// single awaitingHostKey transition emits exactly one challenge (#536).

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -22,6 +22,13 @@ enum SshTaskCommandKind {
   resize,
   requestSnapshot,
   hostKeyDecision,
+
+  // --- SFTP (#559) ---
+  /// List a remote directory over the session's SftpClient.
+  sftpList,
+
+  /// Download a single remote file; the task streams chunks back.
+  sftpDownload,
 }
 
 /// Envelope kind discriminator for task → UI events.
@@ -36,6 +43,66 @@ enum SshTaskEventKind {
   /// Task isolate finished booting (`SessionHost` + gateway wired). The UI
   /// gateway flushes any commands it buffered during isolate spin-up (#539).
   ready,
+
+  // --- SFTP (#559) ---
+  /// A directory listing result (entries for one path).
+  sftpListing,
+
+  /// One chunk of a file being downloaded (base64 bytes + running offset).
+  sftpDownloadChunk,
+
+  /// A download finished — total bytes + the request id.
+  sftpDownloadDone,
+
+  /// An SFTP operation failed (list or download). Carries the request id so
+  /// the UI can match it to the in-flight op without tearing down the session.
+  sftpError,
+}
+
+/// One remote filesystem entry surfaced to the file browser (#559). Kept small
+/// and Dart-serializable so it round-trips across the UI ↔ task IPC boundary.
+/// Mirrors the fields the PWA file explorer renders (name, dir flag, size,
+/// mtime). `path` is the absolute remote path (parent + name) so the UI can
+/// navigate / download without re-joining paths itself.
+class SftpEntry {
+  const SftpEntry({
+    required this.name,
+    required this.path,
+    required this.isDirectory,
+    this.size,
+    this.modifyTime,
+    this.isSymlink = false,
+  });
+
+  final String name;
+  final String path;
+  final bool isDirectory;
+
+  /// Size in bytes (null for directories / when the server omits it).
+  final int? size;
+
+  /// Modification time in seconds since epoch (null when omitted).
+  final int? modifyTime;
+
+  final bool isSymlink;
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'path': path,
+        'isDirectory': isDirectory,
+        if (size != null) 'size': size,
+        if (modifyTime != null) 'modifyTime': modifyTime,
+        if (isSymlink) 'isSymlink': true,
+      };
+
+  factory SftpEntry.fromJson(Map<String, dynamic> json) => SftpEntry(
+        name: json['name'] as String,
+        path: json['path'] as String,
+        isDirectory: json['isDirectory'] as bool,
+        size: json['size'] as int?,
+        modifyTime: json['modifyTime'] as int?,
+        isSymlink: (json['isSymlink'] as bool?) ?? false,
+      );
 }
 
 /// Base for all UI → task command envelopes. Subclasses are concrete records
@@ -95,8 +162,74 @@ sealed class SshTaskCommand {
           sessionId: sessionId,
           accepted: json['accepted'] as bool,
         );
+      case SshTaskCommandKind.sftpList:
+        return SftpListCommand(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          path: json['path'] as String,
+        );
+      case SshTaskCommandKind.sftpDownload:
+        return SftpDownloadCommand(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          path: json['path'] as String,
+        );
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// SFTP commands (#559)
+// ---------------------------------------------------------------------------
+
+/// UI → task: list the remote directory at [path]. The task replies with a
+/// matching [SftpListingEvent] (or [SftpErrorEvent]) carrying [requestId] so
+/// the browser can ignore stale listings after a fast navigation.
+class SftpListCommand extends SshTaskCommand {
+  const SftpListCommand({
+    required String sessionId,
+    required this.requestId,
+    required this.path,
+  }) : super(sessionId);
+
+  final String requestId;
+  final String path;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.sftpList;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'requestId': requestId,
+        'path': path,
+      };
+}
+
+/// UI → task: download the single remote file at [path]. The task streams
+/// [SftpDownloadChunkEvent]s and a terminal [SftpDownloadDoneEvent], all keyed
+/// by [requestId]. Folder/recursive download is Slice 2 — this is one file.
+class SftpDownloadCommand extends SshTaskCommand {
+  const SftpDownloadCommand({
+    required String sessionId,
+    required this.requestId,
+    required this.path,
+  }) : super(sessionId);
+
+  final String requestId;
+  final String path;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.sftpDownload;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'requestId': requestId,
+        'path': path,
+      };
 }
 
 class SshConnectCommand extends SshTaskCommand {
@@ -298,6 +431,36 @@ sealed class SshTaskEvent {
         );
       case SshTaskEventKind.ready:
         return const SshTaskReadyEvent();
+      case SshTaskEventKind.sftpListing:
+        final rawEntries = (json['entries'] as List)
+            .map((e) => SftpEntry.fromJson(Map<String, dynamic>.from(e as Map)))
+            .toList();
+        return SftpListingEvent(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          path: json['path'] as String,
+          entries: rawEntries,
+        );
+      case SshTaskEventKind.sftpDownloadChunk:
+        return SftpDownloadChunkEvent(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          bytes: Uint8List.fromList(base64Decode(json['bytes'] as String)),
+          offset: json['offset'] as int,
+          totalBytes: json['totalBytes'] as int?,
+        );
+      case SshTaskEventKind.sftpDownloadDone:
+        return SftpDownloadDoneEvent(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          totalBytes: json['totalBytes'] as int,
+        );
+      case SshTaskEventKind.sftpError:
+        return SftpErrorEvent(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          message: json['message'] as String,
+        );
     }
   }
 }
@@ -472,5 +635,116 @@ class SshTaskReadyEvent extends SshTaskEvent {
   Map<String, dynamic> toJson() => {
         'kind': kind.name,
         'sessionId': sessionId,
+      };
+}
+
+// ---------------------------------------------------------------------------
+// SFTP events (#559)
+// ---------------------------------------------------------------------------
+
+/// Task → UI: the directory listing for [path]. [requestId] matches the
+/// originating [SftpListCommand] so the browser can drop stale results.
+class SftpListingEvent extends SshTaskEvent {
+  const SftpListingEvent({
+    required String sessionId,
+    required this.requestId,
+    required this.path,
+    required this.entries,
+  }) : super(sessionId);
+
+  final String requestId;
+  final String path;
+  final List<SftpEntry> entries;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.sftpListing;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'requestId': requestId,
+        'path': path,
+        'entries': entries.map((e) => e.toJson()).toList(),
+      };
+}
+
+/// Task → UI: one chunk of a downloading file. Streamed in order; the UI
+/// assembles them into the destination sink. [offset] is the byte offset of
+/// this chunk's first byte; [totalBytes] (when known) drives the progress bar.
+class SftpDownloadChunkEvent extends SshTaskEvent {
+  SftpDownloadChunkEvent({
+    required String sessionId,
+    required this.requestId,
+    required this.bytes,
+    required this.offset,
+    this.totalBytes,
+  }) : super(sessionId);
+
+  final String requestId;
+  final Uint8List bytes;
+  final int offset;
+  final int? totalBytes;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.sftpDownloadChunk;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'requestId': requestId,
+        'bytes': base64Encode(bytes),
+        'offset': offset,
+        if (totalBytes != null) 'totalBytes': totalBytes,
+      };
+}
+
+/// Task → UI: a download completed successfully. [totalBytes] is the full
+/// transferred size; the UI flushes + closes its destination sink on this.
+class SftpDownloadDoneEvent extends SshTaskEvent {
+  const SftpDownloadDoneEvent({
+    required String sessionId,
+    required this.requestId,
+    required this.totalBytes,
+  }) : super(sessionId);
+
+  final String requestId;
+  final int totalBytes;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.sftpDownloadDone;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'requestId': requestId,
+        'totalBytes': totalBytes,
+      };
+}
+
+/// Task → UI: an SFTP list/download op failed. Scoped to [requestId] so it
+/// surfaces as an in-browser error (snackbar) without disturbing the SSH
+/// session itself.
+class SftpErrorEvent extends SshTaskEvent {
+  const SftpErrorEvent({
+    required String sessionId,
+    required this.requestId,
+    required this.message,
+  }) : super(sessionId);
+
+  final String requestId;
+  final String message;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.sftpError;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'requestId': requestId,
+        'message': message,
       };
 }

--- a/native/lib/services/sftp_download.dart
+++ b/native/lib/services/sftp_download.dart
@@ -1,0 +1,115 @@
+// SFTP download destination seam (#559).
+//
+// The task isolate streams file chunks across IPC (base64); the UI assembles
+// them into a destination on the device. This file owns the *destination*
+// abstraction so the chunk-assembly logic is reusable and the storage backend
+// is swappable:
+//
+//   - MVP / this slice: [AppDownloadsSink] writes into the app's external
+//     "Downloads" directory via path_provider — no MANAGE_EXTERNAL_STORAGE,
+//     no SAF prompt. Good enough to validate the round-trip end-to-end.
+//   - Follow-up (owner-validated on device): a SAF/MediaStore-backed sink that
+//     drops files into the shared Downloads collection the user sees in their
+//     file manager. Slot it in by implementing [FileDownloadSink].
+//
+// Keeping the assembly here (not in the widget) means Slice 2's folder
+// download can reuse it per-file.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+
+/// A growing destination for a single downloaded file. Chunks arrive in order
+/// from the task isolate; [addChunk] appends, [finish] flushes + returns a
+/// human-readable location for the success snackbar.
+abstract class FileDownloadSink {
+  Future<void> addChunk(Uint8List bytes);
+
+  /// Flush + close. Returns a display path / URI for the completion message.
+  Future<String> finish();
+
+  /// Abort + clean up a partial file (called on error / cancel).
+  Future<void> abort();
+}
+
+/// Resolves the destination sink for a download. Injected into the browser so
+/// widget tests substitute an in-memory sink (no real filesystem). Production
+/// resolves to an [AppDownloadsSink].
+typedef DownloadSinkFactory = Future<FileDownloadSink> Function(String fileName);
+
+/// Production factory: app-scoped Downloads directory via path_provider.
+Future<FileDownloadSink> defaultDownloadSinkFactory(String fileName) async {
+  return AppDownloadsSink.create(fileName);
+}
+
+/// Writes into the app's external Downloads directory (Android) or the app
+/// documents directory (fallback). Scoped storage — no broad-storage perms.
+class AppDownloadsSink implements FileDownloadSink {
+  AppDownloadsSink._(this._file, this._sink);
+
+  final File _file;
+  final IOSink _sink;
+
+  static Future<AppDownloadsSink> create(String fileName) async {
+    final dir = await _resolveDownloadsDir();
+    final safeName = _sanitize(fileName);
+    final file = File('${dir.path}/$safeName');
+    final sink = file.openWrite();
+    return AppDownloadsSink._(file, sink);
+  }
+
+  static Future<Directory> _resolveDownloadsDir() async {
+    // getDownloadsDirectory() is null on Android; fall back to the app's
+    // external storage dir's Download subfolder, then app documents.
+    Directory? dir;
+    try {
+      dir = await getDownloadsDirectory();
+    } catch (_) {
+      dir = null;
+    }
+    if (dir == null) {
+      try {
+        final ext = await getExternalStorageDirectory();
+        if (ext != null) {
+          dir = Directory('${ext.path}/Download');
+        }
+      } catch (_) {
+        dir = null;
+      }
+    }
+    dir ??= await getApplicationDocumentsDirectory();
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  /// Strip path separators so a remote basename can't escape the target dir.
+  static String _sanitize(String name) {
+    final base = name.split('/').last.split('\\').last;
+    return base.isEmpty ? 'download' : base;
+  }
+
+  @override
+  Future<void> addChunk(Uint8List bytes) async {
+    _sink.add(bytes);
+  }
+
+  @override
+  Future<String> finish() async {
+    await _sink.flush();
+    await _sink.close();
+    return _file.path;
+  }
+
+  @override
+  Future<void> abort() async {
+    try {
+      await _sink.close();
+    } catch (_) {/* ignore */}
+    try {
+      if (await _file.exists()) await _file.delete();
+    } catch (_) {/* ignore */}
+  }
+}

--- a/native/lib/ssh/sftp_session.dart
+++ b/native/lib/ssh/sftp_session.dart
@@ -1,0 +1,142 @@
+// SFTP session wrapper (#559).
+//
+// A thin abstraction over dartssh2's `SftpClient` so the task-side
+// `SessionHost` can be unit-tested with a fake. The real implementation opens
+// an SFTP subsystem channel over the authenticated `SSHClient`; tests inject a
+// [FakeSftpSession] and never touch a socket.
+//
+// Scope (Slice 1): list a directory + download one file (chunked). Upload,
+// mkdir, rename, delete are deliberately absent — they are Slice 2 (#559 says
+// keep this small + shippable). Add them here when that lands.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+
+import '../services/session_messages.dart';
+
+/// Joins a parent directory [parent] with a child [name] into an absolute
+/// remote path, collapsing the duplicate slash at the root. Shared by the host
+/// (when building [SftpEntry.path]) and the browser navigation logic.
+String joinRemotePath(String parent, String name) {
+  if (parent.endsWith('/')) return '$parent$name';
+  return '$parent/$name';
+}
+
+/// The parent directory of an absolute remote [path]. Returns '/' for the root
+/// or a top-level entry. Used by the "up" button in the browser.
+String parentRemotePath(String path) {
+  if (path == '/' || path.isEmpty) return '/';
+  var p = path;
+  if (p.endsWith('/')) p = p.substring(0, p.length - 1);
+  final idx = p.lastIndexOf('/');
+  if (idx <= 0) return '/';
+  return p.substring(0, idx);
+}
+
+/// Abstraction the [SessionHost] talks to. One per live SSH session, opened
+/// lazily on the first SFTP command and reused for subsequent ones.
+abstract class SftpSession {
+  /// List the directory at [path]. Returns [SftpEntry]s with absolute paths.
+  Future<List<SftpEntry>> list(String path);
+
+  /// Download the file at [path], invoking [onChunk] for each block (with the
+  /// byte offset of the block's first byte) and [onProgress] with the running
+  /// total. Returns the total bytes transferred. [totalBytes] is resolved up
+  /// front via stat so the UI can render a determinate progress bar.
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize,
+  });
+
+  /// Stat the file at [path] to learn its size (for progress). Null when the
+  /// server omits the size.
+  Future<int?> sizeOf(String path);
+
+  /// Release the underlying SFTP channel.
+  Future<void> close();
+}
+
+/// Opens an [SftpSession] for a given session id. Injected into [SessionHost]
+/// so tests can substitute a fake without a real `SSHClient`. Returns null
+/// when no authenticated client is available for that session (the host then
+/// emits an [SftpErrorEvent]).
+typedef SftpSessionOpener = Future<SftpSession?> Function(String sessionId);
+
+/// Production [SftpSession] backed by dartssh2's [SftpClient].
+class DartSshSftpSession implements SftpSession {
+  DartSshSftpSession(this._client);
+
+  final SftpClient _client;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async {
+    final names = await _client.listdir(path);
+    final entries = <SftpEntry>[];
+    for (final n in names) {
+      // Skip the "." / ".." pseudo-entries — the browser navigates with the
+      // dedicated up-button instead, matching the PWA file explorer.
+      if (n.filename == '.' || n.filename == '..') continue;
+      final attr = n.attr;
+      entries.add(SftpEntry(
+        name: n.filename,
+        path: joinRemotePath(path, n.filename),
+        isDirectory: attr.isDirectory,
+        size: attr.isDirectory ? null : attr.size,
+        modifyTime: attr.modifyTime,
+        isSymlink: attr.isSymlinkType,
+      ));
+    }
+    entries.sort(_dirsFirstByName);
+    return entries;
+  }
+
+  @override
+  Future<int?> sizeOf(String path) async {
+    final attr = await _client.stat(path);
+    return attr.size;
+  }
+
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async {
+    final file = await _client.open(path);
+    try {
+      var offset = 0;
+      var total = 0;
+      await for (final chunk in file.read(chunkSize: chunkSize)) {
+        onChunk(Uint8List.fromList(chunk), offset);
+        offset += chunk.length;
+        total += chunk.length;
+      }
+      return total;
+    } finally {
+      await file.close();
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    _client.close();
+  }
+}
+
+/// Sort directories before files, each group alphabetical (case-insensitive) —
+/// the same ordering the PWA file explorer uses.
+int _dirsFirstByName(SftpEntry a, SftpEntry b) {
+  if (a.isDirectory != b.isDirectory) {
+    return a.isDirectory ? -1 : 1;
+  }
+  return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+}
+
+extension on SftpFileAttrs {
+  /// dartssh2 exposes `isSymbolicLink`; wrap so the wrapper file owns the name
+  /// the host/UI use (keeps the rename localized if the dep API shifts).
+  bool get isSymlinkType => isSymbolicLink;
+}

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -56,6 +56,12 @@ class SshSessionProxy {
   final StreamController<Uint8List> _outputCtrl =
       StreamController<Uint8List>.broadcast();
 
+  /// SFTP events (#559): directory listings, download chunks/done, errors —
+  /// all keyed by `requestId`. The file browser subscribes and filters by its
+  /// own in-flight request id.
+  final StreamController<SshTaskEvent> _sftpCtrl =
+      StreamController<SshTaskEvent>.broadcast();
+
   SshSessionData _data = const SshSessionData();
   ProxySnapshot _snapshot =
       const ProxySnapshot(state: SshSessionState.idle);
@@ -72,6 +78,11 @@ class SshSessionProxy {
   /// PTY output bytes streamed from the task side. Subscribers feed these
   /// into `Terminal.write(...)`.
   Stream<Uint8List> get output => _outputCtrl.stream;
+
+  /// SFTP events from the task side (#559). Emits [SftpListingEvent],
+  /// [SftpDownloadChunkEvent], [SftpDownloadDoneEvent], [SftpErrorEvent].
+  /// The file browser filters by request id.
+  Stream<SshTaskEvent> get sftpEvents => _sftpCtrl.stream;
 
   /// Latest snapshot received from the task side. Used by the audit screen
   /// and by `rebind()` to redraw without waiting for the next emit.
@@ -168,6 +179,27 @@ class SshSessionProxy {
     ).toJson());
   }
 
+  /// Request a directory listing over SFTP (#559). The matching
+  /// [SftpListingEvent] (or [SftpErrorEvent]) arrives on [sftpEvents] with the
+  /// same [requestId].
+  void sftpList({required String requestId, required String path}) {
+    gateway.send(SftpListCommand(
+      sessionId: sessionId,
+      requestId: requestId,
+      path: path,
+    ).toJson());
+  }
+
+  /// Request a single-file download over SFTP (#559). Chunks + completion
+  /// arrive on [sftpEvents] keyed by [requestId].
+  void sftpDownload({required String requestId, required String path}) {
+    gateway.send(SftpDownloadCommand(
+      sessionId: sessionId,
+      requestId: requestId,
+      path: path,
+    ).toJson());
+  }
+
   /// Send a PTY resize to the remote.
   void sendResize(int cols, int rows, {int pixelWidth = 0, int pixelHeight = 0}) {
     gateway.send(SshResizeCommand(
@@ -188,6 +220,7 @@ class SshSessionProxy {
     _eventSub = null;
     if (!_dataCtrl.isClosed) await _dataCtrl.close();
     if (!_outputCtrl.isClosed) await _outputCtrl.close();
+    if (!_sftpCtrl.isClosed) await _sftpCtrl.close();
   }
 
   void _handleEvent(Map<String, dynamic> payload) {
@@ -250,6 +283,13 @@ class SshSessionProxy {
         // It only reaches here for the matching (empty) sessionId, which no
         // real proxy uses, but handle it for switch exhaustiveness.
         break;
+      case SftpListingEvent():
+      case SftpDownloadChunkEvent():
+      case SftpDownloadDoneEvent():
+      case SftpErrorEvent():
+        // SFTP results (#559) — forward to the file browser, which matches by
+        // request id. They never touch the SSH lifecycle state.
+        if (!_sftpCtrl.isClosed) _sftpCtrl.add(event);
     }
   }
 

--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -1,0 +1,459 @@
+// SFTP file browser screen (#559) — Slice 1 foundation.
+//
+// Lists a remote directory, navigates into/up, and downloads a single tapped
+// file to the device via a [FileDownloadSink]. Drives everything through the
+// session's [SshSessionProxy] (sftpList / sftpDownload + the sftpEvents
+// stream), so the heavy lifting (the SftpClient) lives task-side.
+//
+// Seams left open on purpose:
+//   - `.pdf` tap interception (#557): see [_onFileTap]. A file ending in
+//     `.pdf` routes through [pdfTapInterceptor] when one is registered; today
+//     it falls through to download.
+//   - Upload / mkdir / rename / folder download (Slice 2): not here yet. Add
+//     actions to the AppBar + long-press menu and new proxy commands.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/session_messages.dart';
+import '../services/sftp_download.dart';
+import '../ssh/ssh_session_proxy.dart';
+import '../state/sessions.dart';
+
+/// Resolves the destination sink for downloads. Overridden in widget tests to
+/// avoid touching the real filesystem; production uses the app Downloads dir.
+final downloadSinkFactoryProvider = Provider<DownloadSinkFactory>(
+  (ref) => defaultDownloadSinkFactory,
+);
+
+/// Optional `.pdf` tap interceptor (#557 seam). When non-null, tapping a
+/// `.pdf` file invokes this instead of downloading. The PDF viewer feature
+/// overrides this provider to push its preview route.
+typedef PdfTapInterceptor = void Function(BuildContext context, SftpEntry entry);
+
+final pdfTapInterceptorProvider = Provider<PdfTapInterceptor?>((ref) => null);
+
+/// Push the file browser for [sessionId]. The session menu's "Files" item and
+/// any future caller use this single entry point (#559 bullet 4).
+Future<void> openFileBrowser(BuildContext context, String sessionId) {
+  return Navigator.of(context).push(
+    MaterialPageRoute<void>(
+      builder: (_) => FileBrowserScreen(sessionId: sessionId),
+    ),
+  );
+}
+
+class FileBrowserScreen extends ConsumerStatefulWidget {
+  const FileBrowserScreen({
+    super.key,
+    required this.sessionId,
+    this.initialPath = '/',
+  });
+
+  final String sessionId;
+  final String initialPath;
+
+  @override
+  ConsumerState<FileBrowserScreen> createState() => _FileBrowserScreenState();
+}
+
+class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
+  SshSessionProxy? _proxy;
+  StreamSubscription<SshTaskEvent>? _sub;
+
+  String _path = '/';
+  List<SftpEntry> _entries = const [];
+  bool _loading = true;
+  String? _error;
+
+  /// Monotonic counter → request id, so a late listing for a directory we've
+  /// already navigated away from is dropped.
+  int _seq = 0;
+  String? _listRequestId;
+
+  /// In-flight download request id (null when idle). One at a time in Slice 1.
+  String? _downloadRequestId;
+  int _downloadReceived = 0;
+  int? _downloadTotal;
+  FileDownloadSink? _downloadSink;
+  String? _downloadName;
+
+  bool _attached = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _path = widget.initialPath;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Attach once, after the InheritedWidget (ProviderScope) is available. This
+    // runs before the first build's frame, so the initial listing request fires
+    // immediately rather than waiting on a post-frame callback (which made the
+    // first directory load flaky to observe).
+    if (_attached) return;
+    _attached = true;
+    final entries = ref.read(sessionsProvider).entries;
+    SshSessionProxy? proxy;
+    for (final e in entries) {
+      if (e.id == widget.sessionId) {
+        proxy = e.proxy;
+        break;
+      }
+    }
+    if (proxy == null) {
+      // No setState here — didChangeDependencies runs before build, so just
+      // set the fields and let the imminent build render the error.
+      _loading = false;
+      _error = 'Session is no longer available';
+      return;
+    }
+    _proxy = proxy;
+    _sub = proxy.sftpEvents.listen(_onSftpEvent);
+    // Send the initial listing WITHOUT setState (we're pre-build). The fields
+    // are set directly; the first build reads them.
+    final reqId = _nextRequestId();
+    _listRequestId = reqId;
+    _loading = true;
+    _error = null;
+    proxy.sftpList(requestId: reqId, path: _path);
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    // Abort any partial download so we don't leak a half-written file.
+    unawaited(_downloadSink?.abort());
+    super.dispose();
+  }
+
+  String _nextRequestId() => '${widget.sessionId}#${_seq++}';
+
+  void _list(String path) {
+    final proxy = _proxy;
+    if (proxy == null) return;
+    final reqId = _nextRequestId();
+    setState(() {
+      _path = path;
+      _loading = true;
+      _error = null;
+      _listRequestId = reqId;
+    });
+    proxy.sftpList(requestId: reqId, path: path);
+  }
+
+  void _onSftpEvent(SshTaskEvent event) {
+    if (!mounted) return;
+    switch (event) {
+      case SftpListingEvent():
+        if (event.requestId != _listRequestId) return; // stale
+        setState(() {
+          _entries = event.entries;
+          _loading = false;
+          _error = null;
+        });
+      case SftpDownloadChunkEvent():
+        if (event.requestId != _downloadRequestId) return;
+        unawaited(_onChunk(event));
+      case SftpDownloadDoneEvent():
+        if (event.requestId != _downloadRequestId) return;
+        unawaited(_onDownloadDone(event));
+      case SftpErrorEvent():
+        _onSftpError(event);
+      default:
+        break;
+    }
+  }
+
+  Future<void> _onChunk(SftpDownloadChunkEvent event) async {
+    final sink = _downloadSink;
+    if (sink == null) return;
+    await sink.addChunk(event.bytes);
+    if (!mounted) return;
+    setState(() {
+      _downloadReceived += event.bytes.length;
+      _downloadTotal = event.totalBytes;
+    });
+  }
+
+  Future<void> _onDownloadDone(SftpDownloadDoneEvent event) async {
+    final sink = _downloadSink;
+    final name = _downloadName ?? 'file';
+    _downloadSink = null;
+    String? location;
+    if (sink != null) {
+      try {
+        location = await sink.finish();
+      } catch (e) {
+        location = null;
+      }
+    }
+    if (!mounted) return;
+    setState(() {
+      _downloadRequestId = null;
+      _downloadReceived = 0;
+      _downloadTotal = null;
+      _downloadName = null;
+    });
+    final msg = location != null
+        ? 'Downloaded $name → $location'
+        : 'Downloaded $name';
+    _snack(msg);
+  }
+
+  void _onSftpError(SftpErrorEvent event) {
+    // A listing error fails the directory view; a download error aborts the
+    // transfer. Match by the active request ids.
+    if (event.requestId == _listRequestId) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = event.message;
+      });
+      return;
+    }
+    if (event.requestId == _downloadRequestId) {
+      unawaited(_downloadSink?.abort());
+      _downloadSink = null;
+      if (!mounted) return;
+      setState(() {
+        _downloadRequestId = null;
+        _downloadReceived = 0;
+        _downloadTotal = null;
+        _downloadName = null;
+      });
+      _snack('Download failed: ${event.message}');
+    }
+  }
+
+  void _snack(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _onEntryTap(SftpEntry entry) {
+    if (entry.isDirectory) {
+      _list(entry.path);
+      return;
+    }
+    _onFileTap(entry);
+  }
+
+  void _onFileTap(SftpEntry entry) {
+    // #557 seam: a registered PDF interceptor handles `.pdf` files (e.g. opens
+    // an in-app preview) instead of downloading. Falls through otherwise.
+    final pdfHandler = ref.read(pdfTapInterceptorProvider);
+    if (pdfHandler != null && entry.name.toLowerCase().endsWith('.pdf')) {
+      pdfHandler(context, entry);
+      return;
+    }
+    unawaited(_startDownload(entry));
+  }
+
+  Future<void> _startDownload(SftpEntry entry) async {
+    final proxy = _proxy;
+    if (proxy == null) return;
+    if (_downloadRequestId != null) {
+      _snack('A download is already in progress');
+      return;
+    }
+    final reqId = _nextRequestId();
+    final factory = ref.read(downloadSinkFactoryProvider);
+    FileDownloadSink sink;
+    try {
+      sink = await factory(entry.name);
+    } catch (e) {
+      _snack('Could not start download: $e');
+      return;
+    }
+    if (!mounted) {
+      await sink.abort();
+      return;
+    }
+    setState(() {
+      _downloadRequestId = reqId;
+      _downloadSink = sink;
+      _downloadName = entry.name;
+      _downloadReceived = 0;
+      _downloadTotal = entry.size;
+    });
+    proxy.sftpDownload(requestId: reqId, path: entry.path);
+  }
+
+  void _goUp() {
+    if (_path == '/' || _path.isEmpty) return;
+    var p = _path;
+    if (p.endsWith('/')) p = p.substring(0, p.length - 1);
+    final idx = p.lastIndexOf('/');
+    final parent = idx <= 0 ? '/' : p.substring(0, idx);
+    _list(parent);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final downloading = _downloadRequestId != null;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Files'),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(48),
+          child: _PathBar(
+            path: _path,
+            canGoUp: _path != '/' && _path.isNotEmpty,
+            onUp: _goUp,
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          if (downloading)
+            _DownloadProgress(
+              key: const Key('file-browser-download-progress'),
+              name: _downloadName ?? '',
+              received: _downloadReceived,
+              total: _downloadTotal,
+            ),
+          Expanded(child: _buildBody()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) {
+      return const Center(
+        key: Key('file-browser-loading'),
+        child: CircularProgressIndicator(),
+      );
+    }
+    if (_error != null) {
+      return Center(
+        key: const Key('file-browser-error'),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(_error!, textAlign: TextAlign.center),
+        ),
+      );
+    }
+    if (_entries.isEmpty) {
+      return const Center(
+        key: Key('file-browser-empty'),
+        child: Text('Empty directory'),
+      );
+    }
+    return ListView.builder(
+      key: const Key('file-browser-list'),
+      itemCount: _entries.length,
+      itemBuilder: (context, i) {
+        final e = _entries[i];
+        return _EntryTile(
+          entry: e,
+          onTap: () => _onEntryTap(e),
+        );
+      },
+    );
+  }
+}
+
+class _PathBar extends StatelessWidget {
+  const _PathBar({required this.path, required this.canGoUp, required this.onUp});
+
+  final String path;
+  final bool canGoUp;
+  final VoidCallback onUp;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: Row(
+        children: [
+          IconButton(
+            key: const Key('file-browser-up'),
+            tooltip: 'Up',
+            icon: const Icon(Icons.arrow_upward),
+            onPressed: canGoUp ? onUp : null,
+          ),
+          Expanded(
+            child: Text(
+              path,
+              key: const Key('file-browser-path'),
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          const SizedBox(width: 12),
+        ],
+      ),
+    );
+  }
+}
+
+class _EntryTile extends StatelessWidget {
+  const _EntryTile({required this.entry, required this.onTap});
+
+  final SftpEntry entry;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = entry.isDirectory
+        ? Icons.folder
+        : (entry.isSymlink ? Icons.link : Icons.insert_drive_file_outlined);
+    return ListTile(
+      key: Key('file-entry-${entry.name}'),
+      leading: Icon(icon),
+      title: Text(entry.name, overflow: TextOverflow.ellipsis),
+      subtitle: entry.isDirectory
+          ? null
+          : Text(_formatSize(entry.size)),
+      trailing: entry.isDirectory ? const Icon(Icons.chevron_right) : null,
+      onTap: onTap,
+    );
+  }
+
+  static String _formatSize(int? bytes) {
+    if (bytes == null) return '';
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+  }
+}
+
+class _DownloadProgress extends StatelessWidget {
+  const _DownloadProgress({
+    super.key,
+    required this.name,
+    required this.received,
+    required this.total,
+  });
+
+  final String name;
+  final int received;
+  final int? total;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = total;
+    final value = (t != null && t > 0) ? (received / t).clamp(0.0, 1.0) : null;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Downloading $name…',
+              style: Theme.of(context).textTheme.bodySmall),
+          const SizedBox(height: 4),
+          LinearProgressIndicator(value: value),
+        ],
+      ),
+    );
+  }
+}

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -14,6 +14,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import 'connect_form.dart';
+import 'file_browser_screen.dart';
 
 /// Opens the session menu as a modal bottom sheet. Returns once dismissed.
 Future<void> showSessionMenu(BuildContext context) {
@@ -92,6 +93,24 @@ class SessionMenu extends ConsumerWidget {
               subtitle: Text(palette.label),
               trailing: const Icon(Icons.chevron_right),
               onTap: () => ref.read(terminalThemeProvider.notifier).cycle(),
+            ),
+            // Browse / download remote files over SFTP for the active session
+            // (#559). Disabled when there's no active session.
+            ListTile(
+              key: const Key('session-menu-files'),
+              leading: const Icon(Icons.folder_outlined),
+              title: const Text('Files'),
+              subtitle: const Text('Browse and download remote files (SFTP)'),
+              trailing: const Icon(Icons.chevron_right),
+              enabled: sessions.activeId != null,
+              onTap: sessions.activeId == null
+                  ? null
+                  : () {
+                      final sessionId = sessions.activeId!;
+                      final navigator = Navigator.of(context);
+                      navigator.pop();
+                      openFileBrowser(navigator.context, sessionId);
+                    },
             ),
           ],
         ),

--- a/native/test/services/sftp_host_test.dart
+++ b/native/test/services/sftp_host_test.dart
@@ -1,0 +1,219 @@
+// SessionHost SFTP handler tests (#559).
+//
+// Exercises the task-side ls + download routing with a fake [SftpSession]
+// injected via the host's `sftpOpener` seam — no real socket, no SSHClient.
+// Verifies the host emits the right request-id-scoped events and that errors
+// surface as SftpErrorEvent without tearing the session down.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+
+/// Controller factory whose connect() never resolves a real socket — tests
+/// drive state via debugSetConnectedForTest.
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) {
+      return Future.delayed(const Duration(days: 1), () {
+        throw Exception('socketOpener not used in SFTP tests');
+      });
+    },
+  );
+}
+
+class FakeSftpSession implements SftpSession {
+  FakeSftpSession({
+    this.entries = const [],
+    this.fileBytes = const [],
+    this.throwOnList = false,
+    this.throwOnDownload = false,
+  });
+
+  final List<SftpEntry> entries;
+  final List<int> fileBytes;
+  final bool throwOnList;
+  final bool throwOnDownload;
+  bool closed = false;
+  String? lastListedPath;
+  String? lastDownloadedPath;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async {
+    lastListedPath = path;
+    if (throwOnList) throw Exception('boom-list');
+    return entries;
+  }
+
+  @override
+  Future<int?> sizeOf(String path) async => fileBytes.length;
+
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async {
+    lastDownloadedPath = path;
+    if (throwOnDownload) throw Exception('boom-download');
+    // Emit two chunks to exercise offset accounting.
+    final all = Uint8List.fromList(fileBytes);
+    final mid = (all.length / 2).ceil();
+    if (all.isNotEmpty) {
+      onChunk(Uint8List.sublistView(all, 0, mid), 0);
+      if (mid < all.length) {
+        onChunk(Uint8List.sublistView(all, mid), mid);
+      }
+    }
+    return all.length;
+  }
+
+  @override
+  Future<void> close() async {
+    closed = true;
+  }
+}
+
+void main() {
+  /// Build a host + proxy pair, with a session pre-marked connected so the
+  /// SFTP opener seam is reached.
+  Future<({SessionHost host, SshSessionProxy proxy, InMemoryGatewayPair pair})>
+      setUpConnected(
+    String sid,
+    FakeSftpSession fake,
+  ) async {
+    final pair = InMemoryGatewayPair();
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: _stubControllerFactory,
+      sftpOpener: (_) async => fake,
+      snapshotInterval: const Duration(hours: 1),
+    );
+    final proxy = SshSessionProxy(sessionId: sid, gateway: pair.uiSide);
+    proxy.connect(const SshConnectParams(
+      host: 'h',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    ));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    return (host: host, proxy: proxy, pair: pair);
+  }
+
+  test('sftpList emits a listing event with the entries', () async {
+    final fake = FakeSftpSession(entries: const [
+      SftpEntry(name: 'docs', path: '/docs', isDirectory: true),
+      SftpEntry(name: 'a.txt', path: '/a.txt', isDirectory: false, size: 5),
+    ]);
+    final ctx = await setUpConnected('sid-ls', fake);
+    addTearDown(ctx.pair.dispose);
+    addTearDown(ctx.host.dispose);
+    addTearDown(ctx.proxy.dispose);
+
+    final events = <SshTaskEvent>[];
+    final sub = ctx.proxy.sftpEvents.listen(events.add);
+
+    ctx.proxy.sftpList(requestId: 'sid-ls#0', path: '/');
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    final listing =
+        events.whereType<SftpListingEvent>().toList();
+    expect(listing, isNotEmpty);
+    expect(listing.first.requestId, 'sid-ls#0');
+    expect(listing.first.path, '/');
+    expect(listing.first.entries.map((e) => e.name), ['docs', 'a.txt']);
+    expect(fake.lastListedPath, '/');
+
+    await sub.cancel();
+  });
+
+  test('sftpDownload streams chunks then a done event', () async {
+    final fake = FakeSftpSession(fileBytes: List<int>.generate(10, (i) => i));
+    final ctx = await setUpConnected('sid-dl', fake);
+    addTearDown(ctx.pair.dispose);
+    addTearDown(ctx.host.dispose);
+    addTearDown(ctx.proxy.dispose);
+
+    final chunks = <SftpDownloadChunkEvent>[];
+    SftpDownloadDoneEvent? done;
+    final sub = ctx.proxy.sftpEvents.listen((e) {
+      if (e is SftpDownloadChunkEvent) chunks.add(e);
+      if (e is SftpDownloadDoneEvent) done = e;
+    });
+
+    ctx.proxy.sftpDownload(requestId: 'sid-dl#0', path: '/a.bin');
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(chunks, isNotEmpty);
+    // Reassembled bytes must equal the source file.
+    final assembled = <int>[];
+    for (final c in chunks) {
+      expect(c.requestId, 'sid-dl#0');
+      assembled.addAll(c.bytes);
+    }
+    expect(assembled, List<int>.generate(10, (i) => i));
+    expect(done, isNotNull);
+    expect(done!.totalBytes, 10);
+    expect(chunks.first.totalBytes, 10); // size resolved up front
+    expect(fake.lastDownloadedPath, '/a.bin');
+
+    await sub.cancel();
+  });
+
+  test('list failure surfaces as SftpErrorEvent, session survives', () async {
+    final fake = FakeSftpSession(throwOnList: true);
+    final ctx = await setUpConnected('sid-err', fake);
+    addTearDown(ctx.pair.dispose);
+    addTearDown(ctx.host.dispose);
+    addTearDown(ctx.proxy.dispose);
+
+    SftpErrorEvent? err;
+    final sub = ctx.proxy.sftpEvents.listen((e) {
+      if (e is SftpErrorEvent) err = e;
+    });
+
+    ctx.proxy.sftpList(requestId: 'sid-err#0', path: '/nope');
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(err, isNotNull);
+    expect(err!.requestId, 'sid-err#0');
+    expect(err!.message, contains('List failed'));
+    // The SSH session is still hosted — an SFTP error must not drop it.
+    expect(ctx.host.sessionIds, contains('sid-err'));
+
+    await sub.cancel();
+  });
+
+  test('SFTP op on an unhosted session emits not-connected error', () async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: _stubControllerFactory,
+      sftpOpener: (_) async => FakeSftpSession(),
+      snapshotInterval: const Duration(hours: 1),
+    );
+    addTearDown(host.dispose);
+    final proxy = SshSessionProxy(sessionId: 'ghost', gateway: pair.uiSide);
+    addTearDown(proxy.dispose);
+
+    SftpErrorEvent? err;
+    final sub = proxy.sftpEvents.listen((e) {
+      if (e is SftpErrorEvent) err = e;
+    });
+
+    proxy.sftpList(requestId: 'ghost#0', path: '/');
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(err, isNotNull);
+    expect(err!.message, contains('not connected'));
+
+    await sub.cancel();
+  });
+}

--- a/native/test/services/sftp_messages_test.dart
+++ b/native/test/services/sftp_messages_test.dart
@@ -1,0 +1,141 @@
+// Wire-contract tests for the SFTP IPC envelopes (#559).
+//
+// Every SFTP command/event must round-trip through toJson/fromJson without
+// losing a field — the task host and UI browser both depend on this. Mirrors
+// the existing task_ipc_test.dart pattern.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+
+void main() {
+  group('SftpEntry round-trip', () {
+    test('file entry preserves all fields', () {
+      const e = SftpEntry(
+        name: 'report.pdf',
+        path: '/home/user/report.pdf',
+        isDirectory: false,
+        size: 4096,
+        modifyTime: 1700000000,
+      );
+      final restored = SftpEntry.fromJson(e.toJson());
+      expect(restored.name, 'report.pdf');
+      expect(restored.path, '/home/user/report.pdf');
+      expect(restored.isDirectory, false);
+      expect(restored.size, 4096);
+      expect(restored.modifyTime, 1700000000);
+      expect(restored.isSymlink, false);
+    });
+
+    test('directory entry omits size', () {
+      const e = SftpEntry(
+        name: 'docs',
+        path: '/home/user/docs',
+        isDirectory: true,
+      );
+      final json = e.toJson();
+      expect(json.containsKey('size'), false);
+      final restored = SftpEntry.fromJson(json);
+      expect(restored.isDirectory, true);
+      expect(restored.size, isNull);
+    });
+
+    test('symlink flag survives', () {
+      const e = SftpEntry(
+        name: 'link',
+        path: '/link',
+        isDirectory: false,
+        isSymlink: true,
+      );
+      expect(SftpEntry.fromJson(e.toJson()).isSymlink, true);
+    });
+  });
+
+  group('SFTP command round-trip', () {
+    test('SftpListCommand preserves request id + path', () {
+      const cmd = SftpListCommand(
+        sessionId: 'sid',
+        requestId: 'sid#3',
+        path: '/var/log',
+      );
+      final restored = SshTaskCommand.fromJson(cmd.toJson());
+      expect(restored, isA<SftpListCommand>());
+      restored as SftpListCommand;
+      expect(restored.sessionId, 'sid');
+      expect(restored.requestId, 'sid#3');
+      expect(restored.path, '/var/log');
+    });
+
+    test('SftpDownloadCommand preserves request id + path', () {
+      const cmd = SftpDownloadCommand(
+        sessionId: 'sid',
+        requestId: 'sid#7',
+        path: '/etc/hosts',
+      );
+      final restored =
+          SshTaskCommand.fromJson(cmd.toJson()) as SftpDownloadCommand;
+      expect(restored.requestId, 'sid#7');
+      expect(restored.path, '/etc/hosts');
+    });
+  });
+
+  group('SFTP event round-trip', () {
+    test('SftpListingEvent preserves entries', () {
+      const ev = SftpListingEvent(
+        sessionId: 'sid',
+        requestId: 'sid#1',
+        path: '/',
+        entries: [
+          SftpEntry(name: 'a', path: '/a', isDirectory: true),
+          SftpEntry(name: 'b.txt', path: '/b.txt', isDirectory: false, size: 9),
+        ],
+      );
+      final restored = SshTaskEvent.fromJson(ev.toJson()) as SftpListingEvent;
+      expect(restored.requestId, 'sid#1');
+      expect(restored.path, '/');
+      expect(restored.entries.length, 2);
+      expect(restored.entries[0].name, 'a');
+      expect(restored.entries[0].isDirectory, true);
+      expect(restored.entries[1].size, 9);
+    });
+
+    test('SftpDownloadChunkEvent preserves binary bytes + offset', () {
+      final bytes = Uint8List.fromList([0, 255, 127, 1, 2, 250]);
+      final ev = SftpDownloadChunkEvent(
+        sessionId: 'sid',
+        requestId: 'sid#2',
+        bytes: bytes,
+        offset: 128,
+        totalBytes: 4096,
+      );
+      final restored =
+          SshTaskEvent.fromJson(ev.toJson()) as SftpDownloadChunkEvent;
+      expect(restored.bytes, bytes);
+      expect(restored.offset, 128);
+      expect(restored.totalBytes, 4096);
+    });
+
+    test('SftpDownloadDoneEvent preserves totalBytes', () {
+      const ev = SftpDownloadDoneEvent(
+        sessionId: 'sid',
+        requestId: 'sid#2',
+        totalBytes: 123456,
+      );
+      final restored =
+          SshTaskEvent.fromJson(ev.toJson()) as SftpDownloadDoneEvent;
+      expect(restored.totalBytes, 123456);
+    });
+
+    test('SftpErrorEvent preserves message + request id', () {
+      const ev = SftpErrorEvent(
+        sessionId: 'sid',
+        requestId: 'sid#9',
+        message: 'No such file',
+      );
+      final restored = SshTaskEvent.fromJson(ev.toJson()) as SftpErrorEvent;
+      expect(restored.requestId, 'sid#9');
+      expect(restored.message, 'No such file');
+    });
+  });
+}

--- a/native/test/widget/file_browser_widget_test.dart
+++ b/native/test/widget/file_browser_widget_test.dart
@@ -1,0 +1,239 @@
+// File browser widget test (#559).
+//
+// Renders [FileBrowserScreen] against a real proxy wired to a task-side
+// [SessionHost] with a fake [SftpSession]. Verifies:
+//   - the browser lists the directory entries it receives,
+//   - tapping a directory navigates into it,
+//   - tapping a file triggers the download path (chunks assembled into an
+//     injected in-memory sink, success snackbar shown).
+//
+// The download sink is overridden so no real filesystem is touched.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/sftp_download.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    // Never completes AND creates no timer (a bare Completer.future), so the
+    // connect() stays parked without leaving a pending fake_async timer.
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+class _ScriptedSftpSession implements SftpSession {
+  _ScriptedSftpSession(this._byPath, this._fileBytes);
+
+  final Map<String, List<SftpEntry>> _byPath;
+  final List<int> _fileBytes;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async => _byPath[path] ?? const [];
+
+  @override
+  Future<int?> sizeOf(String path) async => _fileBytes.length;
+
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onChunk(Uint8List.fromList(_fileBytes), 0);
+    return _fileBytes.length;
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+/// In-memory sink so the download path runs without a real filesystem.
+class _MemSink implements FileDownloadSink {
+  final BytesBuilder _b = BytesBuilder();
+  bool finished = false;
+
+  @override
+  Future<void> addChunk(Uint8List bytes) async => _b.add(bytes);
+
+  @override
+  Future<String> finish() async {
+    finished = true;
+    return '/test/Download/captured';
+  }
+
+  @override
+  Future<void> abort() async {}
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 10}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('lists entries; navigates into a dir; tapping a file downloads',
+      (tester) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+
+    final fileBytes = List<int>.generate(12, (i) => i + 1);
+    final fake = _ScriptedSftpSession(
+      {
+        '/': const [
+          SftpEntry(name: 'docs', path: '/docs', isDirectory: true),
+          SftpEntry(name: 'a.txt', path: '/a.txt', isDirectory: false, size: 12),
+        ],
+        '/docs': const [
+          SftpEntry(name: 'inner.bin', path: '/docs/inner.bin', isDirectory: false, size: 12),
+        ],
+      },
+      fileBytes,
+    );
+
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: _stubControllerFactory,
+      sftpOpener: (_) async => fake,
+      snapshotInterval: const Duration(hours: 1),
+    );
+
+    final memSink = _MemSink();
+    final container = ProviderContainer(
+      overrides: [
+        taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+        downloadSinkFactoryProvider
+            .overrideWithValue((name) async => memSink),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    const params = SshConnectParams(
+      host: 'h',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    );
+    final entry =
+        container.read(sessionsProvider.notifier).addOrActivate(params);
+    // Register the session on the host so its SFTP opener can resolve. (The
+    // controller's connect never reaches a real socket; we only need the host
+    // to hold the session entry.)
+    entry.proxy.connect(params);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: FileBrowserScreen(sessionId: entry.id),
+        ),
+      ),
+    );
+    await _pump(tester);
+
+    // Root listing rendered both entries.
+    expect(find.byKey(const Key('file-browser-list')), findsOneWidget);
+    expect(find.byKey(const Key('file-entry-docs')), findsOneWidget);
+    expect(find.byKey(const Key('file-entry-a.txt')), findsOneWidget);
+
+    // Navigate into the directory.
+    await tester.tap(find.byKey(const Key('file-entry-docs')));
+    await _pump(tester);
+    expect(find.byKey(const Key('file-entry-inner.bin')), findsOneWidget);
+    expect(find.text('/docs'), findsOneWidget);
+
+    // Go back up to root.
+    await tester.tap(find.byKey(const Key('file-browser-up')));
+    await _pump(tester);
+    expect(find.byKey(const Key('file-entry-a.txt')), findsOneWidget);
+
+    // Tap the file → download runs through the injected sink.
+    await tester.tap(find.byKey(const Key('file-entry-a.txt')));
+    await _pump(tester);
+
+    expect(memSink.finished, isTrue);
+    expect(memSink._b.toBytes(), Uint8List.fromList(fileBytes));
+    // Success snackbar.
+    expect(find.textContaining('Downloaded a.txt'), findsOneWidget);
+
+    // Cancel the host's periodic snapshot timer before the framework's
+    // pending-timer invariant check (matches multi_session_rebind_test).
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('a list error renders the error state', (tester) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: _stubControllerFactory,
+      sftpOpener: (_) async => _ThrowingSftpSession(),
+      snapshotInterval: const Duration(hours: 1),
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    const params = SshConnectParams(
+      host: 'h',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    );
+    final entry =
+        container.read(sessionsProvider.notifier).addOrActivate(params);
+    entry.proxy.connect(params);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(home: FileBrowserScreen(sessionId: entry.id)),
+      ),
+    );
+    await _pump(tester);
+
+    expect(find.byKey(const Key('file-browser-error')), findsOneWidget);
+
+    host.disposeSyncForTest();
+  });
+}
+
+class _ThrowingSftpSession implements SftpSession {
+  @override
+  Future<List<SftpEntry>> list(String path) async => throw Exception('nope');
+  @override
+  Future<int?> sizeOf(String path) async => null;
+  @override
+  Future<int> download(String path,
+          {required void Function(Uint8List chunk, int offset) onChunk,
+          int chunkSize = 64 * 1024}) async =>
+      0;
+  @override
+  Future<void> close() async {}
+}


### PR DESCRIPTION
## SFTP file explorer foundation (#559, Slice 1)

Wires dartssh2's `SftpClient` over the live SSH session and adds a Material 3
file browser: **list / navigate / download a single file**. Folder ops, upload,
delete/mkdir/rename, and previews are intentionally out of scope (Slice 2 / #557).

### Backend (additive — does NOT touch the #551 connect/keepalive/reconnect paths)
- **`session_messages.dart`** — `SftpEntry` model + `sftpList` / `sftpDownload`
  commands + `sftpListing` / `sftpDownloadChunk` / `sftpDownloadDone` /
  `sftpError` events, all round-trippable across the UI↔task IPC boundary.
- **`session_host.dart`** — a dedicated **SFTP region**. Lazily opens an
  `SftpSession` over the controller's authenticated `SSHClient`
  (`SftpSessionOpener` seam, mockable in tests), routes `ls` + chunked download,
  and scopes results/errors by `requestId` so a failed op never disturbs the SSH
  session. The connect/reconnect/keepalive logic is untouched.
- **`ssh/sftp_session.dart`** — thin `SftpSession` wrapper (`list` / `sizeOf` /
  `download`) + remote path join/parent helpers; dirs-first ordering matching
  the PWA.
- **`ssh_session_proxy.dart`** — `sftpList` / `sftpDownload` + an `sftpEvents`
  stream the browser subscribes to.

### UI
- **`ui/file_browser_screen.dart`** — lists entries, navigates into/up (path bar
  + up button), taps a file → download with a progress bar + result snackbar.
  Keyed widgets throughout for tests.
  - **Seam for #557 (PDF viewer):** `pdfTapInterceptorProvider` — a registered
    interceptor handles `.pdf` taps instead of downloading.
  - **Reusable download path:** `FileDownloadSink` — Slice 2's folder download
    reuses it per-file.
- **`services/sftp_download.dart`** — `FileDownloadSink` seam. MVP
  `AppDownloadsSink` uses path_provider's app-scoped Downloads dir
  (**no `MANAGE_EXTERNAL_STORAGE`**). A real SAF/MediaStore sink slots in by
  implementing the same interface.
- **`session_menu.dart`** — "Files" item → `openFileBrowser(context, sessionId)`
  for the active session.

### Tests (TDD)
- SFTP message round-trip (commands/events + `SftpEntry`).
- Host `ls` + chunked download + error handling with a fake `SftpSession`
  (no socket): verifies chunk reassembly, up-front size for the progress bar,
  request-id scoping, and that an SFTP error leaves the session hosted.
- Widget test: lists entries, navigates into a dir + back up, and a file tap
  drives the download path into an injected in-memory sink (assembled bytes ==
  source, success snackbar). Plus a list-error → error-state case.

`scripts/native-fast-gate.sh` green (243 tests).

### Device validation needed (owner)
The MVP writes to the **app-scoped** Downloads dir via path_provider. The real
SAF/MediaStore download (file visible in the user's file manager) and a
real-file SFTP round-trip against test-sshd need **owner device validation**
before final sign-off.

Closes #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)