### PR TITLE
feat(native): persist accepted host keys (#565)

### DIFF
--- a/native/integration_test/hostkey_persist_test.dart
+++ b/native/integration_test/hostkey_persist_test.dart
@@ -1,0 +1,162 @@
+// On-emulator host-key persistence: connect → accept → reconnect → NO prompt (#565).
+//
+// Device bug: HostKeyStore was in-memory only, and each session gets a fresh
+// controller (hence a fresh store). So every connect re-prompted "Trust +
+// connect". The fix persists accepted fingerprints (SharedPreferences) and
+// hydrates them on a new store, so a known host:port never re-prompts.
+//
+// This is the connect → accept → reconnect → no-prompt STATE TRANSITION:
+//   1. First connect: store starts empty → "Trust + connect" prompt appears,
+//      we ACCEPT it, reach a live shell.
+//   2. Disconnect (removes the session + its controller/store).
+//   3. Reconnect to the SAME host: the new store hydrates the persisted trust,
+//      so NO "Trust + connect" prompt appears, and it still reaches a live shell.
+//
+// PASS = first connect prompts+accepts+shell; second connect reaches shell with
+// NO prompt observed.
+//
+// NOTE: run via `scripts/native-connect-test.sh integration_test/hostkey_persist_test.dart`.
+// Persisted trust from a prior run would mask the first-connect prompt, so we
+// clear SharedPreferences before starting (forces a deterministic fresh state).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+
+Future<void> _fillForm(WidgetTester tester) async {
+  await tester.enterText(find.byKey(const Key('connect-host')), '127.0.0.1');
+  await tester.enterText(find.byKey(const Key('connect-port')), '2222');
+  await tester.enterText(find.byKey(const Key('connect-username')), 'testuser');
+  await tester.enterText(find.byKey(const Key('connect-password')), 'testpass');
+  await tester.pump();
+}
+
+/// Submit, optionally accept the host-key prompt, and poll until the terminal
+/// mounts AND the shell streams bytes. Returns a record:
+///   (reachedShell, sawPrompt).
+Future<({bool reachedShell, bool sawPrompt})> _connect(
+  WidgetTester tester,
+  ProviderContainer container, {
+  required bool acceptPromptIfShown,
+}) async {
+  await tester.tap(find.byKey(const Key('connect-submit')));
+  var connected = false;
+  var sawPrompt = false;
+  for (var i = 0; i < 60; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+    final accept = find.text('Trust + connect');
+    if (accept.evaluate().isNotEmpty) {
+      sawPrompt = true;
+      if (acceptPromptIfShown) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+    }
+    if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+      connected = true;
+      break;
+    }
+  }
+  if (!connected) return (reachedShell: false, sawPrompt: sawPrompt);
+
+  final entry = container.read(sessionsProvider).active;
+  if (entry == null) return (reachedShell: false, sawPrompt: sawPrompt);
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  var gotBytes = false;
+  for (var i = 0; i < 40; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+    if (out.isNotEmpty) {
+      gotBytes = true;
+      break;
+    }
+  }
+  await sub.cancel();
+  return (reachedShell: gotBytes, sawPrompt: sawPrompt);
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'accept host key once, reconnect to same host shows NO prompt (#565)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      // Force a deterministic fresh state: no persisted trust from prior runs,
+      // so the FIRST connect is guaranteed to prompt.
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // First connect — empty store → MUST prompt, we accept, reach a shell.
+      await _fillForm(tester);
+      final first = await _connect(
+        tester,
+        container,
+        acceptPromptIfShown: true,
+      );
+      expect(
+        first.reachedShell,
+        isTrue,
+        reason: 'first connect did not reach a live shell',
+      );
+      expect(
+        first.sawPrompt,
+        isTrue,
+        reason: 'first connect to a brand-new host should prompt to trust',
+      );
+
+      // Disconnect → removes the session + its controller/store.
+      await tester.tap(find.byKey(const Key('terminal-disconnect-button')));
+      var backAtForm = false;
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(const Key('connect-submit')).evaluate().isNotEmpty) {
+          backAtForm = true;
+          break;
+        }
+      }
+      expect(
+        backAtForm,
+        isTrue,
+        reason: 'disconnect did not return to the connect form',
+      );
+
+      // Reconnect to the SAME host — the persisted trust must hydrate into the
+      // fresh session's store, so NO prompt this time, and still reach a shell.
+      await _fillForm(tester);
+      final second = await _connect(
+        tester,
+        container,
+        acceptPromptIfShown: false,
+      );
+      expect(
+        second.reachedShell,
+        isTrue,
+        reason: 'reconnect did not reach a live shell',
+      );
+      expect(
+        second.sawPrompt,
+        isFalse,
+        reason:
+            'RECONNECT re-prompted for an already-trusted host — the '
+            '#565 persistence bug',
+      );
+    },
+  );
+}

--- a/native/lib/ssh/host_key_store.dart
+++ b/native/lib/ssh/host_key_store.dart
@@ -1,36 +1,176 @@
-// In-memory host-key trust store.
+// Persistent host-key trust store (#565).
 //
-// Phase 1 (#501): plain in-memory map. Phase 3 will swap the backing store
-// for flutter_secure_storage so trusted fingerprints survive app restarts.
+// Trust-on-first-use registry that survives connects AND app launches. The
+// SYNC verify path (`SshSessionController._onVerifyHostKey`) reads an in-memory
+// map; an async backend hydrates that map on construction and persists every
+// trust/forget decision.
+//
+// Why SharedPreferences (not flutter_secure_storage): host PUBLIC-key
+// fingerprints are SHA-256 hashes of public keys — they are not secret. Storing
+// them in plain SharedPreferences is the simplest fit and mirrors
+// `profiles_store.dart`. Private keys / passphrases NEVER touch this store
+// (those live in `secrets_store.dart`, Keystore-backed). Per .claude security
+// rules: fingerprints are fine to persist; secrets are not.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// shared_preferences key. Versioned so a future schema change can migrate
+/// in-place (per .claude/rules code-style: version inside the value/key, never
+/// bump to fix cache issues).
+const String hostKeysPrefsKey = 'mobissh.hostkeys.v1';
+
+/// Pluggable persistence backend for trusted host fingerprints.
+///
+/// The map is keyed by `"host:port"` → fingerprint hex. Production uses
+/// [SharedPrefsHostKeyBackend]; tests inject [InMemoryHostKeyBackend].
+abstract class HostKeyBackend {
+  /// Load the full trust map. Returns `{}` when nothing is stored.
+  Future<Map<String, String>> loadAll();
+
+  /// Persist the full trust map, overwriting any prior value.
+  Future<void> saveAll(Map<String, String> map);
+}
+
+/// Production backend: a JSON map under [hostKeysPrefsKey] in
+/// shared_preferences. Corrupt data falls back to an empty map (no crash).
+class SharedPrefsHostKeyBackend implements HostKeyBackend {
+  SharedPrefsHostKeyBackend({SharedPreferences? prefs}) : _prefs = prefs;
+
+  // ignore_for_file: prefer_initializing_formals
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> _ensure() async =>
+      _prefs ??= await SharedPreferences.getInstance();
+
+  @override
+  Future<Map<String, String>> loadAll() async {
+    final prefs = await _ensure();
+    final raw = prefs.getString(hostKeysPrefsKey);
+    if (raw == null || raw.isEmpty) return <String, String>{};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return <String, String>{};
+      final out = <String, String>{};
+      decoded.forEach((k, v) {
+        if (k is String && v is String) out[k] = v;
+      });
+      return out;
+    } on FormatException {
+      return <String, String>{};
+    }
+  }
+
+  @override
+  Future<void> saveAll(Map<String, String> map) async {
+    final prefs = await _ensure();
+    await prefs.setString(hostKeysPrefsKey, jsonEncode(map));
+  }
+}
+
+/// In-memory backend for tests. Pass the SAME instance to two HostKeyStores to
+/// simulate an app relaunch (second store hydrates what the first persisted).
+class InMemoryHostKeyBackend implements HostKeyBackend {
+  InMemoryHostKeyBackend([Map<String, String>? seed])
+    : _store = <String, String>{...?seed};
+
+  final Map<String, String> _store;
+
+  @override
+  Future<Map<String, String>> loadAll() async =>
+      Map<String, String>.from(_store);
+
+  @override
+  Future<void> saveAll(Map<String, String> map) async {
+    _store
+      ..clear()
+      ..addAll(map);
+  }
+}
 
 /// Trust-on-first-use host-key registry.
 ///
 /// Keyed by `"host:port"` -> fingerprint string (caller decides format —
-/// SshSessionController hands us hex of the SHA-256 fingerprint that
-/// dartssh2 provides via `SSHHostkeyVerifyHandler`).
+/// SshSessionController hands us hex of the SHA-256 fingerprint that dartssh2
+/// provides via `SSHHostkeyVerifyHandler`).
+///
+/// The in-memory [_trusted] map is the authoritative source for the SYNC
+/// [isTrusted] verify path. Construction eagerly hydrates it from [_backend];
+/// [trust]/[forget] mutate it synchronously and persist asynchronously. Callers
+/// on the verify path MUST `await ready` first so a freshly-constructed store
+/// (e.g. a new session after app launch) doesn't re-prompt before hydration.
 class HostKeyStore {
-  // TODO(#501 phase 3): persist via flutter_secure_storage.
-  final Map<String, String> _trusted = <String, String>{};
+  HostKeyStore({HostKeyBackend? backend})
+    : _backend = backend ?? SharedPrefsHostKeyBackend() {
+    _ready = _hydrate();
+  }
 
-  /// Returns true iff [fingerprint] matches the previously-trusted value
-  /// for `host:port`.
+  final HostKeyBackend _backend;
+  final Map<String, String> _trusted = <String, String>{};
+  late final Future<void> _ready;
+  bool _hydrated = false;
+
+  /// Resolves once persisted trust has been loaded into the in-memory map.
+  /// Idempotent to await repeatedly. The verify path awaits this ONLY when
+  /// [isHydrated] is still false, so the common (already-loaded) path stays
+  /// synchronous and emits `awaitingHostKey` without an extra event-loop turn.
+  Future<void> get ready => _ready;
+
+  /// True once hydration has completed. Lets the verify path skip the
+  /// `await ready` gap when the map is already loaded (the normal case —
+  /// hydration starts at construction, long before the first verify).
+  bool get isHydrated => _hydrated;
+
+  Future<void> _hydrate() async {
+    Map<String, String> loaded;
+    try {
+      loaded = await _backend.loadAll();
+    } catch (_) {
+      // Backend unavailable (e.g. no platform channel in a unit test, or a
+      // transient storage error). Degrade to an empty trust map rather than
+      // throwing on the verify path — worst case the user re-confirms once.
+      loaded = const <String, String>{};
+    }
+    // Don't clobber any trust decisions that landed between ctor and hydrate
+    // completion — in-memory writes win, hydration only fills gaps.
+    loaded.forEach((k, v) => _trusted.putIfAbsent(k, () => v));
+    _hydrated = true;
+  }
+
+  void _persist() {
+    // Fire-and-forget snapshot of the full map. saveAll is overwrite semantics
+    // so concurrent calls converge on the latest in-memory state. Swallow
+    // backend errors so a failed write never crashes the verify path.
+    unawaited(
+      _backend
+          .saveAll(Map<String, String>.from(_trusted))
+          .catchError((Object _) {}),
+    );
+  }
+
+  /// Returns true iff [fingerprint] matches the previously-trusted value for
+  /// `host:port`. SYNC by design — reads the hydrated in-memory map.
   bool isTrusted(String host, int port, String fingerprint) {
     final stored = _trusted['$host:$port'];
     return stored != null && stored == fingerprint;
   }
 
   /// Returns the trusted fingerprint for `host:port`, or null if none.
-  String? trustedFingerprint(String host, int port) =>
-      _trusted['$host:$port'];
+  String? trustedFingerprint(String host, int port) => _trusted['$host:$port'];
 
-  /// Persist a trust decision. Overwrites any prior entry.
+  /// Persist a trust decision. Overwrites any prior entry. Updates the
+  /// in-memory map synchronously and schedules an async backend write.
   void trust(String host, int port, String fingerprint) {
     _trusted['$host:$port'] = fingerprint;
+    _persist();
   }
 
   /// Remove a trust entry (e.g. user rejected a rotated key).
   void forget(String host, int port) {
-    _trusted.remove('$host:$port');
+    final removed = _trusted.remove('$host:$port');
+    if (removed != null) _persist();
   }
 
   /// Number of trusted hosts. Useful in tests.

--- a/native/lib/ssh/ssh_session.dart
+++ b/native/lib/ssh/ssh_session.dart
@@ -283,6 +283,14 @@ class SshSessionController {
     );
     _armReadyTimer();
 
+    // Hydrate persisted host-key trust before the handshake so the verify
+    // callback sees previously-accepted fingerprints and never re-prompts for
+    // a known host:port (#565). Cheap (a SharedPreferences read) and only the
+    // first connect pays it; subsequent connects find it already hydrated.
+    if (!_hostKeyStore.isHydrated) {
+      await _hostKeyStore.ready;
+    }
+
     // Fail fast on an unusable private key BEFORE touching the network. A
     // passphrase-encrypted key with the wrong passphrase (or a blob mangled on
     // the vault/import round-trip) makes `SSHKeyPair.fromPem` throw. Previously
@@ -784,6 +792,11 @@ class SshSessionController {
     Uint8List fingerprint,
   ) async {
     final hex = _fingerprintHex(fingerprint);
+    // Persisted trust is hydrated in connect() (before the SSHClient is built),
+    // so by the time dartssh2 invokes this callback the in-memory map already
+    // reflects previously-accepted fingerprints (#565). This method stays
+    // synchronous in its emit timing — it must reach `awaitingHostKey` in the
+    // same turn so the connecting-phase timer is cancelled (#542).
     if (_hostKeyStore.isTrusted(params.host, params.port, hex)) {
       _emit(_data.copyWith(state: SshSessionState.authenticating));
       return true;

--- a/native/test/host_key_store_test.dart
+++ b/native/test/host_key_store_test.dart
@@ -1,14 +1,16 @@
-// Unit tests for HostKeyStore — pure in-memory trust map.
+// Unit tests for HostKeyStore — in-memory trust map + persistence (#565).
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/ssh/host_key_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('HostKeyStore', () {
     late HostKeyStore store;
 
     setUp(() {
-      store = HostKeyStore();
+      // Isolated in-memory backend per test so the trust map starts empty.
+      store = HostKeyStore(backend: InMemoryHostKeyBackend());
     });
 
     test('isTrusted returns false for unknown host', () {
@@ -51,6 +53,80 @@ void main() {
       expect(store.length, 2);
       store.forget('a', 22);
       expect(store.length, 1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #565 persistence: trust must survive a NEW HostKeyStore instance (the
+  // "app relaunch" / new-session-controller transition that was re-prompting).
+  // -------------------------------------------------------------------------
+  group('HostKeyStore persistence (#565)', () {
+    test(
+      'trust persists; a NEW store over the same backend hydrates as trusted',
+      () async {
+        final backend = InMemoryHostKeyBackend();
+
+        // First store (this app session) trusts a host.
+        final first = HostKeyStore(backend: backend);
+        await first.ready;
+        first.trust('example.com', 22, 'aabbcc');
+        // Let the fire-and-forget persist land.
+        await Future<void>.delayed(Duration.zero);
+
+        // Second store (simulated app relaunch / new session) over the SAME
+        // backing store must report the host trusted after hydration — WITHOUT
+        // anyone calling trust() on it.
+        final second = HostKeyStore(backend: backend);
+        await second.ready;
+        expect(second.isTrusted('example.com', 22, 'aabbcc'), isTrue);
+        expect(second.trustedFingerprint('example.com', 22), 'aabbcc');
+        expect(second.length, 1);
+      },
+    );
+
+    test(
+      'forget persists; a NEW store no longer reports the host trusted',
+      () async {
+        final backend = InMemoryHostKeyBackend();
+        final first = HostKeyStore(backend: backend);
+        await first.ready;
+        first.trust('example.com', 22, 'aabbcc');
+        await Future<void>.delayed(Duration.zero);
+        first.forget('example.com', 22);
+        await Future<void>.delayed(Duration.zero);
+
+        final second = HostKeyStore(backend: backend);
+        await second.ready;
+        expect(second.isTrusted('example.com', 22, 'aabbcc'), isFalse);
+        expect(second.length, 0);
+      },
+    );
+
+    test(
+      'SharedPreferences backend round-trips trust across instances',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+
+        final first = HostKeyStore(backend: SharedPrefsHostKeyBackend());
+        await first.ready;
+        first.trust('host.example', 2222, 'deadbeef');
+        await Future<void>.delayed(Duration.zero);
+
+        // A brand-new store + brand-new backend reading the same mock prefs.
+        final second = HostKeyStore(backend: SharedPrefsHostKeyBackend());
+        await second.ready;
+        expect(second.isTrusted('host.example', 2222, 'deadbeef'), isTrue);
+      },
+    );
+
+    test('corrupt persisted JSON falls back to empty (no crash)', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        hostKeysPrefsKey: 'not-json{{{',
+      });
+      final store = HostKeyStore(backend: SharedPrefsHostKeyBackend());
+      await store.ready;
+      expect(store.length, 0);
+      expect(store.isTrusted('anything', 22, 'x'), isFalse);
     });
   });
 }

--- a/native/test/services/host_key_ipc_test.dart
+++ b/native/test/services/host_key_ipc_test.dart
@@ -40,10 +40,12 @@ void main() {
 
     test('SshHostKeyDecisionCommand preserves accepted flag', () {
       for (final accepted in [true, false]) {
-        final cmd =
-            SshHostKeyDecisionCommand(sessionId: 'sid', accepted: accepted);
-        final restored = SshTaskCommand.fromJson(cmd.toJson())
-            as SshHostKeyDecisionCommand;
+        final cmd = SshHostKeyDecisionCommand(
+          sessionId: 'sid',
+          accepted: accepted,
+        );
+        final restored =
+            SshTaskCommand.fromJson(cmd.toJson()) as SshHostKeyDecisionCommand;
         expect(restored.sessionId, 'sid');
         expect(restored.accepted, accepted);
       }
@@ -57,7 +59,9 @@ void main() {
     late List<HostKeyStore> stores;
 
     SshSessionController makeController() {
-      final store = HostKeyStore();
+      // In-memory backend: no platform channel in flutter_test, and each
+      // controller gets its own isolated trust store (#565).
+      final store = HostKeyStore(backend: InMemoryHostKeyBackend());
       // socketOpener never resolves so connect() parks in `connecting` and we
       // drive the host-key verify path directly via verifyHostKeyForTest —
       // no real TCP attempt that would race the controller to `failed`.
@@ -95,12 +99,14 @@ void main() {
 
       // Spin up the hosted controller (its connect socketOpener never resolves,
       // so we drive the verify path directly via the test seam below).
-      proxy.connect(const SshConnectParams(
-        host: 'newhost',
-        port: 22,
-        username: 'u',
-        auth: SshAuth.password('p'),
-      ));
+      proxy.connect(
+        const SshConnectParams(
+          host: 'newhost',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(created, hasLength(1));
       final controller = created.first;
@@ -149,12 +155,14 @@ void main() {
       final proxy = SshSessionProxy(sessionId: 'sid-r', gateway: pair.uiSide);
       addTearDown(proxy.dispose);
 
-      proxy.connect(const SshConnectParams(
-        host: 'rejhost',
-        port: 22,
-        username: 'u',
-        auth: SshAuth.password('p'),
-      ));
+      proxy.connect(
+        const SshConnectParams(
+          host: 'rejhost',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
       await Future<void>.delayed(const Duration(milliseconds: 20));
       final controller = created.first;
       final store = stores.first;
@@ -219,9 +227,15 @@ void main() {
       final storeB = stores[1];
 
       final fA = ctrlA.verifyHostKeyForTest(
-          paramsA, 'ssh-ed25519', fp([0xAA, 0xAA]));
+        paramsA,
+        'ssh-ed25519',
+        fp([0xAA, 0xAA]),
+      );
       final fB = ctrlB.verifyHostKeyForTest(
-          paramsB, 'ssh-ed25519', fp([0xBB, 0xBB]));
+        paramsB,
+        'ssh-ed25519',
+        fp([0xBB, 0xBB]),
+      );
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       expect(proxyA.data.pendingHostKey!.fingerprint, 'aaaa');

--- a/native/test/ssh_session_test.dart
+++ b/native/test/ssh_session_test.dart
@@ -170,11 +170,80 @@ void main() {
     });
 
     test('hostKeyStore is exposed for inspection', () {
-      final store = HostKeyStore();
+      final store = HostKeyStore(backend: InMemoryHostKeyBackend());
       final controller = SshSessionController(hostKeyStore: store);
       expect(identical(controller.hostKeyStore, store), isTrue);
       controller.dispose();
     });
+
+    test('verify on an already-trusted host skips the prompt '
+        '(connecting -> authenticating, NO awaitingHostKey) — #565', () async {
+      const params = SshConnectParams(
+        host: 'trusted.example',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      );
+      // Seed persisted trust for the exact fingerprint the verify path will
+      // compute from these bytes (hex of [0xDE,0xAD,0xBE,0xEF]).
+      final backend = InMemoryHostKeyBackend(<String, String>{
+        'trusted.example:22': 'deadbeef',
+      });
+      final store = HostKeyStore(backend: backend);
+      await store.ready;
+
+      final controller = SshSessionController(hostKeyStore: store);
+      final transitions = <SshSessionState>[];
+      final sub = controller.stream.listen((d) => transitions.add(d.state));
+
+      final trusted = await controller.verifyHostKeyForTest(
+        params,
+        'ssh-ed25519',
+        Uint8List.fromList(<int>[0xDE, 0xAD, 0xBE, 0xEF]),
+      );
+
+      expect(trusted, isTrue, reason: 'persisted-trust host must not prompt');
+      expect(controller.data.state, SshSessionState.authenticating);
+      expect(controller.data.pendingHostKey, isNull);
+      expect(
+        transitions,
+        isNot(contains(SshSessionState.awaitingHostKey)),
+        reason: 'a trusted host must NEVER enter the prompt state (#565)',
+      );
+
+      await sub.cancel();
+      await controller.dispose();
+    });
+
+    test(
+      'verify on an UNtrusted host still prompts (awaitingHostKey) — #565 guard',
+      () async {
+        const params = SshConnectParams(
+          host: 'new.example',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        );
+        final store = HostKeyStore(backend: InMemoryHostKeyBackend());
+        final controller = SshSessionController(hostKeyStore: store);
+
+        // ignore: unawaited_futures
+        controller.verifyHostKeyForTest(
+          params,
+          'ssh-ed25519',
+          Uint8List.fromList(<int>[0x01, 0x02]),
+        );
+        // Let the awaited ready + emit settle.
+        await Future<void>.delayed(Duration.zero);
+
+        expect(controller.data.state, SshSessionState.awaitingHostKey);
+        expect(controller.data.pendingHostKey, isNotNull);
+
+        // Resolve the pending completer so it doesn't leak past teardown.
+        controller.rejectHostKey();
+        await controller.dispose();
+      },
+    );
 
     test('SshSessionData.copyWith respects clear flags', () {
       const data = SshSessionData(

--- a/scripts/run-native-test-summary.sh
+++ b/scripts/run-native-test-summary.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the native unit/widget suite and print ONLY the failures + final tally.
+# Avoids the streaming-output truncation that hides the summary line.
+
+LOGDIR="/tmp/mobissh"
+mkdir -p "$LOGDIR"
+LOGFILE="$LOGDIR/native-test-summary-$(date +%Y%m%dT%H%M%S%z).log"
+
+SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
+
+set +e
+"$SCRIPTDIR/flutter-cmd.sh" --in native test --exclude-tags integration --reporter expanded >"$LOGFILE" 2>&1
+code=$?
+set -e
+
+echo "exit_code=$code"
+echo "--- failures (if any) ---"
+grep -nE '\[E\]|: Some tests failed|Failed to load|EXCEPTION|\bfailed\b' "$LOGFILE" || echo "(no failure lines matched)"
+echo "--- tail ---"
+tail -n 15 "$LOGFILE"


### PR DESCRIPTION
## What

Persist accepted host-key fingerprints so a known `host:port` never re-prompts "Trust + connect" — across connects and app launches. Fixes #565.

## Why it was broken

`HostKeyStore` was in-memory only. Each SSH session gets a fresh `HostKeyStore()` via the controller factory (`session_host.dart` / `sessions.dart`), so trust never survived a disconnect/reconnect or an app launch — every connect re-prompted.

## Change

- New `HostKeyBackend` abstraction behind `HostKeyStore`:
  - `SharedPrefsHostKeyBackend` (default, production) — key `mobissh.hostkeys.v1`, a JSON map `host:port` → fingerprint hex.
  - `InMemoryHostKeyBackend` (tests).
- `HostKeyStore` hydrates the in-memory trust map from the backend on construction (`ready` future) and persists on `trust()` / `forget()`. The **synchronous** `isTrusted()` verify path still reads the in-memory map (authoritative).
- `SshSessionController.connect()` awaits `hostKeyStore.ready` before the handshake, so the verify callback sees previously-accepted fingerprints. `_onVerifyHostKey` stays synchronous in its emit timing, preserving the #542 connecting-phase prompt-timer contract.
- Corrupt / unavailable backend degrades to an empty map (no crash); failed writes are swallowed so persistence never breaks the verify path.

### Storage choice: SharedPreferences (not flutter_secure_storage)

Host **public-key** fingerprints are SHA-256 hashes of public keys — not secret. Plain SharedPreferences is the simplest fit and mirrors `profiles_store.dart`. Private keys / passphrases never touch this store (those remain in `secrets_store.dart`, Keystore-backed). Per the repo security rule: fingerprints are fine to persist; secrets are not.

## Tests (state-transition focused)

- `test/host_key_store_test.dart`: trust/forget persist; a **NEW** store over the same backend hydrates as trusted (app-relaunch simulation); SharedPreferences round-trip via `setMockInitialValues`; corrupt-JSON resilience.
- `test/ssh_session_test.dart`: verify on an already-trusted host transitions `connecting → authenticating` with **NO** `awaitingHostKey`; untrusted host still prompts.
- `integration_test/hostkey_persist_test.dart` (emulator): connect + accept → live shell, disconnect, reconnect to the same host → **NO** "Trust + connect" prompt, still reaches a live shell.

## Verification

- `scripts/native-fast-gate.sh`: GREEN (analyze: no issues; test: 274 passed, 5 pre-existing skips).
- Emulator: `scripts/native-connect-test.sh integration_test/hostkey_persist_test.dart` **PASSED** on emulator-5554. Trace confirms the transition — first connect emits `hostKeyChallenge` (accepted), the reconnect emits **no** `hostKeyChallenge` and reaches a live shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)