### PR TITLE
feat(native): session menu to bottom + slim (#566, #567)

### DIFF
--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -1,9 +1,12 @@
 // Session menu (#518) — replaces the chip-row tab strip with a modal
 // bottom sheet that mirrors the PWA's `renderSessionList` / `initSessionMenu`.
 //
-// Contents:
+// #567: slimmed to the session-menu-slim direction — terminal real estate is
+// at a premium, so the sheet keeps only what belongs:
 //   1. List of active sessions (tap to switch, long-press for actions).
-//   2. A "Show keybar" toggle that flips the global `keybarVisibleProvider`.
+//   2. "New session".
+//   3. A compact secondary row of session controls (keybar toggle, theme,
+//      files) — no verbose subtitles, no oversized header.
 //
 // Tap-to-switch dismisses the menu. Long-press opens a contextual menu with
 // Disconnect / Close — same actions the PWA exposes on the session row.
@@ -45,13 +48,6 @@ class SessionMenu extends ConsumerWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-              child: Text(
-                'Sessions',
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-            ),
             if (sessions.entries.isEmpty)
               const Padding(
                 padding: EdgeInsets.all(16),
@@ -64,6 +60,7 @@ class SessionMenu extends ConsumerWidget {
             // connect form on top of the terminal screen (the goal's leg 2).
             ListTile(
               key: const Key('session-menu-new'),
+              dense: true,
               leading: const Icon(Icons.add),
               title: const Text('New session'),
               onTap: () {
@@ -77,10 +74,14 @@ class SessionMenu extends ConsumerWidget {
               },
             ),
             const Divider(height: 1),
+            // Slim secondary controls (#567): no subtitles, dense rows. These
+            // are session-scoped controls that belong in the sheet — keybar
+            // visibility, terminal theme, and SFTP files.
             SwitchListTile(
               key: const Key('session-menu-keybar-toggle'),
-              title: const Text('Show keybar'),
-              subtitle: const Text('Bottom row with Esc, Tab, arrows, Ctrl-C'),
+              dense: true,
+              secondary: const Icon(Icons.keyboard_outlined),
+              title: const Text('Keybar'),
               value: keybarVisible,
               onChanged: (v) => ref.read(keybarVisibleProvider.notifier).set(v),
             ),
@@ -88,19 +89,22 @@ class SessionMenu extends ConsumerWidget {
             // ported theme, wrapping at the end; the selection persists.
             ListTile(
               key: const Key('session-menu-theme-cycle'),
+              dense: true,
               leading: const Icon(Icons.palette_outlined),
-              title: const Text('Terminal theme'),
-              subtitle: Text(palette.label),
-              trailing: const Icon(Icons.chevron_right),
+              title: const Text('Theme'),
+              trailing: Text(
+                palette.label,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
               onTap: () => ref.read(terminalThemeProvider.notifier).cycle(),
             ),
             // Browse / download remote files over SFTP for the active session
             // (#559). Disabled when there's no active session.
             ListTile(
               key: const Key('session-menu-files'),
+              dense: true,
               leading: const Icon(Icons.folder_outlined),
               title: const Text('Files'),
-              subtitle: const Text('Browse and download remote files (SFTP)'),
               trailing: const Icon(Icons.chevron_right),
               enabled: sessions.activeId != null,
               onTap: sessions.activeId == null

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -4,8 +4,14 @@
 // Phase 2.A (#501): single session, one xterm.dart `TerminalView`.
 // Phase 4 (#511): multi-session — horizontal tab strip + `IndexedStack`.
 // #518: tab strip removed; session switching now happens through a session
-// menu (modal bottom sheet, AppBar icon trigger). A bottom keybar with a
-// visibility toggle in the session menu replaces the always-on chrome.
+// menu (modal bottom sheet). A bottom keybar with a visibility toggle in the
+// session menu replaces the always-on chrome.
+// #566: the session-menu trigger moved OFF the top-left AppBar to a slim
+// BOTTOM session bar (thumb-reachable on a phone). The bar shows the active
+// session label and opens the bottom sheet — mirroring the PWA's persistent
+// session bar (`#sessionMenuBtn` in the bottom handle strip). The bar is
+// deliberately a single full-width tap target, leaving a clean seam for a
+// future swipe-to-switch gesture (#568). #567: the sheet itself is slimmed.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -43,12 +49,6 @@ class TerminalScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(activeEntry.label, overflow: TextOverflow.ellipsis),
-        leading: IconButton(
-          key: const Key('session-menu-button'),
-          tooltip: 'Sessions',
-          icon: const Icon(Icons.menu),
-          onPressed: () => showSessionMenu(context),
-        ),
         actions: [
           IconButton(
             key: const Key('terminal-disconnect-button'),
@@ -83,7 +83,78 @@ class TerminalScreen extends ConsumerWidget {
               ),
             ),
             if (keybarVisible) Keybar(activeEntry: activeEntry),
+            // Bottom session bar (#566): the thumb-reachable trigger for the
+            // session menu. Sits below the keybar so the menu sheet rises from
+            // immediately above the affordance that summoned it. A single
+            // full-width tap target leaves a clean seam for swipe-to-switch
+            // (#568) without committing to a gesture here.
+            _SessionBar(label: activeEntry.label, sessionCount: entries.length),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Slim bottom bar that opens the session menu (#566). Mirrors the PWA's
+/// persistent session bar: active session label + a count badge when more than
+/// one session is open, tappable across its full width.
+class _SessionBar extends StatelessWidget {
+  const _SessionBar({required this.label, required this.sessionCount});
+
+  final String label;
+  final int sessionCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      key: const Key('session-bar'),
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: InkWell(
+        // `session-menu-button` is retained as the stable terminal-screen-
+        // mounted marker that smoke/integration tests poll for; it just moved
+        // from the AppBar to the bottom bar. `session-bar-open-menu` is the
+        // screenshot/test-addressable name for the new affordance.
+        key: const Key('session-bar-open-menu'),
+        onTap: () => showSessionMenu(context),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            key: const Key('session-menu-button'),
+            children: [
+              const Icon(Icons.menu, size: 18),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  label,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+              if (sessionCount > 1)
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    '$sessionCount',
+                    style: TextStyle(
+                      color: theme.colorScheme.onPrimary,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              const SizedBox(width: 6),
+              const Icon(Icons.expand_less, size: 18),
+            ],
+          ),
         ),
       ),
     );

--- a/native/test/widget/terminal_screen_widget_test.dart
+++ b/native/test/widget/terminal_screen_widget_test.dart
@@ -18,6 +18,7 @@ import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
 import 'package:mobissh/state/terminal_providers.dart';
 import 'package:mobissh/ui/terminal_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xterm/xterm.dart';
 
 import '../support/fake_ssh_shell_transport.dart';
@@ -47,12 +48,14 @@ Future<({SessionEntry entry, ProviderContainer container})> _setupSingleSession(
 
   final entry = container
       .read(sessionsProvider.notifier)
-      .addOrActivate(SshConnectParams(
-        host: host,
-        port: port,
-        username: username,
-        auth: const SshAuth.password('p'),
-      ));
+      .addOrActivate(
+        SshConnectParams(
+          host: host,
+          port: port,
+          username: username,
+          auth: const SshAuth.password('p'),
+        ),
+      );
 
   await tester.pumpWidget(
     UncontrolledProviderScope(
@@ -69,6 +72,10 @@ Future<({SessionEntry entry, ProviderContainer container})> _setupSingleSession(
 }
 
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   group('TerminalScreen', () {
     testWidgets('renders a TerminalView', (tester) async {
       final transport = FakeSshShellTransport();
@@ -85,19 +92,18 @@ void main() {
       addTearDown(transport.close);
       final ({SessionEntry entry, ProviderContainer container}) setup =
           await _setupSingleSession(
-        tester,
-        transport,
-        host: 'sshd.example',
-        port: 2222,
-        username: 'alice',
-      );
+            tester,
+            transport,
+            host: 'sshd.example',
+            port: 2222,
+            username: 'alice',
+          );
       addTearDown(setup.container.dispose);
 
       expect(find.text('alice@sshd.example:2222'), findsWidgets);
     });
 
-    testWidgets('disconnect button is present in the AppBar',
-        (tester) async {
+    testWidgets('disconnect button is present in the AppBar', (tester) async {
       final transport = FakeSshShellTransport();
       addTearDown(transport.close);
       final ({SessionEntry entry, ProviderContainer container}) setup =
@@ -110,15 +116,74 @@ void main() {
       expect(iconButton.onPressed, isNotNull);
     });
 
-    testWidgets('session menu button is present in the AppBar',
-        (tester) async {
+    testWidgets(
+      'session menu button is present (now on the bottom bar, #566)',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final ({SessionEntry entry, ProviderContainer container}) setup =
+            await _setupSingleSession(tester, transport);
+        addTearDown(setup.container.dispose);
+
+        expect(find.byKey(const Key('session-menu-button')), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'session-menu trigger is NOT in the AppBar leading slot (#566)',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final ({SessionEntry entry, ProviderContainer container}) setup =
+            await _setupSingleSession(tester, transport);
+        addTearDown(setup.container.dispose);
+
+        // The bar is rendered as a descendant of the SafeArea body Column, not
+        // inside the AppBar — guard against a regression that re-adds a leading
+        // AppBar trigger.
+        final appBar = find.byType(AppBar);
+        expect(appBar, findsOneWidget);
+        expect(
+          find.descendant(
+            of: appBar,
+            matching: find.byKey(const Key('session-menu-button')),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('bottom session bar is present and addressable (#566)', (
+      tester,
+    ) async {
       final transport = FakeSshShellTransport();
       addTearDown(transport.close);
       final ({SessionEntry entry, ProviderContainer container}) setup =
           await _setupSingleSession(tester, transport);
       addTearDown(setup.container.dispose);
 
-      expect(find.byKey(const Key('session-menu-button')), findsOneWidget);
+      expect(find.byKey(const Key('session-bar')), findsOneWidget);
+      expect(find.byKey(const Key('session-bar-open-menu')), findsOneWidget);
     });
+
+    testWidgets(
+      'tapping the bottom session bar opens the session menu (#566)',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final ({SessionEntry entry, ProviderContainer container}) setup =
+            await _setupSingleSession(tester, transport);
+        addTearDown(setup.container.dispose);
+
+        expect(find.byKey(const Key('session-menu')), findsNothing);
+
+        await tester.tap(find.byKey(const Key('session-bar-open-menu')));
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 50));
+        }
+
+        expect(find.byKey(const Key('session-menu')), findsOneWidget);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Native Flutter. Reshapes the session menu per owner device feedback (2026-05-31).
Closes #566 and #567 (they touch the same menu, done together).

### #566 — session-menu trigger to the bottom (owner's #1)
- Removed the top-left AppBar `leading` trigger.
- Added a slim **bottom session bar** below the keybar: shows the active session
  label, a count badge when more than one session is open, and an `expand_less`
  chevron. Tapping anywhere on it opens the existing bottom-sheet menu — so the
  sheet now rises from immediately above the affordance that summoned it,
  thumb-reachable on a phone.
- The bar is a single full-width tap target, leaving a clean seam for a future
  swipe-to-switch gesture (#568). Swipe itself is out of scope here.
- Mirrors the PWA's persistent session bar (`#sessionMenuBtn` lives in the bottom
  handle strip).

### #567 — slim the session menu (owner's #2)
- Dropped the "Sessions" header.
- Made New session / keybar toggle / theme / files rows `dense`, removed the
  verbose subtitles (theme label moved to a compact trailing label).
- Kept everything that belongs: session switch (tap row), per-row close,
  long-press disconnect/close, New session, keybar toggle, theme cycle, Files.

## Keys (screenshot/test-addressable)
- New: `Key('session-bar')`, `Key('session-bar-open-menu')`.
- Preserved: `Key('session-menu-button')` — moved from the AppBar onto the bottom
  bar (not renamed), so the many smoke/integration tests that poll it as a
  "terminal screen mounted" marker remain valid.

## Tests
- `terminal_screen_widget_test.dart`: updated the session-menu-button test (now
  bottom bar); added: trigger NOT in the AppBar leading slot, `session-bar` +
  `session-bar-open-menu` present, tapping the bar opens the menu.
- All existing tests referencing `session-menu-button` stay green.

## Gate
`scripts/native-fast-gate.sh` GREEN — `flutter analyze` clean, 277 tests passed.

## Caveats
Visual change — final UX fidelity to the PWA needs orchestrator emulator-screenshot
review and owner device confirmation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)