### PR TITLE
feat(native): tap-to-connect + profile editor (#579)

### DIFF
--- a/native/lib/storage/profiles_store.dart
+++ b/native/lib/storage/profiles_store.dart
@@ -155,11 +155,7 @@ class SavedProfile {
     );
   }
 
-  SavedProfile copyWith({
-    String? title,
-    String? vaultId,
-    String? keyVaultId,
-  }) {
+  SavedProfile copyWith({String? title, String? vaultId, String? keyVaultId}) {
     return SavedProfile(
       title: title ?? this.title,
       host: host,
@@ -235,8 +231,7 @@ class ParsedImport {
 
   /// True when this envelope carries an encrypted vault — caller must prompt
   /// for the master password before [ProfilesStore.applyParsedImport].
-  bool get hasVault =>
-      vaultEncryptedJson != null && vaultMetaJson != null;
+  bool get hasVault => vaultEncryptedJson != null && vaultMetaJson != null;
 }
 
 /// shared_preferences key. Versioned so a future schema change can migrate
@@ -311,15 +306,15 @@ class ProfilesStore {
     }
 
     if (decoded is List) {
-      return ParsedImport(
-        profileEntries: _coerceEntries(decoded),
-      );
+      return ParsedImport(profileEntries: _coerceEntries(decoded));
     }
 
     if (decoded is! Map) {
       return ParsedImport(
         profileEntries: const [],
-        errors: ['Wrong file shape — expected an export envelope or profile array.'],
+        errors: [
+          'Wrong file shape — expected an export envelope or profile array.',
+        ],
       );
     }
 
@@ -327,7 +322,9 @@ class ProfilesStore {
     if (version != null && version != 1) {
       return ParsedImport(
         profileEntries: const [],
-        errors: ['Unsupported export version: $version (this client supports v1).'],
+        errors: [
+          'Unsupported export version: $version (this client supports v1).',
+        ],
       );
     }
 
@@ -347,7 +344,10 @@ class ProfilesStore {
       final meta = vaultRaw['meta'];
       // Both fields must be strings for the envelope to be useful; if either
       // is missing we treat the envelope as "metadata-only" and fall through.
-      if (enc is String && enc.isNotEmpty && meta is String && meta.isNotEmpty) {
+      if (enc is String &&
+          enc.isNotEmpty &&
+          meta is String &&
+          meta.isNotEmpty) {
         vaultEncryptedJson = enc;
         vaultMetaJson = meta;
       }
@@ -392,7 +392,9 @@ class ProfilesStore {
         <String, Map<String, Object?>>{};
     if (parsed.hasVault) {
       if (password == null || password.isEmpty) {
-        return ImportResult(errors: ['Master password required to decrypt vault.']);
+        return ImportResult(
+          errors: ['Master password required to decrypt vault.'],
+        );
       }
       if (secrets == null) {
         return ImportResult(errors: ['Secrets store unavailable.']);
@@ -406,7 +408,9 @@ class ProfilesStore {
       } on VaultDecryptException catch (e) {
         return ImportResult(errors: [e.message]);
       } on VaultEnvelopeException catch (e) {
-        return ImportResult(errors: ['Vault envelope is malformed: ${e.message}']);
+        return ImportResult(
+          errors: ['Vault envelope is malformed: ${e.message}'],
+        );
       }
     }
 
@@ -506,10 +510,43 @@ class ProfilesStore {
     // Without a password we cannot decrypt; the UI is expected to use the
     // two-stage path for vault envelopes. Re-emit a non-vault parsed import
     // so the existing call sites keep their behavior.
-    return applyParsedImport(ParsedImport(
-      profileEntries: parsed.profileEntries,
-      errors: parsed.errors,
-    ));
+    return applyParsedImport(
+      ParsedImport(
+        profileEntries: parsed.profileEntries,
+        errors: parsed.errors,
+      ),
+    );
+  }
+
+  /// Upsert a single profile by identity (#579 profile editor).
+  ///
+  /// When [previousIdentityKey] is supplied and differs from the incoming
+  /// profile's identity, the old entry (matched by that key) is removed first
+  /// — this is the rename case where the editor changed host/port/username.
+  /// Otherwise the matching identity is updated in place; a brand-new identity
+  /// is appended. Mirrors the import upsert semantics (identity-keyed).
+  Future<void> upsert(
+    SavedProfile profile, {
+    String? previousIdentityKey,
+  }) async {
+    final list = await load();
+    final prevKey = previousIdentityKey ?? profile.identityKey;
+    final idx = list.indexWhere((p) => p.identityKey == prevKey);
+    if (idx >= 0) {
+      list[idx] = profile;
+    } else {
+      // Identity didn't match the previous key — maybe the new identity
+      // already exists (collision). Update that in place if so, else append.
+      final collision = list.indexWhere(
+        (p) => p.identityKey == profile.identityKey,
+      );
+      if (collision >= 0) {
+        list[collision] = profile;
+      } else {
+        list.add(profile);
+      }
+    }
+    await save(list);
   }
 
   /// Delete a single profile by identity. Persists if anything was removed.

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -25,6 +25,7 @@ import '../storage/profiles_store.dart';
 import 'diagnostics_section.dart';
 import 'host_key_dialog.dart';
 import 'import_profiles_dialog.dart';
+import 'profile_editor.dart';
 import 'profile_list.dart';
 import 'settings_panel.dart';
 
@@ -106,7 +107,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
         children: [
           // Saved profiles + import action. Collapsed-to-empty-hint when the
           // user has no imported profiles yet.
-          ProfileList(onSelect: _applyProfileToForm),
+          ProfileList(onConnect: _connectFromProfile, onEdit: _editProfile),
           Align(
             alignment: Alignment.centerRight,
             child: TextButton.icon(
@@ -278,6 +279,31 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       auth: auth,
     );
 
+    ctrace(
+      'ui.form',
+      'submit host=$host port=$port user=$username auth=${_authKind.name}',
+    );
+    await _connectWithParams(
+      params,
+      title: _profileTitleForCurrentForm(),
+      initialCommand: _initialCommandCtrl.text,
+    );
+  }
+
+  /// Shared connect path used by BOTH the form Submit and a saved-profile row
+  /// tap (#579). Routes through the sessions notifier (dedupe by
+  /// host:port:user, per-session proxy), arms the run-on-connect command, then
+  /// dispatches `proxy.connect`. When this form was pushed as a "New session"
+  /// route, it pops back to the terminal once the session CONNECTS.
+  ///
+  /// Keeping this separate from [_submit] means tapping a profile reuses the
+  /// exact same connect machinery as the manual form — no second code path to
+  /// drift.
+  Future<void> _connectWithParams(
+    SshConnectParams params, {
+    String? title,
+    required String initialCommand,
+  }) async {
     // Captured before the async gap so we can pop a pushed "New session"
     // route after dispatching connect without touching `context` post-await.
     final navigator = Navigator.of(context);
@@ -293,11 +319,6 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       // #533: connect now dispatches across the task gateway via the per-
       // session [SshSessionProxy] — the underlying `SshSessionController`
       // lives in the task isolate, not the UI.
-      ctrace(
-        'ui.form',
-        'submit host=$host port=$port user=$username auth=${_authKind.name}',
-      );
-      final title = _profileTitleForCurrentForm();
       final entry = ref
           .read(sessionsProvider.notifier)
           .addOrActivate(params, title: title);
@@ -316,7 +337,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
           .arm(
             sessionId: entry.id,
             proxy: entry.proxy,
-            command: _initialCommandCtrl.text,
+            command: initialCommand,
           );
       await entry.proxy.connect(params);
       // Once we've proven we have network reachability, fire-and-forget a
@@ -425,6 +446,92 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     });
     if (profile.vaultId != null || profile.keyVaultId != null) {
       unawaited(_prefillFromVault(profile));
+    }
+  }
+
+  /// #579 tap-to-connect. Resolve the profile's connection params + stored
+  /// credentials, then connect immediately via the shared connect path — no
+  /// separate Connect tap, no form round-trip.
+  ///
+  /// Credential resolution mirrors the PWA's `connectFromProfile`: load creds
+  /// from the vault by vaultId/keyVaultId. If NO stored credentials are found
+  /// (nothing saved on this device, or the secret read came back empty), fall
+  /// back to populating the form + a snackbar so the user can type them — we
+  /// never silently no-op.
+  Future<void> _connectFromProfile(SavedProfile profile) async {
+    final secrets = ref.read(secretsStoreProvider);
+    final creds = await loadProfileCredentials(secrets, profile);
+    if (!mounted) return;
+
+    // Decide auth kind: explicit authType wins, else infer from what the vault
+    // returned / the keyVaultId reference.
+    final wantsKey =
+        profile.authType == 'key' ||
+        (profile.authType == null &&
+            (creds.privateKey != null ||
+                (profile.keyVaultId != null &&
+                    profile.keyVaultId!.isNotEmpty)));
+
+    final hasUsableCreds = wantsKey
+        ? (creds.privateKey != null && creds.privateKey!.isNotEmpty)
+        : (creds.password != null && creds.password!.isNotEmpty);
+
+    if (!hasUsableCreds) {
+      // No stored secret — fall back to the manual form (prefilled metadata)
+      // so the user can enter credentials. Matches the PWA "not saved on this
+      // browser" branch. NOT a silent failure.
+      ctrace(
+        'ui.form',
+        'connectFromProfile ${profile.host}: no stored creds → form fallback',
+      );
+      _applyProfileToForm(profile);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('No saved credentials — enter them to connect.'),
+        ),
+      );
+      return;
+    }
+
+    final SshAuth auth;
+    if (wantsKey) {
+      auth = SshAuth.key(
+        Uint8List.fromList(utf8.encode(creds.privateKey!)),
+        passphrase: (creds.passphrase == null || creds.passphrase!.isEmpty)
+            ? null
+            : creds.passphrase,
+      );
+    } else {
+      auth = SshAuth.password(creds.password!);
+    }
+
+    final params = SshConnectParams(
+      host: profile.host,
+      port: profile.port,
+      username: profile.username,
+      auth: auth,
+    );
+    ctrace(
+      'ui.form',
+      'connectFromProfile ${profile.host} authType=${wantsKey ? 'key' : 'password'} → connect',
+    );
+    // Reflect the chosen profile in the form (and remember it for the session
+    // title) so the UI stays consistent if the user backs out.
+    _applyProfileToForm(profile);
+    await _connectWithParams(
+      params,
+      title: profile.title,
+      initialCommand: profile.initialCommand ?? '',
+    );
+  }
+
+  /// #579 edit pencil. Open the full profile editor; on save, refresh the
+  /// saved-profile list.
+  Future<void> _editProfile(SavedProfile profile) async {
+    final saved = await showProfileEditor(context, profile);
+    if (!mounted) return;
+    if (saved == true) {
+      ref.invalidate(savedProfilesProvider);
     }
   }
 

--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -1,0 +1,375 @@
+// Profile editor (#579).
+//
+// Opened from a profile row's edit pencil ([ProfileList.onEdit]). Pre-populates
+// every editable field of a [SavedProfile] — title, host, port, username,
+// authType, initialCommand, theme, color — plus optional credential fields.
+//
+// Save semantics:
+//   - Metadata (everything except credentials) is upserted into the
+//     `profiles_store` by identity key (host:port:username). When the user
+//     edits host/port/username the old entry is replaced (rename), matching the
+//     import upsert behavior.
+//   - Credential edits (password / private key / passphrase) NEVER touch the
+//     profile JSON — they are written ONLY through the `secrets_store`/vault
+//     path (Android-Keystore-backed flutter_secure_storage). A profile that
+//     lacks a vault reference gets one minted on first credential save. Secrets
+//     are never logged and never stored in shared_preferences (security rule).
+//
+// The editor is a modal route (full page) so it works on small screens with
+// the keyboard up; tests can also pump it directly.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../diagnostics/connect_trace.dart';
+import '../state/profiles_providers.dart';
+import '../storage/profiles_store.dart';
+
+enum _AuthKind { password, key }
+
+/// Push the profile editor as a modal route. Resolves to `true` when the user
+/// saved (caller should refresh the profile list), or `null`/`false` when they
+/// cancelled / backed out.
+Future<bool?> showProfileEditor(BuildContext context, SavedProfile profile) {
+  return Navigator.of(context).push<bool>(
+    MaterialPageRoute<bool>(
+      fullscreenDialog: true,
+      builder: (_) => ProfileEditor(profile: profile),
+    ),
+  );
+}
+
+class ProfileEditor extends ConsumerStatefulWidget {
+  const ProfileEditor({super.key, required this.profile});
+
+  final SavedProfile profile;
+
+  @override
+  ConsumerState<ProfileEditor> createState() => _ProfileEditorState();
+}
+
+class _ProfileEditorState extends ConsumerState<ProfileEditor> {
+  late final TextEditingController _titleCtrl;
+  late final TextEditingController _hostCtrl;
+  late final TextEditingController _portCtrl;
+  late final TextEditingController _userCtrl;
+  late final TextEditingController _initialCommandCtrl;
+  late final TextEditingController _themeCtrl;
+  late final TextEditingController _colorCtrl;
+  final _passwordCtrl = TextEditingController();
+  final _keyCtrl = TextEditingController();
+  final _passphraseCtrl = TextEditingController();
+
+  late _AuthKind _authKind;
+  bool _busy = false;
+
+  /// The identity key the editor opened on. Carried so a host/port/username
+  /// edit replaces the original entry rather than creating a duplicate.
+  late final String _originalIdentityKey;
+
+  @override
+  void initState() {
+    super.initState();
+    final p = widget.profile;
+    _originalIdentityKey = p.identityKey;
+    _titleCtrl = TextEditingController(text: p.title);
+    _hostCtrl = TextEditingController(text: p.host);
+    _portCtrl = TextEditingController(text: p.port.toString());
+    _userCtrl = TextEditingController(text: p.username);
+    _initialCommandCtrl = TextEditingController(text: p.initialCommand ?? '');
+    _themeCtrl = TextEditingController(text: p.theme ?? '');
+    _colorCtrl = TextEditingController(text: p.color ?? '');
+    // Prefer the explicit authType; infer `key` when only a keyVaultId is
+    // present (mirrors the connect form's inference for older profiles).
+    if (p.authType == 'key') {
+      _authKind = _AuthKind.key;
+    } else if (p.authType == 'password') {
+      _authKind = _AuthKind.password;
+    } else if (p.keyVaultId != null && p.keyVaultId!.isNotEmpty) {
+      _authKind = _AuthKind.key;
+    } else {
+      _authKind = _AuthKind.password;
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _hostCtrl.dispose();
+    _portCtrl.dispose();
+    _userCtrl.dispose();
+    _initialCommandCtrl.dispose();
+    _themeCtrl.dispose();
+    _colorCtrl.dispose();
+    _passwordCtrl.dispose();
+    _keyCtrl.dispose();
+    _passphraseCtrl.dispose();
+    super.dispose();
+  }
+
+  String? _emptyToNull(String s) {
+    final t = s.trim();
+    return t.isEmpty ? null : t;
+  }
+
+  Future<void> _save() async {
+    final host = _hostCtrl.text.trim();
+    final username = _userCtrl.text.trim();
+    final port = int.tryParse(_portCtrl.text.trim()) ?? 22;
+    if (host.isEmpty || username.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Host and username are required')),
+      );
+      return;
+    }
+
+    setState(() => _busy = true);
+
+    final store = ref.read(profilesStoreProvider);
+    final secrets = ref.read(secretsStoreProvider);
+    final authType = _authKind == _AuthKind.password ? 'password' : 'key';
+
+    // Resolve vault references. A profile that already has a vaultId/keyVaultId
+    // keeps it; one that's about to gain credentials gets a fresh id minted
+    // from its identity (stable for the same target so a re-edit overwrites the
+    // same secret rather than orphaning blobs).
+    var vaultId = widget.profile.vaultId;
+    var keyVaultId = widget.profile.keyVaultId;
+
+    final newIdentity = '$host:$port:$username';
+
+    // Decide which credential fields the user actually entered. We NEVER log
+    // the values — only whether each is present (length-free here; the connect
+    // form already traces lengths). Writing goes solely through secrets_store.
+    final pw = _passwordCtrl.text;
+    final key = _keyCtrl.text;
+    final passphrase = _passphraseCtrl.text;
+
+    try {
+      if (_authKind == _AuthKind.password && pw.isNotEmpty) {
+        vaultId ??= 'profile-$newIdentity';
+        await secrets.write(vaultId, <String, Object?>{
+          'password': pw,
+          if (passphrase.isNotEmpty) 'passphrase': passphrase,
+        });
+      } else if (_authKind == _AuthKind.key && key.isNotEmpty) {
+        keyVaultId ??= 'profile-key-$newIdentity';
+        // PWA canonical key entry shape: {data: <PEM>, passphrase?}.
+        await secrets.write(keyVaultId, <String, Object?>{
+          'data': key,
+          if (passphrase.isNotEmpty) 'passphrase': passphrase,
+        });
+      } else if (_authKind == _AuthKind.key &&
+          passphrase.isNotEmpty &&
+          keyVaultId != null) {
+        // Passphrase-only update on an existing stored key: merge it in without
+        // requiring the user to re-paste the PEM.
+        final existing = await secrets.read(keyVaultId);
+        final merged = <String, Object?>{
+          ...?existing,
+          'passphrase': passphrase,
+        };
+        await secrets.write(keyVaultId, merged);
+      }
+
+      final updated = SavedProfile(
+        title: _emptyToNull(_titleCtrl.text) ?? '$username@$host',
+        host: host,
+        port: port,
+        username: username,
+        theme: _emptyToNull(_themeCtrl.text),
+        color: _emptyToNull(_colorCtrl.text),
+        authType: authType,
+        vaultId: vaultId,
+        keyVaultId: keyVaultId,
+        initialCommand: _emptyToNull(_initialCommandCtrl.text),
+      );
+
+      await store.upsert(updated, previousIdentityKey: _originalIdentityKey);
+      ctrace(
+        'ui.editor',
+        'saved profile $newIdentity authType=$authType '
+            'hasVaultId=${vaultId != null} hasKeyVaultId=${keyVaultId != null}',
+      );
+      ref.invalidate(savedProfilesProvider);
+      if (!mounted) return;
+      Navigator.of(context).pop(true);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _delete() async {
+    setState(() => _busy = true);
+    final store = ref.read(profilesStoreProvider);
+    final p = widget.profile;
+    await store.remove(host: p.host, port: p.port, username: p.username);
+    ref.invalidate(savedProfilesProvider);
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isKey = _authKind == _AuthKind.key;
+    return Scaffold(
+      key: const Key('profile-editor'),
+      appBar: AppBar(
+        title: const Text('Edit profile'),
+        actions: [
+          IconButton(
+            key: const Key('profile-editor-delete'),
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Delete profile',
+            onPressed: _busy ? null : _delete,
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                key: const Key('profile-editor-title'),
+                controller: _titleCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Name',
+                  hintText: 'Auto: user@host',
+                ),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    flex: 3,
+                    child: TextField(
+                      key: const Key('profile-editor-host'),
+                      controller: _hostCtrl,
+                      decoration: const InputDecoration(labelText: 'Host'),
+                      autocorrect: false,
+                      enableSuggestions: false,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    flex: 1,
+                    child: TextField(
+                      key: const Key('profile-editor-port'),
+                      controller: _portCtrl,
+                      decoration: const InputDecoration(labelText: 'Port'),
+                      keyboardType: TextInputType.number,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                key: const Key('profile-editor-username'),
+                controller: _userCtrl,
+                decoration: const InputDecoration(labelText: 'Username'),
+                autocorrect: false,
+                enableSuggestions: false,
+              ),
+              const SizedBox(height: 12),
+              SegmentedButton<_AuthKind>(
+                segments: const [
+                  ButtonSegment(
+                    value: _AuthKind.password,
+                    label: Text('Password'),
+                    icon: Icon(Icons.password),
+                  ),
+                  ButtonSegment(
+                    value: _AuthKind.key,
+                    label: Text('Key'),
+                    icon: Icon(Icons.vpn_key),
+                  ),
+                ],
+                selected: {_authKind},
+                onSelectionChanged: (s) => setState(() => _authKind = s.first),
+              ),
+              const SizedBox(height: 8),
+              if (!isKey)
+                TextField(
+                  key: const Key('profile-editor-password'),
+                  controller: _passwordCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Password',
+                    hintText: '(stored encrypted — leave blank to keep)',
+                  ),
+                  obscureText: true,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                )
+              else ...[
+                TextField(
+                  key: const Key('profile-editor-key'),
+                  controller: _keyCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Private key (PEM)',
+                    hintText: '(stored encrypted — leave blank to keep)',
+                  ),
+                  maxLines: 4,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  key: const Key('profile-editor-passphrase'),
+                  controller: _passphraseCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Key passphrase (optional)',
+                  ),
+                  obscureText: true,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                ),
+              ],
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('profile-editor-initial-command'),
+                controller: _initialCommandCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Initial command (optional)',
+                  hintText: 'e.g. tmux attach || tmux',
+                ),
+                autocorrect: false,
+                enableSuggestions: false,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('profile-editor-theme'),
+                controller: _themeCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Theme (optional)',
+                  hintText: 'e.g. dark, solarizedDark',
+                ),
+                autocorrect: false,
+                enableSuggestions: false,
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                key: const Key('profile-editor-color'),
+                controller: _colorCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Color (optional)',
+                  hintText: '#ff8800',
+                ),
+                autocorrect: false,
+                enableSuggestions: false,
+              ),
+              const SizedBox(height: 20),
+              FilledButton.icon(
+                key: const Key('profile-editor-save'),
+                onPressed: _busy ? null : _save,
+                icon: const Icon(Icons.save),
+                label: Text(_busy ? 'Saving…' : 'Save'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/native/lib/ui/profile_list.dart
+++ b/native/lib/ui/profile_list.dart
@@ -1,8 +1,9 @@
 // Saved-profile list rendered above the ConnectForm (#501).
 //
 // Empty-state hint nudges the user to import from the PWA. Each row is a tap
-// target that pre-fills the parent form via the [onSelect] callback. The
-// parent owns mutation — this widget is purely presentation + selection.
+// target that CONNECTS immediately via [onConnect] (#579 — PWA tap=connect
+// parity), and carries an edit-pencil ([onEdit]) opening the profile editor.
+// The parent owns mutation — this widget is purely presentation + dispatch.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,11 +14,17 @@ import '../storage/profiles_store.dart';
 typedef ProfileSelectCallback = void Function(SavedProfile profile);
 
 class ProfileList extends ConsumerWidget {
-  const ProfileList({super.key, required this.onSelect});
+  const ProfileList({super.key, required this.onConnect, required this.onEdit});
 
-  /// Fired when the user taps a profile row. Parent populates ConnectForm
-  /// fields with the chosen profile's metadata (host/port/username).
-  final ProfileSelectCallback onSelect;
+  /// Fired when the user taps a profile row. Parent CONNECTS to the chosen
+  /// profile immediately (resolve params + vault creds → addOrActivate →
+  /// proxy.connect). This is the #579 tap-to-connect behavior — no separate
+  /// Connect tap, no form round-trip.
+  final ProfileSelectCallback onConnect;
+
+  /// Fired when the user taps a row's edit pencil. Parent opens the profile
+  /// editor pre-populated from the chosen profile (#579).
+  final ProfileSelectCallback onEdit;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -26,14 +33,20 @@ class ProfileList extends ConsumerWidget {
     return async.when(
       loading: () => const Padding(
         padding: EdgeInsets.symmetric(vertical: 8),
-        child: Center(child: SizedBox(
-          width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2),
-        )),
+        child: Center(
+          child: SizedBox(
+            width: 18,
+            height: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ),
       ),
       error: (e, _) => Padding(
         padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Text('Profiles error: $e',
-            style: const TextStyle(color: Colors.redAccent)),
+        child: Text(
+          'Profiles error: $e',
+          style: const TextStyle(color: Colors.redAccent),
+        ),
       ),
       data: (profiles) {
         if (profiles.isEmpty) {
@@ -67,7 +80,8 @@ class ProfileList extends ConsumerWidget {
                   final p = profiles[i];
                   return _ProfileTile(
                     profile: p,
-                    onTap: () => onSelect(p),
+                    onTap: () => onConnect(p),
+                    onEdit: () => onEdit(p),
                   );
                 },
               ),
@@ -81,10 +95,19 @@ class ProfileList extends ConsumerWidget {
 }
 
 class _ProfileTile extends StatelessWidget {
-  const _ProfileTile({required this.profile, required this.onTap});
+  const _ProfileTile({
+    required this.profile,
+    required this.onTap,
+    required this.onEdit,
+  });
 
   final SavedProfile profile;
+
+  /// Row tap → connect (#579).
   final VoidCallback onTap;
+
+  /// Pencil tap → open the profile editor (#579).
+  final VoidCallback onEdit;
 
   @override
   Widget build(BuildContext context) {
@@ -100,6 +123,15 @@ class _ProfileTile extends StatelessWidget {
       subtitle: Text(
         '${profile.username}@${profile.host}:${profile.port}',
         overflow: TextOverflow.ellipsis,
+      ),
+      // Edit pencil opens the editor; the row tap (onTap) connects. Keeping
+      // the pencil as a distinct trailing target means a row tap never
+      // accidentally edits — it always connects (PWA parity).
+      trailing: IconButton(
+        key: Key('profile-edit-${profile.identityKey}'),
+        icon: const Icon(Icons.edit_outlined),
+        tooltip: 'Edit profile',
+        onPressed: onEdit,
       ),
       onTap: onTap,
     );

--- a/native/test/widget/profile_editor_test.dart
+++ b/native/test/widget/profile_editor_test.dart
@@ -1,0 +1,226 @@
+// Widget tests for [ProfileEditor] (#579).
+//
+// Asserts:
+//   - the editor pre-populates every field from the profile
+//   - editing a metadata field + Save upserts the store (values round-trip)
+//   - a credential edit writes via secrets_store (correct vault id) and the
+//     plaintext secret NEVER lands in shared_preferences (profiles JSON)
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/profile_editor.dart';
+
+/// Read the current text of a [TextField] by key — robust against duplicate
+/// `find.text` matches (e.g. a value that also appears as a label/hint).
+String _fieldText(WidgetTester tester, String key) {
+  final field = tester.widget<TextField>(find.byKey(Key(key)));
+  return field.controller?.text ?? '';
+}
+
+/// Scroll the Save button into view, then tap it. `ensureVisible` plus a tall
+/// test surface (set in [_pump]) guarantees the FilledButton is hit-testable.
+Future<void> _tapSave(WidgetTester tester) async {
+  final save = find.byKey(const Key('profile-editor-save'));
+  await tester.ensureVisible(save);
+  await tester.pumpAndSettle();
+  await tester.tap(save);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required ProfilesStore store,
+  required SecretsStore secrets,
+  required SavedProfile profile,
+}) async {
+  // The editor is taller than the default 800x600 surface; grow it so every
+  // field + the Save button are laid out on-screen and hit-testable.
+  tester.view.physicalSize = const Size(1000, 2000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        profilesStoreProvider.overrideWithValue(store),
+        secretsStoreProvider.overrideWithValue(secrets),
+      ],
+      child: MaterialApp(home: ProfileEditor(profile: profile)),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ProfileEditor', () {
+    testWidgets('pre-populates fields from the profile', (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final profile = SavedProfile(
+        title: 'Home box',
+        host: 'home.example',
+        port: 2222,
+        username: 'me',
+        theme: 'solarizedDark',
+        color: '#ff8800',
+        authType: 'password',
+        initialCommand: 'tmux attach',
+      );
+
+      await _pump(tester, store: store, secrets: secrets, profile: profile);
+
+      expect(find.byKey(const Key('profile-editor')), findsOneWidget);
+      expect(_fieldText(tester, 'profile-editor-title'), 'Home box');
+      expect(_fieldText(tester, 'profile-editor-host'), 'home.example');
+      expect(_fieldText(tester, 'profile-editor-port'), '2222');
+      expect(_fieldText(tester, 'profile-editor-username'), 'me');
+      expect(_fieldText(tester, 'profile-editor-theme'), 'solarizedDark');
+      expect(_fieldText(tester, 'profile-editor-color'), '#ff8800');
+      expect(
+        _fieldText(tester, 'profile-editor-initial-command'),
+        'tmux attach',
+      );
+    });
+
+    testWidgets('editing a metadata field + Save upserts the store', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Old name',
+          host: 'home.example',
+          port: 22,
+          username: 'me',
+          authType: 'password',
+        ),
+      ]);
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+
+      await _pump(
+        tester,
+        store: store,
+        secrets: secrets,
+        profile: (await store.load()).first,
+      );
+
+      // Change the title.
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-title')),
+        'New name',
+      );
+      await _tapSave(tester);
+
+      final list = await store.load();
+      expect(list.length, 1);
+      expect(list.first.title, 'New name');
+      // Identity unchanged → same host/port/user.
+      expect(list.first.identityKey, 'home.example:22:me');
+    });
+
+    testWidgets('editing host/port/username renames in place (no duplicate)', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Box',
+          host: 'old.example',
+          port: 22,
+          username: 'me',
+          authType: 'password',
+        ),
+      ]);
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+
+      await _pump(
+        tester,
+        store: store,
+        secrets: secrets,
+        profile: (await store.load()).first,
+      );
+
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-host')),
+        'new.example',
+      );
+      await _tapSave(tester);
+
+      final list = await store.load();
+      expect(list.length, 1, reason: 'rename must not create a duplicate');
+      expect(list.first.host, 'new.example');
+    });
+
+    testWidgets(
+      'a credential edit writes via secrets_store and never plaintext',
+      (tester) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final store = ProfilesStore();
+        await store.save(<SavedProfile>[
+          SavedProfile(
+            title: 'Box',
+            host: 'home.example',
+            port: 22,
+            username: 'me',
+            authType: 'password',
+          ),
+        ]);
+        final backend = InMemorySecretsBackend();
+        final secrets = SecretsStore(backend: backend);
+
+        await _pump(
+          tester,
+          store: store,
+          secrets: secrets,
+          profile: (await store.load()).first,
+        );
+
+        const secret = 'hunter2-supersecret';
+        await tester.enterText(
+          find.byKey(const Key('profile-editor-password')),
+          secret,
+        );
+        await tester.tap(find.byKey(const Key('profile-editor-save')));
+        await tester.pumpAndSettle();
+
+        // The saved profile must carry a vaultId reference.
+        final saved = (await store.load()).first;
+        expect(saved.vaultId, isNotNull);
+
+        // The secret is retrievable from the vault under that id.
+        final creds = await loadProfileCredentials(secrets, saved);
+        expect(creds.password, secret);
+
+        // SECURITY: the plaintext secret must NOT appear in shared_preferences
+        // (the profiles JSON). Only the vault (secure storage) holds it.
+        final prefs = await SharedPreferences.getInstance();
+        final profilesJson = prefs.getString(profilesPrefsKey) ?? '';
+        expect(
+          profilesJson.contains(secret),
+          isFalse,
+          reason: 'plaintext credential must never be in profiles JSON',
+        );
+
+        // And the secret IS in the secrets backend (encrypted at rest in prod).
+        final all = await backend.readAll();
+        final anyHoldsSecret = all.values.any((v) => v.contains(secret));
+        expect(
+          anyHoldsSecret,
+          isTrue,
+          reason: 'credential must be written through secrets_store',
+        );
+      },
+    );
+  });
+}

--- a/native/test/widget/profile_list_widget_test.dart
+++ b/native/test/widget/profile_list_widget_test.dart
@@ -1,9 +1,10 @@
-// Widget tests for [ProfileList] (#501).
+// Widget tests for [ProfileList] (#501, #579).
 //
 // Asserts:
 //   - empty-state hint renders when no profiles exist
 //   - populated list renders one tile per profile
-//   - tapping a tile fires onSelect with the correct profile
+//   - tapping a tile fires onConnect (tap-to-connect, #579) with the right profile
+//   - tapping the row's edit pencil fires onEdit with the right profile (#579)
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,15 +19,16 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ProfileList', () {
-    testWidgets('renders empty-state hint when store has no profiles',
-        (tester) async {
+    testWidgets('renders empty-state hint when store has no profiles', (
+      tester,
+    ) async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
 
       await tester.pumpWidget(
         ProviderScope(
           child: MaterialApp(
             home: Scaffold(
-              body: ProfileList(onSelect: (_) {}),
+              body: ProfileList(onConnect: (_) {}, onEdit: (_) {}),
             ),
           ),
         ),
@@ -39,28 +41,30 @@ void main() {
     });
 
     testWidgets('renders one tile per saved profile', (tester) async {
-      // Seed prefs via a real ProfilesStore, then override the provider so
-      // the widget's load() goes through the same store.
       SharedPreferences.setMockInitialValues(<String, Object>{});
       final store = ProfilesStore();
       await store.save(<SavedProfile>[
         SavedProfile(
-          title: 'Home', host: 'home.example', port: 22, username: 'me',
+          title: 'Home',
+          host: 'home.example',
+          port: 22,
+          username: 'me',
         ),
         SavedProfile(
-          title: 'Work', host: 'work.example', port: 2222, username: 'me',
+          title: 'Work',
+          host: 'work.example',
+          port: 2222,
+          username: 'me',
           color: '#ff8800',
         ),
       ]);
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            profilesStoreProvider.overrideWithValue(store),
-          ],
+          overrides: [profilesStoreProvider.overrideWithValue(store)],
           child: MaterialApp(
             home: Scaffold(
-              body: ProfileList(onSelect: (_) {}),
+              body: ProfileList(onConnect: (_) {}, onEdit: (_) {}),
             ),
           ),
         ),
@@ -74,41 +78,79 @@ void main() {
       expect(find.text('me@work.example:2222'), findsOneWidget);
     });
 
-    testWidgets('tapping a tile fires onSelect with the correct profile',
-        (tester) async {
+    testWidgets('tapping a tile fires onConnect with the correct profile', (
+      tester,
+    ) async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
       final store = ProfilesStore();
       await store.save(<SavedProfile>[
-        SavedProfile(
-          title: 'A', host: 'a.example', port: 22, username: 'u1',
-        ),
-        SavedProfile(
-          title: 'B', host: 'b.example', port: 22, username: 'u2',
-        ),
+        SavedProfile(title: 'A', host: 'a.example', port: 22, username: 'u1'),
+        SavedProfile(title: 'B', host: 'b.example', port: 22, username: 'u2'),
       ]);
 
-      SavedProfile? selected;
+      SavedProfile? connected;
+      SavedProfile? edited;
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            profilesStoreProvider.overrideWithValue(store),
-          ],
+          overrides: [profilesStoreProvider.overrideWithValue(store)],
           child: MaterialApp(
             home: Scaffold(
-              body: ProfileList(onSelect: (p) => selected = p),
+              body: ProfileList(
+                onConnect: (p) => connected = p,
+                onEdit: (p) => edited = p,
+              ),
             ),
           ),
         ),
       );
       await tester.pumpAndSettle();
 
-      // Tap the B tile.
+      // Tap the B tile body → connect, NOT edit.
       await tester.tap(find.byKey(const Key('profile-tile-b.example:22:u2')));
       await tester.pump();
 
-      expect(selected, isNotNull);
-      expect(selected!.host, 'b.example');
-      expect(selected!.username, 'u2');
+      expect(connected, isNotNull);
+      expect(connected!.host, 'b.example');
+      expect(connected!.username, 'u2');
+      expect(edited, isNull, reason: 'row tap must connect, not edit');
     });
+
+    testWidgets(
+      'tapping the edit pencil fires onEdit with the correct profile',
+      (tester) async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final store = ProfilesStore();
+        await store.save(<SavedProfile>[
+          SavedProfile(title: 'A', host: 'a.example', port: 22, username: 'u1'),
+          SavedProfile(title: 'B', host: 'b.example', port: 22, username: 'u2'),
+        ]);
+
+        SavedProfile? connected;
+        SavedProfile? edited;
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [profilesStoreProvider.overrideWithValue(store)],
+            child: MaterialApp(
+              home: Scaffold(
+                body: ProfileList(
+                  onConnect: (p) => connected = p,
+                  onEdit: (p) => edited = p,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Tap A's edit pencil → edit, NOT connect.
+        await tester.tap(find.byKey(const Key('profile-edit-a.example:22:u1')));
+        await tester.pump();
+
+        expect(edited, isNotNull);
+        expect(edited!.host, 'a.example');
+        expect(edited!.username, 'u1');
+        expect(connected, isNull, reason: 'pencil must edit, not connect');
+      },
+    );
   });
 }

--- a/native/test/widget/profile_tap_connect_test.dart
+++ b/native/test/widget/profile_tap_connect_test.dart
@@ -1,0 +1,156 @@
+// Widget test: tapping a saved-profile row CONNECTS immediately (#579).
+//
+// Locks the tap-to-connect contract: a profile row tap resolves the profile's
+// host/port/username + stored vault credentials and routes them through the
+// shared connect path (addOrActivate → proxy.connect), creating a session
+// entry — NOT merely pre-filling the form (the old behavior).
+//
+// Sessions are proxy-backed; `taskSshGatewayProvider` is overridden with an
+// in-memory gateway pair so addOrActivate + proxy.connect run without binding
+// to platform statics. The in-memory gateway never emits `connected`, so we
+// assert the session entry was created with the profile's params (which is the
+// observable signal that the connect path — not form-fill — ran).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/connect_form.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets(
+    'tapping a profile with stored creds creates a session for its params',
+    (tester) async {
+      // Seed a password profile + its vault secret.
+      final store = ProfilesStore();
+      final backend = InMemorySecretsBackend();
+      final secrets = SecretsStore(backend: backend);
+      await secrets.write('vault-1', <String, Object?>{'password': 'pw'});
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Box',
+          host: 'box.example',
+          port: 2200,
+          username: 'alice',
+          authType: 'password',
+          vaultId: 'vault-1',
+        ),
+      ]);
+
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async {
+        await pair.dispose();
+      });
+      final container = ProviderContainer(
+        overrides: [
+          taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+          profilesStoreProvider.overrideWithValue(store),
+          secretsStoreProvider.overrideWithValue(secrets),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(sessionsProvider).entries, isEmpty);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the profile row → connect.
+      await tester.tap(
+        find.byKey(const Key('profile-tile-box.example:2200:alice')),
+      );
+      await _pumpFrames(tester, count: 30);
+
+      final state = container.read(sessionsProvider);
+      expect(
+        state.entries.length,
+        1,
+        reason: 'profile tap must connect, not just fill the form',
+      );
+      final entry = state.entries.first;
+      expect(entry.host, 'box.example');
+      expect(entry.port, 2200);
+      expect(entry.username, 'alice');
+      expect(entry.title, 'Box');
+    },
+  );
+
+  testWidgets(
+    'tapping a profile with NO stored creds falls back to form (no session)',
+    (tester) async {
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'NoCreds',
+          host: 'bare.example',
+          port: 22,
+          username: 'bob',
+          authType: 'password',
+          // No vaultId → no stored credentials.
+        ),
+      ]);
+
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async {
+        await pair.dispose();
+      });
+      final container = ProviderContainer(
+        overrides: [
+          taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+          profilesStoreProvider.overrideWithValue(store),
+          secretsStoreProvider.overrideWithValue(secrets),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const Key('profile-tile-bare.example:22:bob')),
+      );
+      await _pumpFrames(tester, count: 20);
+
+      // No session created — fell back to form-fill.
+      expect(container.read(sessionsProvider).entries, isEmpty);
+      // The form was prefilled with the profile's host so the user can finish.
+      expect(find.text('bare.example'), findsOneWidget);
+      // And a snackbar nudged them to enter credentials.
+      expect(find.textContaining('No saved credentials'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## #579 — tap-to-connect + profile editor (native Flutter)

Brings the native client to PWA parity for the saved-profile list: tapping a profile **connects immediately** (no separate Connect tap), and each row has an **edit pencil** that opens a full profile editor.

### Tap-to-connect
- Factored the connect dispatch out of `ConnectForm._submit` into a shared `_connectWithParams` (`addOrActivate` → arm initial command → `proxy.connect`). Both the manual form and a profile tap now use the exact same connect path.
- `_connectFromProfile` resolves the profile's host/port/username/authType + stored vault credentials (`loadProfileCredentials` over `secretsStoreProvider`) and connects.
- **Missing-creds fallback:** when no stored credential is found, it pre-fills the form + shows a snackbar ("No saved credentials — enter them to connect") instead of silently no-op'ing. Mirrors the PWA "not saved on this browser" branch.

### Profile editor (`native/lib/ui/profile_editor.dart`)
- Modal route pre-populated with title, host, port, username, authType, initialCommand, theme, color, plus credential fields.
- Save upserts metadata into `profiles_store` by identity key. Editing host/port/username **renames in place** (no duplicate) via the new `ProfilesStore.upsert`.
- **Credential edits go only through `secrets_store`/vault** (flutter_secure_storage) — never plaintext in the profiles JSON, never logged. A `vaultId`/`keyVaultId` is minted on first credential save; passphrase-only updates merge into the existing key entry.
- Delete action removes the profile.

### ProfileList
- Row tap → `onConnect`; trailing pencil `IconButton` (Key `profile-edit-<identityKey>`) → `onEdit`.

### Tests
- `profile_list_widget_test`: row tap fires `onConnect`; pencil fires `onEdit` (each excludes the other).
- `profile_tap_connect_test`: tapping a profile with stored creds creates a session entry for its host/port/user (the observable signal the connect path ran, not form-fill); no-creds tap falls back to the form + snackbar.
- `profile_editor_test`: pre-fill round-trips; metadata save upserts; rename in place (no duplicate); **credential edit writes via secrets_store and the plaintext secret never lands in the profiles JSON**.

`scripts/native-fast-gate.sh` green: analyze clean, 287 tests pass.

### Device validation needed
Tap-to-connect, the editor, and credential edits all touch the Android-Keystore-backed vault and the real connect path — please device-validate on hardware before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)