### PR TITLE
feat: declutter profiles/home view — profile chooser only (#583)

### DIFF
--- a/native/integration_test/connect_key_smoke_test.dart
+++ b/native/integration_test/connect_key_smoke_test.dart
@@ -26,6 +26,8 @@ import 'package:integration_test/integration_test.dart';
 
 import 'package:mobissh/main.dart' show MobisshApp;
 
+import 'support/connect_helpers.dart';
+
 const _testKeyPem = '''-----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
 QyNTUxOQAAACB85qILD6Ykve+v2FrQWtcrsjW1baL6CXJ4LD5mmiDTdgAAAJgTrJmWE6yZ
@@ -37,33 +39,23 @@ NbVtovoJcngsPmaaINN2AAAAFXRlc3R1c2VyQG1vYmlzc2gtdGVzdA==
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('key-auth connect to test-sshd reaches connected state',
-      (tester) async {
+  testWidgets('key-auth connect to test-sshd reaches connected state', (
+    tester,
+  ) async {
     FlutterForegroundTask.initCommunicationPort();
 
     await tester.pumpWidget(const ProviderScope(child: MobisshApp()));
     await tester.pump(const Duration(seconds: 1));
 
-    await tester.enterText(find.byKey(const Key('connect-host')), '127.0.0.1');
-    await tester.enterText(find.byKey(const Key('connect-port')), '2222');
-    await tester.enterText(
-        find.byKey(const Key('connect-username')), 'testuser');
-
-    // Switch to Key auth (SegmentedButton segment labelled "Key").
-    await tester.tap(find.text('Key'));
-    await tester.pump(const Duration(milliseconds: 300));
-
-    await tester.enterText(find.byKey(const Key('connect-key')), _testKeyPem);
-    await tester.pump();
-
-    // Key mode expands the form (4-line key field + passphrase + initial-command
-    // field) past the fold; the submit button is inside the ConnectHomePage
-    // SingleChildScrollView. tap() does not auto-scroll, so bring it on-screen
-    // first (on a real device the user scrolls to it — this mirrors that).
-    final submit = find.byKey(const Key('connect-submit'));
-    await tester.ensureVisible(submit);
-    await tester.pumpAndSettle(const Duration(milliseconds: 300));
-    await tester.tap(submit);
+    // #583: connect ad-hoc via "New connection" → editor (Key mode) →
+    // "Save & connect".
+    await adhocKeyConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      keyPem: _testKeyPem,
+    );
 
     // Poll up to 30s. Accept the host-key prompt when it appears (fresh install
     // → it WILL appear; this is the path the password smoke skipped on a
@@ -86,10 +78,17 @@ void main() {
       }
     }
 
-    expect(acceptedHostKey, isTrue,
-        reason: 'host-key prompt never appeared — fresh install should prompt');
-    expect(connected, isTrue,
-        reason: 'KEY-AUTH session did not reach connected within 30s after '
-            'accepting the host key — the device key-auth hang');
+    expect(
+      acceptedHostKey,
+      isTrue,
+      reason: 'host-key prompt never appeared — fresh install should prompt',
+    );
+    expect(
+      connected,
+      isTrue,
+      reason:
+          'KEY-AUTH session did not reach connected within 30s after '
+          'accepting the host key — the device key-auth hang',
+    );
   });
 }

--- a/native/integration_test/connect_smoke_test.dart
+++ b/native/integration_test/connect_smoke_test.dart
@@ -30,6 +30,8 @@ import 'package:integration_test/integration_test.dart';
 
 import 'package:mobissh/main.dart' show MobisshApp;
 
+import 'support/connect_helpers.dart';
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -40,16 +42,15 @@ void main() {
     await tester.pumpWidget(const ProviderScope(child: MobisshApp()));
     await tester.pump(const Duration(seconds: 1));
 
-    // Fill the connect form. Fields are keyed (#539 testability).
-    await tester.enterText(find.byKey(const Key('connect-host')), '127.0.0.1');
-    await tester.enterText(find.byKey(const Key('connect-port')), '2222');
-    await tester.enterText(
-        find.byKey(const Key('connect-username')), 'testuser');
-    await tester.enterText(
-        find.byKey(const Key('connect-password')), 'testpass');
-    await tester.pump();
-
-    await tester.tap(find.byKey(const Key('connect-submit')));
+    // #583: the inline form is gone — connect ad-hoc via "New connection" →
+    // editor → "Save & connect".
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
 
     // Poll for up to 30s. Can't pumpAndSettle — the terminal animates + the
     // socket is live, so the tree never settles. Pump 500ms slices and look
@@ -75,8 +76,12 @@ void main() {
       }
     }
 
-    expect(connected, isTrue,
-        reason: 'session did not reach connected within 30s — '
-            'this is the #539 connect-deadlock signature');
+    expect(
+      connected,
+      isTrue,
+      reason:
+          'session did not reach connected within 30s — '
+          'this is the #539 connect-deadlock signature',
+    );
   });
 }

--- a/native/integration_test/hostkey_persist_test.dart
+++ b/native/integration_test/hostkey_persist_test.dart
@@ -29,23 +29,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mobissh/main.dart' show MobisshApp;
 import 'package:mobissh/state/sessions.dart';
 
-Future<void> _fillForm(WidgetTester tester) async {
-  await tester.enterText(find.byKey(const Key('connect-host')), '127.0.0.1');
-  await tester.enterText(find.byKey(const Key('connect-port')), '2222');
-  await tester.enterText(find.byKey(const Key('connect-username')), 'testuser');
-  await tester.enterText(find.byKey(const Key('connect-password')), 'testpass');
-  await tester.pump();
-}
+import 'support/connect_helpers.dart';
 
-/// Submit, optionally accept the host-key prompt, and poll until the terminal
-/// mounts AND the shell streams bytes. Returns a record:
-///   (reachedShell, sawPrompt).
-Future<({bool reachedShell, bool sawPrompt})> _connect(
+/// Optionally accept the host-key prompt, and poll until the terminal mounts
+/// AND the shell streams bytes. The connect itself is dispatched by the caller
+/// (ad-hoc editor for the first connect; saved-profile tap on reconnect, #583).
+/// Returns a record: (reachedShell, sawPrompt).
+Future<({bool reachedShell, bool sawPrompt})> _awaitShell(
   WidgetTester tester,
   ProviderContainer container, {
   required bool acceptPromptIfShown,
 }) async {
-  await tester.tap(find.byKey(const Key('connect-submit')));
   var connected = false;
   var sawPrompt = false;
   for (var i = 0; i < 60; i++) {
@@ -104,8 +98,17 @@ void main() {
       await tester.pump(const Duration(seconds: 1));
 
       // First connect — empty store → MUST prompt, we accept, reach a shell.
-      await _fillForm(tester);
-      final first = await _connect(
+      // #583: ad-hoc connect via "New connection" → editor → "Save & connect".
+      // Side effect: the profile 127.0.0.1:2222:testuser is now SAVED with its
+      // credential, so the reconnect below can tap the saved tile.
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      final first = await _awaitShell(
         tester,
         container,
         acceptPromptIfShown: true,
@@ -123,24 +126,28 @@ void main() {
 
       // Disconnect → removes the session + its controller/store.
       await tester.tap(find.byKey(const Key('terminal-disconnect-button')));
-      var backAtForm = false;
+      var backAtChooser = false;
       for (var i = 0; i < 30; i++) {
         await tester.pump(const Duration(milliseconds: 500));
-        if (find.byKey(const Key('connect-submit')).evaluate().isNotEmpty) {
-          backAtForm = true;
+        if (find.byKey(const Key('new-connection')).evaluate().isNotEmpty) {
+          backAtChooser = true;
           break;
         }
       }
       expect(
-        backAtForm,
+        backAtChooser,
         isTrue,
-        reason: 'disconnect did not return to the connect form',
+        reason: 'disconnect did not return to the chooser',
       );
 
-      // Reconnect to the SAME host — the persisted trust must hydrate into the
+      // Reconnect to the SAME host — tap the now-saved profile tile (stored
+      // creds connect directly). The persisted trust must hydrate into the
       // fresh session's store, so NO prompt this time, and still reach a shell.
-      await _fillForm(tester);
-      final second = await _connect(
+      await tester.tap(
+        find.byKey(const Key('profile-tile-127.0.0.1:2222:testuser')),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      final second = await _awaitShell(
         tester,
         container,
         acceptPromptIfShown: false,

--- a/native/integration_test/import_smoke_test.dart
+++ b/native/integration_test/import_smoke_test.dart
@@ -145,9 +145,9 @@ Future<bool> _pump(
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets(
-      'import KEY profile from backup → tap → connect in key mode (#547)',
-      (tester) async {
+  testWidgets('import KEY profile from backup → tap → connect in key mode (#547)', (
+    tester,
+  ) async {
     FlutterForegroundTask.initCommunicationPort();
 
     const masterPassword = 'master';
@@ -176,56 +176,60 @@ void main() {
     // Open the import dialog. The Connect form exposes an import affordance;
     // the dialog itself is keyed `import-profiles-dialog`.
     final importButton = find.byKey(const Key('open-import-profiles-dialog'));
-    expect(importButton.evaluate(), isNotEmpty,
-        reason: 'no import affordance found on the connect screen');
+    expect(
+      importButton.evaluate(),
+      isNotEmpty,
+      reason: 'no import affordance found on the connect screen',
+    );
     await tester.tap(importButton.first);
-    expect(await _pump(tester, find.byKey(const Key('import-profiles-dialog'))),
-        isTrue,
-        reason: 'import dialog did not open');
+    expect(
+      await _pump(tester, find.byKey(const Key('import-profiles-dialog'))),
+      isTrue,
+      reason: 'import dialog did not open',
+    );
 
     // Expand the paste disclosure and paste the envelope JSON.
-    final disclosure = find.byKey(const Key('import-profiles-paste-disclosure'));
+    final disclosure = find.byKey(
+      const Key('import-profiles-paste-disclosure'),
+    );
     if (disclosure.evaluate().isNotEmpty) {
       await tester.tap(disclosure);
       await tester.pump(const Duration(milliseconds: 300));
     }
     await tester.enterText(
-        find.byKey(const Key('import-profiles-input')), envelope);
+      find.byKey(const Key('import-profiles-input')),
+      envelope,
+    );
     await tester.pump(const Duration(milliseconds: 200));
 
     // Stage 1 submit → vault detected → password field appears.
     await tester.tap(find.byKey(const Key('import-profiles-submit')));
     expect(
-        await _pump(tester, find.byKey(const Key('import-profiles-password'))),
-        isTrue,
-        reason: 'password stage did not appear for the encrypted envelope');
+      await _pump(tester, find.byKey(const Key('import-profiles-password'))),
+      isTrue,
+      reason: 'password stage did not appear for the encrypted envelope',
+    );
 
     await tester.enterText(
-        find.byKey(const Key('import-profiles-password')), masterPassword);
+      find.byKey(const Key('import-profiles-password')),
+      masterPassword,
+    );
     await tester.pump(const Duration(milliseconds: 200));
 
     // Stage 2 submit → decrypt (600k PBKDF2 on device) + persist + close.
     await tester.tap(find.byKey(const Key('import-profiles-submit')));
     final tile = find.byKey(const Key('profile-tile-127.0.0.1:2222:testuser'));
-    expect(await _pump(tester, tile, slices: 40),
-        isTrue,
-        reason: 'imported profile tile did not appear after import');
+    expect(
+      await _pump(tester, tile, slices: 40),
+      isTrue,
+      reason: 'imported profile tile did not appear after import',
+    );
 
-    // Tap the saved profile → prefills the form from the resolved secret.
+    // #583: tapping the saved profile CONNECTS directly using the resolved
+    // secret (no inline form to prefill anymore). The #547 assertion — that the
+    // imported key secret actually resolved — is now proven by reaching a live
+    // terminal under KEY auth (a failed resolve would hang / fail auth).
     await tester.tap(tile);
-    // Give the async vault prefill time to land the private key.
-    final keyField = find.byKey(const Key('connect-key'));
-    final keyApplied = await _pump(tester, keyField, slices: 20);
-
-    // MINIMUM acceptance: profile applied in key mode with a non-empty key.
-    if (keyApplied) {
-      final widget = tester.widget<TextField>(keyField);
-      expect(widget.controller?.text ?? '', isNotEmpty,
-          reason: 'key field empty — secret not resolved (the #547 bug)');
-    }
-
-    // FULL acceptance: connect reaches the terminal screen.
-    await tester.tap(find.byKey(const Key('connect-submit')));
     var connected = false;
     for (var i = 0; i < 60; i++) {
       await tester.pump(const Duration(milliseconds: 500));
@@ -240,10 +244,16 @@ void main() {
       }
     }
 
-    // The live socket may flake (bridge down); the key-mode application is the
-    // load-bearing #547 assertion. Connect is the stronger signal when the
-    // bridge is up.
-    expect(connected || keyApplied, isTrue,
-        reason: 'neither connected nor applied key mode — #547 regression');
+    // FULL acceptance: connect reaches the terminal screen. (If the live socket
+    // flakes because the bridge is down, this is the only signal we have now
+    // that the form is gone — the import + tile appearance above already
+    // proved the profile + its vault reference persisted.)
+    expect(
+      connected,
+      isTrue,
+      reason:
+          'import → tap-to-connect did not reach the terminal — '
+          'the resolved key secret may not have applied (#547 regression)',
+    );
   });
 }

--- a/native/integration_test/multi_session_lifecycle_test.dart
+++ b/native/integration_test/multi_session_lifecycle_test.dart
@@ -40,6 +40,8 @@ import 'package:mobissh/main.dart' show MobisshApp;
 import 'package:mobissh/ssh/ssh_session.dart' show SshSessionState;
 import 'package:mobissh/state/sessions.dart';
 
+import 'support/connect_helpers.dart';
+
 const _slice = Duration(milliseconds: 500);
 
 Future<void> _pumpFrames(WidgetTester tester, int count) async {
@@ -68,6 +70,9 @@ Future<bool> _pumpUntil(
   return false;
 }
 
+/// #583: the inline form is gone. An ad-hoc connect (session A from the home
+/// chooser, session B from the pushed New-session chooser) goes through the
+/// "New connection" → editor → "Save & connect" flow.
 Future<void> _fillAndSubmit(
   WidgetTester tester, {
   required String host,
@@ -75,26 +80,31 @@ Future<void> _fillAndSubmit(
   required String user,
   required String pass,
 }) async {
-  await tester.enterText(find.byKey(const Key('connect-host')), host);
-  await tester.enterText(find.byKey(const Key('connect-port')), port);
-  await tester.enterText(find.byKey(const Key('connect-username')), user);
-  await tester.enterText(find.byKey(const Key('connect-password')), pass);
-  await tester.pump();
-  await tester.tap(find.byKey(const Key('connect-submit')));
+  await adhocPasswordConnect(
+    tester,
+    host: host,
+    port: port,
+    user: user,
+    pass: pass,
+  );
 }
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('two sessions connect via the New session UI on emulator',
-      (tester) async {
+  testWidgets('two sessions connect via the New session UI on emulator', (
+    tester,
+  ) async {
     FlutterForegroundTask.initCommunicationPort();
 
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
     await tester.pumpWidget(
-      UncontrolledProviderScope(container: container, child: const MobisshApp()),
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
     );
     await tester.pump(const Duration(seconds: 1));
 
@@ -116,14 +126,20 @@ void main() {
       tester,
       () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
     );
-    expect(reachedA, isTrue,
-        reason: 'session A never reached the terminal screen');
+    expect(
+      reachedA,
+      isTrue,
+      reason: 'session A never reached the terminal screen',
+    );
 
     // 2. New session → session B on port 2223.
     await tester.tap(find.byKey(const Key('session-menu-button')));
     await _pumpFrames(tester, 12);
-    expect(find.byKey(const Key('session-menu-new')), findsOneWidget,
-        reason: 'no "New session" affordance — leg 2 is UI-unreachable');
+    expect(
+      find.byKey(const Key('session-menu-new')),
+      findsOneWidget,
+      reason: 'no "New session" affordance — leg 2 is UI-unreachable',
+    );
     await tester.tap(find.byKey(const Key('session-menu-new')));
     await _pumpFrames(tester, 16);
     expect(find.byKey(const Key('new-session-page')), findsOneWidget);
@@ -141,7 +157,8 @@ void main() {
     expect(
       connectedBoth,
       isTrue,
-      reason: 'both sessions did not reach connected — the New session path '
+      reason:
+          'both sessions did not reach connected — the New session path '
           'cannot establish a 2nd connection',
     );
 

--- a/native/integration_test/reconnect_cycle_test.dart
+++ b/native/integration_test/reconnect_cycle_test.dart
@@ -20,21 +20,22 @@ import 'package:integration_test/integration_test.dart';
 import 'package:mobissh/main.dart' show MobisshApp;
 import 'package:mobissh/state/sessions.dart';
 
-Future<void> _fillForm(WidgetTester tester) async {
-  await tester.enterText(find.byKey(const Key('connect-host')), '127.0.0.1');
-  await tester.enterText(find.byKey(const Key('connect-port')), '2222');
-  await tester.enterText(find.byKey(const Key('connect-username')), 'testuser');
-  await tester.enterText(find.byKey(const Key('connect-password')), 'testpass');
-  await tester.pump();
-}
+import 'support/connect_helpers.dart';
 
-/// Submit and poll until the terminal screen mounts AND the shell streams
-/// bytes. Accepts the host-key prompt if shown. Returns the bytes seen.
+/// #583: open the create-mode editor and connect ad-hoc (no inline form).
+/// Then poll until the terminal screen mounts AND the shell streams bytes.
+/// Accepts the host-key prompt if shown. Returns whether bytes were seen.
 Future<bool> _connectAndProveShell(
   WidgetTester tester,
   ProviderContainer container,
 ) async {
-  await tester.tap(find.byKey(const Key('connect-submit')));
+  await adhocPasswordConnect(
+    tester,
+    host: '127.0.0.1',
+    port: '2222',
+    user: 'testuser',
+    pass: 'testpass',
+  );
   var connected = false;
   for (var i = 0; i < 60; i++) {
     await tester.pump(const Duration(milliseconds: 500));
@@ -69,44 +70,61 @@ Future<bool> _connectAndProveShell(
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('connect, disconnect, then reconnect reaches a live shell again',
-      (tester) async {
+  testWidgets('connect, disconnect, then reconnect reaches a live shell again', (
+    tester,
+  ) async {
     FlutterForegroundTask.initCommunicationPort();
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
     await tester.pumpWidget(
-      UncontrolledProviderScope(container: container, child: const MobisshApp()),
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
     );
     await tester.pump(const Duration(seconds: 1));
 
     // First connect — must reach a live shell on the FIRST submit (no double-tap).
-    await _fillForm(tester);
     final first = await _connectAndProveShell(tester, container);
-    expect(first, isTrue,
-        reason: 'first connect did not reach a live shell on a single tap');
+    expect(
+      first,
+      isTrue,
+      reason: 'first connect did not reach a live shell on a single tap',
+    );
 
     // Disconnect via the AppBar button → should remove the session + return to
-    // the connect form.
+    // the chooser (#583: the home view is the chooser, signalled by the
+    // "New connection" affordance).
     await tester.tap(find.byKey(const Key('terminal-disconnect-button')));
-    var backAtForm = false;
+    var backAtChooser = false;
     for (var i = 0; i < 30; i++) {
       await tester.pump(const Duration(milliseconds: 500));
-      if (find.byKey(const Key('connect-submit')).evaluate().isNotEmpty) {
-        backAtForm = true;
+      if (find.byKey(const Key('new-connection')).evaluate().isNotEmpty) {
+        backAtChooser = true;
         break;
       }
     }
-    expect(backAtForm, isTrue, reason: 'disconnect did not return to the form');
-    expect(container.read(sessionsProvider).entries, isEmpty,
-        reason: 'disconnect must remove the session entry (#564)');
+    expect(
+      backAtChooser,
+      isTrue,
+      reason: 'disconnect did not return to the chooser',
+    );
+    expect(
+      container.read(sessionsProvider).entries,
+      isEmpty,
+      reason: 'disconnect must remove the session entry (#564)',
+    );
 
     // Reconnect — the bug: this did nothing, stuck at idle. Must reach a live
     // shell again.
-    await _fillForm(tester);
     final second = await _connectAndProveShell(tester, container);
-    expect(second, isTrue,
-        reason: 'RECONNECT after disconnect did not reach a live shell — '
-            'the #564 stuck-at-idle bug');
+    expect(
+      second,
+      isTrue,
+      reason:
+          'RECONNECT after disconnect did not reach a live shell — '
+          'the #564 stuck-at-idle bug',
+    );
   });
 }

--- a/native/integration_test/shell_bytes_smoke_test.dart
+++ b/native/integration_test/shell_bytes_smoke_test.dart
@@ -21,29 +21,35 @@ import 'package:integration_test/integration_test.dart';
 import 'package:mobissh/main.dart' show MobisshApp;
 import 'package:mobissh/state/sessions.dart';
 
+import 'support/connect_helpers.dart';
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('connected session streams shell bytes and echoes input',
-      (tester) async {
+  testWidgets('connected session streams shell bytes and echoes input', (
+    tester,
+  ) async {
     FlutterForegroundTask.initCommunicationPort();
 
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
     await tester.pumpWidget(
-      UncontrolledProviderScope(container: container, child: const MobisshApp()),
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
     );
     await tester.pump(const Duration(seconds: 1));
 
-    await tester.enterText(find.byKey(const Key('connect-host')), '127.0.0.1');
-    await tester.enterText(find.byKey(const Key('connect-port')), '2222');
-    await tester.enterText(
-        find.byKey(const Key('connect-username')), 'testuser');
-    await tester.enterText(
-        find.byKey(const Key('connect-password')), 'testpass');
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('connect-submit')));
+    // #583: connect ad-hoc via "New connection" → editor → "Save & connect".
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
 
     // Reach the terminal screen, accepting the host-key prompt if shown.
     var connected = false;
@@ -78,9 +84,13 @@ void main() {
         break;
       }
     }
-    expect(gotPrompt, isTrue,
-        reason: 'terminal received ZERO bytes after connect — the dead-shell '
-            'hang (no PTY opened task-side)');
+    expect(
+      gotPrompt,
+      isTrue,
+      reason:
+          'terminal received ZERO bytes after connect — the dead-shell '
+          'hang (no PTY opened task-side)',
+    );
 
     // 2) A typed command must echo back through the proxy round-trip.
     const marker = 'MOBISSH_SHELL_OK_42';
@@ -93,7 +103,10 @@ void main() {
         break;
       }
     }
-    expect(sawMarker, isTrue,
-        reason: 'typed command never echoed back — input not routed to the PTY');
+    expect(
+      sawMarker,
+      isTrue,
+      reason: 'typed command never echoed back — input not routed to the PTY',
+    );
   });
 }

--- a/native/integration_test/support/connect_helpers.dart
+++ b/native/integration_test/support/connect_helpers.dart
@@ -1,0 +1,91 @@
+// Shared on-emulator connect helpers (#583).
+//
+// The home view is a profile CHOOSER now — the inline connect form was removed.
+// An ad-hoc connection goes through the editor: tap "New connection", fill the
+// editor's host/port/username/credential fields, then "Save & connect"
+// (`connect-submit`). These helpers centralise that flow so every emulator
+// smoke uses the same path.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Open the create-mode profile editor from the chooser's "New connection"
+/// affordance. Works on both the home view and a pushed New-session page.
+Future<void> openNewConnectionEditor(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('new-connection')));
+  for (var i = 0; i < 6; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+}
+
+/// Fill the create-mode editor with a password connection and tap
+/// "Save & connect". Assumes [openNewConnectionEditor] already ran.
+Future<void> fillPasswordAndConnect(
+  WidgetTester tester, {
+  required String host,
+  required String port,
+  required String user,
+  required String pass,
+}) async {
+  await tester.enterText(find.byKey(const Key('profile-editor-host')), host);
+  await tester.enterText(find.byKey(const Key('profile-editor-port')), port);
+  await tester.enterText(
+    find.byKey(const Key('profile-editor-username')),
+    user,
+  );
+  await tester.enterText(
+    find.byKey(const Key('profile-editor-password')),
+    pass,
+  );
+  await tester.pump();
+  final submit = find.byKey(const Key('connect-submit'));
+  await tester.ensureVisible(submit);
+  await tester.pump();
+  await tester.tap(submit);
+}
+
+/// Full ad-hoc password connect from the chooser: open the editor, fill, and
+/// "Save & connect".
+Future<void> adhocPasswordConnect(
+  WidgetTester tester, {
+  required String host,
+  required String port,
+  required String user,
+  required String pass,
+}) async {
+  await openNewConnectionEditor(tester);
+  await fillPasswordAndConnect(
+    tester,
+    host: host,
+    port: port,
+    user: user,
+    pass: pass,
+  );
+}
+
+/// Full ad-hoc KEY-auth connect from the chooser: open the editor, switch to
+/// Key mode, paste the PEM, and "Save & connect".
+Future<void> adhocKeyConnect(
+  WidgetTester tester, {
+  required String host,
+  required String port,
+  required String user,
+  required String keyPem,
+}) async {
+  await openNewConnectionEditor(tester);
+  await tester.enterText(find.byKey(const Key('profile-editor-host')), host);
+  await tester.enterText(find.byKey(const Key('profile-editor-port')), port);
+  await tester.enterText(
+    find.byKey(const Key('profile-editor-username')),
+    user,
+  );
+  // Switch to Key auth (SegmentedButton segment labelled "Key").
+  await tester.tap(find.text('Key'));
+  await tester.pump(const Duration(milliseconds: 300));
+  await tester.enterText(find.byKey(const Key('profile-editor-key')), keyPem);
+  await tester.pump();
+  final submit = find.byKey(const Key('connect-submit'));
+  await tester.ensureVisible(submit);
+  await tester.pumpAndSettle(const Duration(milliseconds: 300));
+  await tester.tap(submit);
+}

--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -136,6 +136,12 @@ class _RootRouterState extends ConsumerState<RootRouter> {
   }
 }
 
+/// The cold-start / home view: an uncluttered profile CHOOSER (#583). It hosts
+/// the profile list (tap = connect, pencil = edit), a "New connection"
+/// affordance, and slim Import/Settings/Diagnostics access. The inline connect
+/// form + connection-status panel were removed — the goal of this view is human
+/// DECISION, not data entry. Connection status is shown on the terminal screen
+/// (the router swaps to it the moment any session connects).
 class ConnectHomePage extends ConsumerWidget {
   const ConnectHomePage({super.key});
 
@@ -143,63 +149,7 @@ class ConnectHomePage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(title: const Text('MobiSSH')),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          child: Column(
-            children: const [ConnectForm(), Divider(), _StatusPanel()],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _StatusPanel extends ConsumerWidget {
-  const _StatusPanel();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final async = ref.watch(sshSessionDataProvider);
-    return async.when(
-      loading: () => const Padding(
-        padding: EdgeInsets.all(16),
-        child: Center(child: CircularProgressIndicator()),
-      ),
-      error: (e, _) => Padding(
-        padding: const EdgeInsets.all(16),
-        child: Text('Provider error: $e'),
-      ),
-      data: (data) => Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'State: ${data.state.name}',
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            if (data.host != null)
-              Text('Target: ${data.username}@${data.host}:${data.port}'),
-            if (data.remoteVersion != null)
-              Text('Server: ${data.remoteVersion}'),
-            if (data.banner != null && data.banner!.isNotEmpty) ...[
-              const SizedBox(height: 8),
-              const Text('Banner:'),
-              SelectableText(
-                data.banner!,
-                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
-              ),
-            ],
-            if (data.error != null) ...[
-              const SizedBox(height: 8),
-              Text(
-                'Error: ${data.error}',
-                style: const TextStyle(color: Colors.redAccent),
-              ),
-            ],
-          ],
-        ),
-      ),
+      body: const SafeArea(child: SingleChildScrollView(child: ConnectForm())),
     );
   }
 }

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -1,10 +1,22 @@
-// Connect form — host/port/username/password (or key) + Submit.
+// Profile chooser — the home/connect view (#583).
 //
-// Phase 1 (#501): no profiles, no persistence. Submit calls the SshSession
-// controller; UI mirrors lifecycle state below the form.
+// History: this widget used to be a full inline connect FORM
+// (host/port/username/auth fields + a Connect button). #580 added tap-a-profile
+// = connect and a pencil = full profile editor, which made the inline form
+// redundant. #583 strips the form: the view is now an uncluttered profile
+// CHOOSER for human decision —
+//   - the saved-profile list (tap = connect, pencil = edit), and
+//   - a single "New" affordance that opens the profile editor in create mode
+//     (the editor is the new / ad-hoc connection entry now), and
+//   - slim access to Import-from-PWA, Settings, and Diagnostics.
 //
-// Profile import (Phase 3 of #501): saved profiles rendered above the form;
-// tapping one populates host/port/username (user still types credentials).
+// CRITICAL plumbing kept here (the relocation trap): the host-key prompt
+// listener (`ref.listen(sshSessionDataProvider)` → [_handleHostKeyPrompt]) and
+// the shared connect dispatch ([_connectWithParams] / [_connectFromProfile] +
+// initial-command arming) live in this State so tap-to-connect AND
+// editor-"Save & connect" both prompt for unknown host keys and run the initial
+// command. The class name is kept as `ConnectForm` (it's referenced by
+// NewSessionPage + tests) even though it no longer renders a form.
 
 import 'dart:async';
 import 'dart:convert';
@@ -29,8 +41,6 @@ import 'profile_editor.dart';
 import 'profile_list.dart';
 import 'settings_panel.dart';
 
-enum _AuthKind { password, key }
-
 class ConnectForm extends ConsumerStatefulWidget {
   const ConnectForm({super.key});
 
@@ -39,56 +49,34 @@ class ConnectForm extends ConsumerStatefulWidget {
 }
 
 class _ConnectFormState extends ConsumerState<ConnectForm> {
-  final _hostCtrl = TextEditingController(text: 'test-sshd');
-  final _portCtrl = TextEditingController(text: '22');
-  final _userCtrl = TextEditingController(text: 'testuser');
-  final _passwordCtrl = TextEditingController();
-  final _keyCtrl = TextEditingController();
-  final _passphraseCtrl = TextEditingController();
-  // Optional command run once after the session connects (#558). Prefilled
-  // from an applied profile's `initialCommand`; empty by default.
-  final _initialCommandCtrl = TextEditingController();
-
-  _AuthKind _authKind = _AuthKind.password;
   bool _busy = false;
 
   /// Active subscription / completer for the "pop on connected" wait. Stored
-  /// so [dispose] can tear them down cleanly when the form unmounts before the
-  /// session reaches `connected` (otherwise the test binding flags a pending
-  /// timer or the awaiter hangs forever).
+  /// so [dispose] can tear them down cleanly when the chooser unmounts before
+  /// the session reaches `connected` (otherwise the test binding flags a
+  /// pending timer or the awaiter hangs forever).
   StreamSubscription<SshSessionData>? _connectedSub;
   Completer<bool>? _connectedCompleter;
 
-  /// Last saved profile applied to the form, if any. Carries the human title
-  /// through to the session (#518). Cleared (effectively) by drift-checking
-  /// host/port/username at submit time so the title doesn't lie about the
-  /// connection target.
-  SavedProfile? _appliedProfile;
-
   @override
   void dispose() {
-    ctrace('ui.form', 'dispose: ConnectForm state being torn down');
-    // Unblock any in-flight "wait for connected" await BEFORE the controllers
-    // tear down, so _popWhenConnected's continuation runs against a dead
-    // widget but doesn't leak a Stream subscription or hang the future.
+    ctrace('ui.chooser', 'dispose: ProfileChooser state being torn down');
+    // Unblock any in-flight "wait for connected" await so the future doesn't
+    // leak a Stream subscription or hang.
     if (_connectedCompleter != null && !_connectedCompleter!.isCompleted) {
       _connectedCompleter!.complete(false);
     }
     _connectedSub?.cancel();
     _connectedSub = null;
-    _hostCtrl.dispose();
-    _portCtrl.dispose();
-    _userCtrl.dispose();
-    _passwordCtrl.dispose();
-    _keyCtrl.dispose();
-    _passphraseCtrl.dispose();
-    _initialCommandCtrl.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    // Watch for host-key prompts; show dialog when one appears.
+    // CRITICAL (relocation trap): watch for host-key prompts so tapping a
+    // profile (or "Save & connect" from the editor) still pops the Trust
+    // dialog for an unknown host. This listener MUST live on the always-mounted
+    // chooser — it was previously on the now-removed inline form.
     ref.listen<AsyncValue<SshSessionData>>(sshSessionDataProvider, (
       prev,
       next,
@@ -105,9 +93,22 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // Saved profiles + import action. Collapsed-to-empty-hint when the
-          // user has no imported profiles yet.
+          // Saved profiles: tap a row = connect, pencil = edit. Empty-state
+          // hint nudges Import when the user has none yet.
           ProfileList(onConnect: _connectFromProfile, onEdit: _editProfile),
+          const SizedBox(height: 4),
+          // The single "New" affordance: opens the editor in create mode. The
+          // editor is the ad-hoc / new-connection entry now that the inline
+          // form is gone (#583).
+          FilledButton.icon(
+            key: const Key('new-connection'),
+            onPressed: _busy ? null : _newConnection,
+            icon: const Icon(Icons.add),
+            label: Text(_busy ? 'Connecting…' : 'New connection'),
+          ),
+          const SizedBox(height: 4),
+          // Slim secondary access: Import-from-PWA. Settings + Diagnostics stay
+          // below as compact disclosures — not a wall of fields.
           Align(
             alignment: Alignment.centerRight,
             child: TextButton.icon(
@@ -117,110 +118,6 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
               label: const Text('Import from PWA'),
             ),
           ),
-          const SizedBox(height: 4),
-          Row(
-            children: [
-              Expanded(
-                flex: 3,
-                child: TextField(
-                  key: const Key('connect-host'),
-                  controller: _hostCtrl,
-                  decoration: const InputDecoration(labelText: 'Host'),
-                  textInputAction: TextInputAction.next,
-                  autocorrect: false,
-                  enableSuggestions: false,
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                flex: 1,
-                child: TextField(
-                  key: const Key('connect-port'),
-                  controller: _portCtrl,
-                  decoration: const InputDecoration(labelText: 'Port'),
-                  keyboardType: TextInputType.number,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            key: const Key('connect-username'),
-            controller: _userCtrl,
-            decoration: const InputDecoration(labelText: 'Username'),
-            textInputAction: TextInputAction.next,
-            autocorrect: false,
-            enableSuggestions: false,
-          ),
-          const SizedBox(height: 12),
-          SegmentedButton<_AuthKind>(
-            segments: const [
-              ButtonSegment(
-                value: _AuthKind.password,
-                label: Text('Password'),
-                icon: Icon(Icons.password),
-              ),
-              ButtonSegment(
-                value: _AuthKind.key,
-                label: Text('Key'),
-                icon: Icon(Icons.vpn_key),
-              ),
-            ],
-            selected: {_authKind},
-            onSelectionChanged: (s) => setState(() => _authKind = s.first),
-          ),
-          const SizedBox(height: 8),
-          if (_authKind == _AuthKind.password)
-            TextField(
-              key: const Key('connect-password'),
-              controller: _passwordCtrl,
-              decoration: const InputDecoration(labelText: 'Password'),
-              obscureText: true,
-              autocorrect: false,
-              enableSuggestions: false,
-            )
-          else ...[
-            TextField(
-              key: const Key('connect-key'),
-              controller: _keyCtrl,
-              decoration: const InputDecoration(
-                labelText: 'Private key (PEM)',
-                hintText: '-----BEGIN OPENSSH PRIVATE KEY-----',
-              ),
-              maxLines: 4,
-              autocorrect: false,
-              enableSuggestions: false,
-            ),
-            const SizedBox(height: 8),
-            TextField(
-              controller: _passphraseCtrl,
-              decoration: const InputDecoration(
-                labelText: 'Key passphrase (optional)',
-              ),
-              obscureText: true,
-              autocorrect: false,
-              enableSuggestions: false,
-            ),
-          ],
-          const SizedBox(height: 12),
-          TextField(
-            key: const Key('connect-initial-command'),
-            controller: _initialCommandCtrl,
-            decoration: const InputDecoration(
-              labelText: 'Initial command (optional)',
-              hintText: 'e.g. tmux attach || tmux',
-            ),
-            autocorrect: false,
-            enableSuggestions: false,
-          ),
-          const SizedBox(height: 16),
-          FilledButton.icon(
-            key: const Key('connect-submit'),
-            onPressed: _canSubmit() ? () => _submit() : null,
-            icon: const Icon(Icons.power_settings_new),
-            label: Text(_busy ? 'Connecting...' : 'Connect'),
-          ),
-          const SizedBox(height: 8),
           const SettingsPanel(),
           const DiagnosticsSection(),
         ],
@@ -228,110 +125,49 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     );
   }
 
-  /// Whether the Connect button is enabled. Gated only on this form's own
-  /// in-flight submit (`_busy`) — NOT on any global/active session state.
-  ///
-  /// Multi-session: the form may be a pushed "New session" page opened while
-  /// other sessions are already `connected`. Gating on the legacy single-
-  /// session shim (`sshSessionDataProvider`) disabled the button whenever any
-  /// session was connected, making it impossible to start a 2nd session.
-  /// `addOrActivate` dedups by host:port:username and the task-side controller
-  /// no-ops a re-connect, so an always-enabled button is safe.
-  bool _canSubmit() => !_busy;
-
-  Future<void> _submit() async {
-    final host = _hostCtrl.text.trim();
-    final port = int.tryParse(_portCtrl.text.trim()) ?? 22;
-    final username = _userCtrl.text.trim();
-
-    if (host.isEmpty || username.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Host and username are required')),
-      );
-      return;
+  /// "New" affordance → open the editor in CREATE mode. On "Save & connect" the
+  /// editor returns the saved profile and we route it through the same connect
+  /// path as a profile-row tap. On plain "Save" we just refresh the list.
+  Future<void> _newConnection() async {
+    final result = await showProfileEditorForNew(context);
+    if (!mounted || result == null) return;
+    if (result.saved) {
+      ref.invalidate(savedProfilesProvider);
     }
-
-    // Credential-presence trace (lengths only — never values). Tells us via
-    // the on-device Connect log whether the vault prefill actually populated
-    // the fields: pwLen=0 / keyLen=0 means prefill returned empty (secret not
-    // found / read failed), vs a non-zero length meaning creds are present and
-    // the server rejected them. (#542/#543 diagnosis of "all auth methods
-    // failed after import".)
-    ctrace(
-      'ui.form',
-      'auth=${_authKind.name} pwLen=${_passwordCtrl.text.length} '
-          'keyLen=${_keyCtrl.text.length} ppLen=${_passphraseCtrl.text.length}',
-    );
-    final SshAuth auth;
-    if (_authKind == _AuthKind.password) {
-      auth = SshAuth.password(_passwordCtrl.text);
-    } else {
-      auth = SshAuth.key(
-        Uint8List.fromList(utf8.encode(_keyCtrl.text)),
-        passphrase: _passphraseCtrl.text.isEmpty ? null : _passphraseCtrl.text,
-      );
+    final toConnect = result.connect;
+    if (toConnect != null) {
+      await _connectFromProfile(toConnect);
     }
-
-    final params = SshConnectParams(
-      host: host,
-      port: port,
-      username: username,
-      auth: auth,
-    );
-
-    ctrace(
-      'ui.form',
-      'submit host=$host port=$port user=$username auth=${_authKind.name}',
-    );
-    await _connectWithParams(
-      params,
-      title: _profileTitleForCurrentForm(),
-      initialCommand: _initialCommandCtrl.text,
-    );
   }
 
-  /// Shared connect path used by BOTH the form Submit and a saved-profile row
-  /// tap (#579). Routes through the sessions notifier (dedupe by
+  /// Shared connect path used by BOTH a saved-profile row tap and the editor's
+  /// "Save & connect". Routes through the sessions notifier (dedupe by
   /// host:port:user, per-session proxy), arms the run-on-connect command, then
-  /// dispatches `proxy.connect`. When this form was pushed as a "New session"
-  /// route, it pops back to the terminal once the session CONNECTS.
-  ///
-  /// Keeping this separate from [_submit] means tapping a profile reuses the
-  /// exact same connect machinery as the manual form — no second code path to
-  /// drift.
+  /// dispatches `proxy.connect`. When this chooser was pushed as a "New
+  /// session" route, it pops back to the terminal once the session CONNECTS.
   Future<void> _connectWithParams(
     SshConnectParams params, {
     String? title,
     required String initialCommand,
   }) async {
-    // Captured before the async gap so we can pop a pushed "New session"
-    // route after dispatching connect without touching `context` post-await.
+    // Captured before the async gap so we can pop a pushed "New session" route
+    // after dispatching connect without touching `context` post-await.
     final navigator = Navigator.of(context);
 
     setState(() => _busy = true);
     try {
-      // Multi-session (#511): route through the sessions notifier so we
-      // dedupe by host:port:user and create a per-session proxy. If a
-      // matching session already exists, addOrActivate returns it without
-      // reconnecting (acceptance bullet 4). The optional title carries the
-      // saved profile's display name into the session (#518).
-      //
-      // #533: connect now dispatches across the task gateway via the per-
-      // session [SshSessionProxy] — the underlying `SshSessionController`
-      // lives in the task isolate, not the UI.
+      // Multi-session (#511): route through the sessions notifier so we dedupe
+      // by host:port:user and create a per-session proxy. If a matching session
+      // already exists, addOrActivate returns it without reconnecting. The
+      // optional title carries the saved profile's display name into the
+      // session (#518).
       final entry = ref
           .read(sessionsProvider.notifier)
           .addOrActivate(params, title: title);
-      // Only fire connect for entries that haven't been kicked off yet —
-      // idle/failed/disconnected states are safe to re-drive; connected/
-      // connecting/authenticating are no-ops inside the task-side controller
-      // itself.
-      ctrace('ui.form', 'entry=${entry.id} → proxy.connect()');
+      ctrace('ui.chooser', 'entry=${entry.id} → proxy.connect()');
       // Arm the run-on-connect command (#558) BEFORE dispatching connect, so
       // the one-shot listener is attached before the task side can emit
-      // `connected`. The runner fires exactly once on the first `connected`
-      // transition for this session id and guards against re-fire on the
-      // #551 reconnect rebind. No-op when the field is empty.
+      // `connected`. No-op when the field is empty.
       ref
           .read(initialCommandRunnerProvider)
           .arm(
@@ -340,18 +176,15 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
             command: initialCommand,
           );
       await entry.proxy.connect(params);
-      // Once we've proven we have network reachability, fire-and-forget a
-      // crash upload sweep. Tailscale being down is the common case at boot
-      // and the second-chance path matters more than blocking the UI.
+      // Once we've proven network reachability, fire-and-forget a crash upload
+      // sweep. Tailscale being down at boot is the common case.
       unawaited(CrashReporter.uploadPending());
-      // When this form was pushed as a "New session" route (over a live
-      // TerminalScreen), return to the terminal once the session CONNECTS —
-      // not on dispatch. Popping early would unmount the form mid-handshake,
-      // so a host-key prompt for the new session would have no form to render
-      // on (and touching `ref` after dispose throws). Staying mounted lets the
-      // form show the trust prompt; once connected we pop back to the terminal.
-      // The root form (ConnectHomePage) can't pop, so this is skipped there —
-      // the router swaps to the terminal screen on `connected` as before.
+      // When this chooser was pushed as a "New session" route (over a live
+      // TerminalScreen), return to the terminal once the session CONNECTS — not
+      // on dispatch. Staying mounted lets the chooser show the trust prompt;
+      // once connected we pop back. The root chooser (ConnectHomePage) can't
+      // pop, so this is skipped there — the router swaps to the terminal screen
+      // on `connected` as before.
       if (navigator.canPop()) {
         await _popWhenConnected(entry, navigator);
       }
@@ -360,30 +193,27 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     }
   }
 
-  /// Wait for the new session's proxy to reach `connected`, then pop the
-  /// pushed "New session" route back to the terminal. Stays mounted while
-  /// waiting so host-key prompts still render on this form. On `failed` we
-  /// stop and stay put so the user sees the error and can retry. On dispose
-  /// (e.g. the user backs out), the completer is short-circuited so the
-  /// awaiter unblocks without leaking the subscription.
+  /// Wait for the new session's proxy to reach `connected`, then pop the pushed
+  /// "New session" route back to the terminal. Stays mounted while waiting so
+  /// host-key prompts still render. On `failed` we stop and stay put so the
+  /// user sees the error. On dispose the completer is short-circuited.
   Future<void> _popWhenConnected(
     SessionEntry entry,
     NavigatorState navigator,
   ) async {
     ctrace(
-      'ui.form',
+      'ui.chooser',
       'popWhenConnected: enter sid=${entry.id} state=${entry.proxy.data.state.name}',
     );
-    // Already there? Pop now.
     if (entry.proxy.data.state == SshSessionState.connected) {
-      ctrace('ui.form', 'popWhenConnected: already connected → pop');
+      ctrace('ui.chooser', 'popWhenConnected: already connected → pop');
       if (mounted && navigator.canPop()) navigator.pop();
       return;
     }
     final completer = Completer<bool>();
     _connectedCompleter = completer;
     _connectedSub = entry.proxy.stream.listen((data) {
-      ctrace('ui.form', 'popWhenConnected: state=${data.state.name}');
+      ctrace('ui.chooser', 'popWhenConnected: state=${data.state.name}');
       if (completer.isCompleted) return;
       if (data.state == SshSessionState.connected) {
         completer.complete(true);
@@ -393,71 +223,27 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     });
     final connected = await completer.future;
     ctrace(
-      'ui.form',
+      'ui.chooser',
       'popWhenConnected: completer=$connected mounted=$mounted canPop=${navigator.canPop()}',
     );
     await _connectedSub?.cancel();
     _connectedSub = null;
     _connectedCompleter = null;
     if (connected && mounted && navigator.canPop()) {
-      ctrace('ui.form', 'popWhenConnected: navigator.pop() now');
+      ctrace('ui.chooser', 'popWhenConnected: navigator.pop() now');
       navigator.pop();
     }
   }
 
-  /// Populate the form with metadata from a saved profile. When the
-  /// profile has a `vaultId` or `keyVaultId`, look up the decrypted secret
-  /// in `flutter_secure_storage` and prefill the password / key fields.
-  /// The user can still edit them before submitting.
-  ///
-  /// Both ids are consulted because a `key`-auth profile imported from the
-  /// PWA stores the private-key blob under `keyVaultId`, not `vaultId`
-  /// (#519).
-  void _applyProfileToForm(SavedProfile profile) {
-    setState(() {
-      _appliedProfile = profile;
-      _hostCtrl.text = profile.host;
-      _portCtrl.text = profile.port.toString();
-      _userCtrl.text = profile.username;
-      // Prefill the optional run-on-connect command (#558). Empty when the
-      // profile carries none.
-      _initialCommandCtrl.text = profile.initialCommand ?? '';
-      // Pick the auth mode. Prefer the explicit authType, but if it's missing
-      // or ambiguous (e.g. a profile imported by an older build that persisted
-      // before authType round-tripped), INFER from keyVaultId: a profile that
-      // carries a key-blob reference is a key-auth profile. Without this, such
-      // a profile defaults to password mode with an empty password field and
-      // every connect fails with "all authentication methods failed" against a
-      // publickey-only host.
-      if (profile.authType == 'key') {
-        _authKind = _AuthKind.key;
-      } else if (profile.authType == 'password') {
-        _authKind = _AuthKind.password;
-      } else if (profile.keyVaultId != null && profile.keyVaultId!.isNotEmpty) {
-        _authKind = _AuthKind.key;
-      } else {
-        _authKind = _AuthKind.password;
-      }
-      ctrace(
-        'ui.form',
-        'applyProfile ${profile.host} authType=${profile.authType} '
-            'keyVaultId=${profile.keyVaultId != null} → mode=${_authKind.name}',
-      );
-    });
-    if (profile.vaultId != null || profile.keyVaultId != null) {
-      unawaited(_prefillFromVault(profile));
-    }
-  }
-
-  /// #579 tap-to-connect. Resolve the profile's connection params + stored
-  /// credentials, then connect immediately via the shared connect path — no
-  /// separate Connect tap, no form round-trip.
+  /// #579 tap-to-connect / #583 editor "Save & connect". Resolve the profile's
+  /// connection params + stored credentials, then connect immediately via the
+  /// shared connect path.
   ///
   /// Credential resolution mirrors the PWA's `connectFromProfile`: load creds
-  /// from the vault by vaultId/keyVaultId. If NO stored credentials are found
-  /// (nothing saved on this device, or the secret read came back empty), fall
-  /// back to populating the form + a snackbar so the user can type them — we
-  /// never silently no-op.
+  /// from the vault by vaultId/keyVaultId. If NO stored credentials are found,
+  /// fall back to opening the profile editor (edit mode for this profile) so
+  /// the user can add the missing credential — NOT a silent no-op, and no
+  /// dangling reference to the removed inline form (#583).
   Future<void> _connectFromProfile(SavedProfile profile) async {
     final secrets = ref.read(secretsStoreProvider);
     final creds = await loadProfileCredentials(secrets, profile);
@@ -477,19 +263,19 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
         : (creds.password != null && creds.password!.isNotEmpty);
 
     if (!hasUsableCreds) {
-      // No stored secret — fall back to the manual form (prefilled metadata)
-      // so the user can enter credentials. Matches the PWA "not saved on this
-      // browser" branch. NOT a silent failure.
+      // No stored secret — open the editor so the user can enter credentials.
+      // Matches the PWA "not saved on this browser" branch. NOT a silent
+      // failure. The editor's "Save & connect" then routes back here.
       ctrace(
-        'ui.form',
-        'connectFromProfile ${profile.host}: no stored creds → form fallback',
+        'ui.chooser',
+        'connectFromProfile ${profile.host}: no stored creds → editor',
       );
-      _applyProfileToForm(profile);
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text('No saved credentials — enter them to connect.'),
         ),
       );
+      await _editProfile(profile);
       return;
     }
 
@@ -512,12 +298,9 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       auth: auth,
     );
     ctrace(
-      'ui.form',
+      'ui.chooser',
       'connectFromProfile ${profile.host} authType=${wantsKey ? 'key' : 'password'} → connect',
     );
-    // Reflect the chosen profile in the form (and remember it for the session
-    // title) so the UI stays consistent if the user backs out.
-    _applyProfileToForm(profile);
     await _connectWithParams(
       params,
       title: profile.title,
@@ -525,47 +308,19 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     );
   }
 
-  /// #579 edit pencil. Open the full profile editor; on save, refresh the
-  /// saved-profile list.
+  /// #579 edit pencil / #583 no-creds fallback. Open the full profile editor;
+  /// on save, refresh the saved-profile list, and if the user chose "Save &
+  /// connect", route through the shared connect path.
   Future<void> _editProfile(SavedProfile profile) async {
-    final saved = await showProfileEditor(context, profile);
-    if (!mounted) return;
-    if (saved == true) {
+    final result = await showProfileEditor(context, profile);
+    if (!mounted || result == null) return;
+    if (result.saved) {
       ref.invalidate(savedProfilesProvider);
     }
-  }
-
-  /// Return the saved profile title to attach to the new session — but only
-  /// if the user hasn't drifted away from the applied profile's host/port/
-  /// username. If they've edited anything, return null so the session falls
-  /// back to `username@host:port` (#518).
-  String? _profileTitleForCurrentForm() {
-    final p = _appliedProfile;
-    if (p == null) return null;
-    final host = _hostCtrl.text.trim();
-    final port = int.tryParse(_portCtrl.text.trim()) ?? 22;
-    final username = _userCtrl.text.trim();
-    if (p.host == host && p.port == port && p.username == username) {
-      return p.title;
+    final toConnect = result.connect;
+    if (toConnect != null) {
+      await _connectFromProfile(toConnect);
     }
-    return null;
-  }
-
-  Future<void> _prefillFromVault(SavedProfile profile) async {
-    final secrets = ref.read(secretsStoreProvider);
-    final creds = await loadProfileCredentials(secrets, profile);
-    if (!mounted || creds.isEmpty) return;
-    setState(() {
-      final pw = creds.password;
-      if (pw != null) _passwordCtrl.text = pw;
-      final key = creds.privateKey;
-      if (key != null) {
-        _keyCtrl.text = key;
-        _authKind = _AuthKind.key;
-      }
-      final passphrase = creds.passphrase;
-      if (passphrase != null) _passphraseCtrl.text = passphrase;
-    });
   }
 
   Future<void> _openImportDialog() async {
@@ -586,18 +341,9 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
 
   Future<void> _handleHostKeyPrompt(PendingHostKey pending) async {
     final accepted = await showHostKeyDialog(context, pending: pending);
-    // Defensive — the form can be popped (e.g. New session route) while the
+    // Defensive — the chooser can be popped (e.g. New session route) while the
     // dialog is in-flight. Touching `ref` after dispose throws StateError.
-    // The new-session flow now stays mounted until connected, so this only
-    // fires on edge cases (user backs out mid-handshake); skipping the
-    // decision lets the task-side controller fall through its own timeout.
     if (!mounted) return;
-    // #533: host-key over-IPC is a follow-up — the proxy's accept/reject
-    // are no-ops today because the gateway envelope contract doesn't carry
-    // `pendingHostKey` state. The trust-on-first-use cache in the task-side
-    // controller handles cached fingerprints; first-time prompts surface
-    // through the dialog but the decision currently round-trips only through
-    // the in-process host. See [SshSessionProxy.acceptHostKey].
     final proxy = ref.read(sshSessionProxyProvider);
     if (accepted) {
       proxy.acceptHostKey();
@@ -607,15 +353,12 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
   }
 }
 
-/// Full-screen page hosting a [ConnectForm] for starting an ADDITIONAL session
-/// while others are already connected. Pushed from the session menu's
-/// "New session" tile (the goal's leg 2: connect a second session).
-///
-/// Without this, the `RootRouter` shows the terminal screen the moment any
-/// session connects, so there's no way back to the connect form to start a
-/// second one. The form pops this route itself once connect is dispatched
-/// (see [_ConnectFormState._submit]), landing back on the terminal screen with
-/// the new session active.
+/// Full-screen page hosting the profile [ConnectForm] chooser for starting an
+/// ADDITIONAL session while others are already connected (#583). Pushed from
+/// the session menu's "New session" tile (the goal's leg 2). It shows the SAME
+/// chooser as the home view: pick a profile = open as a new session; "New" =
+/// editor. The chooser pops this route itself once the new session CONNECTS
+/// (see [_ConnectFormState._popWhenConnected]).
 class NewSessionPage extends StatelessWidget {
   const NewSessionPage({super.key});
 

--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -27,22 +27,64 @@ import '../storage/profiles_store.dart';
 
 enum _AuthKind { password, key }
 
-/// Push the profile editor as a modal route. Resolves to `true` when the user
-/// saved (caller should refresh the profile list), or `null`/`false` when they
-/// cancelled / backed out.
-Future<bool?> showProfileEditor(BuildContext context, SavedProfile profile) {
-  return Navigator.of(context).push<bool>(
-    MaterialPageRoute<bool>(
+/// Outcome of the profile editor (#583). The editor is now the SINGLE entry for
+/// both editing a saved profile AND creating a new / ad-hoc connection — the
+/// inline connect form on the home view was removed. The caller (the profile
+/// chooser) inspects the result to decide whether to just refresh the list or
+/// to also connect to the saved profile.
+class ProfileEditorResult {
+  const ProfileEditorResult({required this.saved, this.connect});
+
+  /// True when the store was mutated (save or delete) — caller refreshes list.
+  final bool saved;
+
+  /// Non-null when the user chose "Save & connect": the profile to connect to.
+  /// The chooser routes this through its shared connect path so the host-key
+  /// prompt + initial-command arming run exactly as a profile-row tap does.
+  final SavedProfile? connect;
+}
+
+/// Push the profile editor as a modal route to EDIT an existing profile.
+/// Resolves to a [ProfileEditorResult] (`saved`/`connect`), or `null` when the
+/// user backed out without saving.
+Future<ProfileEditorResult?> showProfileEditor(
+  BuildContext context,
+  SavedProfile profile,
+) {
+  return Navigator.of(context).push<ProfileEditorResult>(
+    MaterialPageRoute<ProfileEditorResult>(
       fullscreenDialog: true,
       builder: (_) => ProfileEditor(profile: profile),
     ),
   );
 }
 
+/// A blank profile used to open the editor in CREATE mode (#583). Sensible
+/// defaults so the user starts on an empty form (host/username empty, port 22).
+SavedProfile blankProfile() =>
+    SavedProfile(title: '', host: '', port: 22, username: '');
+
+/// Push the editor in CREATE mode for a brand-new / ad-hoc connection (#583).
+/// This is the home view's "New" affordance: the editor IS the new-connection
+/// entry now that the inline form is gone. Same return contract as
+/// [showProfileEditor].
+Future<ProfileEditorResult?> showProfileEditorForNew(BuildContext context) {
+  return Navigator.of(context).push<ProfileEditorResult>(
+    MaterialPageRoute<ProfileEditorResult>(
+      fullscreenDialog: true,
+      builder: (_) => ProfileEditor(profile: blankProfile(), isNew: true),
+    ),
+  );
+}
+
 class ProfileEditor extends ConsumerStatefulWidget {
-  const ProfileEditor({super.key, required this.profile});
+  const ProfileEditor({super.key, required this.profile, this.isNew = false});
 
   final SavedProfile profile;
+
+  /// When true the editor renders in CREATE mode: blank starting fields, no
+  /// delete action, "Edit profile" → "New connection" title (#583).
+  final bool isNew;
 
   @override
   ConsumerState<ProfileEditor> createState() => _ProfileEditorState();
@@ -113,6 +155,24 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
   }
 
   Future<void> _save() async {
+    final saved = await _persist();
+    if (saved == null || !mounted) return;
+    Navigator.of(context).pop(const ProfileEditorResult(saved: true));
+  }
+
+  /// Save & connect (#583): persist the profile then hand it back to the
+  /// chooser so it connects via the shared connect path (host-key prompt +
+  /// initial-command arming included). The editor is the new-connection entry
+  /// now that the inline form is gone.
+  Future<void> _saveAndConnect() async {
+    final saved = await _persist();
+    if (saved == null || !mounted) return;
+    Navigator.of(context).pop(ProfileEditorResult(saved: true, connect: saved));
+  }
+
+  /// Persist the current fields to the store + vault. Returns the saved
+  /// profile on success, or null when validation failed (caller stays open).
+  Future<SavedProfile?> _persist() async {
     final host = _hostCtrl.text.trim();
     final username = _userCtrl.text.trim();
     final port = int.tryParse(_portCtrl.text.trim()) ?? 22;
@@ -120,7 +180,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Host and username are required')),
       );
-      return;
+      return null;
     }
 
     setState(() => _busy = true);
@@ -192,8 +252,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
             'hasVaultId=${vaultId != null} hasKeyVaultId=${keyVaultId != null}',
       );
       ref.invalidate(savedProfilesProvider);
-      if (!mounted) return;
-      Navigator.of(context).pop(true);
+      return updated;
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -206,7 +265,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
     await store.remove(host: p.host, port: p.port, username: p.username);
     ref.invalidate(savedProfilesProvider);
     if (!mounted) return;
-    Navigator.of(context).pop(true);
+    Navigator.of(context).pop(const ProfileEditorResult(saved: true));
   }
 
   @override
@@ -215,14 +274,16 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
     return Scaffold(
       key: const Key('profile-editor'),
       appBar: AppBar(
-        title: const Text('Edit profile'),
+        title: Text(widget.isNew ? 'New connection' : 'Edit profile'),
         actions: [
-          IconButton(
-            key: const Key('profile-editor-delete'),
-            icon: const Icon(Icons.delete_outline),
-            tooltip: 'Delete profile',
-            onPressed: _busy ? null : _delete,
-          ),
+          // No delete in create mode — there's nothing persisted yet (#583).
+          if (!widget.isNew)
+            IconButton(
+              key: const Key('profile-editor-delete'),
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Delete profile',
+              onPressed: _busy ? null : _delete,
+            ),
         ],
       ),
       body: SafeArea(
@@ -360,7 +421,18 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
                 enableSuggestions: false,
               ),
               const SizedBox(height: 20),
+              // Save & connect (#583): the editor is the new-connection entry
+              // now that the inline form is gone. `connect-submit` key keeps the
+              // emulator connect smokes addressable. Connects via the chooser's
+              // shared path (host-key prompt + initial-command arming).
               FilledButton.icon(
+                key: const Key('connect-submit'),
+                onPressed: _busy ? null : _saveAndConnect,
+                icon: const Icon(Icons.power_settings_new),
+                label: Text(_busy ? 'Connecting…' : 'Save & connect'),
+              ),
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
                 key: const Key('profile-editor-save'),
                 onPressed: _busy ? null : _save,
                 icon: const Icon(Icons.save),

--- a/native/test/widget/initial_command_field_test.dart
+++ b/native/test/widget/initial_command_field_test.dart
@@ -1,32 +1,32 @@
-// Widget test: the connect form's "Initial command" field (#558).
+// Widget test: the "Initial command" field lives on the profile editor (#558,
+// relocated by #583).
 //
-//   1. The field exists on the connect form.
-//   2. Tapping a saved profile that carries an `initialCommand` prefills it.
+// History: this used to assert the inline connect form had an initial-command
+// field and that tapping a profile prefilled it. #583 removed the inline form;
+// the editor is now the new/ad-hoc connection entry, so the initial-command
+// field lives there. These tests lock:
+//   1. The editor renders an initial-command field.
+//   2. Editing a profile that carries an `initialCommand` prefills it.
 //   3. A profile without an `initialCommand` leaves the field empty.
-//
-// The form's profile list reads `savedProfilesProvider`; we override it with a
-// fixed list so no real ProfilesStore IO happens. The chosen profiles have no
-// vault references, so `_prefillFromVault` never runs.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mobissh/services/task_ssh_gateway.dart';
 import 'package:mobissh/state/profiles_providers.dart';
-import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/storage/profiles_store.dart';
-import 'package:mobissh/ui/connect_form.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/profile_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-Widget _app(List<SavedProfile> profiles, InMemoryGatewayPair pair) {
+Widget _editorApp(SavedProfile profile) {
   return ProviderScope(
     overrides: [
-      savedProfilesProvider.overrideWith((ref) async => profiles),
-      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      profilesStoreProvider.overrideWithValue(ProfilesStore()),
+      secretsStoreProvider.overrideWithValue(
+        SecretsStore(backend: InMemorySecretsBackend()),
+      ),
     ],
-    child: const MaterialApp(
-      home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
-    ),
+    child: MaterialApp(home: ProfileEditor(profile: profile)),
   );
 }
 
@@ -43,18 +43,19 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  testWidgets('connect form renders an initial-command field', (tester) async {
-    final pair = InMemoryGatewayPair();
-    addTearDown(() async => pair.dispose());
-    await tester.pumpWidget(_app(const [], pair));
+  testWidgets('profile editor renders an initial-command field', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_editorApp(blankProfile()));
     await _settle(tester);
 
-    expect(find.byKey(const Key('connect-initial-command')), findsOneWidget);
+    expect(
+      find.byKey(const Key('profile-editor-initial-command')),
+      findsOneWidget,
+    );
   });
 
-  testWidgets('tapping a profile prefills its initialCommand', (tester) async {
-    final pair = InMemoryGatewayPair();
-    addTearDown(() async => pair.dispose());
+  testWidgets('editing a profile prefills its initialCommand', (tester) async {
     final profile = SavedProfile(
       title: 'Box',
       host: 'box.example',
@@ -62,14 +63,11 @@ void main() {
       username: 'me',
       initialCommand: 'tmux attach || tmux new',
     );
-    await tester.pumpWidget(_app([profile], pair));
-    await _settle(tester);
-
-    await tester.tap(find.byKey(Key('profile-tile-${profile.identityKey}')));
+    await tester.pumpWidget(_editorApp(profile));
     await _settle(tester);
 
     final field = tester.widget<TextField>(
-      find.byKey(const Key('connect-initial-command')),
+      find.byKey(const Key('profile-editor-initial-command')),
     );
     expect(field.controller?.text, 'tmux attach || tmux new');
   });
@@ -77,22 +75,17 @@ void main() {
   testWidgets('profile without initialCommand leaves the field empty', (
     tester,
   ) async {
-    final pair = InMemoryGatewayPair();
-    addTearDown(() async => pair.dispose());
     final profile = SavedProfile(
       title: 'Plain',
       host: 'plain.example',
       port: 22,
       username: 'me',
     );
-    await tester.pumpWidget(_app([profile], pair));
-    await _settle(tester);
-
-    await tester.tap(find.byKey(Key('profile-tile-${profile.identityKey}')));
+    await tester.pumpWidget(_editorApp(profile));
     await _settle(tester);
 
     final field = tester.widget<TextField>(
-      find.byKey(const Key('connect-initial-command')),
+      find.byKey(const Key('profile-editor-initial-command')),
     );
     expect(field.controller?.text, isEmpty);
   });

--- a/native/test/widget/new_session_affordance_test.dart
+++ b/native/test/widget/new_session_affordance_test.dart
@@ -21,9 +21,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/services/task_ssh_gateway.dart';
 import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/profiles_providers.dart';
 import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
 import 'package:mobissh/state/terminal_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
 import 'package:mobissh/ui/terminal_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -34,8 +37,17 @@ ProviderContainer _makeContainer() {
   final container = ProviderContainer(
     overrides: [
       taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      // The "New connection" → editor → "Save & connect" flow writes the
+      // credential through secretsStore and reads it back to connect, so both
+      // stores must be in-memory test seams (the default secure storage has no
+      // platform channel under flutter_test).
+      profilesStoreProvider.overrideWithValue(ProfilesStore()),
+      secretsStoreProvider.overrideWithValue(
+        SecretsStore(backend: InMemorySecretsBackend()),
+      ),
       sshShellOpenerProvider.overrideWithValue(
-          (ref, sessionId, terminal) async => FakeSshShellTransport()),
+        (ref, sessionId, terminal) async => FakeSshShellTransport(),
+      ),
     ],
   );
   addTearDown(() async {
@@ -61,7 +73,9 @@ void main() {
     final container = _makeContainer();
     addTearDown(container.dispose);
 
-    container.read(sessionsProvider.notifier).addOrActivate(
+    container
+        .read(sessionsProvider.notifier)
+        .addOrActivate(
           const SshConnectParams(
             host: 'host-a',
             port: 22,
@@ -85,59 +99,86 @@ void main() {
   });
 
   testWidgets(
-      'New session: menu -> connect form -> submit adds a 2nd session and pops',
-      (tester) async {
-    final container = _makeContainer();
-    addTearDown(container.dispose);
+    'New session: menu -> chooser -> New -> Save&connect adds a 2nd session',
+    (tester) async {
+      // #583: the new-session page is the profile CHOOSER now (no inline form).
+      // Starting an ad-hoc 2nd session goes through the editor: "New connection"
+      // -> fill the editor -> "Save & connect".
+      final container = _makeContainer();
+      addTearDown(container.dispose);
 
-    final notifier = container.read(sessionsProvider.notifier);
-    final a = notifier.addOrActivate(const SshConnectParams(
-      host: 'host-a',
-      port: 22,
-      username: 'u',
-      auth: SshAuth.password('p'),
-    ));
-    expect(container.read(sessionsProvider).entries.length, 1);
+      final notifier = container.read(sessionsProvider.notifier);
+      final a = notifier.addOrActivate(
+        const SshConnectParams(
+          host: 'host-a',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+      expect(container.read(sessionsProvider).entries.length, 1);
 
-    await tester.pumpWidget(
-      UncontrolledProviderScope(
-        container: container,
-        child: const MaterialApp(home: TerminalScreen()),
-      ),
-    );
-    await _pumpFrames(tester);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: TerminalScreen()),
+        ),
+      );
+      await _pumpFrames(tester);
 
-    // Open the session menu and tap "New session".
-    await tester.tap(find.byKey(const Key('session-menu-button')));
-    await _pumpFrames(tester);
-    await tester.tap(find.byKey(const Key('session-menu-new')));
-    await _pumpFrames(tester);
+      // Open the session menu and tap "New session".
+      await tester.tap(find.byKey(const Key('session-menu-button')));
+      await _pumpFrames(tester);
+      await tester.tap(find.byKey(const Key('session-menu-new')));
+      await _pumpFrames(tester);
 
-    // The menu is gone and the connect form is pushed on top.
-    expect(find.byKey(const Key('session-menu')), findsNothing);
-    expect(find.byKey(const Key('new-session-page')), findsOneWidget);
-    expect(find.byKey(const Key('new-session-form')), findsOneWidget);
+      // The menu is gone and the chooser is pushed on top — NOT a form.
+      expect(find.byKey(const Key('session-menu')), findsNothing);
+      expect(find.byKey(const Key('new-session-page')), findsOneWidget);
+      expect(find.byKey(const Key('new-session-form')), findsOneWidget);
 
-    // Fill a DIFFERENT host:port:username so addOrActivate creates a new
-    // entry (not a dedup-activate of host-a).
-    await tester.enterText(find.byKey(const Key('connect-host')), 'host-b');
-    await tester.enterText(find.byKey(const Key('connect-port')), '22');
-    await tester.enterText(find.byKey(const Key('connect-username')), 'u');
-    await tester.enterText(
-        find.byKey(const Key('connect-password')), 'p2');
-    await _pumpFrames(tester);
+      // Open the editor in create mode via the "New connection" affordance.
+      await tester.tap(find.byKey(const Key('new-connection')));
+      await _pumpFrames(tester);
+      expect(find.byKey(const Key('profile-editor')), findsOneWidget);
 
-    await tester.tap(find.byKey(const Key('connect-submit')));
-    await _pumpFrames(tester, count: 30);
+      // Fill a DIFFERENT host:port:username so addOrActivate creates a new
+      // entry (not a dedup-activate of host-a).
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-host')),
+        'host-b',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-port')),
+        '22',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-username')),
+        'u',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-password')),
+        'p2',
+      );
+      await _pumpFrames(tester);
 
-    // A second session now exists and is active. The pushed route stays
-    // mounted until its session reaches `connected` (so host-key prompts
-    // still render on this form) — that pop is exercised by the emulator
-    // integration test (`multi_session_lifecycle_test.dart`); the in-memory
-    // gateway here never emits a `connected` state, so we don't assert pop.
-    final state = container.read(sessionsProvider);
-    expect(state.entries.length, 2);
-    expect(state.activeId, isNot(a.id));
-    expect(state.active?.host, 'host-b');
-  });
+      // "Save & connect" persists the profile then routes through the chooser's
+      // shared connect path.
+      final submit = find.byKey(const Key('connect-submit'));
+      await tester.ensureVisible(submit);
+      await _pumpFrames(tester);
+      await tester.tap(submit);
+      await _pumpFrames(tester, count: 30);
+
+      // A second session now exists and is active. The pushed route stays
+      // mounted until its session reaches `connected` (so host-key prompts
+      // still render on the chooser) — that pop is exercised by the emulator
+      // integration test (`multi_session_lifecycle_test.dart`); the in-memory
+      // gateway here never emits a `connected` state, so we don't assert pop.
+      final state = container.read(sessionsProvider);
+      expect(state.entries.length, 2);
+      expect(state.activeId, isNot(a.id));
+      expect(state.active?.host, 'host-b');
+    },
+  );
 }

--- a/native/test/widget/profile_chooser_test.dart
+++ b/native/test/widget/profile_chooser_test.dart
@@ -1,0 +1,221 @@
+// Widget tests for the decluttered profile CHOOSER home view (#583).
+//
+// Locks the #583 contract:
+//   1. The home view (ConnectForm chooser) renders the profile list + a "New"
+//      affordance + Import, and does NOT contain the removed inline form
+//      (no connect-submit, no host/port TextFields, no status panel).
+//   2. The host-key prompt listener is STILL present off the formless chooser:
+//      when sshSessionDataProvider emits a pendingHostKey, the Trust dialog is
+//      shown. THIS is the regression guard for the relocation trap.
+//   3. Tapping "New connection" opens the editor in create mode (blank fields);
+//      Save upserts a profile.
+//
+// Sessions are proxy-backed; taskSshGatewayProvider is overridden with an
+// in-memory gateway pair so the connect path runs without binding to platform
+// statics.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/connect_form.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+ProviderContainer _container({
+  required ProfilesStore store,
+  required SecretsStore secrets,
+  required InMemoryGatewayPair pair,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      profilesStoreProvider.overrideWithValue(store),
+      secretsStoreProvider.overrideWithValue(secrets),
+    ],
+  );
+  return container;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('chooser renders profile list + New + Import; no inline form', (
+    tester,
+  ) async {
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    final container = _container(store: store, secrets: secrets, pair: pair);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Present: the New affordance + the Import action.
+    expect(find.byKey(const Key('new-connection')), findsOneWidget);
+    expect(
+      find.byKey(const Key('open-import-profiles-dialog')),
+      findsOneWidget,
+    );
+    // Empty profile list hint is present (no profiles seeded).
+    expect(find.byKey(const Key('profile-list-empty')), findsOneWidget);
+
+    // ABSENT: the removed inline form — no Connect button, no host/port/
+    // username/password fields on the home view.
+    expect(find.byKey(const Key('connect-submit')), findsNothing);
+    expect(find.byKey(const Key('connect-host')), findsNothing);
+    expect(find.byKey(const Key('connect-port')), findsNothing);
+    expect(find.byKey(const Key('connect-username')), findsNothing);
+    expect(find.byKey(const Key('connect-password')), findsNothing);
+    expect(find.byKey(const Key('connect-initial-command')), findsNothing);
+    // ABSENT: the status panel text.
+    expect(find.textContaining('State:'), findsNothing);
+  });
+
+  testWidgets('host-key prompt listener is present off the formless chooser '
+      '(relocation regression guard)', (tester) async {
+    // Seed a password profile + its vault secret so a tap connects.
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    await secrets.write('vault-1', <String, Object?>{'password': 'pw'});
+    await store.save(<SavedProfile>[
+      SavedProfile(
+        title: 'Box',
+        host: 'box.example',
+        port: 22,
+        username: 'alice',
+        authType: 'password',
+        vaultId: 'vault-1',
+      ),
+    ]);
+
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    final container = _container(store: store, secrets: secrets, pair: pair);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Tap the profile to connect — this creates the session entry whose proxy
+    // the host-key listener watches via sshSessionDataProvider.
+    await tester.tap(
+      find.byKey(const Key('profile-tile-box.example:22:alice')),
+    );
+    await _pumpFrames(tester, count: 30);
+
+    // Drive a host-key challenge from the task side through the gateway. The
+    // proxy turns it into a pendingHostKey; the chooser's
+    // ref.listen(sshSessionDataProvider) must then fire showHostKeyDialog.
+    final entry = container.read(sessionsProvider).entries.first;
+    pair.taskSide.send(
+      SshHostKeyChallengeEvent(
+        sessionId: entry.id,
+        host: 'box.example',
+        port: 22,
+        keyType: 'ssh-ed25519',
+        fingerprint: 'SHA256:abc123',
+      ).toJson(),
+    );
+    await _pumpFrames(tester, count: 20);
+
+    // The Trust + connect dialog appeared — the listener survived the form
+    // removal. Without the relocated listener, no dialog renders.
+    expect(find.text('Trust + connect'), findsOneWidget);
+  });
+
+  testWidgets('New connection opens the editor in create mode; Save upserts', (
+    tester,
+  ) async {
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    final container = _container(store: store, secrets: secrets, pair: pair);
+    addTearDown(container.dispose);
+
+    // Tall surface so the editor's Save button is on-screen and hit-testable.
+    tester.view.physicalSize = const Size(1000, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('new-connection')));
+    await tester.pumpAndSettle();
+
+    // Editor opened in create mode: title says "New connection", fields blank.
+    expect(find.byKey(const Key('profile-editor')), findsOneWidget);
+    expect(find.text('New connection'), findsOneWidget);
+    expect(
+      tester
+          .widget<TextField>(find.byKey(const Key('profile-editor-host')))
+          .controller
+          ?.text,
+      isEmpty,
+    );
+
+    // Fill in a new connection + Save (plain save, not connect).
+    await tester.enterText(
+      find.byKey(const Key('profile-editor-host')),
+      'new.example',
+    );
+    await tester.enterText(
+      find.byKey(const Key('profile-editor-username')),
+      'carol',
+    );
+    final save = find.byKey(const Key('profile-editor-save'));
+    await tester.ensureVisible(save);
+    await tester.pumpAndSettle();
+    await tester.tap(save);
+    await tester.pumpAndSettle();
+
+    final list = await store.load();
+    expect(list.length, 1);
+    expect(list.first.host, 'new.example');
+    expect(list.first.username, 'carol');
+    // No session created on a plain Save.
+    expect(container.read(sessionsProvider).entries, isEmpty);
+  });
+}

--- a/native/test/widget/profile_tap_connect_test.dart
+++ b/native/test/widget/profile_tap_connect_test.dart
@@ -102,8 +102,11 @@ void main() {
   );
 
   testWidgets(
-    'tapping a profile with NO stored creds falls back to form (no session)',
+    'tapping a profile with NO stored creds opens the editor (no session)',
     (tester) async {
+      // #583: the inline form is gone, so the no-creds fallback opens the
+      // profile editor (edit mode, prefilled) so the user can add the missing
+      // credential — NOT a silent no-op, and NOT the removed form.
       final store = ProfilesStore();
       final secrets = SecretsStore(backend: InMemorySecretsBackend());
       await store.save(<SavedProfile>[
@@ -145,11 +148,19 @@ void main() {
       );
       await _pumpFrames(tester, count: 20);
 
-      // No session created — fell back to form-fill.
+      // No session created — there were no usable credentials.
       expect(container.read(sessionsProvider).entries, isEmpty);
-      // The form was prefilled with the profile's host so the user can finish.
-      expect(find.text('bare.example'), findsOneWidget);
-      // And a snackbar nudged them to enter credentials.
+      // The editor opened, prefilled with the profile's host so the user can
+      // add the credential and connect.
+      expect(find.byKey(const Key('profile-editor')), findsOneWidget);
+      expect(
+        tester
+            .widget<TextField>(find.byKey(const Key('profile-editor-host')))
+            .controller
+            ?.text,
+        'bare.example',
+      );
+      // A snackbar nudged them to enter credentials.
       expect(find.textContaining('No saved credentials'), findsOneWidget);
     },
   );


### PR DESCRIPTION
## Summary
Declutters the native home/profiles view into an uncluttered profile **chooser** for human decision. The inline connect form (host/port/username/auth/initial-command fields + Connect button) and the connection-status panel are removed. Tap a profile = connect; pencil = edit; a single "New connection" affordance opens the editor for an ad-hoc / new connection. Mirrors the refined PWA's profile-first connect view (#580 / `feedback_native_is_pwa_ux_duplicate`).

## What moved (the relocation trap)
The form removal could have silently dropped the connect plumbing. It was **relocated**, not lost, onto the always-mounted chooser `State` (`native/lib/ui/connect_form.dart`):
- Host-key prompt listener: `ref.listen(sshSessionDataProvider)` → `_handleHostKeyPrompt` → `showHostKeyDialog`.
- Connect dispatch: `_connectWithParams` (addOrActivate → arm `InitialCommandRunner` → `proxy.connect`) and `_connectFromProfile`.
- `_popWhenConnected` for the pushed New-session route.

The editor (`native/lib/ui/profile_editor.dart`) is now the new/ad-hoc connection entry:
- `showProfileEditorForNew` + `blankProfile()` for create mode (blank fields, no delete, "New connection" title).
- A `connect-submit`-keyed **Save & connect** button that persists then returns the saved profile so the chooser connects it through the same shared path. Plain **Save** remains.
- `ProfileEditorResult { saved, connect }` is the editor's return contract.

The no-stored-creds fallback now opens the editor (edit mode, prefilled) instead of the removed form — not a silent no-op.

`NewSessionPage` hosts the same chooser (keeps `new-session-page` / `new-session-form` keys). `ConnectHomePage` body is now just the chooser; `_StatusPanel` is deleted (`native/lib/main.dart`).

## Test coverage
New `native/test/widget/profile_chooser_test.dart`:
- Chooser renders the profile list + New + Import and does **NOT** contain `connect-submit`, the host/port/username/password/initial-command fields, or the status panel.
- **Host-key-listener regression guard:** tapping a profile connects, then an `SshHostKeyChallengeEvent` driven through the in-memory gateway must surface the `Trust + connect` dialog off the formless chooser. This is the explicit guard against the relocation trap.
- "New connection" opens the editor in create mode (blank) and Save upserts a profile (no session on plain Save).

Updated existing tests:
- `profile_tap_connect_test.dart`: no-creds tap opens the editor (not the removed form).
- `initial_command_field_test.dart`: the initial-command field now lives on the editor.
- `new_session_affordance_test.dart`: New session → chooser → "New connection" → editor → Save & connect adds the 2nd session.
- Emulator integration smokes (`connect_smoke`, `connect_key_smoke`, `shell_bytes_smoke`, `reconnect_cycle`, `hostkey_persist`, `multi_session_lifecycle`, `import_smoke`) routed through New → editor → Save & connect via a shared `integration_test/support/connect_helpers.dart` (`adhocPasswordConnect` / `adhocKeyConnect`). These run on the orchestrator's emulator, not the fast gate.

`scripts/native-fast-gate.sh`: analyze clean, 297 tests pass (integration-tagged skipped).

## Device validation (orchestrator / not done here)
Mobile UX — needs emulator/device validation of: decluttered view, tap-to-connect + host-key prompt, "New connection" create + connect. Not device-tested in this PR.

Closes #583