### PR TITLE
fix: SFTP/PDF download honors chunk offset — byte-exact reassembly (#591)

### DIFF
--- a/native/lib/services/pdf_fetcher.dart
+++ b/native/lib/services/pdf_fetcher.dart
@@ -54,6 +54,12 @@ class ProxyPdfFetcher implements PdfFetcher {
     final completer = Completer<File>();
     var received = 0;
 
+    // Serialize sink writes through a single Future chain. Chunks can arrive
+    // reordered over the gateway (#591); the sink writes each at its offset, so
+    // ordering doesn't affect correctness, but we still chain so `done` runs
+    // AFTER every chunk write has completed and so write errors surface.
+    Future<void> pending = Future<void>.value();
+
     late final StreamSubscription<SshTaskEvent> sub;
     Future<void> cleanupAndFail(Object error) async {
       await sink.abort();
@@ -66,13 +72,16 @@ class ProxyPdfFetcher implements PdfFetcher {
           if (event.requestId != requestId) return;
           received += event.bytes.length;
           onProgress?.call(received, event.totalBytes);
-          // addChunk is fire-and-forget ordered; await via microtask chain.
-          unawaited(sink.addChunk(event.bytes));
+          final bytes = event.bytes;
+          final offset = event.offset;
+          pending = pending.then((_) => sink.addChunk(bytes, offset));
         case SftpDownloadDoneEvent():
           if (event.requestId != requestId) return;
+          final expected = event.totalBytes;
           unawaited(() async {
             try {
-              await sink.finish();
+              await pending; // drain all chunk writes first
+              await sink.finish(expectedTotal: expected);
               if (!completer.isCompleted) completer.complete(sink.file);
             } catch (e) {
               await cleanupAndFail(e);

--- a/native/lib/services/sftp_download.dart
+++ b/native/lib/services/sftp_download.dart
@@ -1,4 +1,4 @@
-// SFTP download destination seam (#559).
+// SFTP download destination seam (#559, #591).
 //
 // The task isolate streams file chunks across IPC (base64); the UI assembles
 // them into a destination on the device. This file owns the *destination*
@@ -14,20 +14,33 @@
 //
 // Keeping the assembly here (not in the widget) means Slice 2's folder
 // download can reuse it per-file.
+//
+// #591 (data corruption): chunks MUST be written at their byte offset, not
+// appended in arrival order. Each [SftpDownloadChunkEvent] carries an `offset`;
+// the gateway can deliver them reordered (and a fire-and-forget write can race
+// them), so an append-only sink silently corrupts any multi-chunk file. The
+// sinks below write each chunk at its offset via a [RandomAccessFile] and
+// [finish] verifies the total length so a truncated transfer can't be reported
+// as a success.
 
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:path_provider/path_provider.dart';
 
-/// A growing destination for a single downloaded file. Chunks arrive in order
-/// from the task isolate; [addChunk] appends, [finish] flushes + returns a
-/// human-readable location for the success snackbar.
+/// A destination for a single downloaded file. Chunks arrive from the task
+/// isolate keyed by their byte [offset] (NOT guaranteed in order); [addChunk]
+/// writes each at its offset, [finish] verifies the total length, flushes +
+/// closes, and returns a human-readable location for the success snackbar.
 abstract class FileDownloadSink {
-  Future<void> addChunk(Uint8List bytes);
+  /// Write [bytes] at byte [offset]. Safe to call out of order.
+  Future<void> addChunk(Uint8List bytes, int offset);
 
-  /// Flush + close. Returns a display path / URI for the completion message.
-  Future<String> finish();
+  /// Flush + close. [expectedTotal], when known (the server-reported size /
+  /// the `done` event's totalBytes), is verified against the bytes actually
+  /// written; a mismatch throws so a corrupt/truncated file is never reported
+  /// as a successful download. Returns a display path / URI.
+  Future<String> finish({int? expectedTotal});
 
   /// Abort + clean up a partial file (called on error / cancel).
   Future<void> abort();
@@ -44,20 +57,93 @@ Future<FileDownloadSink> defaultDownloadSinkFactory(String fileName) async {
   return AppDownloadsSink.create(fileName);
 }
 
+/// Offset-honoring core sink: writes chunks at their byte offset into a given
+/// [File] via a [RandomAccessFile], tracks the highest end position written,
+/// and verifies the total length on [finish]. Both [AppDownloadsSink] and
+/// [TempFileSink] resolve a destination directory then delegate here, so the
+/// reassembly logic is shared and unit-testable without path_provider (pass a
+/// plain temp [File]).
+class OffsetFileSink implements FileDownloadSink {
+  OffsetFileSink._(this.file, this._raf);
+
+  /// The file being assembled.
+  final File file;
+  final RandomAccessFile _raf;
+
+  /// One byte past the highest offset written — the assembled length so far.
+  int _highWater = 0;
+
+  /// Open [file] for random-access writing (truncating any prior content).
+  static Future<OffsetFileSink> create(File file) async {
+    final parent = file.parent;
+    if (!await parent.exists()) {
+      await parent.create(recursive: true);
+    }
+    // WRITE mode truncates to empty, giving us a clean canvas to seek into.
+    final raf = await file.open(mode: FileMode.write);
+    return OffsetFileSink._(file, raf);
+  }
+
+  @override
+  Future<void> addChunk(Uint8List bytes, int offset) async {
+    if (bytes.isEmpty) return;
+    await _raf.setPosition(offset);
+    await _raf.writeFrom(bytes);
+    final end = offset + bytes.length;
+    if (end > _highWater) _highWater = end;
+  }
+
+  @override
+  Future<String> finish({int? expectedTotal}) async {
+    await _raf.flush();
+    await _raf.close();
+    if (expectedTotal != null && _highWater != expectedTotal) {
+      // The transfer is short (or over-long): do NOT present a corrupt file as
+      // a completed download. Clean up and surface the mismatch.
+      try {
+        if (await file.exists()) await file.delete();
+      } catch (_) {
+        /* best-effort */
+      }
+      throw Exception(
+        'Download incomplete: wrote $_highWater of $expectedTotal bytes',
+      );
+    }
+    return file.path;
+  }
+
+  @override
+  Future<void> abort() async {
+    try {
+      await _raf.close();
+    } catch (_) {
+      /* ignore */
+    }
+    try {
+      if (await file.exists()) await file.delete();
+    } catch (_) {
+      /* ignore */
+    }
+  }
+}
+
 /// Writes into the app's external Downloads directory (Android) or the app
 /// documents directory (fallback). Scoped storage — no broad-storage perms.
+/// Delegates offset-honoring assembly + length verification to [OffsetFileSink].
 class AppDownloadsSink implements FileDownloadSink {
-  AppDownloadsSink._(this._file, this._sink);
+  AppDownloadsSink._(this._inner);
 
-  final File _file;
-  final IOSink _sink;
+  final OffsetFileSink _inner;
+
+  /// The destination file path (for tests / callers that need it).
+  String get path => _inner.file.path;
 
   static Future<AppDownloadsSink> create(String fileName) async {
     final dir = await _resolveDownloadsDir();
     final safeName = _sanitize(fileName);
     final file = File('${dir.path}/$safeName');
-    final sink = file.openWrite();
-    return AppDownloadsSink._(file, sink);
+    final inner = await OffsetFileSink.create(file);
+    return AppDownloadsSink._(inner);
   }
 
   static Future<Directory> _resolveDownloadsDir() async {
@@ -93,42 +179,29 @@ class AppDownloadsSink implements FileDownloadSink {
   }
 
   @override
-  Future<void> addChunk(Uint8List bytes) async {
-    _sink.add(bytes);
-  }
+  Future<void> addChunk(Uint8List bytes, int offset) =>
+      _inner.addChunk(bytes, offset);
 
   @override
-  Future<String> finish() async {
-    await _sink.flush();
-    await _sink.close();
-    return _file.path;
-  }
+  Future<String> finish({int? expectedTotal}) =>
+      _inner.finish(expectedTotal: expectedTotal);
 
   @override
-  Future<void> abort() async {
-    try {
-      await _sink.close();
-    } catch (_) {
-      /* ignore */
-    }
-    try {
-      if (await _file.exists()) await _file.delete();
-    } catch (_) {
-      /* ignore */
-    }
-  }
+  Future<void> abort() => _inner.abort();
 }
 
 /// Writes a download into a private app TEMP directory rather than Downloads.
 /// Used by the in-app PDF viewer (#557): the file is fetched to temp, rendered,
 /// then deleted on close. [finish] returns the temp file path; [file] exposes
-/// the [File] so the caller can delete it explicitly.
+/// the [File] so the caller can delete it explicitly. Delegates offset-honoring
+/// assembly + length verification to [OffsetFileSink].
 class TempFileSink implements FileDownloadSink {
-  TempFileSink._(this.file, this._sink);
+  TempFileSink._(this._inner);
+
+  final OffsetFileSink _inner;
 
   /// The temp file being written. The caller deletes this when done.
-  final File file;
-  final IOSink _sink;
+  File get file => _inner.file;
 
   static Future<TempFileSink> create(String fileName) async {
     final base = await getTemporaryDirectory();
@@ -138,7 +211,8 @@ class TempFileSink implements FileDownloadSink {
     final safeName = _sanitizeTemp(fileName);
     final stamp = DateTime.now().microsecondsSinceEpoch;
     final file = File('${dir.path}/$stamp-$safeName');
-    return TempFileSink._(file, file.openWrite());
+    final inner = await OffsetFileSink.create(file);
+    return TempFileSink._(inner);
   }
 
   static String _sanitizeTemp(String name) {
@@ -147,28 +221,13 @@ class TempFileSink implements FileDownloadSink {
   }
 
   @override
-  Future<void> addChunk(Uint8List bytes) async {
-    _sink.add(bytes);
-  }
+  Future<void> addChunk(Uint8List bytes, int offset) =>
+      _inner.addChunk(bytes, offset);
 
   @override
-  Future<String> finish() async {
-    await _sink.flush();
-    await _sink.close();
-    return file.path;
-  }
+  Future<String> finish({int? expectedTotal}) =>
+      _inner.finish(expectedTotal: expectedTotal);
 
   @override
-  Future<void> abort() async {
-    try {
-      await _sink.close();
-    } catch (_) {
-      /* ignore */
-    }
-    try {
-      if (await file.exists()) await file.delete();
-    } catch (_) {
-      /* ignore */
-    }
-  }
+  Future<void> abort() => _inner.abort();
 }

--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -96,6 +96,12 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
   FileDownloadSink? _downloadSink;
   String? _downloadName;
 
+  /// Serializes sink writes so a `done` event flushes only after every chunk
+  /// write has completed. Chunks can arrive reordered over the gateway (#591);
+  /// the sink writes each at its byte offset so order doesn't affect the bytes,
+  /// but chaining keeps `finish` strictly after the last write.
+  Future<void> _downloadWrites = Future<void>.value();
+
   bool _attached = false;
 
   @override
@@ -174,7 +180,7 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
         });
       case SftpDownloadChunkEvent():
         if (event.requestId != _downloadRequestId) return;
-        unawaited(_onChunk(event));
+        _onChunk(event);
       case SftpDownloadDoneEvent():
         if (event.requestId != _downloadRequestId) return;
         unawaited(_onDownloadDone(event));
@@ -185,13 +191,17 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     }
   }
 
-  Future<void> _onChunk(SftpDownloadChunkEvent event) async {
+  void _onChunk(SftpDownloadChunkEvent event) {
     final sink = _downloadSink;
     if (sink == null) return;
-    await sink.addChunk(event.bytes);
+    final bytes = event.bytes;
+    final offset = event.offset;
+    // Write at the chunk's byte offset (#591). Chain writes so `done` only
+    // flushes after they all complete.
+    _downloadWrites = _downloadWrites.then((_) => sink.addChunk(bytes, offset));
     if (!mounted) return;
     setState(() {
-      _downloadReceived += event.bytes.length;
+      _downloadReceived += bytes.length;
       _downloadTotal = event.totalBytes;
     });
   }
@@ -201,13 +211,20 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     final name = _downloadName ?? 'file';
     _downloadSink = null;
     String? location;
+    var failed = false;
     if (sink != null) {
       try {
-        location = await sink.finish();
+        await _downloadWrites; // drain all chunk writes first
+        location = await sink.finish(expectedTotal: event.totalBytes);
       } catch (e) {
+        // Length mismatch / write failure → the file is corrupt. Clean up and
+        // report failure rather than claiming a successful download (#591).
+        failed = true;
+        await sink.abort();
         location = null;
       }
     }
+    _downloadWrites = Future<void>.value();
     if (!mounted) return;
     setState(() {
       _downloadRequestId = null;
@@ -215,6 +232,10 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
       _downloadTotal = null;
       _downloadName = null;
     });
+    if (failed) {
+      _snack('Download failed: $name was incomplete');
+      return;
+    }
     final msg = location != null
         ? 'Downloaded $name → $location'
         : 'Downloaded $name';

--- a/native/test/services/sftp_download_reassembly_test.dart
+++ b/native/test/services/sftp_download_reassembly_test.dart
@@ -1,0 +1,124 @@
+// Regression test for #591 — SFTP/PDF download corrupts large files when
+// chunks are written without honoring their byte offset.
+//
+// The download path carries a byte `offset` for every chunk
+// (SftpDownloadChunkEvent.offset) but the destination sink historically
+// appended chunks in *arrival order*, assuming in-order delivery. A reordered
+// or partial chunk therefore produced a corrupt file. This test drives the sink
+// with chunks delivered OUT OF ORDER and asserts the reassembled file is
+// byte-for-byte identical to the source (content digest + exact byte compare),
+// which fails on the append-in-arrival-order implementation.
+
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/sftp_download.dart';
+
+/// Byte-exact comparison via a content digest. Avoids pulling in the `crypto`
+/// package (only a transitive dep): a simple FNV-1a-style rolling hash over
+/// every byte detects any reorder/truncation/overlap corruption, and we also
+/// assert exact length + a direct byte equality.
+int _digest(List<int> bytes) {
+  var h = 0xcbf29ce484222325 & 0x7fffffffffffffff;
+  for (final b in bytes) {
+    h = (h ^ b) & 0x7fffffffffffffff;
+    h = (h * 0x100000001b3) & 0x7fffffffffffffff;
+  }
+  return h;
+}
+
+/// Split [source] into fixed-size chunks paired with their byte offset.
+List<({Uint8List bytes, int offset})> _chunkify(Uint8List source, int size) {
+  final out = <({Uint8List bytes, int offset})>[];
+  for (var o = 0; o < source.length; o += size) {
+    final end = min(o + size, source.length);
+    out.add((bytes: Uint8List.sublistView(source, o, end), offset: o));
+  }
+  return out;
+}
+
+void main() {
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('mobissh_dl_591_');
+  });
+
+  tearDown(() async {
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  /// Source large enough to need many chunks: 256 KiB of pseudo-random bytes.
+  Uint8List makeSource() {
+    final rng = Random(0xC0FFEE);
+    final b = Uint8List(256 * 1024);
+    for (var i = 0; i < b.length; i++) {
+      b[i] = rng.nextInt(256);
+    }
+    return b;
+  }
+
+  test(
+    'reassembles a multi-chunk file byte-exact when chunks arrive in order',
+    () async {
+      final source = makeSource();
+      final file = File('${tmp.path}/in-order.bin');
+      final sink = await OffsetFileSink.create(file);
+
+      for (final c in _chunkify(source, 64 * 1024)) {
+        await sink.addChunk(c.bytes, c.offset);
+      }
+      await sink.finish(expectedTotal: source.length);
+
+      final written = await file.readAsBytes();
+      expect(written.length, source.length);
+      expect(_digest(written), _digest(source));
+      expect(written, equals(source));
+    },
+  );
+
+  test('reassembles a multi-chunk file byte-exact when chunks arrive REORDERED '
+      '(the #591 corruption case)', () async {
+    final source = makeSource();
+    final file = File('${tmp.path}/reordered.bin');
+    final sink = await OffsetFileSink.create(file);
+
+    final chunks = _chunkify(source, 64 * 1024);
+    // Shuffle so chunks are delivered out of arrival order — exactly the
+    // condition that corrupts an append-only sink.
+    chunks.shuffle(Random(42));
+    for (final c in chunks) {
+      await sink.addChunk(c.bytes, c.offset);
+    }
+    await sink.finish(expectedTotal: source.length);
+
+    final written = await file.readAsBytes();
+    expect(written.length, source.length);
+    expect(
+      _digest(written),
+      _digest(source),
+      reason: 'reordered chunks must reassemble byte-for-byte by offset',
+    );
+    expect(written, equals(source));
+  });
+
+  test('finish() rejects a truncated transfer (length verification)', () async {
+    final source = makeSource();
+    final file = File('${tmp.path}/short.bin');
+    final sink = await OffsetFileSink.create(file);
+
+    // Deliver everything except the last chunk.
+    final chunks = _chunkify(source, 64 * 1024);
+    for (final c in chunks.sublist(0, chunks.length - 1)) {
+      await sink.addChunk(c.bytes, c.offset);
+    }
+
+    expect(
+      () => sink.finish(expectedTotal: source.length),
+      throwsA(isA<Exception>()),
+      reason: 'a transfer missing bytes must not be reported as complete',
+    );
+  });
+}

--- a/native/test/widget/file_browser_widget_test.dart
+++ b/native/test/widget/file_browser_widget_test.dart
@@ -62,17 +62,31 @@ class _ScriptedSftpSession implements SftpSession {
   Future<void> close() async {}
 }
 
-/// In-memory sink so the download path runs without a real filesystem.
+/// In-memory sink so the download path runs without a real filesystem. Honors
+/// the chunk byte offset (#591) by writing into an offset-indexed buffer, so it
+/// faithfully mirrors the real [OffsetFileSink] semantics.
 class _MemSink implements FileDownloadSink {
-  final BytesBuilder _b = BytesBuilder();
+  final List<int> _buf = <int>[];
   bool finished = false;
+  int? finishExpectedTotal;
 
   @override
-  Future<void> addChunk(Uint8List bytes) async => _b.add(bytes);
+  Future<void> addChunk(Uint8List bytes, int offset) async {
+    final end = offset + bytes.length;
+    while (_buf.length < end) {
+      _buf.add(0);
+    }
+    for (var i = 0; i < bytes.length; i++) {
+      _buf[offset + i] = bytes[i];
+    }
+  }
+
+  Uint8List toBytes() => Uint8List.fromList(_buf);
 
   @override
-  Future<String> finish() async {
+  Future<String> finish({int? expectedTotal}) async {
     finished = true;
+    finishExpectedTotal = expectedTotal;
     return '/test/Download/captured';
   }
 
@@ -93,24 +107,27 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  testWidgets('lists entries; navigates into a dir; tapping a file downloads',
-      (tester) async {
+  testWidgets('lists entries; navigates into a dir; tapping a file downloads', (
+    tester,
+  ) async {
     final pair = InMemoryGatewayPair();
     addTearDown(pair.dispose);
 
     final fileBytes = List<int>.generate(12, (i) => i + 1);
-    final fake = _ScriptedSftpSession(
-      {
-        '/': const [
-          SftpEntry(name: 'docs', path: '/docs', isDirectory: true),
-          SftpEntry(name: 'a.txt', path: '/a.txt', isDirectory: false, size: 12),
-        ],
-        '/docs': const [
-          SftpEntry(name: 'inner.bin', path: '/docs/inner.bin', isDirectory: false, size: 12),
-        ],
-      },
-      fileBytes,
-    );
+    final fake = _ScriptedSftpSession({
+      '/': const [
+        SftpEntry(name: 'docs', path: '/docs', isDirectory: true),
+        SftpEntry(name: 'a.txt', path: '/a.txt', isDirectory: false, size: 12),
+      ],
+      '/docs': const [
+        SftpEntry(
+          name: 'inner.bin',
+          path: '/docs/inner.bin',
+          isDirectory: false,
+          size: 12,
+        ),
+      ],
+    }, fileBytes);
 
     final host = SessionHost(
       gateway: pair.taskSide,
@@ -123,8 +140,7 @@ void main() {
     final container = ProviderContainer(
       overrides: [
         taskSshGatewayProvider.overrideWithValue(pair.uiSide),
-        downloadSinkFactoryProvider
-            .overrideWithValue((name) async => memSink),
+        downloadSinkFactoryProvider.overrideWithValue((name) async => memSink),
       ],
     );
     addTearDown(container.dispose);
@@ -135,8 +151,9 @@ void main() {
       username: 'u',
       auth: SshAuth.password('p'),
     );
-    final entry =
-        container.read(sessionsProvider.notifier).addOrActivate(params);
+    final entry = container
+        .read(sessionsProvider.notifier)
+        .addOrActivate(params);
     // Register the session on the host so its SFTP opener can resolve. (The
     // controller's connect never reaches a real socket; we only need the host
     // to hold the session entry.)
@@ -145,9 +162,7 @@ void main() {
     await tester.pumpWidget(
       UncontrolledProviderScope(
         container: container,
-        child: MaterialApp(
-          home: FileBrowserScreen(sessionId: entry.id),
-        ),
+        child: MaterialApp(home: FileBrowserScreen(sessionId: entry.id)),
       ),
     );
     await _pump(tester);
@@ -173,7 +188,7 @@ void main() {
     await _pump(tester);
 
     expect(memSink.finished, isTrue);
-    expect(memSink._b.toBytes(), Uint8List.fromList(fileBytes));
+    expect(memSink.toBytes(), Uint8List.fromList(fileBytes));
     // Success snackbar.
     expect(find.textContaining('Downloaded a.txt'), findsOneWidget);
 
@@ -194,9 +209,7 @@ void main() {
     );
 
     final container = ProviderContainer(
-      overrides: [
-        taskSshGatewayProvider.overrideWithValue(pair.uiSide),
-      ],
+      overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
     );
     addTearDown(container.dispose);
 
@@ -206,8 +219,9 @@ void main() {
       username: 'u',
       auth: SshAuth.password('p'),
     );
-    final entry =
-        container.read(sessionsProvider.notifier).addOrActivate(params);
+    final entry = container
+        .read(sessionsProvider.notifier)
+        .addOrActivate(params);
     entry.proxy.connect(params);
 
     await tester.pumpWidget(
@@ -230,10 +244,11 @@ class _ThrowingSftpSession implements SftpSession {
   @override
   Future<int?> sizeOf(String path) async => null;
   @override
-  Future<int> download(String path,
-          {required void Function(Uint8List chunk, int offset) onChunk,
-          int chunkSize = 64 * 1024}) async =>
-      0;
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async => 0;
   @override
   Future<void> close() async {}
 }


### PR DESCRIPTION
## Summary

P0 data-corruption fix. Large multi-chunk SFTP downloads (and PDF fetches) were
silently corrupted. The byte `offset` was carried end-to-end already
(`SftpDownloadChunkEvent.offset` survives the task-isolate IPC envelope), but
the **destination sink dropped it** and appended chunks in arrival order,
assuming in-order delivery. `pdf_fetcher` even did
`unawaited(sink.addChunk(...))`, actively racing the writes. A reordered or
partial chunk produced a corrupt file, and nothing verified the total length.

## Root cause

`FileDownloadSink.addChunk(Uint8List bytes)` had no offset parameter; both
`AppDownloadsSink` and `TempFileSink` just appended via `IOSink.add`. Both
consumers (`pdf_fetcher.dart`, `file_browser_screen.dart`) dropped
`event.offset` and fed bytes in receive order. Single-chunk files looked fine;
multi-chunk files corrupted.

## Fix (carry + honor offset, verify length — smallest correct change)

- `FileDownloadSink.addChunk(bytes, offset)`; `finish({int? expectedTotal})`
  verifies bytes written against the expected size.
- New `OffsetFileSink` core writes each chunk **at its byte offset** via
  `RandomAccessFile` (`setPosition` + `writeFrom`), tracks the high-water
  length, and on `finish` throws + deletes the partial if the length doesn't
  match. `AppDownloadsSink` / `TempFileSink` delegate to it.
- `pdf_fetcher.dart` and `file_browser_screen.dart` pass `event.offset`,
  serialize writes through a single `Future` chain so `done` flushes only after
  every write completes, and on a length mismatch abort + report failure
  instead of claiming success.

## Byte-exact red → green test

`native/test/services/sftp_download_reassembly_test.dart`:

- **Reorder case (the #591 corruption):** chunkify a 256 KiB pseudo-random
  source into 64 KiB chunks, **shuffle** them, feed to the sink, then assert the
  written file equals the source byte-for-byte (content digest + exact byte
  compare + exact length).
- In-order case (sanity).
- Truncation case: `finish(expectedTotal:)` throws when a chunk is missing.

Confirmed **red** before the fix: `OffsetFileSink` / the offset-aware API didn't
exist (append-in-arrival-order sink can't reassemble reordered chunks).
**Green** after. The widget test's `_MemSink` was updated to the offset-aware
contract and still asserts byte-exact assembly.

`scripts/native-fast-gate.sh`: analyze clean, all 301 tests pass.

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)