### PR TITLE
fix: reconnect re-opens a live shell — byte-flow restored (#590)

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -194,6 +194,18 @@ class SessionHost {
         _emitConnectStatus(cmd.sessionId, data);
         prevState = data.state;
       }
+      // Drop the prior shell the instant the transport leaves `connected`
+      // (reconnecting / softDisconnected / failed / disconnected). The old PTY
+      // belongs to a dead `SSHClient`; relying on the async `transport.done`
+      // callback to clear `hosted.shell` is a RACE — on auto-reconnect the new
+      // `connected` can arrive before that microtask runs, so `_ensureShell`
+      // sees a non-null (dead) handle, no-ops, and zero bytes flow while the
+      // UI shows `connected` (#590, the stale-shell dead-terminal). Clearing
+      // here, synchronously, guarantees the next `connected` opens a FRESH
+      // shell whose output re-pipes to the terminal.
+      if (data.state != SshSessionState.connected) {
+        _dropShell(hosted);
+      }
       // Open the PTY shell the first time we reach `connected` (and re-open
       // after a reconnect, which re-enters `connected`). Without this the
       // terminal screen mounts but never receives a single byte — the device
@@ -270,6 +282,35 @@ class SessionHost {
     _gateway.send(SshClosedEvent(sessionId: sessionId).toJson());
   }
 
+  /// Synchronously drop the live shell handle for [hosted] when the session
+  /// leaves `connected`. Cancels the output subscription and closes the PTY so
+  /// the NEXT `connected` (auto-reconnect) re-opens a fresh shell via
+  /// [_ensureShell] instead of reusing a dead handle (#590). Idempotent: a
+  /// no-op when no shell is open. `shellOpening` is also cleared so an in-flight
+  /// open from the prior connection can't win a late race and re-attach a stale
+  /// transport.
+  void _dropShell(_HostedSession hosted) {
+    hosted.shellOpening = false;
+    // Invalidate any in-flight open: a `_shellOpener` await that started under
+    // the prior connection must NOT attach its (now stale) transport after we
+    // reconnect. `_ensureShell` re-checks the generation after its await.
+    hosted.shellGeneration += 1;
+    final sub = hosted.shellSub;
+    hosted.shellSub = null;
+    if (sub != null) {
+      unawaited(sub.cancel());
+    }
+    final shell = hosted.shell;
+    hosted.shell = null;
+    if (shell != null) {
+      try {
+        shell.close();
+      } catch (_) {
+        /* ignore */
+      }
+    }
+  }
+
   /// Open the PTY shell for [sessionId] once authenticated, and pipe its
   /// output back to the UI terminal as [SshOutputEvent]s. Idempotent: a second
   /// call while a shell is open or opening is a no-op (covers the reconnect
@@ -280,6 +321,7 @@ class SessionHost {
     final client = hosted.controller.client;
     if (client == null) return;
     hosted.shellOpening = true;
+    final openGen = hosted.shellGeneration;
     try {
       final cols = hosted.metrics.lastCols ?? 80;
       final rows = hosted.metrics.lastRows ?? 24;
@@ -288,8 +330,12 @@ class SessionHost {
         _emitStatus(sessionId, '\r\n[mobissh] no shell channel available\r\n');
         return;
       }
-      // The session may have been torn down while we awaited the channel.
-      if (!_sessions.containsKey(sessionId)) {
+      // The session may have been torn down — or dropped + reconnected (#590) —
+      // while we awaited the channel. If the generation moved, this transport
+      // belongs to a connection that's already gone: close it and bail so the
+      // post-reconnect `_ensureShell` opens the live one.
+      if (!_sessions.containsKey(sessionId) ||
+          hosted.shellGeneration != openGen) {
         try {
           transport.close();
         } catch (_) {
@@ -311,8 +357,12 @@ class SessionHost {
         },
       );
       // Drop the shell when the remote channel closes so a reconnect re-opens.
+      // Guard with the generation: a late `done` from THIS transport must not
+      // null out a shell that a subsequent reconnect already re-opened (#590).
+      final doneGen = hosted.shellGeneration;
       unawaited(
         transport.done.then((_) {
+          if (hosted.shellGeneration != doneGen) return;
           hosted.shellSub?.cancel();
           hosted.shellSub = null;
           hosted.shell = null;
@@ -654,6 +704,12 @@ class _HostedSession {
   SshShellTransport? shell;
   StreamSubscription<Uint8List>? shellSub;
   bool shellOpening = false;
+
+  /// Monotonic token bumped each time the shell is dropped (#590). An in-flight
+  /// [SessionHost._ensureShell] open captures this before awaiting and discards
+  /// its transport if the token changed — so a stale open from a dropped
+  /// connection can't re-attach after a reconnect.
+  int shellGeneration = 0;
 
   /// Fingerprint of the host-key challenge already forwarded to the UI, so a
   /// single awaitingHostKey transition emits exactly one challenge (#536).

--- a/native/test/services/reconnect_shell_revive_test.dart
+++ b/native/test/services/reconnect_shell_revive_test.dart
@@ -1,0 +1,258 @@
+// #590 — auto-reconnect must re-open a LIVE shell (byte-flow restored).
+//
+// State-transition regression: after the SSH transport drops and the controller
+// auto-reconnects (reconnecting/softDisconnected → connected), the task-side
+// host previously reused the prior connection's (dead) PTY shell handle. The
+// `_HostedSession.shell` guard in `_ensureShell` made the second `connected`
+// a no-op, so ZERO bytes flowed while the UI showed `connected` — a live-looking
+// but frozen terminal.
+//
+// This is the byte-flow gate the fast gate was missing for the reconnect path.
+// It runs HEADLESS via InMemoryGatewayPair + a fake `HostShellOpener` that
+// hands out a FRESH transport per open (each emitting a prompt byte). The bug =
+// the SECOND byte-flow assertion fails because no new shell was opened on
+// reconnect.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/ssh/ssh_shell.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+
+/// A socket that never emits and never errors — lets us construct a real
+/// [SSHClient] so `controller.client` is non-null (the gate `_ensureShell`
+/// checks) WITHOUT any network IO or pending timers.
+class _SilentSocket implements SSHSocket {
+  final _outbound = StreamController<List<int>>();
+  final _doneCompleter = Completer<void>();
+
+  @override
+  Stream<Uint8List> get stream => const Stream<Uint8List>.empty();
+
+  @override
+  StreamSink<List<int>> get sink => _outbound.sink;
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() async {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    await _outbound.close();
+    return done;
+  }
+
+  @override
+  void destroy() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+}
+
+/// Controller that exposes a non-null [client] sentinel so the host's shell
+/// opener seam is reached, and lets the test drive `connected` /
+/// transport-drop transitions deterministically (no real socket auth).
+class _DrivableController extends SshSessionController {
+  _DrivableController(this._client);
+
+  final SSHClient _client;
+
+  @override
+  SSHClient? get client => _client;
+}
+
+/// A fake PTY transport. Each instance emits a one-byte "prompt" on open so a
+/// listener can prove bytes flowed for THIS connection. `done` can be completed
+/// to simulate the channel closing on transport drop.
+class _FakeShellTransport implements SshShellTransport {
+  _FakeShellTransport(this.tag);
+
+  final String tag;
+  final _outCtrl = StreamController<Uint8List>.broadcast();
+  final _doneCompleter = Completer<void>();
+  bool closed = false;
+
+  void emitPrompt() {
+    if (!_outCtrl.isClosed) {
+      _outCtrl.add(Uint8List.fromList('$tag\$ '.codeUnits));
+    }
+  }
+
+  @override
+  Stream<Uint8List> get output => _outCtrl.stream;
+
+  @override
+  void send(Uint8List bytes) {}
+
+  @override
+  void resize(int cols, int rows, {int pixelWidth = 0, int pixelHeight = 0}) {}
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  void completeDone() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+
+  @override
+  void close() {
+    closed = true;
+    completeDone();
+    if (!_outCtrl.isClosed) _outCtrl.close();
+  }
+}
+
+void main() {
+  test(
+    'auto-reconnect re-opens a LIVE shell — bytes flow every cycle (#590)',
+    () async {
+      const sid = 'h:22:u:1';
+
+      // Construct one real SSHClient over a silent socket so `client` is
+      // non-null. We never authenticate; the host only reads `client` to decide
+      // a shell can be opened, and the fake opener ignores the value.
+      final socket = _SilentSocket();
+      final sentinelClient = SSHClient(socket, username: 'u');
+      addTearDown(() {
+        try {
+          sentinelClient.close();
+        } catch (_) {}
+        socket.destroy();
+      });
+
+      late _DrivableController controller;
+      _DrivableController factory() {
+        controller = _DrivableController(sentinelClient);
+        return controller;
+      }
+
+      // Hand out a fresh transport per open. A new live connection => a new
+      // shell => a new prompt byte. If the host reuses the dead handle, the
+      // opener is NOT called a second time and no second transport exists.
+      final opened = <_FakeShellTransport>[];
+      Future<SshShellTransport?> opener(SSHClient c, int cols, int rows) async {
+        final t = _FakeShellTransport('s${opened.length}');
+        opened.add(t);
+        // Emit the prompt on the next microtask so the host's listen() is wired.
+        scheduleMicrotask(t.emitPrompt);
+        return t;
+      }
+
+      final pair = InMemoryGatewayPair();
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: factory,
+        shellOpener: opener,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      final proxy = SshSessionProxy(sessionId: sid, gateway: pair.uiSide);
+      addTearDown(() async {
+        await proxy.dispose();
+        await host.dispose();
+        await pair.dispose();
+      });
+
+      // Capture everything the task side streams to the UI terminal.
+      final out = <int>[];
+      final sub = proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+
+      // Kick off connect so the host hosts the session + wires its state
+      // listener. The real auth never completes (silent socket), so we drive
+      // `connected` ourselves via the controller.
+      proxy.connect(
+        const SshConnectParams(
+          host: 'h',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      Future<void> settle() =>
+          Future<void>.delayed(const Duration(milliseconds: 30));
+
+      // --- Cycle 1: first connect → live shell ---
+      controller.debugSetConnectedForTest(
+        const SshConnectParams(
+          host: 'h',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+      await settle();
+
+      expect(opened.length, 1, reason: 'first connect should open one shell');
+      expect(
+        out.isNotEmpty,
+        isTrue,
+        reason: 'first connect produced no shell bytes',
+      );
+
+      // --- Transport drops → session leaves `connected` ---
+      // Emit a non-connected transition (the auto-reconnect path passes through
+      // reconnecting/softDisconnected/idle on its way back to connected). The
+      // host must DROP the prior shell here.
+      //
+      // CRITICAL to reproduce the RACE: do NOT complete the old transport's
+      // `done` before the reconnect. On a real socket drop the controller can
+      // re-reach `connected` BEFORE the dead PTY channel's `done` microtask
+      // runs — so the stale `hosted.shell` is still non-null when the second
+      // `connected` fires. Relying on `transport.done` to clear it (the old
+      // behavior) loses this race; the fix clears synchronously on the
+      // non-connected transition. We complete the old `done` only AFTER the
+      // reconnect, mimicking the lagging channel-close.
+      await controller.disconnect();
+      await settle();
+
+      final beforeReconnect = out.length;
+
+      // --- Cycle 2: reconnect re-enters connected ---
+      controller.debugSetConnectedForTest(
+        const SshConnectParams(
+          host: 'h',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+      await settle();
+
+      // The lagging channel-close from the dropped connection arrives LATE,
+      // after the reconnect already re-entered connected. With the old
+      // transport.done-clears-shell behavior this would null out the freshly
+      // opened shell; the fix's generation guard ignores this stale `done`.
+      opened.first.completeDone();
+      await settle();
+
+      // THE BUG: with the stale-shell reuse, the opener is never called a
+      // second time and no new bytes arrive while state == connected.
+      expect(
+        opened.length,
+        2,
+        reason:
+            'reconnect did NOT open a fresh shell — reused the dead handle (#590)',
+      );
+      // The live (second) shell must still be attached after the stale `done`.
+      expect(
+        opened.last.closed,
+        isFalse,
+        reason: 'the reconnect shell was torn down by a stale channel-close',
+      );
+      expect(
+        out.length,
+        greaterThan(beforeReconnect),
+        reason:
+            'reconnect reached `connected` but ZERO new shell bytes flowed — '
+            'the dead-shell hang (#590)',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Auto-reconnect could leave a session in `connected` state with a DEAD shell —
the terminal looked connected but zero bytes flowed (no prompt, typing did
nothing). The task-side `SessionHost` reused the prior connection's PTY shell
handle on the second `connected`: `_ensureShell` no-ops when
`hosted.shell != null`, and the only thing clearing the stale handle was the
async `transport.done` callback. That's a RACE — on a real socket drop the
controller can re-reach `connected` before that microtask runs, so the dead
handle blocks the re-open and no output re-pipes to the terminal.

## Fix (smallest change, in `SessionHost`'s per-session state listener)

- Drop the prior shell **synchronously** the instant the controller leaves
  `connected` (reconnecting / softDisconnected / failed / disconnected) via a
  new `_dropShell`, so the next `connected` always opens a fresh shell.
- Add a `shellGeneration` token bumped on every drop. An in-flight
  `_ensureShell` open captures it before awaiting and discards its transport if
  the generation moved — a stale open from a dropped connection can't re-attach
  after reconnect. The `transport.done` cleanup is likewise generation-guarded
  so a lagging channel-close from the old connection can't null out the freshly
  opened shell.

## The red→green transition test

`native/test/services/reconnect_shell_revive_test.dart` — HEADLESS, runs in the
FAST gate (this is exactly the byte-flow gate content the gate was missing for
the reconnect path). Uses `InMemoryGatewayPair` + a fake `HostShellOpener` that
hands out a fresh transport per open (each emitting a prompt byte):

1. connect → assert shell bytes flow (first transport opened, prompt arrives)
2. transport drops → session leaves `connected` (prior shell must be dropped)
3. reconnect re-enters `connected` → assert a **second** shell opens AND new
   bytes flow
4. the old transport's `done` completes only AFTER the reconnect (mimicking the
   lagging channel-close) → asserts the live shell is NOT torn down by the stale
   close

Reproduced red on the prior code (opener called once, `opened.length == 1`),
green with the fix. Full `scripts/native-fast-gate.sh` passes (analyze clean,
299 tests).

Device validation of the live reconnect on real hardware is left to the
orchestrator (mobile UX).

Closes #590