### PR TITLE
fix: editor action bar stays above the keyboard — ad-hoc connect reachable (#594)

### DIFF
--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -271,8 +271,20 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
   @override
   Widget build(BuildContext context) {
     final isKey = _authKind == _AuthKind.key;
+    // Keyboard height. We size and float the action bar against this ourselves
+    // (resizeToAvoidBottomInset:false below) so the buttons stay directly above
+    // the soft keyboard and remain hit-testable — the #585 session-menu pattern
+    // applied to the editor footer (#594). A device-real keyboard occupies the
+    // lower viewport; if the buttons lived at the bottom of the scrolling form
+    // they'd sit behind it and ad-hoc connect would be unreachable.
+    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
     return Scaffold(
       key: const Key('profile-editor'),
+      // We manage the keyboard inset manually in the footer so the action bar
+      // floats above the keyboard without the Scaffold also reserving for it
+      // (which would double-count). The scroll body gets bottom padding to clear
+      // both the keyboard and the fixed footer.
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         title: Text(widget.isNew ? 'New connection' : 'Edit profile'),
         actions: [
@@ -286,9 +298,22 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
             ),
         ],
       ),
+      // Fixed action footer (#594). Floats above the keyboard via the
+      // viewInsets padding so Save & Save&connect are always reachable with the
+      // keyboard up. Mirrors the PWA editor where the connect/save action is
+      // always reachable.
+      bottomNavigationBar: _ActionBar(
+        key: const Key('profile-editor-action-bar'),
+        busy: _busy,
+        keyboardInset: keyboardInset,
+        onConnect: _busy ? null : _saveAndConnect,
+        onSave: _busy ? null : _save,
+      ),
       body: SafeArea(
         child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
+          // Bottom padding clears the keyboard AND the fixed action footer so
+          // the last field can scroll into the keyboard-free area.
+          padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + keyboardInset + 120),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
@@ -420,26 +445,76 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
                 autocorrect: false,
                 enableSuggestions: false,
               ),
-              const SizedBox(height: 20),
-              // Save & connect (#583): the editor is the new-connection entry
-              // now that the inline form is gone. `connect-submit` key keeps the
-              // emulator connect smokes addressable. Connects via the chooser's
-              // shared path (host-key prompt + initial-command arming).
-              FilledButton.icon(
-                key: const Key('connect-submit'),
-                onPressed: _busy ? null : _saveAndConnect,
-                icon: const Icon(Icons.power_settings_new),
-                label: Text(_busy ? 'Connecting…' : 'Save & connect'),
-              ),
-              const SizedBox(height: 8),
-              OutlinedButton.icon(
-                key: const Key('profile-editor-save'),
-                onPressed: _busy ? null : _save,
-                icon: const Icon(Icons.save),
-                label: Text(_busy ? 'Saving…' : 'Save'),
-              ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Fixed action footer for the editor (#594). Holds the two actions
+/// (`connect-submit` = Save & connect, `profile-editor-save` = Save) and floats
+/// directly above the soft keyboard by padding itself with the current
+/// keyboard inset. Because the parent Scaffold uses
+/// `resizeToAvoidBottomInset:false`, this widget owns the inset entirely, so the
+/// buttons stay on-screen and hit-testable with the keyboard up — mirroring the
+/// #585 session-menu overlay pattern and the always-reachable PWA editor action.
+class _ActionBar extends StatelessWidget {
+  const _ActionBar({
+    super.key,
+    required this.busy,
+    required this.keyboardInset,
+    required this.onConnect,
+    required this.onSave,
+  });
+
+  final bool busy;
+  final double keyboardInset;
+  final VoidCallback? onConnect;
+  final VoidCallback? onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      // Opaque surface so the floating bar reads as a footer, not transparent
+      // over the scrolling fields beneath it.
+      color: Theme.of(context).colorScheme.surface,
+      elevation: 8,
+      child: Padding(
+        // bottom: keyboardInset floats the bar above the keyboard; when the
+        // keyboard is down it falls back to the safe-area inset.
+        padding: EdgeInsets.fromLTRB(
+          16,
+          12,
+          16,
+          12 +
+              (keyboardInset > 0
+                  ? keyboardInset
+                  : MediaQuery.paddingOf(context).bottom),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Save & connect (#583): the editor is the new-connection entry now
+            // that the inline form is gone. `connect-submit` key keeps the
+            // emulator connect smokes addressable. Connects via the chooser's
+            // shared path (host-key prompt + initial-command arming).
+            FilledButton.icon(
+              key: const Key('connect-submit'),
+              onPressed: onConnect,
+              icon: const Icon(Icons.power_settings_new),
+              label: Text(busy ? 'Connecting…' : 'Save & connect'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              key: const Key('profile-editor-save'),
+              onPressed: onSave,
+              icon: const Icon(Icons.save),
+              label: Text(busy ? 'Saving…' : 'Save'),
+            ),
+          ],
         ),
       ),
     );

--- a/native/test/widget/profile_editor_test.dart
+++ b/native/test/widget/profile_editor_test.dart
@@ -223,4 +223,122 @@ void main() {
       },
     );
   });
+
+  // #594: the action bar (Save & connect / Save) must stay reachable with the
+  // soft keyboard UP. The save-semantics tests above use a 1000x2000 surface
+  // with NO keyboard inset — that's the false green this group exists to catch.
+  // Here we pump at a realistic phone size AND inject a keyboard inset via a
+  // MediaQuery override, then assert both action buttons are hit-testable and
+  // their centers fall ABOVE the keyboard inset (inside the visible viewport).
+  group('ProfileEditor action bar — keyboard safety (#594)', () {
+    // Logical phone-ish viewport (dpr 1 for simple px==logical math).
+    const screenSize = Size(360, 800);
+    // A soft keyboard typically eats ~40% of the height; 360 here is well
+    // within that and mirrors the device failure (connect-submit was at dy~794
+    // on an ~800-tall screen, i.e. behind the keyboard).
+    const keyboardHeight = 360.0;
+
+    Future<void> pumpWithKeyboard(
+      WidgetTester tester, {
+      required bool isNew,
+    }) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final profile = SavedProfile(
+        title: 'Box',
+        host: 'home.example',
+        port: 22,
+        username: 'me',
+        authType: 'key',
+      );
+
+      tester.view.physicalSize = screenSize;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            profilesStoreProvider.overrideWithValue(store),
+            secretsStoreProvider.overrideWithValue(secrets),
+          ],
+          child: MaterialApp(
+            // Simulate the soft keyboard occupying the lower viewport. This is
+            // what the tall-surface tests omitted, producing a false green.
+            home: Builder(
+              builder: (context) => MediaQuery(
+                data: MediaQuery.of(context).copyWith(
+                  viewInsets: const EdgeInsets.only(bottom: keyboardHeight),
+                ),
+                child: ProfileEditor(profile: profile, isNew: isNew),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    void expectButtonReachable(WidgetTester tester, Key key) {
+      final finder = find.byKey(key);
+      expect(finder, findsOneWidget, reason: '$key must be present');
+
+      final center = tester.getCenter(finder);
+      // Must be on-screen horizontally/vertically...
+      expect(
+        center.dy,
+        greaterThan(0),
+        reason: '$key center must be on-screen (dy>0)',
+      );
+      // ...and ABOVE the keyboard: its center must sit in the visible area, not
+      // behind the keyboard inset. This is the exact device failure (#594):
+      // connect-submit derived an offset inside the keyboard band → no hit test.
+      expect(
+        center.dy,
+        lessThan(screenSize.height - keyboardHeight),
+        reason:
+            '$key center (dy=${center.dy}) is behind the keyboard '
+            '(visible area ends at ${screenSize.height - keyboardHeight}) — '
+            'it would not hit-test on a real device',
+      );
+
+      // And it must actually pass a hit test at its center (no occluding
+      // widget, not off-screen) — tap should reach the button, not throw.
+      final result = tester.hitTestOnBinding(center);
+      final hit = result.path.any((entry) => entry.target is RenderBox);
+      expect(
+        hit,
+        isTrue,
+        reason: '$key must be hit-testable at its center with the keyboard up',
+      );
+    }
+
+    testWidgets('connect-submit is reachable above the keyboard (new mode)', (
+      tester,
+    ) async {
+      await pumpWithKeyboard(tester, isNew: true);
+      expectButtonReachable(tester, const Key('connect-submit'));
+    });
+
+    testWidgets('Save is reachable above the keyboard (edit mode)', (
+      tester,
+    ) async {
+      await pumpWithKeyboard(tester, isNew: false);
+      expectButtonReachable(tester, const Key('profile-editor-save'));
+    });
+
+    testWidgets('both actions live in the fixed footer above the keyboard', (
+      tester,
+    ) async {
+      await pumpWithKeyboard(tester, isNew: true);
+      expect(
+        find.byKey(const Key('profile-editor-action-bar')),
+        findsOneWidget,
+      );
+      expectButtonReachable(tester, const Key('connect-submit'));
+      expectButtonReachable(tester, const Key('profile-editor-save'));
+    });
+  });
 }


### PR DESCRIPTION
## Summary
After #583 made the profile editor the ad-hoc / new-connection entry, its
"Save & connect" (`connect-submit`) and "Save" (`profile-editor-save`) buttons
lived at the bottom of the scrolling form. On a real phone with the soft
keyboard up, they sat **behind the keyboard** and were not hit-testable — so the
#589 integration gate's `connect_key_smoke_test.dart` failed at `adhocKeyConnect`
(connect-submit derived an off-screen offset). Ad-hoc key-connect was broken on
device.

## Fix
Mirrors the #585 session-menu overlay pattern. The two actions move out of the
scrolling form into a fixed `Scaffold.bottomNavigationBar` footer (`_ActionBar`)
that floats directly above the keyboard by padding with
`MediaQuery.viewInsetsOf(context).bottom`. The Scaffold sets
`resizeToAvoidBottomInset: false` so the footer owns the inset (no
double-counting); the scroll body gets bottom padding so the last field clears
both the keyboard and the footer. Fields scroll above; the action bar is always
reachable with the keyboard up — matching the always-reachable PWA editor action.

No redesign of the editor — only the action bar was made keyboard-safe. Button
keys (`connect-submit`, `profile-editor-save`) are unchanged, so existing
emulator smokes and chooser/affordance widget tests stay addressable.

## The keyboard-inset test (no false green)
The prior editor widget tests passed only on a 1000x2000 / 2400px synthetic
surface with NO keyboard inset — that's the false green. Added a
`keyboard safety (#594)` group that:
- pumps the editor at a realistic phone size (360x800, dpr 1), and
- injects a simulated keyboard via a `MediaQuery` override
  (`viewInsets.bottom = 360`), then
- asserts both action buttons are present, hit-testable at their center
  (`hitTestOnBinding`), and their centers fall **above** the keyboard inset
  (`center.dy < screenHeight - keyboardHeight`).

Against the old layout the buttons render below the fold / behind the inset and
this assertion fails; with the fix they sit in the floating footer and pass.

## Validation
- `scripts/native-fast-gate.sh`: green (analyze clean, all tests pass incl. the
  3 new keyboard-safety tests).
- `dart format` applied to both edited files.
- **Real proof is the on-device gate:** the orchestrator runs
  `scripts/native-integration-suite.sh` (#589 `connect_key_smoke`) on the
  emulator — that is the validation step for this device-only bug. Not
  device-tested in this PR.

Closes #594