### PR TITLE
fix: re-import upsert applies changed authType — no stale password mode (#595)

### DIFF
--- a/native/integration_test/import_upsert_diversity_test.dart
+++ b/native/integration_test/import_upsert_diversity_test.dart
@@ -292,12 +292,19 @@ void main() {
             'password field present — editor opened in password mode for '
             'a KEY profile (stale authType)',
       );
-      // Back out of the editor before checking the diversity row.
-      final keyBack = find.byTooltip('Back');
-      if (keyBack.evaluate().isNotEmpty) {
-        await tester.tap(keyBack.first);
+      // Back out of the editor before checking the diversity row. The editor
+      // is a `fullscreenDialog` route, so on Android its leading affordance is
+      // a Material CloseButton (X), NOT a Back/Cupertino button — `pageBack()`
+      // looks for a CupertinoNavigationBarBackButton and finds none. Tap the
+      // CloseButton (covers fullscreenDialog on every platform); fall back to
+      // BackButton / a Back tooltip for non-dialog presentations.
+      final keyClose = find.byType(CloseButton);
+      if (keyClose.evaluate().isNotEmpty) {
+        await tester.tap(keyClose.first);
+      } else if (find.byType(BackButton).evaluate().isNotEmpty) {
+        await tester.tap(find.byType(BackButton).first);
       } else {
-        await tester.pageBack();
+        await tester.tap(find.byTooltip('Back').first);
       }
       expect(
         await _pumpUntilGone(

--- a/native/integration_test/import_upsert_diversity_test.dart
+++ b/native/integration_test/import_upsert_diversity_test.dart
@@ -1,19 +1,25 @@
-// On-emulator import DIVERSITY + upsert-over-stale smoke (#547 follow-up).
+// On-emulator import DIVERSITY + upsert-over-stale smoke (#547 follow-up, #595).
 //
 // Reproduces the device bug the first import_smoke_test missed: a profile that
 // ALREADY exists in the store (stale identity-only, authType=null — the
 // pre-#510 persisted shape) is re-imported as a KEY profile. The importer
 // upserts the store, but if the UI doesn't invalidate `savedProfilesProvider`
 // on an upsert (added=0, updated=1), the profile list keeps serving the STALE
-// object → tapping it shows password mode with no key. That's exactly the
+// object → opening it shows password mode with no key. That's exactly the
 // user report: "fd-dev is a key profile; imported and selected it, password is
 // highlighted not key."
 //
 // Diversity: the envelope carries a KEY profile (the formerly-stale host) AND a
 // PASSWORD profile, so we assert each resolves to the correct auth mode.
 //
-// Network: scripts/native-connect-test.sh sets up the test-sshd bridge on
-// 127.0.0.1:2222.
+// UI contract (#583 + #595): the inline connect form was removed — a row TAP
+// connects directly (no `connect-key`/`connect-password` fields exist anymore).
+// The per-profile authType is now surfaced through the profile EDITOR, opened
+// via the row's edit pencil (`profile-edit-<identityKey>`). So the on-device
+// proof that the upsert refreshed the per-profile authType is: open the editor
+// for the formerly-stale row and assert it renders KEY mode (the
+// `profile-editor-key` field present, `profile-editor-password` absent), and
+// the diversity (password) row renders PASSWORD mode.
 
 import 'dart:convert';
 import 'dart:math';
@@ -21,7 +27,6 @@ import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -52,27 +57,36 @@ Future<String> _buildEnvelope({
     bits: 256,
   );
   final random = Random.secure();
-  final salt =
-      Uint8List.fromList(List<int>.generate(32, (_) => random.nextInt(256)));
-  final dekBytes =
-      Uint8List.fromList(List<int>.generate(32, (_) => random.nextInt(256)));
+  final salt = Uint8List.fromList(
+    List<int>.generate(32, (_) => random.nextInt(256)),
+  );
+  final dekBytes = Uint8List.fromList(
+    List<int>.generate(32, (_) => random.nextInt(256)),
+  );
   final dek = SecretKey(dekBytes);
   final kek = await pbkdf2.deriveKey(
     secretKey: SecretKey(utf8.encode(password)),
     nonce: salt,
   );
   final aesGcm = AesGcm.with256bits();
-  final dekWrapIv =
-      Uint8List.fromList(List<int>.generate(12, (_) => random.nextInt(256)));
-  final dekWrapBox =
-      await aesGcm.encrypt(dekBytes, secretKey: kek, nonce: dekWrapIv);
-  final dekWrapCt =
-      Uint8List.fromList([...dekWrapBox.cipherText, ...dekWrapBox.mac.bytes]);
+  final dekWrapIv = Uint8List.fromList(
+    List<int>.generate(12, (_) => random.nextInt(256)),
+  );
+  final dekWrapBox = await aesGcm.encrypt(
+    dekBytes,
+    secretKey: kek,
+    nonce: dekWrapIv,
+  );
+  final dekWrapCt = Uint8List.fromList([
+    ...dekWrapBox.cipherText,
+    ...dekWrapBox.mac.bytes,
+  ]);
 
   final encrypted = <String, Map<String, String>>{};
   for (final entry in secrets.entries) {
-    final iv =
-        Uint8List.fromList(List<int>.generate(12, (_) => random.nextInt(256)));
+    final iv = Uint8List.fromList(
+      List<int>.generate(12, (_) => random.nextInt(256)),
+    );
     final box = await aesGcm.encrypt(
       utf8.encode(jsonEncode(entry.value)),
       secretKey: dek,
@@ -135,130 +149,194 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-      're-import over a STALE identity-only profile shows KEY mode on tap (#547)',
-      (tester) async {
-    FlutterForegroundTask.initCommunicationPort();
+    're-import over a STALE identity-only profile shows KEY mode in editor (#547/#595)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
 
-    // 1. Pre-seed the REAL store so BOTH imported identities already exist as
-    //    stale identity-only profiles (the pre-#510 persisted shape: no
-    //    authType, no vaultId/keyVaultId). This mirrors the user's device,
-    //    where all 7 profiles were imported by an old build and persist across
-    //    reinstalls. Because both already exist, the re-import is
-    //    added=0/updated=2 — exactly the case the buggy `if (added > 0)`
-    //    invalidate condition fails to refresh.
-    final store = ProfilesStore();
-    await store.save([
-      SavedProfile(
-        title: 'fd-dev (stale)',
-        host: '127.0.0.1',
-        port: 2222,
-        username: 'testuser',
-      ),
-      SavedProfile(
-        title: 'pw-host (stale)',
-        host: '198.51.100.7',
-        port: 22,
-        username: 'alice',
-      ),
-    ]);
+      // 1. Pre-seed the REAL store so BOTH imported identities already exist as
+      //    stale identity-only profiles (the pre-#510 persisted shape: no
+      //    authType, no vaultId/keyVaultId). This mirrors the user's device,
+      //    where all 7 profiles were imported by an old build and persist across
+      //    reinstalls. Because both already exist, the re-import is
+      //    added=0/updated=2 — exactly the case the buggy `if (added > 0)`
+      //    invalidate condition fails to refresh.
+      final store = ProfilesStore();
+      await store.save([
+        SavedProfile(
+          title: 'fd-dev (stale)',
+          host: '127.0.0.1',
+          port: 2222,
+          username: 'testuser',
+        ),
+        SavedProfile(
+          title: 'pw-host (stale)',
+          host: '198.51.100.7',
+          port: 22,
+          username: 'alice',
+        ),
+      ]);
 
-    const masterPassword = 'master';
-    const keyVaultId = 'k-testsshd';
-    const pwVaultId = 'v-pwhost';
-    final envelope = await _buildEnvelope(
-      password: masterPassword,
-      profiles: <Map<String, dynamic>>[
-        // Same identity as the stale profile, now KEY auth.
-        <String, dynamic>{
-          'title': 'fd-dev',
-          'host': '127.0.0.1',
-          'port': 2222,
-          'username': 'testuser',
-          'authType': 'key',
-          'keyVaultId': keyVaultId,
+      const masterPassword = 'master';
+      const keyVaultId = 'k-testsshd';
+      const pwVaultId = 'v-pwhost';
+      final envelope = await _buildEnvelope(
+        password: masterPassword,
+        profiles: <Map<String, dynamic>>[
+          // Same identity as the stale profile, now KEY auth.
+          <String, dynamic>{
+            'title': 'fd-dev',
+            'host': '127.0.0.1',
+            'port': 2222,
+            'username': 'testuser',
+            'authType': 'key',
+            'keyVaultId': keyVaultId,
+          },
+          // A second, password-auth profile for diversity.
+          <String, dynamic>{
+            'title': 'pw-host',
+            'host': '198.51.100.7',
+            'port': 22,
+            'username': 'alice',
+            'authType': 'password',
+            'vaultId': pwVaultId,
+          },
+        ],
+        secrets: <String, Map<String, Object?>>{
+          keyVaultId: <String, Object?>{'data': _testPrivateKeyPem},
+          pwVaultId: <String, Object?>{'password': 'hunter2'},
         },
-        // A second, password-auth profile for diversity.
-        <String, dynamic>{
-          'title': 'pw-host',
-          'host': '198.51.100.7',
-          'port': 22,
-          'username': 'alice',
-          'authType': 'password',
-          'vaultId': pwVaultId,
-        },
-      ],
-      secrets: <String, Map<String, Object?>>{
-        keyVaultId: <String, Object?>{'data': _testPrivateKeyPem},
-        pwVaultId: <String, Object?>{'password': 'hunter2'},
-      },
-    );
+      );
 
-    await tester.pumpWidget(const ProviderScope(child: MobisshApp()));
-    await tester.pump(const Duration(seconds: 1));
+      await tester.pumpWidget(const ProviderScope(child: MobisshApp()));
+      await tester.pump(const Duration(seconds: 1));
 
-    // 2. Import the diverse envelope (upserts the stale profile to key auth).
-    await tester.tap(find.byKey(const Key('open-import-profiles-dialog')).first);
-    expect(await _pump(tester, find.byKey(const Key('import-profiles-dialog'))),
-        isTrue);
-    final disclosure = find.byKey(const Key('import-profiles-paste-disclosure'));
-    if (disclosure.evaluate().isNotEmpty) {
-      await tester.tap(disclosure);
-      await tester.pump(const Duration(milliseconds: 300));
-    }
-    await tester.enterText(
-        find.byKey(const Key('import-profiles-input')), envelope);
-    await tester.pump(const Duration(milliseconds: 200));
-    await tester.tap(find.byKey(const Key('import-profiles-submit')));
-    expect(
-        await _pump(tester, find.byKey(const Key('import-profiles-password'))),
-        isTrue);
-    await tester.enterText(
-        find.byKey(const Key('import-profiles-password')), masterPassword);
-    await tester.pump(const Duration(milliseconds: 200));
-    await tester.tap(find.byKey(const Key('import-profiles-submit')));
-
-    // Wait for the dialog to fully close — otherwise the (offstage) profile
-    // tile behind the closing dialog is "found" immediately and our tap lands
-    // on the dialog, not the tile.
-    expect(
-        await _pumpUntilGone(
-            tester, find.byKey(const Key('import-profiles-dialog')),
-            slices: 40),
+      // 2. Import the diverse envelope (upserts the stale profile to key auth).
+      await tester.tap(
+        find.byKey(const Key('open-import-profiles-dialog')).first,
+      );
+      expect(
+        await _pump(tester, find.byKey(const Key('import-profiles-dialog'))),
         isTrue,
-        reason: 'import dialog never closed after vault submit');
+      );
+      final disclosure = find.byKey(
+        const Key('import-profiles-paste-disclosure'),
+      );
+      if (disclosure.evaluate().isNotEmpty) {
+        await tester.tap(disclosure);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      await tester.enterText(
+        find.byKey(const Key('import-profiles-input')),
+        envelope,
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(find.byKey(const Key('import-profiles-submit')));
+      expect(
+        await _pump(tester, find.byKey(const Key('import-profiles-password'))),
+        isTrue,
+      );
+      await tester.enterText(
+        find.byKey(const Key('import-profiles-password')),
+        masterPassword,
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(find.byKey(const Key('import-profiles-submit')));
 
-    // 3. Tap the formerly-stale KEY profile. It MUST apply in KEY mode with the
-    //    resolved private key — the bug is the stale list serving the old
-    //    identity-only object (authType=null) → password mode, no key.
-    final keyTile =
-        find.byKey(const Key('profile-tile-127.0.0.1:2222:testuser'));
-    expect(await _pump(tester, keyTile, slices: 20), isTrue,
-        reason: 'key profile tile missing after import');
-    await tester.tap(keyTile);
-    final keyField = find.byKey(const Key('connect-key'));
-    expect(await _pump(tester, keyField, slices: 20), isTrue,
-        reason: 'KEY field not shown — profile applied in password mode '
-            '(stale list not refreshed on upsert — the #547 follow-up bug)');
-    // Credential resolution is async; let it land before reading the field.
-    await tester.pump(const Duration(seconds: 1));
-    final keyWidget = tester.widget<TextField>(keyField);
-    expect(keyWidget.controller?.text ?? '', isNotEmpty,
-        reason: 'key field empty — secret not resolved for upserted profile');
+      // Wait for the dialog to fully close — otherwise the (offstage) profile
+      // tile behind the closing dialog is "found" immediately and our tap lands
+      // on the dialog, not the tile.
+      expect(
+        await _pumpUntilGone(
+          tester,
+          find.byKey(const Key('import-profiles-dialog')),
+          slices: 40,
+        ),
+        isTrue,
+        reason: 'import dialog never closed after vault submit',
+      );
 
-    // 4. Diversity: the OTHER upserted profile is password-auth. Tapping it
-    //    must apply PASSWORD mode with the resolved password (and NOT show a
-    //    key field). Confirms the upsert refresh is correct per-auth-type.
-    final pwTile = find.byKey(const Key('profile-tile-198.51.100.7:22:alice'));
-    expect(await _pump(tester, pwTile, slices: 20), isTrue,
-        reason: 'password profile tile missing after import');
-    await tester.tap(pwTile);
-    final pwField = find.byKey(const Key('connect-password'));
-    expect(await _pump(tester, pwField, slices: 20), isTrue,
-        reason: 'password field not shown for the password-auth profile');
-    await tester.pump(const Duration(seconds: 1));
-    final pwWidget = tester.widget<TextField>(pwField);
-    expect(pwWidget.controller?.text ?? '', isNotEmpty,
-        reason: 'password field empty — secret not resolved for upserted '
-            'password profile');
-  });
+      // 3. Open the formerly-stale KEY profile in the editor (edit pencil). It
+      //    MUST render in KEY mode — the bug is the stale list serving the old
+      //    identity-only object (authType=null) → editor opens in password mode.
+      //    Post-#583 there is no inline `connect-key` field; the editor's auth
+      //    SegmentedButton is the per-profile authType surface.
+      final keyEdit = find.byKey(
+        const Key('profile-edit-127.0.0.1:2222:testuser'),
+      );
+      expect(
+        await _pump(tester, keyEdit, slices: 20),
+        isTrue,
+        reason: 'key profile row missing after import',
+      );
+      await tester.tap(keyEdit);
+      expect(
+        await _pump(tester, find.byKey(const Key('profile-editor'))),
+        isTrue,
+        reason: 'editor did not open for the key profile',
+      );
+      final keyField = find.byKey(const Key('profile-editor-key'));
+      expect(
+        await _pump(tester, keyField, slices: 20),
+        isTrue,
+        reason:
+            'KEY field not shown — editor opened in password mode '
+            '(stale authType not refreshed on upsert — the #547 follow-up '
+            'bug, #595)',
+      );
+      // In KEY mode the password field is hidden (the editor swaps fields by
+      // authType). Its presence would mean the editor opened in password mode.
+      expect(
+        find.byKey(const Key('profile-editor-password')),
+        findsNothing,
+        reason:
+            'password field present — editor opened in password mode for '
+            'a KEY profile (stale authType)',
+      );
+      // Back out of the editor before checking the diversity row.
+      final keyBack = find.byTooltip('Back');
+      if (keyBack.evaluate().isNotEmpty) {
+        await tester.tap(keyBack.first);
+      } else {
+        await tester.pageBack();
+      }
+      expect(
+        await _pumpUntilGone(
+          tester,
+          find.byKey(const Key('profile-editor')),
+          slices: 40,
+        ),
+        isTrue,
+        reason: 'editor never closed after backing out of the key profile',
+      );
+
+      // 4. Diversity: the OTHER upserted profile is password-auth. Its editor
+      //    must render PASSWORD mode (and NOT a key field). Confirms the upsert
+      //    refresh is correct per-auth-type.
+      final pwEdit = find.byKey(
+        const Key('profile-edit-198.51.100.7:22:alice'),
+      );
+      expect(
+        await _pump(tester, pwEdit, slices: 20),
+        isTrue,
+        reason: 'password profile row missing after import',
+      );
+      await tester.tap(pwEdit);
+      expect(
+        await _pump(tester, find.byKey(const Key('profile-editor'))),
+        isTrue,
+        reason: 'editor did not open for the password profile',
+      );
+      final pwField = find.byKey(const Key('profile-editor-password'));
+      expect(
+        await _pump(tester, pwField, slices: 20),
+        isTrue,
+        reason: 'password field not shown for the password-auth profile',
+      );
+      expect(
+        find.byKey(const Key('profile-editor-key')),
+        findsNothing,
+        reason: 'key field present for a PASSWORD profile — wrong authType',
+      );
+    },
+  );
 }

--- a/native/test/widget/import_upsert_authtype_test.dart
+++ b/native/test/widget/import_upsert_authtype_test.dart
@@ -1,0 +1,191 @@
+// Widget test: a re-import upsert that CHANGES authType is reflected on the
+// next profile tap — no stale password mode (#595, the #547 follow-up).
+//
+// Headless reproduction of the on-device bug found by the #589 integration
+// gate (import_upsert_diversity_test.dart): a STALE profile is re-imported with
+// a CHANGED authType. #547 made the LIST refresh after an upsert; the remaining
+// gap is the per-profile authType used by the connect path. If the upserted
+// profile still carries the OLD authType, tapping it connects in the OLD mode.
+// We seed the stale profile as authType=password WITH a usable password secret,
+// then re-import it as authType=key — so a stale authType connects in PASSWORD
+// mode and a refreshed one connects in KEY mode. (Seeding the password secret
+// is what makes this a strict authType test: the keyVaultId-inference fallback
+// only fires when authType is null, so it cannot mask a stale `password`.)
+//
+// Observable contract (no inline connect form exists post-#583): tapping a
+// profile routes through `_connectFromProfile`, which resolves the profile's
+// authType + vault credentials and dispatches `proxy.connect`. The connect
+// command crosses the in-memory gateway as a JSON payload carrying
+// `auth: {type: 'key'|'password', ...}`. We capture that payload on the task
+// side and assert `auth.type == 'key'` after the upsert — the direct proof the
+// fresh authType reached the connect path.
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/connect_form.dart';
+
+const String _testKeyPem = '''
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACB85qILD6Ykve+v2FrQWtcrsjW1baL6CXJ4LD5mmiDTdgAAAJgTrJmWE6yZ
+lgAAAAtzc2gtZWQyNTUxOQAAACB85qILD6Ykve+v2FrQWtcrsjW1baL6CXJ4LD5mmiDTdg
+AAAEBbgsew/IHGlnh7mBUSl/1dndeVjG9AmMGYWl0TNGsVK3zmogsPpiS976/YWtBa1yuy
+NbVtovoJcngsPmaaINN2AAAAFXRlc3R1c2VyQG1vYmlzc2gtdGVzdA==
+-----END OPENSSH PRIVATE KEY-----
+''';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets(
+    're-import upsert to KEY auth: next tap connects with auth.type=key (#595)',
+    (tester) async {
+      // 1. Pre-seed the store with a STALE PASSWORD profile that ALSO has a
+      //    usable password secret. This is deliberately the hardest case: if
+      //    the list serves the stale object, `_connectFromProfile` sees
+      //    authType=password + a usable password and connects in PASSWORD mode
+      //    — the bug. Seeding a password secret here means a stale authType
+      //    cannot be masked by the keyVaultId-inference fallback (which only
+      //    fires when authType is null). The ONLY thing that flips the connect
+      //    to KEY mode is the upsert refreshing the per-profile authType.
+      const pwVaultId = 'v-box';
+      const keyVaultId = 'k-box';
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write(pwVaultId, <String, Object?>{'password': 'stalepw'});
+      await secrets.write(keyVaultId, <String, Object?>{'data': _testKeyPem});
+
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'fd-dev (stale password)',
+          host: 'box.example',
+          port: 2222,
+          username: 'testuser',
+          authType: 'password',
+          vaultId: pwVaultId,
+        ),
+      ]);
+
+      // 2. Capture the connect command the proxy dispatches across the gateway.
+      final pair = InMemoryGatewayPair();
+      final connectCommands = <Map<String, dynamic>>[];
+      final sub = pair.taskSide.incoming.listen((payload) {
+        if (payload['kind'] == 'connect') {
+          connectCommands.add(Map<String, dynamic>.from(payload));
+        }
+      });
+      addTearDown(() async {
+        await sub.cancel();
+        await pair.dispose();
+      });
+
+      final container = ProviderContainer(
+        overrides: [
+          taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+          profilesStoreProvider.overrideWithValue(store),
+          secretsStoreProvider.overrideWithValue(secrets),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 3. Re-import the SAME identity, now KEY auth, through the real dialog.
+      //    Plain (no-vault) envelope → single-stage submit. This upserts the
+      //    stale profile (added=0, updated=1) — the #547 follow-up case.
+      final envelope = jsonEncode(<String, Object?>{
+        'version': 1,
+        'profiles': <Map<String, dynamic>>[
+          <String, dynamic>{
+            'title': 'fd-dev',
+            'host': 'box.example',
+            'port': 2222,
+            'username': 'testuser',
+            'authType': 'key',
+            'keyVaultId': keyVaultId,
+          },
+        ],
+      });
+
+      await tester.tap(find.byKey(const Key('open-import-profiles-dialog')));
+      await tester.pumpAndSettle();
+      // Expand the paste disclosure, then paste + submit.
+      await tester.tap(
+        find.byKey(const Key('import-profiles-paste-disclosure')),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('import-profiles-input')),
+        envelope,
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(find.byKey(const Key('import-profiles-submit')));
+      await tester.pumpAndSettle();
+
+      // The store now holds the upserted KEY profile.
+      final loaded = await store.load();
+      expect(
+        loaded.single.authType,
+        'key',
+        reason: 'store must hold the upserted authType=key',
+      );
+
+      // 4. Tap the formerly-stale profile. With a fresh authType it must
+      //    connect in KEY mode. The bug: a stale authType (null/password)
+      //    routes to password mode (or the no-creds editor fallback), so the
+      //    connect command's auth.type is NOT 'key'.
+      await tester.tap(
+        find.byKey(const Key('profile-tile-box.example:2222:testuser')),
+      );
+      await _pumpFrames(tester, count: 40);
+
+      expect(
+        connectCommands,
+        isNotEmpty,
+        reason:
+            'tapping the upserted profile must dispatch a connect — a '
+            'stale authType=null with no usable creds opens the editor '
+            'instead of connecting',
+      );
+      final auth = Map<String, dynamic>.from(
+        connectCommands.last['auth'] as Map,
+      );
+      expect(
+        auth['type'],
+        'key',
+        reason:
+            'connect must use KEY auth after the upsert changed '
+            'authType from null → key (the #547 follow-up bug: stale '
+            'per-profile authType applied in password mode)',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

The #589 integration gate flagged `import_upsert_diversity_test.dart:239`
failing on-device, framed as a #547 follow-up: re-import over a stale
identity-only profile shows PASSWORD mode, not KEY.

Investigation shows the **production path is already correct**:
- `ProfilesStore.applyParsedImport` / `.upsert` both REPLACE `authType`.
- `import_profiles_dialog` invalidates `savedProfilesProvider` on
  `added > 0 || updated > 0` (the #547 fix, 34674d2).
- `ProfileList` watches the provider and hands the fresh `SavedProfile` to
  `_connectFromProfile`, which reads `profile.authType`.

The real cause of the gate failure is a **stale test**: it asserts
`connect-key` / `connect-password` field keys that the inline connect form
owned — and that form was DELETED in #583 (chooser rewrite; a row tap now
CONNECTS directly, there is no inline auth field). The integration test was
authored at 34674d2 (#547), before #579/#583 landed.

This is therefore a **test-only PR**: a strict headless regression guard plus a
repair of the on-device gate.

## The red -> green headless test

`native/test/widget/import_upsert_authtype_test.dart` (runs in the fast gate):

- Seeds a STALE `authType=password` profile WITH a usable password secret. The
  password secret is deliberate: it defeats the `keyVaultId`-inference fallback
  (which only fires when `authType == null`), so a stale `password` cannot be
  masked — the ONLY thing that flips the connect to KEY is the upsert refreshing
  the per-profile `authType`.
- Re-imports the same identity as `authType=key` through the real import dialog
  (upsert: added=0, updated=1 — the #547 follow-up case).
- Taps the row and captures the `connect` command crossing an
  `InMemoryGatewayPair`, asserting `auth.type == 'key'`.

Verified red -> green: reverting the #547 invalidate to `added > 0` makes the
test fail with `Expected 'key', Actual 'password'` (log:
`connectFromProfile box.example authType=password -> connect`); restoring the
`added > 0 || updated > 0` condition passes.

## On-device confirmation

`native/integration_test/import_upsert_diversity_test.dart` is the #589
on-device gate. Repaired to the post-#583 UI: the per-profile authType surface
is now the profile EDITOR, opened via the row edit pencil
(`profile-edit-<identityKey>`). It asserts the KEY row's editor renders KEY mode
(`profile-editor-key` present, `profile-editor-password` absent) and the
diversity PASSWORD row renders PASSWORD mode — instead of the removed
`connect-key` / `connect-password` fields. The orchestrator runs the #589
integration gate on the emulator as the on-device confirmation.

## Gate

`scripts/native-fast-gate.sh` green: analyze clean, 303 tests pass (5
integration-tagged skipped, as expected for the fast tier).

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)