### PR TITLE
feat: per-session terminal theme + font size, from the session menu (#601, #571)

### DIFF
--- a/native/lib/state/ui_prefs_providers.dart
+++ b/native/lib/state/ui_prefs_providers.dart
@@ -19,6 +19,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xterm/xterm.dart';
 
+import 'sessions.dart';
+
 /// SharedPreferences key. Matches the keep-alive naming style.
 const String keybarVisiblePrefKey = 'mobissh.ui.keybarVisible';
 
@@ -80,6 +82,9 @@ const double fontSizeDefault = 13.0;
 /// constant (`{ MIN: 8, MAX: 32 }` in `src/modules/constants.ts`).
 const double kFontSizeMin = 8.0;
 const double kFontSizeMax = 32.0;
+
+/// Step (logical px) for the session-menu font-size −/＋ stepper (#601).
+const double kFontSizeStep = 1.0;
 
 /// Persisted terminal font size. Synchronous value (defaulted while prefs
 /// hydrate) so the terminal can render immediately. `set` clamps to
@@ -276,12 +281,174 @@ final terminalThemeProvider = StateNotifierProvider<TerminalThemeNotifier, int>(
   },
 );
 
-/// Convenience: the currently-selected [NamedTerminalTheme]. Guards against a
-/// stale out-of-range index by falling back to the default palette.
+/// Convenience: the currently-selected GLOBAL [NamedTerminalTheme]. Guards
+/// against a stale out-of-range index by falling back to the default palette.
+///
+/// NOTE (#601/#571): this resolves the *global* default theme. The terminal
+/// screen and session menu now read the PER-SESSION palette via
+/// [activeSessionThemeProvider]; this provider is retained as the source of the
+/// default a brand-new session inherits.
 final activeTerminalThemeProvider = Provider<NamedTerminalTheme>((ref) {
   final index = ref.watch(terminalThemeProvider);
   if (index < 0 || index >= terminalPalettes.length) {
     return terminalPalettes[terminalThemeDefault];
   }
   return terminalPalettes[index];
+});
+
+// ── Per-session terminal appearance (#601, #571) ──────────────────────────
+//
+// The owner wants to differentiate sessions: prod = small + one theme, dev =
+// large + another. So terminal theme + font size are PER-SESSION (keyed by
+// session id), NOT global. Changing one session's theme/font leaves every
+// other session UNCHANGED (isolation — memory: feedback_feature_scoping_and_
+// isolation_tests). A NEW session inherits the persisted global default (the
+// last-used theme/font, hydrated by [TerminalThemeNotifier]/[FontSizeNotifier]
+// from SharedPreferences) — it does NOT copy a live sibling's values.
+//
+// Per-session values live in-memory only: session ids carry a `createdAtMs`
+// suffix, so they are ephemeral by construction (a session never survives a
+// relaunch). The DEFAULT for new sessions is what persists, via the existing
+// global notifiers — that's the knob worth remembering across launches.
+
+/// Immutable per-session terminal appearance: which palette index + the font
+/// size in logical px. Both are clamped/validated by the notifier before they
+/// land here.
+@immutable
+class SessionAppearance {
+  const SessionAppearance({required this.themeIndex, required this.fontSize});
+
+  final int themeIndex;
+  final double fontSize;
+
+  SessionAppearance copyWith({int? themeIndex, double? fontSize}) {
+    return SessionAppearance(
+      themeIndex: themeIndex ?? this.themeIndex,
+      fontSize: fontSize ?? this.fontSize,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is SessionAppearance &&
+      other.themeIndex == themeIndex &&
+      other.fontSize == fontSize;
+
+  @override
+  int get hashCode => Object.hash(themeIndex, fontSize);
+}
+
+/// Owns the per-session appearance map (sessionId → [SessionAppearance]).
+///
+/// A session not yet in the map is treated as carrying the current global
+/// default ([_default]); the first mutation materializes its entry. Mutations
+/// touch ONLY the named session's entry, so sibling sessions never change —
+/// and they deliberately do NOT clobber the global default, so a per-session
+/// tweak never changes what the next NEW session inherits.
+class SessionAppearanceNotifier
+    extends Notifier<Map<String, SessionAppearance>> {
+  @override
+  Map<String, SessionAppearance> build() => const {};
+
+  /// The default a session without an explicit entry carries. Seeded from the
+  /// persisted global theme/font notifiers so a new session inherits the
+  /// last-used values rather than a hardcoded constant.
+  SessionAppearance get _default => SessionAppearance(
+    themeIndex: ref.read(terminalThemeProvider),
+    fontSize: ref.read(fontSizeProvider),
+  );
+
+  /// Read a session's appearance, falling back to the current default for a
+  /// session that hasn't been customized yet.
+  SessionAppearance appearanceOf(String sessionId) =>
+      state[sessionId] ?? _default;
+
+  static int _validTheme(int i) =>
+      (i >= 0 && i < terminalPalettes.length) ? i : terminalThemeDefault;
+
+  static double _clampFont(double v) => v.clamp(kFontSizeMin, kFontSizeMax);
+
+  void _put(String sessionId, SessionAppearance next) {
+    state = {...state, sessionId: next};
+  }
+
+  /// Set [sessionId]'s palette index (clamped to a valid index). Affects only
+  /// this session — sibling sessions and the global default are untouched.
+  void setTheme(String sessionId, int index) {
+    final i = _validTheme(index);
+    _put(sessionId, appearanceOf(sessionId).copyWith(themeIndex: i));
+  }
+
+  /// Advance [sessionId]'s palette to the next one, wrapping at the end.
+  void cycleTheme(String sessionId) {
+    final cur = appearanceOf(sessionId).themeIndex;
+    setTheme(sessionId, (cur + 1) % terminalPalettes.length);
+  }
+
+  /// Set [sessionId]'s font size (clamped). Affects only this session — sibling
+  /// sessions and the global default are untouched.
+  void setFontSize(String sessionId, double size) {
+    final s = _clampFont(size);
+    _put(sessionId, appearanceOf(sessionId).copyWith(fontSize: s));
+  }
+
+  /// Step [sessionId]'s font size by [delta] logical px (clamped).
+  void adjustFontSize(String sessionId, double delta) {
+    setFontSize(sessionId, appearanceOf(sessionId).fontSize + delta);
+  }
+}
+
+final sessionAppearanceProvider =
+    NotifierProvider<SessionAppearanceNotifier, Map<String, SessionAppearance>>(
+      SessionAppearanceNotifier.new,
+    );
+
+/// Per-session palette index. Falls back to the current default for an
+/// un-customized session. Rebuilds when that session's entry changes.
+final sessionThemeProvider = Provider.family<int, String>((ref, sessionId) {
+  ref.watch(sessionAppearanceProvider);
+  return ref
+      .read(sessionAppearanceProvider.notifier)
+      .appearanceOf(sessionId)
+      .themeIndex;
+});
+
+/// Per-session font size. Falls back to the current default for an
+/// un-customized session.
+final sessionFontSizeProvider = Provider.family<double, String>((
+  ref,
+  sessionId,
+) {
+  ref.watch(sessionAppearanceProvider);
+  return ref
+      .read(sessionAppearanceProvider.notifier)
+      .appearanceOf(sessionId)
+      .fontSize;
+});
+
+/// The [NamedTerminalTheme] for a given session, guarding a stale index.
+final sessionTerminalThemeProvider =
+    Provider.family<NamedTerminalTheme, String>((ref, sessionId) {
+      final index = ref.watch(sessionThemeProvider(sessionId));
+      if (index < 0 || index >= terminalPalettes.length) {
+        return terminalPalettes[terminalThemeDefault];
+      }
+      return terminalPalettes[index];
+    });
+
+/// The ACTIVE session's [NamedTerminalTheme] — what the session menu's Theme
+/// row label reflects. Falls back to the global default when no session is
+/// active.
+final activeSessionThemeProvider = Provider<NamedTerminalTheme>((ref) {
+  final activeId = ref.watch(activeSessionIdProvider);
+  if (activeId == null) return ref.watch(activeTerminalThemeProvider);
+  return ref.watch(sessionTerminalThemeProvider(activeId));
+});
+
+/// The ACTIVE session's font size — what the session menu's font stepper shows.
+/// Falls back to the global default when no session is active.
+final activeSessionFontSizeProvider = Provider<double>((ref) {
+  final activeId = ref.watch(activeSessionIdProvider);
+  if (activeId == null) return ref.watch(fontSizeProvider);
+  return ref.watch(sessionFontSizeProvider(activeId));
 });

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -112,7 +112,12 @@ class SessionMenu extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final sessions = ref.watch(sessionsProvider);
     final keybarVisible = ref.watch(keybarVisibleProvider);
-    final palette = ref.watch(activeTerminalThemeProvider);
+    // Theme + font are PER-SESSION (#601, #571): the menu rows read and mutate
+    // the ACTIVE session only. With no active session (empty list) these resolve
+    // to the global default so the rows still render sensibly.
+    final activeId = sessions.activeId;
+    final palette = ref.watch(activeSessionThemeProvider);
+    final fontSize = ref.watch(activeSessionFontSizeProvider);
 
     return SingleChildScrollView(
       child: Column(
@@ -172,8 +177,9 @@ class SessionMenu extends ConsumerWidget {
             value: keybarVisible,
             onChanged: (v) => ref.read(keybarVisibleProvider.notifier).set(v),
           ),
-          // Cycle the terminal palette (#552). Tapping advances to the next
-          // ported theme, wrapping at the end; the selection persists.
+          // Cycle the ACTIVE session's terminal palette (#601, #571). Tapping
+          // advances to the next ported theme, wrapping at the end. Per-session:
+          // it changes ONLY the active session, never the others.
           ListTile(
             key: const Key('session-menu-theme-cycle'),
             dense: true,
@@ -183,7 +189,58 @@ class SessionMenu extends ConsumerWidget {
               palette.label,
               style: Theme.of(context).textTheme.bodySmall,
             ),
-            onTap: () => ref.read(terminalThemeProvider.notifier).cycle(),
+            enabled: activeId != null,
+            onTap: activeId == null
+                ? null
+                : () => ref
+                      .read(sessionAppearanceProvider.notifier)
+                      .cycleTheme(activeId),
+          ),
+          // Font-size stepper for the ACTIVE session (#601). The owner shrinks
+          // the font for more terminal real estate, or grows it for legibility,
+          // per session — prod small, dev large. −/＋ step by [kFontSizeStep],
+          // clamped to [kFontSizeMin]..[kFontSizeMax]; the current value shows
+          // between the buttons. Monochrome Material icons only (no emoji).
+          ListTile(
+            key: const Key('session-menu-fontsize'),
+            dense: true,
+            leading: const Icon(Icons.format_size),
+            title: const Text('Font size'),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  key: const Key('session-menu-fontsize-dec'),
+                  tooltip: 'Decrease font size',
+                  visualDensity: VisualDensity.compact,
+                  icon: const Icon(Icons.remove),
+                  onPressed: activeId == null
+                      ? null
+                      : () => ref
+                            .read(sessionAppearanceProvider.notifier)
+                            .adjustFontSize(activeId, -kFontSizeStep),
+                ),
+                SizedBox(
+                  width: 28,
+                  child: Text(
+                    '${fontSize.round()}',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+                IconButton(
+                  key: const Key('session-menu-fontsize-inc'),
+                  tooltip: 'Increase font size',
+                  visualDensity: VisualDensity.compact,
+                  icon: const Icon(Icons.add),
+                  onPressed: activeId == null
+                      ? null
+                      : () => ref
+                            .read(sessionAppearanceProvider.notifier)
+                            .adjustFontSize(activeId, kFontSizeStep),
+                ),
+              ],
+            ),
           ),
           // Browse / download remote files over SFTP for the active session
           // (#559). Disabled when there's no active session.

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -342,8 +342,10 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody> {
   Widget build(BuildContext context) {
     final terminal = ref.watch(terminalProvider(widget.sessionId));
     final shellAsync = ref.watch(sshShellProvider(widget.sessionId));
-    final fontSize = ref.watch(fontSizeProvider);
-    final palette = ref.watch(activeTerminalThemeProvider);
+    // Per-session theme + font (#601, #571): each session's TerminalView reads
+    // ITS OWN palette + font size, so two visible sessions can differ.
+    final fontSize = ref.watch(sessionFontSizeProvider(widget.sessionId));
+    final palette = ref.watch(sessionTerminalThemeProvider(widget.sessionId));
 
     return Column(
       children: [

--- a/native/test/state/per_session_appearance_test.dart
+++ b/native/test/state/per_session_appearance_test.dart
@@ -1,0 +1,186 @@
+// Per-session terminal theme + font size (#601, #571).
+//
+// These tests assert ISOLATION (memory: feedback_feature_scoping_and_isolation
+// _tests), not merely that a per-session knob exists:
+//   - Two sessions carry independent theme + font size; mutating one leaves the
+//     other UNCHANGED (no leakage).
+//   - Switching the active session does not mutate either session's values.
+//   - A new session inherits the persisted global default, not another live
+//     session's value.
+//
+// On the OLD global providers these would be RED: a single StateNotifier holds
+// one index / one font size, so changing it for "session A" changes it for B.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+ProviderContainer _makeContainer() {
+  final pair = InMemoryGatewayPair();
+  final container = ProviderContainer(
+    overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+  );
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  addTearDown(container.dispose);
+  return container;
+}
+
+SessionEntry _add(ProviderContainer c, String host) {
+  return c
+      .read(sessionsProvider.notifier)
+      .addOrActivate(
+        SshConnectParams(
+          host: host,
+          port: 22,
+          username: 'u',
+          auth: const SshAuth.password('p'),
+        ),
+      );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('per-session terminal theme', () {
+    test('changing one session theme does not leak to the other', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      final b = _add(c, 'host-b');
+
+      final appearance = c.read(sessionAppearanceProvider.notifier);
+      appearance.setTheme(a.id, 1);
+
+      expect(c.read(sessionThemeProvider(a.id)), 1);
+      expect(
+        c.read(sessionThemeProvider(b.id)),
+        terminalThemeDefault,
+        reason: 'session B theme must be untouched by a change to A',
+      );
+    });
+
+    test('cycle advances ONLY the named session', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      final b = _add(c, 'host-b');
+
+      final appearance = c.read(sessionAppearanceProvider.notifier);
+      appearance.cycleTheme(a.id);
+
+      expect(c.read(sessionThemeProvider(a.id)), 1);
+      expect(c.read(sessionThemeProvider(b.id)), terminalThemeDefault);
+    });
+
+    test('activeSessionTheme resolves the active session palette', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      final b = _add(c, 'host-b'); // b is now active
+
+      c.read(sessionAppearanceProvider.notifier).setTheme(a.id, 1);
+
+      // Active is b → still default palette.
+      expect(
+        c.read(activeSessionThemeProvider).label,
+        terminalPalettes[terminalThemeDefault].label,
+      );
+
+      c.read(sessionsProvider.notifier).setActive(a.id);
+      expect(
+        c.read(activeSessionThemeProvider).label,
+        terminalPalettes[1].label,
+      );
+
+      // Switching active did NOT change either stored value.
+      expect(c.read(sessionThemeProvider(a.id)), 1);
+      expect(c.read(sessionThemeProvider(b.id)), terminalThemeDefault);
+    });
+  });
+
+  group('per-session font size', () {
+    test('changing one session font does not leak to the other', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      final b = _add(c, 'host-b');
+
+      c.read(sessionAppearanceProvider.notifier).setFontSize(a.id, 22);
+
+      expect(c.read(sessionFontSizeProvider(a.id)), 22);
+      expect(
+        c.read(sessionFontSizeProvider(b.id)),
+        fontSizeDefault,
+        reason: 'session B font must be untouched by a change to A',
+      );
+    });
+
+    test('adjustFont steps and clamps the named session only', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      final b = _add(c, 'host-b');
+
+      final appearance = c.read(sessionAppearanceProvider.notifier);
+      appearance.adjustFontSize(a.id, 2);
+      expect(c.read(sessionFontSizeProvider(a.id)), fontSizeDefault + 2);
+      expect(c.read(sessionFontSizeProvider(b.id)), fontSizeDefault);
+
+      // Clamp below min.
+      appearance.setFontSize(a.id, kFontSizeMin);
+      appearance.adjustFontSize(a.id, -100);
+      expect(c.read(sessionFontSizeProvider(a.id)), kFontSizeMin);
+
+      // Clamp above max.
+      appearance.setFontSize(a.id, kFontSizeMax);
+      appearance.adjustFontSize(a.id, 100);
+      expect(c.read(sessionFontSizeProvider(a.id)), kFontSizeMax);
+    });
+
+    test('switching active does not mutate any session font', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      final b = _add(c, 'host-b');
+
+      final appearance = c.read(sessionAppearanceProvider.notifier);
+      appearance.setFontSize(a.id, 20);
+      appearance.setFontSize(b.id, 10);
+
+      c.read(sessionsProvider.notifier).setActive(a.id);
+      c.read(sessionsProvider.notifier).setActive(b.id);
+
+      expect(c.read(sessionFontSizeProvider(a.id)), 20);
+      expect(c.read(sessionFontSizeProvider(b.id)), 10);
+    });
+  });
+
+  group('defaults + new-session inheritance', () {
+    test('a fresh session reads the defaults', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      expect(c.read(sessionThemeProvider(a.id)), terminalThemeDefault);
+      expect(c.read(sessionFontSizeProvider(a.id)), fontSizeDefault);
+    });
+
+    test('a new session inherits the persisted global default, not a live '
+        'sibling value', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+
+      // The owner shrinks + recolors session A. This must NOT become the value
+      // a brand-new session B inherits — B inherits the persisted default.
+      c.read(sessionAppearanceProvider.notifier).setFontSize(a.id, 26);
+      c.read(sessionAppearanceProvider.notifier).setTheme(a.id, 1);
+
+      final b = _add(c, 'host-b');
+      expect(c.read(sessionFontSizeProvider(b.id)), fontSizeDefault);
+      expect(c.read(sessionThemeProvider(b.id)), terminalThemeDefault);
+    });
+  });
+}

--- a/native/test/widget/appearance_settings_widget_test.dart
+++ b/native/test/widget/appearance_settings_widget_test.dart
@@ -125,13 +125,16 @@ void main() {
       return container;
     }
 
-    testWidgets('theme-cycle item present and advances palette', (
+    // #601/#571: the theme cycle is now PER-SESSION. Tapping it advances the
+    // ACTIVE session's palette index, not a global one. (The global
+    // `terminalThemeProvider` is now only the default a new session inherits.)
+    testWidgets('theme-cycle item present and advances the active session', (
       tester,
     ) async {
       final container = makeContainer();
       addTearDown(container.dispose);
 
-      container
+      final entry = container
           .read(sessionsProvider.notifier)
           .addOrActivate(
             const SshConnectParams(
@@ -142,7 +145,10 @@ void main() {
             ),
           );
 
-      expect(container.read(terminalThemeProvider), terminalThemeDefault);
+      expect(
+        container.read(sessionThemeProvider(entry.id)),
+        terminalThemeDefault,
+      );
 
       await tester.pumpWidget(host(container));
       await tester.tap(find.byKey(const Key('open-menu')));
@@ -154,10 +160,7 @@ void main() {
       await tester.tap(item);
       await _pumpFrames(tester);
 
-      expect(container.read(terminalThemeProvider), 1);
-
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getInt(terminalThemePrefKey), 1);
+      expect(container.read(sessionThemeProvider(entry.id)), 1);
     });
   });
 }

--- a/native/test/widget/session_menu_appearance_test.dart
+++ b/native/test/widget/session_menu_appearance_test.dart
@@ -1,0 +1,147 @@
+// Session-menu per-session theme + font controls (#601, #571).
+//
+// The menu's Theme cycle row and the NEW font-size stepper must mutate ONLY the
+// ACTIVE session. With two sessions open, operating the menu on the active one
+// must leave the other's theme + font unchanged (isolation, not just presence).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/ui/session_menu.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _host({required ProviderContainer container}) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(
+              key: const Key('open-menu'),
+              onPressed: () => showSessionMenu(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+ProviderContainer _makeContainer() {
+  final pair = InMemoryGatewayPair();
+  final container = ProviderContainer(
+    overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+  );
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  addTearDown(container.dispose);
+  return container;
+}
+
+SessionEntry _add(ProviderContainer c, String host) {
+  return c
+      .read(sessionsProvider.notifier)
+      .addOrActivate(
+        SshConnectParams(
+          host: host,
+          port: 22,
+          username: 'u',
+          auth: const SshAuth.password('p'),
+        ),
+      );
+}
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 8}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('SessionMenu appearance controls', () {
+    testWidgets('font + / - changes ONLY the active session', (tester) async {
+      final container = _makeContainer();
+      final a = _add(container, 'host-a');
+      final b = _add(container, 'host-b'); // b active
+
+      await tester.pumpWidget(_host(container: container));
+      await tester.tap(find.byKey(const Key('open-menu')));
+      await _pumpFrames(tester);
+
+      expect(find.byKey(const Key('session-menu-fontsize')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('session-menu-fontsize-inc')));
+      await _pumpFrames(tester);
+
+      expect(
+        container.read(sessionFontSizeProvider(b.id)),
+        greaterThan(fontSizeDefault),
+        reason: 'active session font should grow',
+      );
+      expect(
+        container.read(sessionFontSizeProvider(a.id)),
+        fontSizeDefault,
+        reason: 'inactive session font must be unchanged',
+      );
+
+      await tester.tap(find.byKey(const Key('session-menu-fontsize-dec')));
+      await tester.tap(find.byKey(const Key('session-menu-fontsize-dec')));
+      await _pumpFrames(tester);
+
+      expect(
+        container.read(sessionFontSizeProvider(b.id)),
+        lessThan(fontSizeDefault),
+      );
+      expect(container.read(sessionFontSizeProvider(a.id)), fontSizeDefault);
+    });
+
+    testWidgets('theme cycle changes ONLY the active session', (tester) async {
+      final container = _makeContainer();
+      final a = _add(container, 'host-a');
+      final b = _add(container, 'host-b'); // b active
+
+      await tester.pumpWidget(_host(container: container));
+      await tester.tap(find.byKey(const Key('open-menu')));
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(const Key('session-menu-theme-cycle')));
+      await _pumpFrames(tester);
+
+      expect(container.read(sessionThemeProvider(b.id)), 1);
+      expect(
+        container.read(sessionThemeProvider(a.id)),
+        terminalThemeDefault,
+        reason: 'inactive session theme must be unchanged',
+      );
+    });
+
+    testWidgets('font stepper shows the active session current value', (
+      tester,
+    ) async {
+      final container = _makeContainer();
+      _add(container, 'host-a');
+      final b = _add(container, 'host-b');
+      container.read(sessionAppearanceProvider.notifier).setFontSize(b.id, 17);
+
+      await tester.pumpWidget(_host(container: container));
+      await tester.tap(find.byKey(const Key('open-menu')));
+      await _pumpFrames(tester);
+
+      expect(find.text('17'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Per-session terminal **theme** and **font size**, both adjustable from the session menu — so the owner can differentiate concurrent sessions (prod = small + one theme, dev = large + another).

Today `terminalThemeProvider` and `fontSizeProvider` are GLOBAL single notifiers, so changing one session changed ALL. This PR makes both per-session (keyed by sessionId) — the shared global→per-session refactor that #601 and #571 both need, done together.

### What changed
- **`native/lib/state/ui_prefs_providers.dart`** — `SessionAppearance {themeIndex, fontSize}` + `SessionAppearanceNotifier` over `Map<sessionId, SessionAppearance>`. `.family` selectors (`sessionThemeProvider`, `sessionFontSizeProvider`, `sessionTerminalThemeProvider`) and active-session resolvers (`activeSessionThemeProvider`, `activeSessionFontSizeProvider`). A per-session mutation touches ONLY that session and does NOT clobber the global default; an un-customized session falls back to the persisted global default, so a NEW session inherits the last-used default — not a live sibling's value.
- **`native/lib/ui/session_menu.dart`** — the Theme cycle row now acts on the ACTIVE session; a NEW `session-menu-fontsize` −/＋ stepper (`-dec`/`-inc`, monochrome `Icons.format_size`/`remove`/`add`) steps the active session's font (clamped 8..32) and shows the current value. Rows disable when no session is active.
- **`native/lib/ui/terminal_screen.dart`** — each session's `TerminalView` reads its own per-session theme + font, so two visible sessions can differ.

## Isolation tests (red → green)
Per `feedback_feature_scoping_and_isolation_tests`, the tests assert ISOLATION, not mere presence. They are RED on the old global providers (a single notifier means changing A changes B) and GREEN after the refactor.

- `native/test/state/per_session_appearance_test.dart` (8): change A's theme/font → B UNCHANGED; cycle/adjust affect only the named session; switching active mutates neither; a new session inherits the default, not a sibling's value; clamp bounds.
- `native/test/widget/session_menu_appearance_test.dart` (3): the menu's font −/＋ and theme cycle mutate ONLY the active session; the stepper shows the active session's current value.
- Updated `native/test/widget/appearance_settings_widget_test.dart`: the theme-cycle test asserted the old GLOBAL provider; rewritten to assert the active session's per-session theme.

`scripts/native-fast-gate.sh`: analyze clean, **317 pass / 5 integration skipped / 0 fail**.

## Notes
- Profile-theme seeding (#571 "seed from `profile.theme` on connect") is deferred — it needs threading the profile theme name through `addOrActivate`. New sessions inherit the persisted default, which both issues explicitly allow ("inherits the last-used or a default").
- Not device-tested. The session-menu font/theme + two-session distinct-appearance is an orchestrator emulator-screenshot check.

Closes #601
Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)