### PR TITLE
feat: tappable session notifications — ready/stop returns to the originating session (#575)

### DIFF
--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -15,6 +15,7 @@ import 'ssh/ssh_session.dart';
 import 'state/connection_providers.dart';
 import 'state/keepalive_providers.dart';
 import 'state/lifecycle_providers.dart';
+import 'state/notification_providers.dart';
 import 'state/sessions.dart';
 import 'state/terminal_providers.dart';
 import 'ui/connect_form.dart';
@@ -79,6 +80,20 @@ class RootRouter extends ConsumerStatefulWidget {
 
 class _RootRouterState extends ConsumerState<RootRouter> {
   @override
+  void initState() {
+    super.initState();
+    // #575 cold-start: a notification tapped while the app was killed persisted
+    // its sessionId via FlutterForegroundTask.saveData; consume it after the
+    // first frame so any restored sessions exist before we focus one.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(
+        ref.read(notificationFocusRouterProvider).consumePendingFocus(),
+      );
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     // Touch the keepalive controller so it attaches to the SSH session
     // controller at app start; this is what starts/stops the foreground
@@ -120,6 +135,12 @@ class _RootRouterState extends ConsumerState<RootRouter> {
         for (final e in ref.read(sessionsProvider).entries) {
           e.proxy.rebind();
         }
+        // #575 warm-resume: if the user got here by tapping a session
+        // notification, focus the originating session. One-shot (takePending
+        // clears) so an ordinary resume doesn't re-focus.
+        unawaited(
+          ref.read(notificationFocusRouterProvider).consumePendingFocus(),
+        );
         setState(() {});
       }
     });

--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -18,6 +18,8 @@ import '../diagnostics/connect_trace.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import 'session_host.dart';
+import 'session_notification.dart';
+import 'session_notification_poster.dart';
 import 'task_ssh_gateway.dart';
 
 /// Top-level entry point for the foreground task isolate. Must be
@@ -41,10 +43,19 @@ class KeepaliveTaskHandler extends TaskHandler {
   /// which constructs a real host wired to FFT static methods. Tests inject
   /// a stub host bound to a [StubFftTransport] so the wire contract can be
   /// exercised without binding to platform channels.
-  KeepaliveTaskHandler({SessionHostBuilder? hostBuilder})
-    : _hostBuilder = hostBuilder ?? _defaultHostBuilder;
+  ///
+  /// [notificationPoster] (#575) surfaces tappable session notifications + owns
+  /// the tap → pending-focus hand-off. Production uses the default FFT-backed
+  /// poster; tests can inject a fake or leave it null (no notifications).
+  KeepaliveTaskHandler({
+    SessionHostBuilder? hostBuilder,
+    SessionNotificationPoster? notificationPoster,
+  }) : _injectedHostBuilder = hostBuilder,
+       // ignore: prefer_initializing_formals
+       _notificationPoster = notificationPoster;
 
-  final SessionHostBuilder _hostBuilder;
+  final SessionHostBuilder? _injectedHostBuilder;
+  SessionNotificationPoster? _notificationPoster;
   TaskSideFftTransport? _transport;
   SessionHost? _host;
 
@@ -60,11 +71,30 @@ class KeepaliveTaskHandler extends TaskHandler {
     final transport = TaskSideFftTransport();
     final gateway = TaskSideForegroundGateway(transport: transport);
     _transport = transport;
+    // #575: build the notification poster if one wasn't injected. It surfaces
+    // tappable session notifications and records the originating session so a
+    // tap (onNotificationPressed) returns the user there.
+    _notificationPoster ??= _defaultNotificationPoster();
     // The host announces readiness in its constructor (#539): the first
     // task → UI payload it sends is an `SshTaskReadyEvent`, which the UI-side
     // gateway uses to flush any commands buffered during isolate spin-up.
-    _host = _hostBuilder(gateway);
+    final builder = _injectedHostBuilder;
+    _host = builder != null
+        ? builder(gateway)
+        : SessionHost(
+            gateway: gateway,
+            notificationPoster: _notificationPoster,
+          );
     ctrace('task', 'onStart: host built (ready event should be sent)');
+  }
+
+  @override
+  void onNotificationPressed() {
+    // #575: the user tapped the session notification. Record the originating
+    // session as the pending focus + bring the app to the foreground; the UI
+    // isolate routes to that session on resume.
+    ctrace('task', 'onNotificationPressed → routing to originating session');
+    unawaited(_notificationPoster?.onTapped());
   }
 
   @override
@@ -104,8 +134,40 @@ class KeepaliveTaskHandler extends TaskHandler {
 /// the [KeepaliveTaskHandler] without binding to FFT statics.
 typedef SessionHostBuilder = SessionHost Function(TaskSshGateway gateway);
 
-SessionHost _defaultHostBuilder(TaskSshGateway gateway) =>
-    SessionHost(gateway: gateway);
+/// Build the production notification poster (#575), bound to FFT statics:
+/// updates the foreground-service notification, persists the pending focus via
+/// `saveData` (survives process death → cold-start tap routing), and launches
+/// the app on tap. Runs inside the task isolate.
+SessionNotificationPoster _defaultNotificationPoster() {
+  return SessionNotificationPoster(
+    bridge: PendingFocusBridge(const _FftTaskKeyValueStore()),
+    update: ({required String title, required String text}) async {
+      await FlutterForegroundTask.updateService(
+        notificationTitle: title,
+        notificationText: text,
+      );
+    },
+    launch: FlutterForegroundTask.launchApp,
+  );
+}
+
+/// Task-isolate [KeyValueStore] over `FlutterForegroundTask.saveData/getData`.
+/// Mirrors the UI-side `FftKeyValueStore` (in notification_providers.dart) so
+/// both isolates read/write the SAME persistent store.
+class _FftTaskKeyValueStore implements KeyValueStore {
+  const _FftTaskKeyValueStore();
+
+  @override
+  Future<String?> getString(String key) =>
+      FlutterForegroundTask.getData<String>(key: key);
+
+  @override
+  Future<void> setString(String key, String value) =>
+      FlutterForegroundTask.saveData(key: key, value: value);
+
+  @override
+  Future<void> remove(String key) => FlutterForegroundTask.removeData(key: key);
+}
 
 /// Thin wrapper over the static `FlutterForegroundTask` API. Lets us inject a
 /// fake in tests so we don't bind to platform method channels.

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -28,6 +28,9 @@ import '../ssh/ssh_session.dart';
 import '../ssh/ssh_shell.dart';
 import '../ssh/sftp_session.dart';
 import 'session_messages.dart';
+import 'session_notification.dart';
+import 'session_notification_poster.dart';
+import 'session_signal_detector.dart';
 import 'task_ssh_gateway.dart';
 
 /// Factory injected by the UI / tests. Production uses the default which
@@ -57,11 +60,13 @@ class SessionHost {
     SshControllerFactory? controllerFactory,
     SftpSessionOpener? sftpOpener,
     HostShellOpener? shellOpener,
+    SessionNotificationPoster? notificationPoster,
     this.snapshotInterval = const Duration(seconds: 2),
   }) : _gateway = gateway,
        _factory = controllerFactory ?? _defaultControllerFactory,
        _sftpOpener = sftpOpener,
-       _shellOpener = shellOpener ?? _defaultShellOpener {
+       _shellOpener = shellOpener ?? _defaultShellOpener,
+       _notificationPoster = notificationPoster {
     _commandSub = _gateway.incoming.listen(_dispatch);
     _snapshotTimer = Timer.periodic(snapshotInterval, (_) => _pushSnapshots());
     ctrace('task.host', 'ctor: listening; sending SshTaskReadyEvent');
@@ -83,6 +88,11 @@ class SessionHost {
 
   /// Opens the PTY shell once a session reaches `connected`.
   final HostShellOpener _shellOpener;
+
+  /// Surfaces tappable session notifications (#575). Null in tests / on
+  /// platforms without a foreground service — the host then runs without
+  /// notifications.
+  final SessionNotificationPoster? _notificationPoster;
 
   /// How often a snapshot is pushed to the UI side. Tests use a short
   /// interval; production defaults to two seconds.
@@ -172,7 +182,16 @@ class SessionHost {
       return;
     }
     final controller = _factory();
-    final hosted = _HostedSession(controller: controller);
+    // Human label for notifications (#575): prefer the saved profile title, fall
+    // back to user@host:port (mirrors SessionEntry.label).
+    final label = (cmd.title != null && cmd.title!.isNotEmpty)
+        ? cmd.title!
+        : '${cmd.username}@${cmd.host}:${cmd.port}';
+    final hosted = _HostedSession(controller: controller, label: label);
+    // Detector scans this session's PTY output for OSC-9/BEL "ready" signals.
+    hosted.signalDetector = SessionSignalDetector(
+      onSignal: (signal) => _onSessionSignal(cmd.sessionId, hosted, signal),
+    );
     _sessions[cmd.sessionId] = hosted;
 
     // Forward state transitions back as events.
@@ -192,6 +211,16 @@ class SessionHost {
       // a stall shows WHERE it stopped instead of a blank cursor.
       if (data.state != prevState) {
         _emitConnectStatus(cmd.sessionId, data);
+        // #575: a session that STOPS (disconnected/failed) posts a "disconnected"
+        // notification so the user knows it dropped even while in another app.
+        if (data.state == SshSessionState.disconnected ||
+            data.state == SshSessionState.failed) {
+          _postSessionNotification(
+            cmd.sessionId,
+            hosted,
+            SessionSignalKind.stopped,
+          );
+        }
         prevState = data.state;
       }
       // Drop the prior shell the instant the transport leaves `connected`
@@ -348,6 +377,8 @@ class SessionHost {
         (bytes) {
           hosted.metrics.bytesIn += bytes.length;
           hosted.appendScrollback(bytes);
+          // #575: scan PTY output for OSC-9/BEL "ready for review" signals.
+          hosted.signalDetector?.feed(bytes);
           _gateway.send(
             SshOutputEvent(sessionId: sessionId, bytes: bytes).toJson(),
           );
@@ -406,6 +437,45 @@ class SessionHost {
         line = null;
     }
     if (line != null) _emitStatus(sessionId, '$line\r\n');
+  }
+
+  /// A detector fired a "ready" signal from this session's PTY output (#575).
+  void _onSessionSignal(
+    String sessionId,
+    _HostedSession hosted,
+    SessionSignal signal,
+  ) {
+    _postSessionNotification(
+      sessionId,
+      hosted,
+      signal.kind,
+      message: signal.message,
+    );
+  }
+
+  /// Post a tappable notification for [sessionId] (#575). No-op when no poster
+  /// is wired (tests / desktop). Errors are swallowed — a failed notification
+  /// must never disturb the SSH session.
+  void _postSessionNotification(
+    String sessionId,
+    _HostedSession hosted,
+    SessionSignalKind kind, {
+    String? message,
+  }) {
+    final poster = _notificationPoster;
+    if (poster == null) return;
+    unawaited(
+      poster
+          .notify(
+            sessionId: sessionId,
+            label: hosted.label,
+            kind: kind,
+            message: message,
+          )
+          .catchError((Object e) {
+            ctrace('task.host', 'notify FAILED sid=$sessionId — $e');
+          }),
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -687,9 +757,16 @@ class SessionMetrics {
 }
 
 class _HostedSession {
-  _HostedSession({required this.controller});
+  _HostedSession({required this.controller, this.label = ''});
 
   final SshSessionController controller;
+
+  /// Human label for notifications (#575): profile title or user@host:port.
+  final String label;
+
+  /// Per-session PTY signal scanner (#575). Null until a connect sets it.
+  SessionSignalDetector? signalDetector;
+
   StreamSubscription<SshSessionData>? stateSub;
   final SessionMetrics metrics = SessionMetrics();
 

--- a/native/lib/services/session_notification.dart
+++ b/native/lib/services/session_notification.dart
@@ -1,0 +1,163 @@
+// Meaningful OS notifications for SSH sessions (#575).
+//
+// When a remote process in a session signals "ready for review" or the session
+// stops/disconnects, we surface a tappable Android notification whose tap
+// returns the user to the EXACT originating session.
+//
+// This module owns the two PURE, headless-testable pieces of that path:
+//
+//   1. [SessionNotification] — maps a session event (its human label + a signal
+//      kind + an optional message) to the notification's title/body, the
+//      sessionId payload the tap carries, and a per-session tag so repeated
+//      signals from one session REPLACE rather than stack (PWA notification-tag
+//      parity).
+//
+//   2. [PendingFocusBridge] — the cross-isolate hand-off. The notification tap
+//      is delivered to the foreground-task isolate (`TaskHandler
+//      .onNotificationPressed`); it records the originating sessionId here and
+//      launches the app. The UI isolate reads + clears it on resume/init and
+//      calls `sessionsProvider.notifier.setActive(sessionId)`. The bridge is
+//      abstracted over a [KeyValueStore] seam so production wires it to
+//      `FlutterForegroundTask.saveData/getData` (which survives process death,
+//      covering the cold-start case) while tests use an in-memory map.
+//
+// SECURITY: a notification only ever carries the session LABEL (user@host:port
+// or profile title), a fixed human phrase, and the opaque sessionId. It never
+// carries auth material — see the "no secret material" test.
+
+import 'dart:async';
+
+/// What a remote signal meant. Mapped from the session lifecycle / PTY signal
+/// into a human notification phrase.
+enum SessionSignalKind {
+  /// The remote signalled it is ready for the user (e.g. OSC 9 / a long-running
+  /// command finished, or the shell re-attached after a reconnect).
+  ready,
+
+  /// The session stopped — disconnected, failed, or the keep-alive service was
+  /// torn down.
+  stopped,
+}
+
+/// An immutable description of a tappable session notification. Pure data —
+/// the platform posting happens elsewhere (the foreground-task isolate updates
+/// its service notification with these fields).
+class SessionNotification {
+  const SessionNotification({
+    required this.title,
+    required this.body,
+    required this.payload,
+    required this.tag,
+  });
+
+  /// Notification title — the session's human label (user@host:port or the
+  /// saved profile title).
+  final String title;
+
+  /// Notification body — the human meaning of the signal.
+  final String body;
+
+  /// Opaque payload carried by the notification so the tap can route back to
+  /// the originating session. It is exactly the sessionId.
+  final String payload;
+
+  /// Android notification tag. Keyed by sessionId so a later signal from the
+  /// same session REPLACES the prior notification instead of stacking, while
+  /// distinct sessions get distinct tags (PWA notification-tag parity).
+  final String tag;
+
+  /// Tag prefix so the session notification never collides with the
+  /// foreground-service keep-alive notification.
+  static const String _tagPrefix = 'mobissh.session.';
+
+  /// Build a notification description for [sessionId] (its [label]) given the
+  /// [kind] of signal. An optional [message] (the parsed remote text, e.g. the
+  /// OSC-9 message) is appended to the body when present.
+  static SessionNotification build({
+    required String sessionId,
+    required String label,
+    required SessionSignalKind kind,
+    String? message,
+  }) {
+    final base = switch (kind) {
+      SessionSignalKind.ready => 'ready for review',
+      SessionSignalKind.stopped => 'disconnected',
+    };
+    final trimmed = message?.trim();
+    final body = (trimmed != null && trimmed.isNotEmpty)
+        ? '$base — $trimmed'
+        : base;
+    return SessionNotification(
+      title: label,
+      body: body,
+      payload: sessionId,
+      tag: '$_tagPrefix$sessionId',
+    );
+  }
+
+  /// Parse the sessionId out of a notification payload. Tolerant of a null or
+  /// empty payload (returns null → "no pending focus").
+  static String? parsePayload(String? payload) {
+    if (payload == null || payload.isEmpty) return null;
+    return payload;
+  }
+}
+
+/// Minimal key/value persistence seam. Production binds this to the
+/// foreground-task plugin's cross-isolate data store
+/// (`FlutterForegroundTask.saveData/getData/removeData`), which survives
+/// process death — so a tap on a cold-started app still routes to the right
+/// session. Tests use [MapKeyValueStore].
+abstract class KeyValueStore {
+  Future<String?> getString(String key);
+  Future<void> setString(String key, String value);
+  Future<void> remove(String key);
+}
+
+/// In-memory [KeyValueStore] for tests.
+class MapKeyValueStore implements KeyValueStore {
+  final Map<String, String> _m = {};
+
+  @override
+  Future<String?> getString(String key) async => _m[key];
+
+  @override
+  Future<void> setString(String key, String value) async {
+    _m[key] = value;
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    _m.remove(key);
+  }
+}
+
+/// Cross-isolate "session to focus on next resume" hand-off (#575).
+///
+/// The notification tap is handled in the foreground-task isolate, which cannot
+/// touch the UI's Riverpod containers. It records the originating sessionId
+/// here (and calls `launchApp`); the UI isolate reads + clears it on resume.
+class PendingFocusBridge {
+  PendingFocusBridge(this._store);
+
+  final KeyValueStore _store;
+
+  /// Storage key. Namespaced to avoid clashing with other app data.
+  static const String _key = 'mobissh.pendingFocusSessionId';
+
+  /// Record [sessionId] as the session to focus when the UI next resumes.
+  /// Latest write wins (the most recently tapped notification).
+  Future<void> setPending(String sessionId) =>
+      _store.setString(_key, sessionId);
+
+  /// Non-destructive read of the pending focus, or null when none is pending.
+  Future<String?> readPending() => _store.getString(_key);
+
+  /// One-shot consume: returns the pending sessionId (or null) AND clears it so
+  /// a later resume doesn't re-focus the same session.
+  Future<String?> takePending() async {
+    final v = await _store.getString(_key);
+    if (v != null) await _store.remove(_key);
+    return (v == null || v.isEmpty) ? null : v;
+  }
+}

--- a/native/lib/services/session_notification_poster.dart
+++ b/native/lib/services/session_notification_poster.dart
@@ -1,0 +1,81 @@
+// Posts tappable session notifications from the foreground-task isolate (#575).
+//
+// The task isolate owns the single foreground-service notification and is the
+// only place the notification tap (`TaskHandler.onNotificationPressed`) is
+// delivered. So session-event notifications are surfaced by UPDATING that
+// notification's title/body to the event content and recording the originating
+// sessionId in a [PendingFocusBridge]. When the user taps it, the handler reads
+// back that sessionId, persists it as the "pending focus", and launches the app
+// — the UI isolate routes to that session on resume.
+//
+// This module is the seam between the pure [SessionNotification] builder and
+// the platform. Production binds [post] to `FlutterForegroundTask.updateService`
+// and [bridge] to the FFT-backed store; tests inject fakes so the wiring is
+// exercised without platform channels.
+//
+// ignore_for_file: prefer_initializing_formals
+
+import 'dart:async';
+
+import 'session_notification.dart';
+
+/// Platform sink for an updated notification. Production wires this to
+/// `FlutterForegroundTask.updateService(notificationTitle:, notificationText:)`.
+typedef NotificationUpdater =
+    Future<void> Function({required String title, required String text});
+
+/// Brings the app to the foreground. Production wires this to
+/// `FlutterForegroundTask.launchApp()`.
+typedef AppLauncher = void Function();
+
+/// Surfaces session signals as the (single) foreground-service notification and
+/// owns the tap → pending-focus hand-off.
+class SessionNotificationPoster {
+  SessionNotificationPoster({
+    required PendingFocusBridge bridge,
+    required NotificationUpdater update,
+    required AppLauncher launch,
+  }) : _bridge = bridge,
+       _update = update,
+       _launch = launch;
+
+  final PendingFocusBridge _bridge;
+  final NotificationUpdater _update;
+  final AppLauncher _launch;
+
+  /// The sessionId of the most recently posted notification — the session the
+  /// notification currently points at. A tap routes here.
+  String? _lastSessionId;
+
+  /// Visible for tests.
+  String? get lastSessionId => _lastSessionId;
+
+  /// Surface a signal for [sessionId] (its human [label]). Updates the
+  /// foreground notification and remembers the session so a tap routes to it.
+  Future<void> notify({
+    required String sessionId,
+    required String label,
+    required SessionSignalKind kind,
+    String? message,
+  }) async {
+    final n = SessionNotification.build(
+      sessionId: sessionId,
+      label: label,
+      kind: kind,
+      message: message,
+    );
+    _lastSessionId = sessionId;
+    await _update(title: n.title, text: n.body);
+  }
+
+  /// Called when the notification is tapped. Records the originating session as
+  /// the pending focus (so the UI isolate focuses it on resume) and brings the
+  /// app to the foreground. No-op when nothing has been posted yet.
+  Future<void> onTapped() async {
+    final sessionId = _lastSessionId;
+    if (sessionId != null) {
+      await _bridge.setPending(sessionId);
+    }
+    _launch();
+  }
+}

--- a/native/lib/services/session_signal_detector.dart
+++ b/native/lib/services/session_signal_detector.dart
@@ -1,0 +1,147 @@
+// Per-session PTY signal detector (#575).
+//
+// Scans a session's output stream for "attention" signals the remote emits:
+//   - OSC 9  (ESC ] 9 ; <message> BEL | ST) — the iTerm/desktop-notification
+//     convention the PWA already uses (notify-bell.sh emits OSC 9). Carries a
+//     human message.
+//   - the terminal BEL (\a / 0x07) as a fallback attention signal (no message).
+//
+// One detector per session (keyed by sessionId at the call site). Escape
+// sequences can be split across PTY chunks, so the detector buffers the partial
+// tail across [feed] calls. It emits a [SessionSignal] which the task isolate
+// turns into a tappable notification via [SessionNotification].
+//
+// This is intentionally a SMALL, single-pass scanner — the shared
+// SessionStreamParser the issue mentions (path/URL detection for #570) can grow
+// from this seam, but #575 only needs OSC-9 + BEL.
+
+import 'dart:typed_data';
+
+import 'session_notification.dart';
+
+/// A detected attention signal from a session's output stream.
+class SessionSignal {
+  const SessionSignal({required this.kind, this.message});
+
+  final SessionSignalKind kind;
+
+  /// The OSC-9 message text, or null for a bare BEL.
+  final String? message;
+}
+
+const int _esc = 0x1b; // ESC
+const int _bel = 0x07; // BEL / \a
+const int _backslash = 0x5c; // '\' (ST is ESC \)
+const int _bracket = 0x5d; // ']'
+
+/// Scans PTY bytes for OSC-9 / BEL signals, buffering across chunk boundaries.
+class SessionSignalDetector {
+  SessionSignalDetector({required this.onSignal, this.maxBuffer = 4096});
+
+  /// Invoked once per detected signal.
+  final void Function(SessionSignal signal) onSignal;
+
+  /// Cap on the carry-over buffer so a stream that never terminates an OSC
+  /// sequence can't grow unbounded. When exceeded we drop the oldest bytes.
+  final int maxBuffer;
+
+  /// Carry-over bytes from a partial escape sequence at the end of the last
+  /// feed. Empty most of the time.
+  final List<int> _buf = [];
+
+  /// Feed a chunk of PTY output. Emits zero or more signals.
+  void feed(Uint8List chunk) {
+    _buf.addAll(chunk);
+    _scan();
+    // Bound the buffer: if an OSC start never terminates, keep only the tail.
+    if (_buf.length > maxBuffer) {
+      _buf.removeRange(0, _buf.length - maxBuffer);
+    }
+  }
+
+  void _scan() {
+    var i = 0;
+    while (i < _buf.length) {
+      final byte = _buf[i];
+      if (byte == _esc) {
+        // Possible OSC: ESC ] 9 ; ... (BEL | ESC \)
+        final consumed = _tryOsc9(i);
+        if (consumed == _needMore) {
+          // Incomplete escape — keep everything from `i` onward for next feed.
+          _buf.removeRange(0, i);
+          return;
+        }
+        if (consumed > 0) {
+          _buf.removeRange(0, consumed);
+          i = 0;
+          continue;
+        }
+        // Not an OSC 9 we handle — skip the ESC and keep scanning.
+        i += 1;
+        continue;
+      }
+      if (byte == _bel) {
+        // Standalone BEL → fallback attention signal.
+        onSignal(const SessionSignal(kind: SessionSignalKind.ready));
+        _buf.removeRange(0, i + 1);
+        i = 0;
+        continue;
+      }
+      i += 1;
+    }
+    // Reaching here means no pending partial sequence; nothing buffered is
+    // mid-escape, so we can drop everything scanned (no signal bytes remain).
+    _buf.clear();
+  }
+
+  /// Sentinel: the sequence starting at the scan index is an OSC that hasn't
+  /// terminated yet — wait for more bytes.
+  static const int _needMore = -1;
+
+  /// Try to parse an OSC 9 sequence starting at [start] (which is the ESC).
+  /// Returns the number of bytes consumed (start..terminator inclusive) on a
+  /// successful parse (and fires [onSignal]); 0 when this ESC does not begin an
+  /// OSC 9 we handle; [_needMore] when the sequence is incomplete.
+  int _tryOsc9(int start) {
+    // Need at least ESC ] 9 ;
+    if (start + 1 >= _buf.length) return _needMore;
+    if (_buf[start + 1] != _bracket) return 0; // not an OSC at all
+    if (start + 2 >= _buf.length) return _needMore;
+    if (_buf[start + 2] != 0x39 /* '9' */ ) return 0; // OSC but not 9
+    if (start + 3 >= _buf.length) return _needMore;
+    if (_buf[start + 3] != 0x3b /* ';' */ ) return 0;
+
+    // Collect the message until BEL or ST (ESC \).
+    final msg = <int>[];
+    var j = start + 4;
+    while (j < _buf.length) {
+      final b = _buf[j];
+      if (b == _bel) {
+        _emitOsc(msg);
+        return (j - start) + 1;
+      }
+      if (b == _esc) {
+        if (j + 1 >= _buf.length) return _needMore; // maybe ST split
+        if (_buf[j + 1] == _backslash) {
+          _emitOsc(msg);
+          return (j - start) + 2;
+        }
+        // ESC not followed by \ inside an OSC — malformed; stop the sequence.
+        return 0;
+      }
+      msg.add(b);
+      j += 1;
+    }
+    return _needMore; // ran out of bytes before a terminator
+  }
+
+  void _emitOsc(List<int> msgBytes) {
+    final text = String.fromCharCodes(msgBytes).trim();
+    onSignal(
+      SessionSignal(
+        kind: SessionSignalKind.ready,
+        message: text.isEmpty ? null : text,
+      ),
+    );
+  }
+}

--- a/native/lib/state/notification_providers.dart
+++ b/native/lib/state/notification_providers.dart
@@ -1,0 +1,85 @@
+// Riverpod wiring for tappable session notifications (#575).
+//
+// Two providers:
+//   - [pendingFocusBridgeProvider] resolves the cross-isolate "session to
+//     focus" hand-off. Production binds it to the foreground-task plugin's
+//     persistent data store (survives process death → cold-start tap routing);
+//     tests override it with an in-memory bridge.
+//   - [notificationFocusRouterProvider] consumes the pending focus and calls
+//     `sessionsProvider.notifier.setActive(sessionId)`. The UI calls
+//     `consumePendingFocus()` on app init + on every `resumed` lifecycle event
+//     so a tapped notification lands the user on the originating session.
+//
+// ignore_for_file: prefer_initializing_formals
+
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../diagnostics/connect_trace.dart';
+import '../platform/desktop.dart';
+import '../services/session_notification.dart';
+import 'sessions.dart';
+
+/// [KeyValueStore] backed by `FlutterForegroundTask.saveData/getData`. This
+/// store is shared between the UI isolate and the foreground-task isolate AND
+/// persists across process death, so a notification tapped while the app is
+/// killed still records the originating session for the next cold start to
+/// route. Android-only — desktop uses [MapKeyValueStore] (no FFT plugin).
+class FftKeyValueStore implements KeyValueStore {
+  const FftKeyValueStore();
+
+  @override
+  Future<String?> getString(String key) =>
+      FlutterForegroundTask.getData<String>(key: key);
+
+  @override
+  Future<void> setString(String key, String value) =>
+      FlutterForegroundTask.saveData(key: key, value: value);
+
+  @override
+  Future<void> remove(String key) => FlutterForegroundTask.removeData(key: key);
+}
+
+/// The pending-focus hand-off. Desktop (#577) has no FFT plugin and no task
+/// isolate, so it gets an in-memory bridge (no real OS notifications there);
+/// Android uses the persistent FFT-backed store. Tests override this provider.
+final pendingFocusBridgeProvider = Provider<PendingFocusBridge>((ref) {
+  final store = ref.watch(isDesktopProvider)
+      ? MapKeyValueStore()
+      : const FftKeyValueStore();
+  return PendingFocusBridge(store);
+});
+
+/// Routes a tapped notification's pending sessionId to the active session.
+class NotificationFocusRouter {
+  NotificationFocusRouter({
+    required PendingFocusBridge bridge,
+    required void Function(String sessionId) focus,
+  }) : _bridge = bridge,
+       _focus = focus;
+
+  final PendingFocusBridge _bridge;
+  final void Function(String sessionId) _focus;
+
+  /// Consume any pending focus (one-shot) and focus that session. No-op when
+  /// nothing is pending. Safe when the sessionId is unknown — `setActive`
+  /// itself is a no-op for an absent id. Called on app init + on `resumed`.
+  Future<void> consumePendingFocus() async {
+    final sessionId = await _bridge.takePending();
+    if (sessionId == null) return;
+    ctrace('ui.notif', 'consumePendingFocus → setActive($sessionId)');
+    _focus(sessionId);
+  }
+}
+
+/// App-wide router. Reads the bridge + the sessions notifier so a tapped
+/// notification focuses the originating session.
+final notificationFocusRouterProvider = Provider<NotificationFocusRouter>((
+  ref,
+) {
+  return NotificationFocusRouter(
+    bridge: ref.watch(pendingFocusBridgeProvider),
+    focus: (sessionId) =>
+        ref.read(sessionsProvider.notifier).setActive(sessionId),
+  );
+});

--- a/native/test/services/session_notification_poster_test.dart
+++ b/native/test/services/session_notification_poster_test.dart
@@ -1,0 +1,81 @@
+// Tests for the task-isolate notification poster (#575). Exercises the wiring
+// between a session signal, the notification update, and the tap → pending
+// focus + launchApp hand-off, without binding to FlutterForegroundTask.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_notification.dart';
+import 'package:mobissh/services/session_notification_poster.dart';
+
+void main() {
+  test('notify updates the notification with the built title/body', () async {
+    final updates = <Map<String, String>>[];
+    var launched = 0;
+    final bridge = PendingFocusBridge(MapKeyValueStore());
+    final poster = SessionNotificationPoster(
+      bridge: bridge,
+      update: ({required title, required text}) async {
+        updates.add({'title': title, 'text': text});
+      },
+      launch: () => launched++,
+    );
+
+    await poster.notify(
+      sessionId: 'h:22:u:1',
+      label: 'u@h:22',
+      kind: SessionSignalKind.ready,
+      message: 'build done',
+    );
+
+    expect(updates, hasLength(1));
+    expect(updates.first['title'], 'u@h:22');
+    expect(updates.first['text'], contains('build done'));
+    expect(launched, 0, reason: 'posting does not launch the app');
+  });
+
+  test(
+    'tap records the LAST notified session as pending focus + launches',
+    () async {
+      var launched = 0;
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final poster = SessionNotificationPoster(
+        bridge: bridge,
+        update: ({required title, required text}) async {},
+        launch: () => launched++,
+      );
+
+      await poster.notify(
+        sessionId: 'A:22:u:1',
+        label: 'u@A:22',
+        kind: SessionSignalKind.ready,
+      );
+      await poster.notify(
+        sessionId: 'B:22:u:2',
+        label: 'u@B:22',
+        kind: SessionSignalKind.ready,
+      );
+
+      await poster.onTapped();
+
+      // The notification currently points at the most recently notified session.
+      expect(await bridge.takePending(), 'B:22:u:2');
+      expect(launched, 1);
+    },
+  );
+
+  test(
+    'tap before any notification is a safe no-op (still launches)',
+    () async {
+      var launched = 0;
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final poster = SessionNotificationPoster(
+        bridge: bridge,
+        update: ({required title, required text}) async {},
+        launch: () => launched++,
+      );
+
+      await poster.onTapped();
+      expect(await bridge.takePending(), isNull);
+      expect(launched, 1);
+    },
+  );
+}

--- a/native/test/services/session_notification_test.dart
+++ b/native/test/services/session_notification_test.dart
@@ -1,0 +1,188 @@
+// Tests for #575 — tappable session notifications.
+//
+// Three headless-testable units:
+//   1. SessionNotification.build — maps a session event (label + signal kind)
+//      to a notification's title/body + sessionId payload. Asserts the payload
+//      round-trips and carries NO secret material.
+//   2. PendingFocusBridge — the cross-isolate "session to focus" hand-off used
+//      when a notification is tapped. set → read → clear round-trips over an
+//      injectable KeyValueStore seam (no platform channels in tests).
+//   3. The notification-tap router — given a pending sessionId, calls
+//      sessionsProvider.notifier.setActive(sessionId), including the per-session
+//      ISOLATION case (a signal from A focuses A, never B).
+//
+// The full tap → launchApp → foreground → focus path is device-only and is
+// flagged for emulator validation; here we test the seams it composes.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_notification.dart';
+
+void main() {
+  group('SessionNotification.build', () {
+    test('ready signal → human title/body + sessionId payload', () {
+      final n = SessionNotification.build(
+        sessionId: 'host.example:22:alice:1234',
+        label: 'alice@host.example:22',
+        kind: SessionSignalKind.ready,
+      );
+      // Body conveys the meaning; title identifies the session.
+      expect(n.title, 'alice@host.example:22');
+      expect(n.body.toLowerCase(), contains('ready'));
+      // Payload carries the originating sessionId verbatim so the tap can
+      // route back to that exact session.
+      expect(n.payload, 'host.example:22:alice:1234');
+    });
+
+    test('stopped signal → "disconnected" body', () {
+      final n = SessionNotification.build(
+        sessionId: 's:22:u:9',
+        label: 'u@s:22',
+        kind: SessionSignalKind.stopped,
+      );
+      expect(n.title, 'u@s:22');
+      expect(n.body.toLowerCase(), contains('disconnect'));
+      expect(n.payload, 's:22:u:9');
+    });
+
+    test('custom message text from the signal is surfaced in the body', () {
+      final n = SessionNotification.build(
+        sessionId: 's:22:u:9',
+        label: 'u@s:22',
+        kind: SessionSignalKind.ready,
+        message: 'build finished',
+      );
+      expect(n.body, contains('build finished'));
+    });
+
+    test('payload round-trips through toPayload/parsePayload', () {
+      const sid = 'h:2222:bob:42';
+      final n = SessionNotification.build(
+        sessionId: sid,
+        label: 'bob@h:2222',
+        kind: SessionSignalKind.ready,
+      );
+      expect(SessionNotification.parsePayload(n.payload), sid);
+    });
+
+    test('parsePayload tolerates null/empty (no pending focus)', () {
+      expect(SessionNotification.parsePayload(null), isNull);
+      expect(SessionNotification.parsePayload(''), isNull);
+    });
+
+    test('android tag is keyed by sessionId so repeats replace, not stack', () {
+      final a1 = SessionNotification.build(
+        sessionId: 'h:22:u:1',
+        label: 'u@h:22',
+        kind: SessionSignalKind.ready,
+      );
+      final a2 = SessionNotification.build(
+        sessionId: 'h:22:u:1',
+        label: 'u@h:22',
+        kind: SessionSignalKind.stopped,
+      );
+      final b = SessionNotification.build(
+        sessionId: 'h:22:u:2',
+        label: 'u@h:22',
+        kind: SessionSignalKind.ready,
+      );
+      // Same session → same tag (replace). Different session → different tag.
+      expect(a1.tag, a2.tag);
+      expect(a1.tag, isNot(b.tag));
+    });
+
+    test(
+      'carries no secret material (password/passphrase/pem) in any field',
+      () {
+        final n = SessionNotification.build(
+          sessionId: 'h:22:u:1',
+          label: 'u@h:22',
+          kind: SessionSignalKind.ready,
+          message: 'ok',
+        );
+        final blob = '${n.title}|${n.body}|${n.payload}|${n.tag}'.toLowerCase();
+        expect(blob, isNot(contains('password')));
+        expect(blob, isNot(contains('passphrase')));
+        expect(blob, isNot(contains('begin')));
+        expect(blob, isNot(contains('private key')));
+      },
+    );
+  });
+
+  group('PendingFocusBridge', () {
+    test(
+      'set then read returns the sessionId; read does NOT consume',
+      () async {
+        final store = MapKeyValueStore();
+        final bridge = PendingFocusBridge(store);
+        await bridge.setPending('h:22:u:1');
+        expect(await bridge.readPending(), 'h:22:u:1');
+        // A bare read is non-destructive; the consumer clears explicitly.
+        expect(await bridge.readPending(), 'h:22:u:1');
+      },
+    );
+
+    test('takePending reads AND clears (one-shot consume on resume)', () async {
+      final store = MapKeyValueStore();
+      final bridge = PendingFocusBridge(store);
+      await bridge.setPending('h:22:u:1');
+      expect(await bridge.takePending(), 'h:22:u:1');
+      // Consumed — a second take yields nothing so resume doesn't re-focus.
+      expect(await bridge.takePending(), isNull);
+    });
+
+    test('readPending is null when nothing is pending', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      expect(await bridge.readPending(), isNull);
+    });
+
+    test('a later signal overwrites the pending focus (latest wins)', () async {
+      final store = MapKeyValueStore();
+      final bridge = PendingFocusBridge(store);
+      await bridge.setPending('h:22:u:1');
+      await bridge.setPending('h:22:u:2');
+      expect(await bridge.takePending(), 'h:22:u:2');
+    });
+  });
+
+  group('notification-tap routing', () {
+    test('routing a pending sessionId focuses THAT session (A not B)', () {
+      final focused = <String>[];
+      // The router is a pure mapping from a pending sessionId to a setActive
+      // call. The real provider path calls sessionsProvider.notifier.setActive;
+      // here we capture the calls to assert isolation.
+      void route(String? pending) {
+        if (pending == null) return;
+        focused.add(pending);
+      }
+
+      // Signal from A.
+      final tapA = SessionNotification.build(
+        sessionId: 'A:22:u:1',
+        label: 'u@A:22',
+        kind: SessionSignalKind.ready,
+      );
+      route(SessionNotification.parsePayload(tapA.payload));
+      expect(focused, ['A:22:u:1']);
+
+      // Signal from B does not retroactively re-focus A.
+      final tapB = SessionNotification.build(
+        sessionId: 'B:22:u:2',
+        label: 'u@B:22',
+        kind: SessionSignalKind.stopped,
+      );
+      route(SessionNotification.parsePayload(tapB.payload));
+      expect(focused, ['A:22:u:1', 'B:22:u:2']);
+    });
+
+    test('null payload is a no-op (no focus change)', () {
+      final focused = <String>[];
+      void route(String? pending) {
+        if (pending == null) return;
+        focused.add(pending);
+      }
+
+      route(SessionNotification.parsePayload(null));
+      expect(focused, isEmpty);
+    });
+  });
+}

--- a/native/test/services/session_signal_detector_test.dart
+++ b/native/test/services/session_signal_detector_test.dart
@@ -1,0 +1,77 @@
+// Tests for the per-session signal detector (#575).
+//
+// The detector scans a session's PTY output stream for "attention" signals:
+//   - OSC 9  (ESC ] 9 ; <message> BEL|ST) — the iTerm/desktop-notification
+//     convention the PWA already uses (notify-bell.sh emits OSC 9).
+//   - the terminal BEL (\a) as a fallback attention signal (no message).
+//
+// It is keyed by sessionId and emits a [SessionSignalKind.ready] with the
+// parsed message. Chunk boundaries can split an escape sequence, so the
+// detector must buffer across feeds. This is the producer half of the
+// notification path; posting the OS notification + the tap are device-only.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_notification.dart';
+import 'package:mobissh/services/session_signal_detector.dart';
+
+Uint8List _b(String s) => Uint8List.fromList(s.codeUnits);
+
+void main() {
+  test('OSC 9 with BEL terminator → ready signal carrying the message', () {
+    final signals = <SessionSignal>[];
+    final d = SessionSignalDetector(onSignal: signals.add);
+    // ESC ] 9 ; build finished BEL
+    d.feed(_b('\x1b]9;build finished\x07'));
+    expect(signals, hasLength(1));
+    expect(signals.first.kind, SessionSignalKind.ready);
+    expect(signals.first.message, 'build finished');
+  });
+
+  test('OSC 9 with ST (ESC backslash) terminator is also recognized', () {
+    final signals = <SessionSignal>[];
+    final d = SessionSignalDetector(onSignal: signals.add);
+    d.feed(_b('\x1b]9;ready\x1b\\'));
+    expect(signals, hasLength(1));
+    expect(signals.first.message, 'ready');
+  });
+
+  test('bare BEL → ready signal with no message (fallback attention)', () {
+    final signals = <SessionSignal>[];
+    final d = SessionSignalDetector(onSignal: signals.add);
+    d.feed(_b('done\x07'));
+    expect(signals, hasLength(1));
+    expect(signals.first.kind, SessionSignalKind.ready);
+    expect(signals.first.message, isNull);
+  });
+
+  test('escape sequence split across two feeds is still detected', () {
+    final signals = <SessionSignal>[];
+    final d = SessionSignalDetector(onSignal: signals.add);
+    d.feed(_b('\x1b]9;hello'));
+    expect(signals, isEmpty, reason: 'incomplete sequence — wait for more');
+    d.feed(_b(' world\x07'));
+    expect(signals, hasLength(1));
+    expect(signals.first.message, 'hello world');
+  });
+
+  test('plain output with no signal emits nothing', () {
+    final signals = <SessionSignal>[];
+    final d = SessionSignalDetector(onSignal: signals.add);
+    d.feed(_b('just some normal terminal output\nline 2\n'));
+    expect(signals, isEmpty);
+  });
+
+  test(
+    'OSC 9 takes precedence over a BEL inside the same chunk (no double)',
+    () {
+      final signals = <SessionSignal>[];
+      final d = SessionSignalDetector(onSignal: signals.add);
+      // The BEL here is the OSC terminator, not a standalone bell.
+      d.feed(_b('\x1b]9;all set\x07'));
+      expect(signals, hasLength(1));
+      expect(signals.first.message, 'all set');
+    },
+  );
+}

--- a/native/test/state/notification_focus_test.dart
+++ b/native/test/state/notification_focus_test.dart
@@ -1,0 +1,103 @@
+// Integration of the #575 notification-tap focus path with the real session
+// collection providers. Proves that consuming a pending focus (the sessionId a
+// tapped notification carried) calls sessionsProvider.notifier.setActive on the
+// ACTUAL notifier, and that the per-session isolation holds (focusing A leaves
+// B untouched). The physical tap → launchApp → foreground is device-only.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_notification.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/notification_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+
+ProviderContainer _makeContainer(PendingFocusBridge bridge) {
+  final pair = InMemoryGatewayPair();
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      pendingFocusBridgeProvider.overrideWithValue(bridge),
+    ],
+  );
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  return container;
+}
+
+SshConnectParams _params({String host = 'h', String username = 'u'}) {
+  return SshConnectParams(
+    host: host,
+    port: 22,
+    username: username,
+    auth: const SshAuth.password('p'),
+  );
+}
+
+void main() {
+  test(
+    'consuming a pending focus calls setActive on the originating session',
+    () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final c = _makeContainer(bridge);
+      addTearDown(c.dispose);
+
+      final notifier = c.read(sessionsProvider.notifier);
+      final a = notifier.addOrActivate(_params(host: 'A'));
+      final b = notifier.addOrActivate(_params(host: 'B'));
+      // B is active after the second add.
+      expect(c.read(sessionsProvider).activeId, b.id);
+
+      // A notification from session A was tapped → bridge holds A's id.
+      final tap = SessionNotification.build(
+        sessionId: a.id,
+        label: a.label,
+        kind: SessionSignalKind.ready,
+      );
+      await bridge.setPending(SessionNotification.parsePayload(tap.payload)!);
+
+      // Consume the pending focus (what the resume hook does).
+      await c.read(notificationFocusRouterProvider).consumePendingFocus();
+
+      // Lands on A — the originating session.
+      expect(c.read(sessionsProvider).activeId, a.id);
+      // B still exists and is untouched (isolation).
+      expect(
+        c.read(sessionsProvider).entries.map((e) => e.id),
+        containsAll(<String>[a.id, b.id]),
+      );
+      // One-shot: consuming again does nothing (no spurious re-focus on resume).
+      await c.read(notificationFocusRouterProvider).consumePendingFocus();
+      expect(c.read(sessionsProvider).activeId, a.id);
+    },
+  );
+
+  test('no pending focus → active session unchanged', () async {
+    final bridge = PendingFocusBridge(MapKeyValueStore());
+    final c = _makeContainer(bridge);
+    addTearDown(c.dispose);
+
+    final notifier = c.read(sessionsProvider.notifier);
+    final a = notifier.addOrActivate(_params(host: 'A'));
+    expect(c.read(sessionsProvider).activeId, a.id);
+
+    await c.read(notificationFocusRouterProvider).consumePendingFocus();
+    expect(c.read(sessionsProvider).activeId, a.id);
+  });
+
+  test('pending focus for an unknown session is a safe no-op', () async {
+    final bridge = PendingFocusBridge(MapKeyValueStore());
+    final c = _makeContainer(bridge);
+    addTearDown(c.dispose);
+
+    final notifier = c.read(sessionsProvider.notifier);
+    final a = notifier.addOrActivate(_params(host: 'A'));
+    await bridge.setPending('gone:22:u:999');
+
+    await c.read(notificationFocusRouterProvider).consumePendingFocus();
+    // setActive is a no-op for an absent id → active stays on the real session.
+    expect(c.read(sessionsProvider).activeId, a.id);
+  });
+}


### PR DESCRIPTION
## Summary
Route a remote ready/stop signal to a tappable Android notification; tapping it brings the app to the foreground and focuses the EXACT originating session.

The native app depends only on `flutter_foreground_task`, which manages ONE notification (the foreground-service notification) and delivers the tap via `TaskHandler.onNotificationPressed` (no per-notification payload arg). So:
- a session **ready** (OSC 9 / BEL in PTY output) or **stop** (disconnected/failed) updates the FGS notification title/body to the event content and records the originating sessionId;
- **tapping** it records that sessionId as a pending focus (via the FFT `saveData` KV store, which survives process death → also covers cold-start) and launches the app;
- the UI isolate consumes the pending focus on init + on resume and calls `sessionsProvider.notifier.setActive(sessionId)`.

## What changed
New modules (each headless-tested):
- `services/session_notification.dart` — pure event → `{title, body, payload, tag}` builder + `PendingFocusBridge` over a `KeyValueStore` seam.
- `services/session_signal_detector.dart` — per-session OSC-9/BEL PTY scanner that buffers across chunk boundaries (the shared-parser seam #570 can grow from).
- `services/session_notification_poster.dart` — task-isolate `notify()` + tap hand-off (`onTapped()` → pending focus + launchApp).
- `state/notification_providers.dart` — `pendingFocusBridgeProvider` (FFT-backed on Android, in-memory on desktop) + `notificationFocusRouterProvider`.

Wiring:
- `SessionHost` feeds PTY output through the detector and posts a "disconnected" notification on terminal transitions.
- `KeepaliveTaskHandler.onNotificationPressed` → `poster.onTapped()`.
- `main.dart` consumes the pending focus on init (cold-start) + on resume (warm).

## Tests (headless, TDD red→green)
- `session_notification_test.dart` — event→content mapping, payload round-trip, per-session tag (replace not stack), **no secret material** in any field, bridge set/read/take one-shot, latest-wins, tap-routing isolation (A focuses A not B).
- `session_signal_detector_test.dart` — OSC 9 (BEL + ST terminators), bare BEL, split-across-chunks, plain output no-op.
- `session_notification_poster_test.dart` — notify updates the notification; tap records the last-notified session + launches; tap-before-notify is a safe no-op.
- `notification_focus_test.dart` — consuming a pending focus calls `setActive` on the REAL notifier; isolation (B untouched); one-shot (no re-focus on a second resume); unknown sessionId is a safe no-op.

Gate: `scripts/native-fast-gate.sh` passes — analyze clean, 331 unit tests pass.

## Device-only (needs emulator validation)
The physical **tap → launchApp → foreground → setActive** path and the real OS notification render cannot be exercised headless. POST_NOTIFICATIONS is already requested at FGS start (`keepalive_task.dart`). Flagged for orchestrator emulator validation.

## Security
Notifications carry only the session label, a fixed human phrase, and the opaque sessionId — never auth material (asserted by test).

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)