### PR TITLE
ux: keybar polish — monochrome arrows, squarer, ^keys last, PWA default layout (#606)

### DIFF
--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -41,23 +41,56 @@ class KeybarKey {
   final IconData? icon;
 }
 
-/// Default key layout — one flat line (scrolls horizontally), same key set and
-/// order as the PWA's `DEFAULT_KEY_BAR_CONFIG` in `src/modules/keybar-config.ts`.
+/// Default key layout — one flat line (scrolls horizontally), mirroring the
+/// PWA's `DEFAULT_KEY_BAR_CONFIG` (src/modules/keybar-config.ts) as the
+/// AUTHORITATIVE key SET.
+///
+/// ORDER CONTRACT (do not regress — this keeps drifting): navigation and
+/// symbol keys come FIRST, and the control sequences (^C / ^Z / ^B / ^D) are
+/// grouped LAST at the END of the bar. The PWA config is the spec for which
+/// keys exist; the control-keys-last grouping is owner-mandated (repeat
+/// correction). If you add a control sequence, append it to the control group
+/// at the end — never interspersed among the nav/symbol keys.
+///
+/// All four arrows use monochrome Material `Icon`s (theme-tinted via the
+/// [KeybarKey.icon] path) instead of the unicode ◀▲▼▶ glyphs, which the
+/// platform colorizes inconsistently (emoji-style fills). No colorful/emoji
+/// glyphs — see memory feedback_monochrome_icons_no_emoji.
 const List<KeybarKey> kDefaultKeybarKeys = [
+  // --- nav / symbol keys first ---
   KeybarKey(id: 'keyEsc', label: 'Esc', sequence: '\x1b'),
   KeybarKey(id: 'keyTab', label: '↹', sequence: '\t'),
   KeybarKey(id: 'keySlash', label: '/', sequence: '/'),
   KeybarKey(id: 'keyDash', label: '-', sequence: '-'),
   KeybarKey(id: 'keyPipe', label: '|', sequence: '|'),
-  KeybarKey(id: 'keyCtrlC', label: '^C', sequence: '\x03'),
-  KeybarKey(id: 'keyCtrlZ', label: '^Z', sequence: '\x1a'),
-  KeybarKey(id: 'keyCtrlD', label: '^D', sequence: '\x04'),
-  KeybarKey(id: 'keyLeft', label: '◀', sequence: '\x1b[D'),
-  KeybarKey(id: 'keyUp', label: '▲', sequence: '\x1b[A'),
-  KeybarKey(id: 'keyDown', label: '▼', sequence: '\x1b[B'),
-  KeybarKey(id: 'keyRight', label: '▶', sequence: '\x1b[C'),
+  KeybarKey(
+    id: 'keyLeft',
+    label: 'Left',
+    sequence: '\x1b[D',
+    icon: Icons.keyboard_arrow_left,
+  ),
+  KeybarKey(
+    id: 'keyUp',
+    label: 'Up',
+    sequence: '\x1b[A',
+    icon: Icons.keyboard_arrow_up,
+  ),
+  KeybarKey(
+    id: 'keyDown',
+    label: 'Down',
+    sequence: '\x1b[B',
+    icon: Icons.keyboard_arrow_down,
+  ),
+  KeybarKey(
+    id: 'keyRight',
+    label: 'Right',
+    sequence: '\x1b[C',
+    icon: Icons.keyboard_arrow_right,
+  ),
   KeybarKey(id: 'keyHome', label: 'Home', sequence: '\x1b[H'),
   KeybarKey(id: 'keyEnd', label: 'End', sequence: '\x1b[F'),
+  KeybarKey(id: 'keyPgUp', label: 'PgUp', sequence: '\x1b[5~'),
+  KeybarKey(id: 'keyPgDn', label: 'PgDn', sequence: '\x1b[6~'),
   KeybarKey(id: 'keyEnter', label: '↵', sequence: '\r'),
   KeybarKey(
     id: 'keyPaste',
@@ -65,6 +98,11 @@ const List<KeybarKey> kDefaultKeybarKeys = [
     sequence: '', // handled out-of-band
     icon: Icons.content_paste,
   ),
+  // --- control sequences grouped LAST (owner-mandated, do not intersperse) ---
+  KeybarKey(id: 'keyCtrlC', label: '^C', sequence: '\x03'),
+  KeybarKey(id: 'keyCtrlZ', label: '^Z', sequence: '\x1a'),
+  KeybarKey(id: 'keyCtrlB', label: '^B', sequence: '\x02'),
+  KeybarKey(id: 'keyCtrlD', label: '^D', sequence: '\x04'),
 ];
 
 class Keybar extends ConsumerWidget {
@@ -150,6 +188,10 @@ class _KeybarButton extends StatelessWidget {
         // tap target) instead of squeezing N keys to fit the viewport width.
         minimumSize: const Size(48, 44),
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        // Squarer look matching the PWA keybar — subtle rounding, not pill.
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(6)),
+        ),
       ),
       child: child,
     );

--- a/native/test/widget/keybar_test.dart
+++ b/native/test/widget/keybar_test.dart
@@ -34,20 +34,88 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
+  group('kDefaultKeybarKeys layout (#606)', () {
+    test(
+      'control sequences are grouped at the END, after all nav/symbol keys',
+      () {
+        final ids = kDefaultKeybarKeys.map((k) => k.id).toList();
+        final ctrlIds = ['keyCtrlC', 'keyCtrlZ', 'keyCtrlB', 'keyCtrlD'];
+        // Every control key must come after every non-control key.
+        final lastNonCtrlIndex = ids.lastIndexWhere(
+          (id) => !ctrlIds.contains(id),
+        );
+        final firstCtrlIndex = ids.indexWhere((id) => ctrlIds.contains(id));
+        expect(
+          firstCtrlIndex,
+          greaterThan(lastNonCtrlIndex),
+          reason:
+              'control keys ($ctrlIds) must be grouped at the end, not '
+              'interspersed among nav/symbol keys. Order was: $ids',
+        );
+        // And they must be contiguous at the tail.
+        expect(
+          ids.sublist(ids.length - ctrlIds.length),
+          equals(ctrlIds),
+          reason: 'control keys should be the final contiguous block',
+        );
+      },
+    );
+
+    test('default set includes Esc, Tab, four arrows, Home, End', () {
+      final ids = kDefaultKeybarKeys.map((k) => k.id).toSet();
+      for (final required in [
+        'keyEsc',
+        'keyTab',
+        'keyLeft',
+        'keyUp',
+        'keyDown',
+        'keyRight',
+        'keyHome',
+        'keyEnd',
+      ]) {
+        expect(
+          ids,
+          contains(required),
+          reason: 'default keybar must include $required',
+        );
+      }
+    });
+
+    test('all four arrows use the monochrome icon path (icon != null)', () {
+      final arrows = kDefaultKeybarKeys
+          .where(
+            (k) => ['keyLeft', 'keyUp', 'keyDown', 'keyRight'].contains(k.id),
+          )
+          .toList();
+      expect(arrows.length, 4);
+      for (final a in arrows) {
+        expect(
+          a.icon,
+          isNotNull,
+          reason:
+              '${a.id} must render as a theme-tinted Material icon, not '
+              'a unicode glyph that the platform colorizes inconsistently',
+        );
+      }
+    });
+  });
+
   group('Keybar widget', () {
-    testWidgets('renders without throwing for an active session', (tester) async {
+    testWidgets('renders without throwing for an active session', (
+      tester,
+    ) async {
       final pair = InMemoryGatewayPair();
       addTearDown(() async {
         await pair.dispose();
       });
       final container = ProviderContainer(
-        overrides: [
-          taskSshGatewayProvider.overrideWithValue(pair.uiSide),
-        ],
+        overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
       );
       addTearDown(container.dispose);
 
-      final entry = container.read(sessionsProvider.notifier).addOrActivate(
+      final entry = container
+          .read(sessionsProvider.notifier)
+          .addOrActivate(
             const SshConnectParams(
               host: 'h',
               port: 22,
@@ -59,7 +127,9 @@ void main() {
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
-          child: MaterialApp(home: Scaffold(body: Keybar(activeEntry: entry))),
+          child: MaterialApp(
+            home: Scaffold(body: Keybar(activeEntry: entry)),
+          ),
         ),
       );
       await _pumpFrames(tester);


### PR DESCRIPTION
## Summary
Keybar polish for the native Flutter app, from owner device feedback on the one-line scrollable keybar (`native/lib/ui/keybar.dart`).

- **Monochrome arrows.** All four arrows now render as theme-tinted Material `Icon`s (`Icons.keyboard_arrow_left/up/down/right`) via the existing `KeybarKey.icon` path — the same path the Paste key uses. Previously the unicode `◀▶` glyphs rendered white-on-orange (emoji-style filled) while `▲▼` were monochrome. All four now tint to `colorScheme.onSurface` and look consistent. No emoji glyphs (memory: feedback_monochrome_icons_no_emoji).
- **Less rounding.** `_KeybarButton` (OutlinedButton) now uses `OutlinedButton.styleFrom(shape: RoundedRectangleBorder(radius 6))` for a squarer, PWA-matching look instead of the default pill.
- **Control sequences last.** `^C / ^Z / ^B / ^D` are grouped at the END of the bar, after all nav/symbol keys (repeat correction — they kept drifting interspersed). Added an explicit ORDER CONTRACT code comment so it stops regressing.

## PWA-order parity
`kDefaultKeybarKeys` mirrors the PWA `DEFAULT_KEY_BAR_CONFIG` (`src/modules/keybar-config.ts`) as the authoritative key SET — now including PgUp/PgDn for full parity. The control-keys-last grouping is the owner-mandated ordering on top of that set. Default set includes Esc, Tab, the four arrows, Home, End.

## Tests
`native/test/widget/keybar_test.dart`:
- control sequences are the final contiguous block (after every nav/symbol key)
- the required nav set (Esc, Tab, four arrows, Home, End) is present
- all four arrows use the icon path (`KeybarKey.icon != null`) so they render monochrome

Existing render smoketest stays green. `scripts/native-fast-gate.sh` passes (analyze clean, 325 tests pass).

Visuals are device-validated by the orchestrator (emulator screenshot).

Closes #606