### PR TITLE
feat: full PWA theme set + profile default-theme into session (#613)

### DIFF
--- a/native/lib/state/ui_prefs_providers.dart
+++ b/native/lib/state/ui_prefs_providers.dart
@@ -185,7 +185,13 @@ final fontSizeProvider = StateNotifierProvider<FontSizeNotifier, double>((ref) {
 /// A named terminal palette: a label for the UI + the xterm `TerminalTheme`.
 @immutable
 class NamedTerminalTheme {
-  const NamedTerminalTheme(this.label, this.theme);
+  const NamedTerminalTheme(this.key, this.label, this.theme);
+
+  /// The PWA `ThemeName` (e.g. 'dark', 'dracula', 'tokyoNight') — the stable
+  /// identity that makes a profile's saved/imported `theme` mappable to a native
+  /// palette via [paletteIndexForThemeName]. Mirrors the object KEY in the PWA
+  /// `THEMES` map (src/modules/constants.ts).
+  final String key;
 
   final String label;
   final TerminalTheme theme;
@@ -245,13 +251,19 @@ Color _hexa(String rgba) {
   return Color((a << 24) | rgb);
 }
 
-/// Ported terminal palettes (#552). Mapped from the PWA `THEMES` map in
-/// `src/modules/terminal.ts`. Keep this list ordered and extensible — adding
-/// a palette is a one-line append, and the theme-cycle menu item wraps over
-/// the whole list. Slice 2 (#552 notes) adds the remaining PWA palettes.
+/// Ported terminal palettes (#552, #613). Mapped from the PWA `THEMES` map in
+/// `src/modules/constants.ts` (the AUTHORITATIVE source), ordered to match
+/// `THEME_ORDER`. Each entry carries the PWA `ThemeName` as its [key] so a
+/// profile's saved/imported `theme` is mappable to a palette via
+/// [paletteIndexForThemeName]. Only the fields the PWA themes actually specify
+/// (background/foreground/cursor/selectionBackground + optional white/
+/// brightWhite on light themes) are overridden; the rest reuse the xterm.dart
+/// default ANSI set (see [_ansi]). The PWA `app:` chrome block is intentionally
+/// ignored (it styles the PWA shell, not the terminal). Adding a palette is a
+/// one-line append; the theme-cycle wraps over the whole list.
 final List<NamedTerminalTheme> terminalPalettes = [
-  // PWA `dark`
   NamedTerminalTheme(
+    'dark',
     'Dark',
     _ansi(
       background: _hex('#000000'),
@@ -260,8 +272,20 @@ final List<NamedTerminalTheme> terminalPalettes = [
       selection: _hexa('#00ff8844'),
     ),
   ),
-  // PWA `solarizedDark`
   NamedTerminalTheme(
+    'light',
+    'Light',
+    _ansi(
+      background: _hex('#ffffff'),
+      foreground: _hex('#1a1a1a'),
+      cursor: _hex('#0055cc'),
+      selection: _hexa('#0055cc44'),
+      white: _hex('#e8e8ec'),
+      brightWhite: _hex('#d8d8df'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'solarizedDark',
     'Solarized Dark',
     _ansi(
       background: _hex('#002b36'),
@@ -270,7 +294,401 @@ final List<NamedTerminalTheme> terminalPalettes = [
       selection: _hexa('#268bd244'),
     ),
   ),
+  NamedTerminalTheme(
+    'solarizedLight',
+    'Solarized Light',
+    _ansi(
+      background: _hex('#fdf6e3'),
+      foreground: _hex('#657b83'),
+      cursor: _hex('#268bd2'),
+      selection: _hexa('#268bd244'),
+      white: _hex('#eee8d5'),
+      brightWhite: _hex('#d3c8a8'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'highContrast',
+    'High Contrast',
+    _ansi(
+      background: _hex('#000000'),
+      foreground: _hex('#ffffff'),
+      cursor: _hex('#ffff00'),
+      selection: _hexa('#ffff0044'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'highContrastLight',
+    'High Contrast Light',
+    _ansi(
+      background: _hex('#ffffff'),
+      foreground: _hex('#000000'),
+      cursor: _hex('#0000ff'),
+      selection: _hexa('#0000ff44'),
+      white: _hex('#e0e0e0'),
+      brightWhite: _hex('#c0c0c0'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'dracula',
+    'Dracula',
+    _ansi(
+      background: _hex('#282a36'),
+      foreground: _hex('#f8f8f2'),
+      cursor: _hex('#f8f8f2'),
+      selection: _hex('#44475a'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'draculaLight',
+    'Dracula Light',
+    _ansi(
+      background: _hex('#f8f8f2'),
+      foreground: _hex('#282a36'),
+      cursor: _hex('#bd93f9'),
+      selection: _hexa('#bd93f944'),
+      white: _hex('#e8e8e0'),
+      brightWhite: _hex('#d8d8d0'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'nord',
+    'Nord',
+    _ansi(
+      background: _hex('#2e3440'),
+      foreground: _hex('#d8dee9'),
+      cursor: _hex('#d8dee9'),
+      selection: _hex('#434c5e'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'nordLight',
+    'Nord Light',
+    _ansi(
+      background: _hex('#eceff4'),
+      foreground: _hex('#2e3440'),
+      cursor: _hex('#5e81ac'),
+      selection: _hexa('#5e81ac33'),
+      white: _hex('#dde2e8'),
+      brightWhite: _hex('#c8d0d8'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'gruvboxDark',
+    'Gruvbox Dark',
+    _ansi(
+      background: _hex('#282828'),
+      foreground: _hex('#ebdbb2'),
+      cursor: _hex('#ebdbb2'),
+      selection: _hex('#504945'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'gruvboxLight',
+    'Gruvbox Light',
+    _ansi(
+      background: _hex('#fbf1c7'),
+      foreground: _hex('#3c3836'),
+      cursor: _hex('#9d0006'),
+      selection: _hexa('#9d000633'),
+      white: _hex('#ebdbb2'),
+      brightWhite: _hex('#d5c4a1'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'monokai',
+    'Monokai',
+    _ansi(
+      background: _hex('#272822'),
+      foreground: _hex('#f8f8f2'),
+      cursor: _hex('#f8f8f2'),
+      selection: _hex('#49483e'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'monokaiLight',
+    'Monokai Light',
+    _ansi(
+      background: _hex('#fafafa'),
+      foreground: _hex('#272822'),
+      cursor: _hex('#75af00'),
+      selection: _hexa('#75af0033'),
+      white: _hex('#e8e8e0'),
+      brightWhite: _hex('#d0d0c8'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'tokyoNight',
+    'Tokyo Night',
+    _ansi(
+      background: _hex('#1a1b26'),
+      foreground: _hex('#a9b1d6'),
+      cursor: _hex('#c0caf5'),
+      selection: _hex('#33467c'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'tokyoNightDay',
+    'Tokyo Night Day',
+    _ansi(
+      background: _hex('#e1e2e7'),
+      foreground: _hex('#3760bf'),
+      cursor: _hex('#2e7de9'),
+      selection: _hexa('#2e7de933'),
+      white: _hex('#cfd0d6'),
+      brightWhite: _hex('#b8b9c0'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'ocean',
+    'Ocean',
+    _ansi(
+      background: _hex('#050d18'),
+      foreground: _hex('#b2d8f0'),
+      cursor: _hex('#00bcd4'),
+      selection: _hexa('#00bcd444'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'oceanLight',
+    'Ocean Light',
+    _ansi(
+      background: _hex('#e8f4fa'),
+      foreground: _hex('#0d3b54'),
+      cursor: _hex('#00838f'),
+      selection: _hexa('#00838f33'),
+      white: _hex('#d0e4ee'),
+      brightWhite: _hex('#b6cfdc'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'ember',
+    'Ember',
+    _ansi(
+      background: _hex('#1a0a0a'),
+      foreground: _hex('#f0c8b0'),
+      cursor: _hex('#ff5722'),
+      selection: _hexa('#ff572244'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'emberLight',
+    'Ember Light',
+    _ansi(
+      background: _hex('#fdf2eb'),
+      foreground: _hex('#5a2410'),
+      cursor: _hex('#d84315'),
+      selection: _hexa('#d8431533'),
+      white: _hex('#f5e2d3'),
+      brightWhite: _hex('#e8cab2'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'forest',
+    'Forest',
+    _ansi(
+      background: _hex('#0a1a0a'),
+      foreground: _hex('#b8d8b0'),
+      cursor: _hex('#4caf50'),
+      selection: _hexa('#4caf5044'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'forestLight',
+    'Forest Light',
+    _ansi(
+      background: _hex('#f0f5ec'),
+      foreground: _hex('#1b3a1b'),
+      cursor: _hex('#2e7d32'),
+      selection: _hexa('#2e7d3233'),
+      white: _hex('#dfe9da'),
+      brightWhite: _hex('#c5d3bd'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'sunset',
+    'Sunset',
+    _ansi(
+      background: _hex('#1a0f1e'),
+      foreground: _hex('#e8c8e0'),
+      cursor: _hex('#ff9800'),
+      selection: _hexa('#ff980044'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'sunsetLight',
+    'Sunset Light',
+    _ansi(
+      background: _hex('#fdf3ea'),
+      foreground: _hex('#4a2510'),
+      cursor: _hex('#e65100'),
+      selection: _hexa('#e6510033'),
+      white: _hex('#f4e2d4'),
+      brightWhite: _hex('#e8c9b3'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'synthwave',
+    'Synthwave',
+    _ansi(
+      background: _hex('#0f0a1a'),
+      foreground: _hex('#e0d0f0'),
+      cursor: _hex('#ff00ff'),
+      selection: _hexa('#ff00ff33'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'synthwaveLight',
+    'Synthwave Light',
+    _ansi(
+      background: _hex('#f5ebff'),
+      foreground: _hex('#3a1058'),
+      cursor: _hex('#c800c8'),
+      selection: _hexa('#c800c833'),
+      white: _hex('#e3d4f2'),
+      brightWhite: _hex('#cdb6e3'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'commodore',
+    'Commodore',
+    _ansi(
+      background: _hex('#3a3ac8'),
+      foreground: _hex('#ffffff'),
+      cursor: _hex('#ffff55'),
+      selection: _hexa('#ffffff44'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'commodoreLight',
+    'Commodore Light',
+    _ansi(
+      background: _hex('#d8d8e8'),
+      foreground: _hex('#2828a0'),
+      cursor: _hex('#a83a3a'),
+      selection: _hexa('#a83a3a33'),
+      white: _hex('#c8c8d8'),
+      brightWhite: _hex('#b0b0c8'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'terminal',
+    'Terminal',
+    _ansi(
+      background: _hex('#21388a'),
+      foreground: _hex('#ffffff'),
+      cursor: _hex('#ffffff'),
+      selection: _hexa('#ffffff44'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'terminalLight',
+    'Terminal Light',
+    _ansi(
+      background: _hex('#e8edf8'),
+      foreground: _hex('#192c70'),
+      cursor: _hex('#9c6800'),
+      selection: _hexa('#9c680033'),
+      white: _hex('#d2dbeb'),
+      brightWhite: _hex('#b8c5dc'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'borland',
+    'Borland',
+    _ansi(
+      background: _hex('#0000aa'),
+      foreground: _hex('#ffff55'),
+      cursor: _hex('#ffffff'),
+      selection: _hex('#00aaaa'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'borlandLight',
+    'Borland Light',
+    _ansi(
+      background: _hex('#fff8d8'),
+      foreground: _hex('#000088'),
+      cursor: _hex('#005577'),
+      selection: _hexa('#00aaaa55'),
+      white: _hex('#f0e8c0'),
+      brightWhite: _hex('#d8cfa0'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'arcticDark',
+    'Arctic Dark',
+    _ansi(
+      background: _hex('#0a1828'),
+      foreground: _hex('#a8c8e8'),
+      cursor: _hex('#3399ff'),
+      selection: _hexa('#3399ff33'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'arctic',
+    'Arctic',
+    _ansi(
+      background: _hex('#e8f0f8'),
+      foreground: _hex('#1a3050'),
+      cursor: _hex('#0066cc'),
+      selection: _hexa('#0066cc33'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'cobalt',
+    'Cobalt',
+    _ansi(
+      background: _hex('#002240'),
+      foreground: _hex('#ffffff'),
+      cursor: _hex('#ffcc00'),
+      selection: _hexa('#ffcc0033'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'cobaltLight',
+    'Cobalt Light',
+    _ansi(
+      background: _hex('#e6f1fb'),
+      foreground: _hex('#002240'),
+      cursor: _hex('#a87600'),
+      selection: _hexa('#a8760033'),
+      white: _hex('#cfdfee'),
+      brightWhite: _hex('#b5cadd'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'matrix',
+    'Matrix',
+    _ansi(
+      background: _hex('#000800'),
+      foreground: _hex('#00ff41'),
+      cursor: _hex('#00ff41'),
+      selection: _hexa('#00ff4133'),
+    ),
+  ),
+  NamedTerminalTheme(
+    'matrixLight',
+    'Matrix Light',
+    _ansi(
+      background: _hex('#f0fff0'),
+      foreground: _hex('#003300'),
+      cursor: _hex('#008822'),
+      selection: _hexa('#00882233'),
+      white: _hex('#daefdc'),
+      brightWhite: _hex('#bcd9c1'),
+    ),
+  ),
 ];
+
+/// PWA→native theme map (#613): resolve a profile's `theme` (a PWA `ThemeName`)
+/// to an index into [terminalPalettes]. Unknown or null names fall back to the
+/// default palette ([terminalThemeDefault], index 0 → 'dark') so a stale/typo
+/// theme never crashes the session.
+int paletteIndexForThemeName(String? name) {
+  if (name == null) return terminalThemeDefault;
+  final i = terminalPalettes.indexWhere((p) => p.key == name);
+  return i >= 0 ? i : terminalThemeDefault;
+}
 
 /// SharedPreferences key for the selected terminal palette index.
 const String terminalThemePrefKey = 'mobissh.ui.terminalThemeIndex';

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -33,6 +33,7 @@ import '../ssh/ssh_session.dart';
 import '../state/connection_providers.dart';
 import '../state/profiles_providers.dart';
 import '../state/sessions.dart';
+import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
 import 'diagnostics_section.dart';
 import 'host_key_dialog.dart';
@@ -149,6 +150,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     SshConnectParams params, {
     String? title,
     required String initialCommand,
+    String? themeName,
   }) async {
     // Captured before the async gap so we can pop a pushed "New session" route
     // after dispatching connect without touching `context` post-await.
@@ -165,6 +167,19 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
           .read(sessionsProvider.notifier)
           .addOrActivate(params, title: title);
       ctrace('ui.chooser', 'entry=${entry.id} → proxy.connect()');
+      // #613: apply the profile's default theme to THIS session (per-session,
+      // #601 — keyed by the new session's id, NOT global). Only when the profile
+      // carries a theme; an unknown/typo name maps to the default palette.
+      if (themeName != null) {
+        ref
+            .read(sessionAppearanceProvider.notifier)
+            .setTheme(entry.id, paletteIndexForThemeName(themeName));
+        ctrace(
+          'ui.chooser',
+          'applied profile theme "$themeName" → '
+              'palette ${paletteIndexForThemeName(themeName)} for ${entry.id}',
+        );
+      }
       // Arm the run-on-connect command (#558) BEFORE dispatching connect, so
       // the one-shot listener is attached before the task side can emit
       // `connected`. No-op when the field is empty.
@@ -305,6 +320,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       params,
       title: profile.title,
       initialCommand: profile.initialCommand ?? '',
+      themeName: profile.theme,
     );
   }
 

--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -23,6 +23,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../diagnostics/connect_trace.dart';
 import '../state/profiles_providers.dart';
+import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
 
 enum _AuthKind { password, key }
@@ -96,8 +97,13 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
   late final TextEditingController _portCtrl;
   late final TextEditingController _userCtrl;
   late final TextEditingController _initialCommandCtrl;
-  late final TextEditingController _themeCtrl;
   late final TextEditingController _colorCtrl;
+
+  /// Selected theme = a PWA `ThemeName` key from [terminalPalettes] (#613). The
+  /// editor shows the palette LABEL but stores the KEY into [SavedProfile.theme]
+  /// so connect can map it back via [paletteIndexForThemeName]. Defaults to the
+  /// profile's current theme key, falling back to the default palette key.
+  late String _themeKey;
   final _passwordCtrl = TextEditingController();
   final _keyCtrl = TextEditingController();
   final _passphraseCtrl = TextEditingController();
@@ -119,8 +125,12 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
     _portCtrl = TextEditingController(text: p.port.toString());
     _userCtrl = TextEditingController(text: p.username);
     _initialCommandCtrl = TextEditingController(text: p.initialCommand ?? '');
-    _themeCtrl = TextEditingController(text: p.theme ?? '');
     _colorCtrl = TextEditingController(text: p.color ?? '');
+    // Seed the picker from the profile's stored theme key when it maps to a
+    // known palette; otherwise fall back to the default palette's key.
+    final known =
+        p.theme != null && terminalPalettes.any((t) => t.key == p.theme);
+    _themeKey = known ? p.theme! : terminalPalettes[terminalThemeDefault].key;
     // Prefer the explicit authType; infer `key` when only a keyVaultId is
     // present (mirrors the connect form's inference for older profiles).
     if (p.authType == 'key') {
@@ -141,7 +151,6 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
     _portCtrl.dispose();
     _userCtrl.dispose();
     _initialCommandCtrl.dispose();
-    _themeCtrl.dispose();
     _colorCtrl.dispose();
     _passwordCtrl.dispose();
     _keyCtrl.dispose();
@@ -237,7 +246,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
         host: host,
         port: port,
         username: username,
-        theme: _emptyToNull(_themeCtrl.text),
+        theme: _themeKey,
         color: _emptyToNull(_colorCtrl.text),
         authType: authType,
         vaultId: vaultId,
@@ -424,15 +433,35 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
                 enableSuggestions: false,
               ),
               const SizedBox(height: 12),
-              TextField(
-                key: const Key('profile-editor-theme'),
-                controller: _themeCtrl,
+              // #613: theme PICKER over the full ported palette set. Shows the
+              // palette label; stores the PWA theme KEY into SavedProfile.theme
+              // so connect maps it back via paletteIndexForThemeName.
+              InputDecorator(
                 decoration: const InputDecoration(
-                  labelText: 'Theme (optional)',
-                  hintText: 'e.g. dark, solarizedDark',
+                  labelText: 'Theme',
+                  border: OutlineInputBorder(),
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
                 ),
-                autocorrect: false,
-                enableSuggestions: false,
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    key: const Key('profile-editor-theme-picker'),
+                    isExpanded: true,
+                    value: _themeKey,
+                    items: [
+                      for (final palette in terminalPalettes)
+                        DropdownMenuItem<String>(
+                          value: palette.key,
+                          child: Text(palette.label),
+                        ),
+                    ],
+                    onChanged: (value) {
+                      if (value != null) setState(() => _themeKey = value);
+                    },
+                  ),
+                ),
               ),
               const SizedBox(height: 8),
               TextField(

--- a/native/test/state/theme_palette_map_test.dart
+++ b/native/test/state/theme_palette_map_test.dart
@@ -1,0 +1,134 @@
+// #613 — full PWA theme set + PWA→native map.
+//
+// The PWA `THEMES` map (src/modules/constants.ts, ordered by THEME_ORDER) is the
+// AUTHORITATIVE theme set. Native `terminalPalettes` must port EVERY entry, keyed
+// by the PWA ThemeName, and `paletteIndexForThemeName` is the PWA→native lookup
+// that wires a profile's saved/imported `theme` into a session.
+//
+// These tests guard:
+//   - coverage: a palette exists for EVERY PWA theme key (so a future PWA theme
+//     added without a native palette FAILS here — drift detection).
+//   - mapping: each key resolves to a DISTINCT palette index; unknown/null → default.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+
+/// The PWA `THEME_ORDER` from src/modules/constants.ts — hardcoded so that
+/// adding a PWA theme without a matching native palette surfaces as a failing
+/// test (the sync-check). Keep in THEME_ORDER order.
+const List<String> kPwaThemeKeys = <String>[
+  'dark',
+  'light',
+  'solarizedDark',
+  'solarizedLight',
+  'highContrast',
+  'highContrastLight',
+  'dracula',
+  'draculaLight',
+  'nord',
+  'nordLight',
+  'gruvboxDark',
+  'gruvboxLight',
+  'monokai',
+  'monokaiLight',
+  'tokyoNight',
+  'tokyoNightDay',
+  'ocean',
+  'oceanLight',
+  'ember',
+  'emberLight',
+  'forest',
+  'forestLight',
+  'sunset',
+  'sunsetLight',
+  'synthwave',
+  'synthwaveLight',
+  'commodore',
+  'commodoreLight',
+  'terminal',
+  'terminalLight',
+  'borland',
+  'borlandLight',
+  'arcticDark',
+  'arctic',
+  'cobalt',
+  'cobaltLight',
+  'matrix',
+  'matrixLight',
+];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('terminalPalettes coverage', () {
+    test('a palette exists for EVERY PWA theme key', () {
+      final keys = terminalPalettes.map((p) => p.key).toSet();
+      for (final pwaKey in kPwaThemeKeys) {
+        expect(
+          keys.contains(pwaKey),
+          isTrue,
+          reason:
+              'PWA theme "$pwaKey" has no native palette — port it to '
+              'terminalPalettes (#613 drift guard)',
+        );
+      }
+    });
+
+    test('palettes are ordered to match THEME_ORDER', () {
+      // The first len(kPwaThemeKeys) palettes must be in THEME_ORDER order so a
+      // profile theme key resolves to the expected palette and cycle order
+      // matches the PWA.
+      for (var i = 0; i < kPwaThemeKeys.length; i++) {
+        expect(terminalPalettes[i].key, kPwaThemeKeys[i]);
+      }
+    });
+
+    test('default palette index 0 is the PWA `dark` theme', () {
+      expect(terminalThemeDefault, 0);
+      expect(terminalPalettes[terminalThemeDefault].key, 'dark');
+      expect(terminalPalettes[terminalThemeDefault].label, 'Dark');
+    });
+
+    test('every palette key is unique', () {
+      final keys = terminalPalettes.map((p) => p.key).toList();
+      expect(
+        keys.toSet().length,
+        keys.length,
+        reason: 'palette keys must be unique',
+      );
+    });
+  });
+
+  group('paletteIndexForThemeName (PWA→native map)', () {
+    test('every PWA key resolves to a DISTINCT palette index', () {
+      final indices = <int>{};
+      for (final key in kPwaThemeKeys) {
+        final idx = paletteIndexForThemeName(key);
+        expect(
+          terminalPalettes[idx].key,
+          key,
+          reason: 'key "$key" must map to the palette with that key',
+        );
+        expect(
+          indices.add(idx),
+          isTrue,
+          reason: 'key "$key" mapped to an already-used index — not distinct',
+        );
+      }
+      expect(indices.length, kPwaThemeKeys.length);
+    });
+
+    test('unknown name falls back to the default index', () {
+      expect(paletteIndexForThemeName('no-such-theme'), terminalThemeDefault);
+    });
+
+    test('null falls back to the default index', () {
+      expect(paletteIndexForThemeName(null), terminalThemeDefault);
+    });
+
+    test('a representative theme maps to the right palette', () {
+      final draculaIdx = paletteIndexForThemeName('dracula');
+      expect(terminalPalettes[draculaIdx].label, 'Dracula');
+    });
+  });
+}

--- a/native/test/widget/connect_applies_theme_test.dart
+++ b/native/test/widget/connect_applies_theme_test.dart
@@ -1,0 +1,194 @@
+// #613 — connecting from a profile applies its default theme to THAT session.
+//
+// profile.theme used to be dead data on native (stored + imported, never
+// applied). This locks the wiring: tapping a profile whose theme is 'dracula'
+// must set the NEW session's per-session appearance theme (#601) to the dracula
+// palette — keyed by the session id, NOT global. A second session connected from
+// a profile WITHOUT a theme stays the default (per-session isolation; memory:
+// feedback_feature_scoping_and_isolation_tests).
+//
+// Drives the real ConnectForm connect path (addOrActivate → proxy.connect) with
+// an in-memory gateway, then asserts via sessionThemeProvider on the created
+// entry's id.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/connect_form.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 30}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+Future<ProviderContainer> _pump(
+  WidgetTester tester, {
+  required ProfilesStore store,
+  required SecretsStore secrets,
+}) async {
+  final pair = InMemoryGatewayPair();
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      profilesStoreProvider.overrideWithValue(store),
+      secretsStoreProvider.overrideWithValue(secrets),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(
+        home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('connecting a profile with theme=dracula themes that session', (
+    tester,
+  ) async {
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    await secrets.write('vault-1', <String, Object?>{'password': 'pw'});
+    await store.save(<SavedProfile>[
+      SavedProfile(
+        title: 'Dark box',
+        host: 'dracula.example',
+        port: 22,
+        username: 'alice',
+        authType: 'password',
+        vaultId: 'vault-1',
+        theme: 'dracula',
+      ),
+    ]);
+
+    final container = await _pump(tester, store: store, secrets: secrets);
+
+    await tester.tap(
+      find.byKey(const Key('profile-tile-dracula.example:22:alice')),
+    );
+    await _pumpFrames(tester);
+
+    final entries = container.read(sessionsProvider).entries;
+    expect(entries.length, 1);
+    final id = entries.first.id;
+
+    final draculaIdx = paletteIndexForThemeName('dracula');
+    expect(
+      container.read(sessionThemeProvider(id)),
+      draculaIdx,
+      reason: 'session must open in the profile\'s configured theme',
+    );
+    expect(container.read(sessionTerminalThemeProvider(id)).label, 'Dracula');
+  });
+
+  testWidgets(
+    'a second session WITHOUT a profile theme stays default (isolation)',
+    (tester) async {
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('vault-1', <String, Object?>{'password': 'pw'});
+      await secrets.write('vault-2', <String, Object?>{'password': 'pw'});
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Themed',
+          host: 'dracula.example',
+          port: 22,
+          username: 'alice',
+          authType: 'password',
+          vaultId: 'vault-1',
+          theme: 'dracula',
+        ),
+        SavedProfile(
+          title: 'Plain',
+          host: 'plain.example',
+          port: 22,
+          username: 'bob',
+          authType: 'password',
+          vaultId: 'vault-2',
+          // no theme
+        ),
+      ]);
+
+      final container = await _pump(tester, store: store, secrets: secrets);
+
+      await tester.tap(
+        find.byKey(const Key('profile-tile-dracula.example:22:alice')),
+      );
+      await _pumpFrames(tester);
+      await tester.tap(
+        find.byKey(const Key('profile-tile-plain.example:22:bob')),
+      );
+      await _pumpFrames(tester);
+
+      final entries = container.read(sessionsProvider).entries;
+      expect(entries.length, 2);
+      final themed = entries.firstWhere((e) => e.host == 'dracula.example');
+      final plain = entries.firstWhere((e) => e.host == 'plain.example');
+
+      expect(
+        container.read(sessionThemeProvider(themed.id)),
+        paletteIndexForThemeName('dracula'),
+      );
+      expect(
+        container.read(sessionThemeProvider(plain.id)),
+        terminalThemeDefault,
+        reason: 'a profile without a theme must not inherit the themed one',
+      );
+    },
+  );
+
+  testWidgets(
+    'connecting a profile with an unknown theme falls back to default',
+    (tester) async {
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('vault-1', <String, Object?>{'password': 'pw'});
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Mystery',
+          host: 'mystery.example',
+          port: 22,
+          username: 'alice',
+          authType: 'password',
+          vaultId: 'vault-1',
+          theme: 'no-such-theme',
+        ),
+      ]);
+
+      final container = await _pump(tester, store: store, secrets: secrets);
+
+      await tester.tap(
+        find.byKey(const Key('profile-tile-mystery.example:22:alice')),
+      );
+      await _pumpFrames(tester);
+
+      final id = container.read(sessionsProvider).entries.first.id;
+      expect(container.read(sessionThemeProvider(id)), terminalThemeDefault);
+    },
+  );
+}

--- a/native/test/widget/profile_editor_test.dart
+++ b/native/test/widget/profile_editor_test.dart
@@ -83,7 +83,12 @@ void main() {
       expect(_fieldText(tester, 'profile-editor-host'), 'home.example');
       expect(_fieldText(tester, 'profile-editor-port'), '2222');
       expect(_fieldText(tester, 'profile-editor-username'), 'me');
-      expect(_fieldText(tester, 'profile-editor-theme'), 'solarizedDark');
+      // #613: theme is now a picker (dropdown) storing the PWA key, not a text
+      // field — see profile_editor_theme_picker_test.dart for picker coverage.
+      final themePicker = tester.widget<DropdownButton<String>>(
+        find.byKey(const Key('profile-editor-theme-picker')),
+      );
+      expect(themePicker.value, 'solarizedDark');
       expect(_fieldText(tester, 'profile-editor-color'), '#ff8800');
       expect(
         _fieldText(tester, 'profile-editor-initial-command'),

--- a/native/test/widget/profile_editor_theme_picker_test.dart
+++ b/native/test/widget/profile_editor_theme_picker_test.dart
@@ -1,0 +1,156 @@
+// #613 — the profile editor's theme field is a PICKER (dropdown over the full
+// palette set), not a raw text field. It shows the palette LABEL and stores the
+// PWA theme KEY into SavedProfile.theme. Pre-populates from an existing
+// profile.theme.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/profile_editor.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required ProfilesStore store,
+  required SecretsStore secrets,
+  required SavedProfile profile,
+}) async {
+  tester.view.physicalSize = const Size(1000, 2000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        profilesStoreProvider.overrideWithValue(store),
+        secretsStoreProvider.overrideWithValue(secrets),
+      ],
+      child: MaterialApp(home: ProfileEditor(profile: profile)),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _tapSave(WidgetTester tester) async {
+  final save = find.byKey(const Key('profile-editor-save'));
+  await tester.ensureVisible(save);
+  await tester.pumpAndSettle();
+  await tester.tap(save);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('renders a theme picker (dropdown), not a raw text field', (
+    tester,
+  ) async {
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    await _pump(
+      tester,
+      store: store,
+      secrets: secrets,
+      profile: SavedProfile(title: 't', host: 'h', port: 22, username: 'u'),
+    );
+
+    expect(
+      find.byKey(const Key('profile-editor-theme-picker')),
+      findsOneWidget,
+    );
+    expect(
+      find.byType(DropdownButton<String>),
+      findsWidgets,
+      reason: 'theme field must be a dropdown picker',
+    );
+  });
+
+  testWidgets('pre-populates the picker from an existing profile.theme', (
+    tester,
+  ) async {
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    await _pump(
+      tester,
+      store: store,
+      secrets: secrets,
+      profile: SavedProfile(
+        title: 't',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        theme: 'dracula',
+      ),
+    );
+
+    final dropdown = tester.widget<DropdownButton<String>>(
+      find.byKey(const Key('profile-editor-theme-picker')),
+    );
+    expect(dropdown.value, 'dracula');
+  });
+
+  testWidgets('defaults the picker to dark when profile has no theme', (
+    tester,
+  ) async {
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    await _pump(
+      tester,
+      store: store,
+      secrets: secrets,
+      profile: SavedProfile(title: 't', host: 'h', port: 22, username: 'u'),
+    );
+
+    final dropdown = tester.widget<DropdownButton<String>>(
+      find.byKey(const Key('profile-editor-theme-picker')),
+    );
+    expect(dropdown.value, 'dark');
+  });
+
+  testWidgets('selecting a theme stores its KEY into the saved profile', (
+    tester,
+  ) async {
+    final store = ProfilesStore();
+    await store.save(<SavedProfile>[
+      SavedProfile(
+        title: 'Box',
+        host: 'home.example',
+        port: 22,
+        username: 'me',
+        authType: 'password',
+      ),
+    ]);
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    await _pump(
+      tester,
+      store: store,
+      secrets: secrets,
+      profile: (await store.load()).first,
+    );
+
+    // Open the dropdown and pick the Nord palette by its label.
+    await tester.tap(find.byKey(const Key('profile-editor-theme-picker')));
+    await tester.pumpAndSettle();
+    final nordLabel = terminalPalettes.firstWhere((p) => p.key == 'nord').label;
+    await tester.tap(find.text(nordLabel).last);
+    await tester.pumpAndSettle();
+
+    await _tapSave(tester);
+
+    final saved = (await store.load()).first;
+    expect(
+      saved.theme,
+      'nord',
+      reason: 'the PWA KEY, not the label, is stored',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Ports the FULL PWA theme set to the native Flutter app and wires a profile's
default theme into the session it opens — closing two coupled gaps: native had
only 2 palettes, and `profile.theme` was dead data (stored + imported, never
applied).

### Part A — full theme set, keyed (PWA→native map)
- `NamedTerminalTheme` gains a `String key` = the PWA `ThemeName`.
- Every entry in `src/modules/constants.ts` `THEMES` (authoritative source,
  ordered by `THEME_ORDER` — 38 palettes) is ported into `terminalPalettes`,
  in order, reusing the existing `_ansi` / `_hex` / `_hexa` helpers. Only the
  fields the PWA themes specify are overridden: `background`, `foreground`,
  `cursor`, `selectionBackground`, plus the light-theme `white` / `brightWhite`
  overrides. The PWA `app:` chrome block is intentionally ignored.
- `paletteIndexForThemeName(String?)` resolves a PWA theme name → palette index;
  unknown / null fall back to `terminalThemeDefault` (0 → `dark`). This is the
  PWA→native map. `terminalThemeDefault` stays 0; the cycle / per-session
  providers index the list, so they pick up all new palettes automatically.

### Part B — apply on connect + editor picker
- `connect_form`: in the shared connect path, after the session entry exists,
  the new session's per-session appearance theme (#601) is set via
  `sessionAppearanceProvider.notifier.setTheme(entry.id, paletteIndexForThemeName(profile.theme))`
  — per-session, keyed by the new session's id (NOT global), and only when the
  profile carries a theme. A PWA-exported profile with `theme: 'dracula'` now
  opens dracula on native (import already carries the field).
- `profile_editor`: the raw theme TEXT field is replaced with a
  `DropdownButton` picker over `terminalPalettes` — shows the palette label,
  stores the PWA key into `SavedProfile.theme`. Default selection = the
  profile's current theme key, falling back to `dark`.

## Tests (TDD, headless — red→green)
- `theme_palette_map_test`: a palette exists for EVERY PWA theme key (drift
  guard — a future PWA theme without a native palette fails here), THEME_ORDER
  ordering, unique keys, and `paletteIndexForThemeName` resolving every key to a
  DISTINCT index with unknown/null → default.
- `connect_applies_theme_test`: connecting a `theme='dracula'` profile resolves
  that session's `sessionThemeProvider` to the dracula palette; a second session
  WITHOUT a theme stays default (per-session ISOLATION); an unknown theme falls
  back to default.
- `profile_editor_theme_picker_test`: the picker renders (dropdown, not text
  field), pre-populates from `profile.theme`, defaults to `dark`, and stores the
  selected KEY (not the label).

`scripts/native-fast-gate.sh` green (340 tests). Theme rendering itself is
device-validated by the orchestrator (emulator screenshot) + owner — not claimed
device-tested here.

Closes #613