### PR TITLE
fix(P0): run-on-connect command gates on shell-ready, not bare connected (#619)

### DIFF
--- a/native/integration_test/initial_command_smoke_test.dart
+++ b/native/integration_test/initial_command_smoke_test.dart
@@ -18,8 +18,6 @@
 //
 // Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
 
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -84,20 +82,21 @@ void main() {
     final entry = container.read(sessionsProvider).active;
     expect(entry, isNotNull, reason: 'no active session after connect');
 
-    // Capture everything the task side streams to the UI terminal.
-    final out = <int>[];
-    final sub = entry!.proxy.output.listen(out.addAll);
-    addTearDown(sub.cancel);
-
-    // The initial command ran iff the marker shows up TWICE: once in the echoed
-    // command line (`echo MARKER`) and once in its stdout (`MARKER`). A single
-    // occurrence would just be the command line; the run-on-connect was dropped.
+    // The run-on-connect command fires on shell-ready DURING connect, which can
+    // be BEFORE this test gets to subscribe. proxy.output is a broadcast stream
+    // (drops events while no one is listening), so a listener attached here
+    // races the command's echo and can miss it — flaky under load. Assert
+    // against the proxy's cached scrollbackTail instead: it accumulates from
+    // session creation (the entry's own terminal subscription is wired then)
+    // and is independent of when this test looks. The marker shows up TWICE —
+    // once in the echoed command line (`echo MARKER`) and once in its stdout
+    // (`MARKER`); a single occurrence would just be the command line with the
+    // run-on-connect dropped.
     var ran = false;
     for (var i = 0; i < 60; i++) {
       await tester.pump(const Duration(milliseconds: 500));
-      final text = utf8.decode(out, allowMalformed: true);
-      final count = marker.allMatches(text).length;
-      if (count >= 2) {
+      final text = entry!.proxy.snapshot.scrollbackTail;
+      if (marker.allMatches(text).length >= 2) {
         ran = true;
         break;
       }
@@ -107,8 +106,8 @@ void main() {
       isTrue,
       reason:
           'run-on-connect command never executed — its output ($marker) did '
-          'not appear in the shell. The command was dropped before the PTY '
-          'shell opened (#619).',
+          'not appear in the session scrollback. The command was dropped before '
+          'the PTY shell opened (#619).',
     );
   });
 }

--- a/native/integration_test/initial_command_smoke_test.dart
+++ b/native/integration_test/initial_command_smoke_test.dart
@@ -1,0 +1,114 @@
+// On-emulator RUN-ON-CONNECT smoke (#619) — proves the configured initial
+// command actually executes after connect, WITHOUT the user typing it.
+//
+// The device bug: the run-on-connect command (#558) reached some hosts but not
+// others (the owner's slow "ra-server" dropped it). Root cause: the UI fired
+// the command on the bare `connected` state, racing ahead of the async task-
+// side PTY shell open — `_handleInput` then dropped the bytes to scrollback.
+// The fix gates the send on a task-side shell-ready signal. This smoke connects
+// with an initial command of `echo <marker>` and asserts the marker appears in
+// the shell output — i.e. the command ran on its own, not via a typed input.
+//
+// The headless race test (test/services/initial_command_shell_ready_test.dart)
+// reproduces the slow-host timing deterministically with a delayed fake shell;
+// this device smoke confirms the same on a real PTY. The owner's real failing
+// case is ra-server (a genuinely slow host) — flag it for device validation;
+// the emulator's test-sshd is a fast host, so this is a regression guard that
+// the command fires at all on the new shell-ready path, not a slow-host proof.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('configured run-on-connect command executes after connect', (
+    tester,
+  ) async {
+    FlutterForegroundTask.initCommunicationPort();
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    // The marker is emitted ONLY if the initial command ran on its own; the
+    // test never types it. A unique token avoids matching the echoed command
+    // line itself (the command text contains the marker, but so would the
+    // output line — we assert the output count is >= 2 occurrences below).
+    const marker = 'MOBISSH_INITCMD_OK_77';
+
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+      initialCommand: 'echo $marker',
+    );
+
+    // Reach the terminal screen, accepting the host-key prompt if shown.
+    var connected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        connected = true;
+        break;
+      }
+    }
+    expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after connect');
+
+    // Capture everything the task side streams to the UI terminal.
+    final out = <int>[];
+    final sub = entry!.proxy.output.listen(out.addAll);
+    addTearDown(sub.cancel);
+
+    // The initial command ran iff the marker shows up TWICE: once in the echoed
+    // command line (`echo MARKER`) and once in its stdout (`MARKER`). A single
+    // occurrence would just be the command line; the run-on-connect was dropped.
+    var ran = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final text = utf8.decode(out, allowMalformed: true);
+      final count = marker.allMatches(text).length;
+      if (count >= 2) {
+        ran = true;
+        break;
+      }
+    }
+    expect(
+      ran,
+      isTrue,
+      reason:
+          'run-on-connect command never executed — its output ($marker) did '
+          'not appear in the shell. The command was dropped before the PTY '
+          'shell opened (#619).',
+    );
+  });
+}

--- a/native/integration_test/support/connect_helpers.dart
+++ b/native/integration_test/support/connect_helpers.dart
@@ -19,13 +19,15 @@ Future<void> openNewConnectionEditor(WidgetTester tester) async {
 }
 
 /// Fill the create-mode editor with a password connection and tap
-/// "Save & connect". Assumes [openNewConnectionEditor] already ran.
+/// "Save & connect". Assumes [openNewConnectionEditor] already ran. An optional
+/// [initialCommand] fills the run-on-connect field (#558/#619).
 Future<void> fillPasswordAndConnect(
   WidgetTester tester, {
   required String host,
   required String port,
   required String user,
   required String pass,
+  String? initialCommand,
 }) async {
   await tester.enterText(find.byKey(const Key('profile-editor-host')), host);
   await tester.enterText(find.byKey(const Key('profile-editor-port')), port);
@@ -37,6 +39,11 @@ Future<void> fillPasswordAndConnect(
     find.byKey(const Key('profile-editor-password')),
     pass,
   );
+  if (initialCommand != null) {
+    final field = find.byKey(const Key('profile-editor-initial-command'));
+    await tester.ensureVisible(field);
+    await tester.enterText(field, initialCommand);
+  }
   await tester.pump();
   final submit = find.byKey(const Key('connect-submit'));
   await tester.ensureVisible(submit);
@@ -45,13 +52,15 @@ Future<void> fillPasswordAndConnect(
 }
 
 /// Full ad-hoc password connect from the chooser: open the editor, fill, and
-/// "Save & connect".
+/// "Save & connect". An optional [initialCommand] sets the run-on-connect
+/// command (#558/#619).
 Future<void> adhocPasswordConnect(
   WidgetTester tester, {
   required String host,
   required String port,
   required String user,
   required String pass,
+  String? initialCommand,
 }) async {
   await openNewConnectionEditor(tester);
   await fillPasswordAndConnect(
@@ -60,6 +69,7 @@ Future<void> adhocPasswordConnect(
     port: port,
     user: user,
     pass: pass,
+    initialCommand: initialCommand,
   );
 }
 

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -344,6 +344,13 @@ class SessionHost {
         return;
       }
       hosted.shell = transport;
+      // Announce shell-ready BEFORE wiring output so the UI's run-on-connect
+      // command (#619) can fire the instant stdin is writable — gating on the
+      // bare `connected` state raced ahead of this open on slow hosts and the
+      // command bytes were dropped to scrollback by `_handleInput`. Re-emitted
+      // on every (re)open; the UI runner is one-shot so a reconnect re-open
+      // can't re-run the command.
+      _gateway.send(SshShellReadyEvent(sessionId: sessionId).toJson());
       hosted.shellSub = transport.output.listen(
         (bytes) {
           hosted.metrics.bytesIn += bytes.length;

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -344,13 +344,14 @@ class SessionHost {
         return;
       }
       hosted.shell = transport;
-      // Announce shell-ready BEFORE wiring output so the UI's run-on-connect
-      // command (#619) can fire the instant stdin is writable — gating on the
-      // bare `connected` state raced ahead of this open on slow hosts and the
-      // command bytes were dropped to scrollback by `_handleInput`. Re-emitted
-      // on every (re)open; the UI runner is one-shot so a reconnect re-open
-      // can't re-run the command.
-      _gateway.send(SshShellReadyEvent(sessionId: sessionId).toJson());
+      // Wire the output listener BEFORE announcing shell-ready (#619). The UI's
+      // run-on-connect command fires on shell-ready, writes to stdin, and the
+      // shell echoes + runs it immediately. If we announced ready first (the
+      // original #619 fix did), that first output chunk — the command echo and
+      // its stdout — would be produced with no listener attached yet and lost:
+      // the command ran on the remote but its output never reached the UI, and
+      // any output-asserting test saw nothing. stdin is already writable via
+      // `hosted.shell = transport` above, so announcing a few lines later is free.
       hosted.shellSub = transport.output.listen(
         (bytes) {
           hosted.metrics.bytesIn += bytes.length;
@@ -363,6 +364,12 @@ class SessionHost {
           _emitStatus(sessionId, '\r\n[mobissh] shell stream error: $e\r\n');
         },
       );
+      // Now that output is wired and stdin is writable, announce shell-ready so
+      // the UI's run-on-connect command can fire (gating on the bare `connected`
+      // state raced ahead of this open on slow hosts and the bytes were dropped
+      // to scrollback by `_handleInput`). Re-emitted on every (re)open; the UI
+      // runner is one-shot so a reconnect re-open can't re-run the command.
+      _gateway.send(SshShellReadyEvent(sessionId: sessionId).toJson());
       // Drop the shell when the remote channel closes so a reconnect re-opens.
       // Guard with the generation: a late `done` from THIS transport must not
       // null out a shell that a subsequent reconnect already re-opened (#590).

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -44,6 +44,14 @@ enum SshTaskEventKind {
   /// gateway flushes any commands it buffered during isolate spin-up (#539).
   ready,
 
+  /// The PTY shell for a session is open + writable (its stdin is wired and
+  /// its output is being piped back). Emitted once per shell open, including
+  /// after a reconnect re-opens the shell (#619). The UI gates the
+  /// run-on-connect "initial command" on THIS, not the bare `connected` state,
+  /// so a slow host's shell can't be raced ahead of by the command bytes
+  /// (which `_handleInput` would otherwise drop to scrollback).
+  shellReady,
+
   // --- SFTP (#559) ---
   /// A directory listing result (entries for one path).
   sftpListing,
@@ -431,6 +439,8 @@ sealed class SshTaskEvent {
         );
       case SshTaskEventKind.ready:
         return const SshTaskReadyEvent();
+      case SshTaskEventKind.shellReady:
+        return SshShellReadyEvent(sessionId: sessionId);
       case SshTaskEventKind.sftpListing:
         final rawEntries = (json['entries'] as List)
             .map((e) => SftpEntry.fromJson(Map<String, dynamic>.from(e as Map)))
@@ -630,6 +640,26 @@ class SshTaskReadyEvent extends SshTaskEvent {
 
   @override
   SshTaskEventKind get kind => SshTaskEventKind.ready;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+      };
+}
+
+/// Task → UI: the PTY shell for [sessionId] is open + writable (#619). Emitted
+/// by `SessionHost._ensureShell` right after the shell transport is attached
+/// and its output subscription is wired. The UI proxy turns this into a
+/// `shellReady` stream tick that the run-on-connect initial command gates on —
+/// sending the command on the bare `connected` STATE raced ahead of the shell
+/// on slow hosts (ra-server), and `_handleInput` dropped the bytes to
+/// scrollback instead of the (not-yet-open) shell.
+class SshShellReadyEvent extends SshTaskEvent {
+  const SshShellReadyEvent({required String sessionId}) : super(sessionId);
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.shellReady;
 
   @override
   Map<String, dynamic> toJson() => {

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -56,6 +56,13 @@ class SshSessionProxy {
   final StreamController<Uint8List> _outputCtrl =
       StreamController<Uint8List>.broadcast();
 
+  /// Shell-ready ticks (#619). Emits once each time the task side opens the
+  /// PTY shell (initial connect + every reconnect re-open). The run-on-connect
+  /// initial command gates on this, NOT the bare `connected` state, so the
+  /// command can't race ahead of a slow host's shell-open and get dropped.
+  final StreamController<void> _shellReadyCtrl =
+      StreamController<void>.broadcast();
+
   /// SFTP events (#559): directory listings, download chunks/done, errors —
   /// all keyed by `requestId`. The file browser subscribes and filters by its
   /// own in-flight request id.
@@ -78,6 +85,12 @@ class SshSessionProxy {
   /// PTY output bytes streamed from the task side. Subscribers feed these
   /// into `Terminal.write(...)`.
   Stream<Uint8List> get output => _outputCtrl.stream;
+
+  /// Fires when the task side reports the PTY shell is open + writable (#619).
+  /// One tick per shell open. The run-on-connect [InitialCommandRunner] listens
+  /// here instead of on the `connected` state so the command lands in the live
+  /// shell rather than racing ahead of it on a slow host.
+  Stream<void> get shellReady => _shellReadyCtrl.stream;
 
   /// SFTP events from the task side (#559). Emits [SftpListingEvent],
   /// [SftpDownloadChunkEvent], [SftpDownloadDoneEvent], [SftpErrorEvent].
@@ -220,6 +233,7 @@ class SshSessionProxy {
     _eventSub = null;
     if (!_dataCtrl.isClosed) await _dataCtrl.close();
     if (!_outputCtrl.isClosed) await _outputCtrl.close();
+    if (!_shellReadyCtrl.isClosed) await _shellReadyCtrl.close();
     if (!_sftpCtrl.isClosed) await _sftpCtrl.close();
   }
 
@@ -277,6 +291,10 @@ class SshSessionProxy {
           ),
         );
         if (!_dataCtrl.isClosed) _dataCtrl.add(_data);
+      case SshShellReadyEvent():
+        // The task side opened the PTY shell (#619). Tick the shell-ready
+        // stream so the run-on-connect command fires now that stdin is wired.
+        if (!_shellReadyCtrl.isClosed) _shellReadyCtrl.add(null);
       case SshTaskReadyEvent():
         // Task-global readiness signal (#539). Per-session proxies ignore it —
         // the UI-side gateway already consumed it to flush buffered commands.

--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -271,8 +271,18 @@ class SessionsNotifier extends Notifier<SessionsState> {
   }
 }
 
-/// Fires a profile's "initial command" (#558) exactly once per session, on the
-/// FIRST transition to `connected`.
+/// Fires a profile's "initial command" (#558) exactly once per session, when
+/// the PTY shell first becomes ready — NOT on the bare `connected` STATE.
+///
+/// #619: gating on `connected` raced the shell open. The task-side shell
+/// (`session_host.dart` `_ensureShell`) opens ASYNCHRONOUSLY after `connected`;
+/// on a slow host (the owner's "ra-server") the command's `sendInput` reached
+/// the task before `hosted.shell` was wired, so `_handleInput` dropped the
+/// bytes into scrollback instead of the live shell — the command silently
+/// vanished. Fast hosts opened the shell in time and the command landed,
+/// explaining the per-host inconsistency. We now wait for the task's explicit
+/// shell-ready signal ([SshSessionProxy.shellReady]) so stdin is provably
+/// writable before we send.
 ///
 /// The command is sent UI-side through the existing PTY input path
 /// (`proxy.sendInput(utf8.encode(cmd + "\n"))`) — deliberately NOT through
@@ -280,11 +290,11 @@ class SessionsNotifier extends Notifier<SessionsState> {
 /// SFTP work. Sending via the proxy is equivalent to the user typing the
 /// command into the terminal and pressing Enter.
 ///
-/// The once-only guard is the crux: the merged reconnect work (#551) rebinds
-/// the proxy on resume and may RE-EMIT `connected`. Without a guard the
-/// command would re-run on every background→resume. We track which session
+/// The once-only guard is the crux: the merged reconnect work (#551) re-opens
+/// the shell on resume, which RE-EMITS shell-ready. Without a guard the command
+/// would re-run on every background→resume / reconnect. We track which session
 /// ids have already fired in [_fired]; a fired id never fires again for the
-/// life of the runner, regardless of how many `connected` events arrive.
+/// life of the runner, regardless of how many shell-ready ticks arrive.
 class InitialCommandRunner {
   InitialCommandRunner();
 
@@ -293,19 +303,26 @@ class InitialCommandRunner {
   /// to the same target each get their own one-shot.
   final Set<String> _fired = <String>{};
 
-  final List<StreamSubscription<SshSessionData>> _subs = [];
+  final List<StreamSubscription<void>> _subs = [];
 
   /// True once the initial command has fired for [sessionId]. Test seam.
   bool hasFired(String sessionId) => _fired.contains(sessionId);
 
-  /// Arm a one-shot: when [proxy] first reaches `connected`, send
+  /// Arm a one-shot: when [proxy] reports the PTY shell is ready (#619), send
   /// `command + "\n"` through its input path. No-op when [command] is empty
   /// or the session has already fired.
   ///
-  /// If the proxy is ALREADY `connected` at arm time (e.g. a dedup
-  /// re-activate of a live session), this does NOT fire — the command applies
-  /// to a fresh connect only, matching the PWA's "run after the shell opens"
-  /// behavior and the acceptance bullet "does not re-run on resume".
+  /// Gating on shell-ready (not the bare `connected` state) is the fix for the
+  /// slow-host drop: the task-side shell opens asynchronously after `connected`
+  /// and `_handleInput` discards input that arrives before the shell is wired.
+  ///
+  /// If the proxy is ALREADY `connected` at arm time (e.g. a dedup re-activate
+  /// of a live session whose shell is long since open), this does NOT arm — the
+  /// command applies to a fresh connect only, matching the PWA's "run after the
+  /// shell opens" behavior and the acceptance bullet "does not re-run on
+  /// resume". A live session won't re-tick shell-ready unless it reconnects, and
+  /// the one-shot guard would suppress that anyway, but skipping the arm keeps
+  /// the intent explicit.
   void arm({
     required String sessionId,
     required SshSessionProxy proxy,
@@ -316,18 +333,17 @@ class InitialCommandRunner {
     if (_fired.contains(sessionId)) return;
     // Already connected when armed → this is a re-activate of a live session,
     // not a fresh connect. Don't fire (and don't arm a listener that would
-    // fire on a future reconnect's re-emit).
+    // fire on a future reconnect's shell re-open).
     if (proxy.data.state == SshSessionState.connected) return;
 
-    late final StreamSubscription<SshSessionData> sub;
-    sub = proxy.stream.listen((data) {
-      if (data.state != SshSessionState.connected) return;
+    late final StreamSubscription<void> sub;
+    sub = proxy.shellReady.listen((_) {
       if (_fired.contains(sessionId)) return;
       _fired.add(sessionId);
       ctrace('ui.initcmd', 'firing initial command for sid=$sessionId');
       proxy.sendInput(Uint8List.fromList(utf8.encode('$cmd\n')));
-      // One-shot: stop listening so a later rebind/reconnect re-emit of
-      // `connected` (#551) can't re-trigger.
+      // One-shot: stop listening so a later reconnect shell re-open (#551)
+      // can't re-trigger.
       sub.cancel();
       _subs.remove(sub);
     });
@@ -335,7 +351,7 @@ class InitialCommandRunner {
   }
 
   /// Cancel any still-armed listeners. Fired runners have already self-
-  /// cancelled; this cleans up sessions that never reached `connected`.
+  /// cancelled; this cleans up sessions whose shell never opened.
   void dispose() {
     for (final s in _subs) {
       s.cancel();

--- a/native/test/services/initial_command_shell_ready_test.dart
+++ b/native/test/services/initial_command_shell_ready_test.dart
@@ -1,0 +1,286 @@
+// #619 — the run-on-connect initial command must gate on SHELL-READY, not the
+// bare `connected` state transition.
+//
+// The race: the UI `InitialCommandRunner` fires the command via
+// `proxy.sendInput` on the `connected` transition, but the task-side PTY shell
+// is opened ASYNCHRONOUSLY (`_ensureShell`) after `connected`. On a slow host
+// the shell isn't wired yet when the command bytes arrive, so `_handleInput`
+// drops them into scrollback instead of the live shell — the command is lost.
+//
+// This test reproduces the race deterministically with a fake `HostShellOpener`
+// whose open is DELAYED relative to `connected`. We assert the initial command
+// bytes reach the LIVE shell (its `send`), not scrollback, and only AFTER the
+// shell is ready. RED on the old `connected`-gated runner (sent too early →
+// dropped); GREEN once the runner gates on the task-side shell-ready signal.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/ssh/ssh_shell.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/sessions.dart';
+
+/// Silent socket → lets us build a real [SSHClient] so `controller.client` is
+/// non-null without any network IO or pending timers.
+class _SilentSocket implements SSHSocket {
+  final _outbound = StreamController<List<int>>();
+  final _doneCompleter = Completer<void>();
+
+  @override
+  Stream<Uint8List> get stream => const Stream<Uint8List>.empty();
+
+  @override
+  StreamSink<List<int>> get sink => _outbound.sink;
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() async {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    await _outbound.close();
+    return done;
+  }
+
+  @override
+  void destroy() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+}
+
+class _DrivableController extends SshSessionController {
+  _DrivableController(this._client);
+  final SSHClient _client;
+  @override
+  SSHClient? get client => _client;
+
+  // Suppress the real socket connect: we drive `connected` /
+  // disconnect transitions explicitly via [debugSetConnectedForTest] and
+  // [disconnect]. Without this, the production `connect` opens a real socket
+  // that fails DNS lookup and transitions the session to `failed`, which would
+  // drop the (deliberately delayed) shell before it opens.
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+/// Fake PTY transport that records the bytes the host's `_handleInput` wrote to
+/// the LIVE shell (`send`). If the initial command races ahead of shell-open,
+/// `_handleInput` routes it to scrollback instead and `sent` stays empty.
+class _RecordingShellTransport implements SshShellTransport {
+  final _outCtrl = StreamController<Uint8List>.broadcast();
+  final _doneCompleter = Completer<void>();
+  final BytesBuilder sent = BytesBuilder(copy: false);
+  bool closed = false;
+
+  @override
+  Stream<Uint8List> get output => _outCtrl.stream;
+
+  @override
+  void send(Uint8List bytes) => sent.add(bytes);
+
+  @override
+  void resize(int cols, int rows, {int pixelWidth = 0, int pixelHeight = 0}) {}
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  void close() {
+    closed = true;
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    if (!_outCtrl.isClosed) _outCtrl.close();
+  }
+}
+
+void main() {
+  test(
+    'initial command reaches the live shell when shell-open is DELAYED (#619)',
+    () async {
+      const sid = 'slow:22:u:1';
+
+      final socket = _SilentSocket();
+      final sentinelClient = SSHClient(socket, username: 'u');
+      addTearDown(() {
+        try {
+          sentinelClient.close();
+        } catch (_) {}
+        socket.destroy();
+      });
+
+      late _DrivableController controller;
+      _DrivableController factory() {
+        controller = _DrivableController(sentinelClient);
+        return controller;
+      }
+
+      // The crux: the shell opens with a DELAY after `connected`. A naive
+      // runner that fires on `connected` would send the command during this
+      // window, before the shell exists → dropped to scrollback.
+      final opened = <_RecordingShellTransport>[];
+      Future<SshShellTransport?> opener(SSHClient c, int cols, int rows) async {
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+        final t = _RecordingShellTransport();
+        opened.add(t);
+        return t;
+      }
+
+      final pair = InMemoryGatewayPair();
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: factory,
+        shellOpener: opener,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      final proxy = SshSessionProxy(sessionId: sid, gateway: pair.uiSide);
+      final runner = InitialCommandRunner();
+      addTearDown(() async {
+        runner.dispose();
+        await proxy.dispose();
+        await host.dispose();
+        await pair.dispose();
+      });
+
+      // Arm BEFORE connect (matches _connectWithParams ordering).
+      runner.arm(sessionId: sid, proxy: proxy, command: 'tmux a');
+
+      proxy.connect(
+        const SshConnectParams(
+          host: 'slow',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Drive `connected` — the shell open is still pending (80ms delay).
+      controller.debugSetConnectedForTest(
+        const SshConnectParams(
+          host: 'slow',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+
+      // Let the `connected` event propagate to the UI. A runner that fires on
+      // bare `connected` sends the command NOW — before the shell exists.
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      // Now let the delayed shell finish opening + the shell-ready signal flow.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(opened.length, 1, reason: 'one shell should have opened');
+      final shellBytes = String.fromCharCodes(opened.first.sent.toBytes());
+      expect(
+        shellBytes,
+        'tmux a\n',
+        reason:
+            'initial command must reach the LIVE shell after shell-ready; '
+            'if it raced ahead of shell-open it was dropped to scrollback',
+      );
+      expect(runner.hasFired(sid), isTrue);
+    },
+  );
+
+  test('initial command does NOT re-fire when the shell re-opens on reconnect '
+      '(#619/#551)', () async {
+    const sid = 'h:22:u:1';
+
+    final socket = _SilentSocket();
+    final sentinelClient = SSHClient(socket, username: 'u');
+    addTearDown(() {
+      try {
+        sentinelClient.close();
+      } catch (_) {}
+      socket.destroy();
+    });
+
+    late _DrivableController controller;
+    _DrivableController factory() {
+      controller = _DrivableController(sentinelClient);
+      return controller;
+    }
+
+    final opened = <_RecordingShellTransport>[];
+    Future<SshShellTransport?> opener(SSHClient c, int cols, int rows) async {
+      final t = _RecordingShellTransport();
+      opened.add(t);
+      return t;
+    }
+
+    final pair = InMemoryGatewayPair();
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: factory,
+      shellOpener: opener,
+      snapshotInterval: const Duration(hours: 1),
+    );
+    final proxy = SshSessionProxy(sessionId: sid, gateway: pair.uiSide);
+    final runner = InitialCommandRunner();
+    addTearDown(() async {
+      runner.dispose();
+      await proxy.dispose();
+      await host.dispose();
+      await pair.dispose();
+    });
+
+    runner.arm(sessionId: sid, proxy: proxy, command: 'echo hi');
+
+    proxy.connect(
+      const SshConnectParams(
+        host: 'h',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    Future<void> settle() =>
+        Future<void>.delayed(const Duration(milliseconds: 40));
+
+    controller.debugSetConnectedForTest(
+      const SshConnectParams(
+        host: 'h',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ),
+    );
+    await settle();
+    expect(
+      String.fromCharCodes(opened.first.sent.toBytes()),
+      'echo hi\n',
+      reason: 'fired once on the first shell-ready',
+    );
+
+    // Reconnect: drop, then re-enter connected → the host re-opens a fresh
+    // shell and re-emits shell-ready. The runner is one-shot; it must NOT
+    // re-send the command into the new shell.
+    await controller.disconnect();
+    await settle();
+    controller.debugSetConnectedForTest(
+      const SshConnectParams(
+        host: 'h',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      ),
+    );
+    await settle();
+
+    expect(opened.length, 2, reason: 'reconnect re-opened a fresh shell');
+    expect(
+      opened.last.sent.length,
+      0,
+      reason: 'initial command must NOT re-run into the reconnect shell',
+    );
+  });
+}

--- a/native/test/state/initial_command_runner_test.dart
+++ b/native/test/state/initial_command_runner_test.dart
@@ -1,14 +1,16 @@
 // Unit tests for the run-on-connect "initial command" once-only fire (#558).
 //
 // The runner arms a one-shot listener on a session's [SshSessionProxy]. On the
-// FIRST `connected` transition it sends `command + "\n"` through the proxy's
-// PTY input path (`sendInput`). It must NOT re-fire when the #551 reconnect
-// work rebinds and re-emits `connected` on a background→resume.
+// first SHELL-READY signal (#619 — NOT the bare `connected` state, which raced
+// the async shell open on slow hosts) it sends `command + "\n"` through the
+// proxy's PTY input path (`sendInput`). It must NOT re-fire when the #551
+// reconnect work re-opens the shell on a background→resume.
 //
 // We drive a REAL proxy via an [InMemoryGatewayPair]: state events injected
-// from the task side flip the proxy to `connected`; input commands the proxy
-// sends are observed back on the task side, so we assert on the exact wire
-// bytes (`base64(utf8(cmd + "\n"))`).
+// from the task side flip the proxy to `connected`; a [SshShellReadyEvent]
+// signals the shell is writable; input commands the proxy sends are observed
+// back on the task side, so we assert on the exact wire bytes
+// (`base64(utf8(cmd + "\n"))`).
 
 import 'dart:async';
 import 'dart:convert';
@@ -60,7 +62,15 @@ void main() {
       await Future<void>.delayed(Duration.zero);
     }
 
-    test('sends command + newline once on first connected', () async {
+    // Signal the task-side PTY shell is open + writable (#619). The runner
+    // gates the initial command on THIS, not the bare `connected` state.
+    Future<void> emitShellReady() async {
+      pair.taskSide.send(SshShellReadyEvent(sessionId: sid).toJson());
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    test('sends command + newline once on first shell-ready', () async {
       final runner = InitialCommandRunner();
       addTearDown(runner.dispose);
       runner.arm(sessionId: sid, proxy: proxy, command: 'tmux attach');
@@ -68,25 +78,37 @@ void main() {
       await emitState(SshSessionState.connecting);
       expect(sentInputs, isEmpty, reason: 'not fired before connected');
 
+      // #619: reaching `connected` is NOT enough — the shell opens async after
+      // it. The command must wait for shell-ready, not fire on `connected`.
       await emitState(SshSessionState.connected);
+      expect(
+        sentInputs,
+        isEmpty,
+        reason: 'must NOT fire on bare connected — shell may not be open yet',
+      );
+
+      await emitShellReady();
       expect(sentInputs, ['tmux attach\n']);
       expect(runner.hasFired(sid), isTrue);
     });
 
     test(
-      'does NOT re-fire on a second connected (reconnect rebind #551)',
+      'does NOT re-fire on a second shell-ready (reconnect re-open #551)',
       () async {
         final runner = InitialCommandRunner();
         addTearDown(runner.dispose);
         runner.arm(sessionId: sid, proxy: proxy, command: 'echo hi');
 
         await emitState(SshSessionState.connected);
+        await emitShellReady();
         expect(sentInputs, ['echo hi\n']);
 
-        // Simulate background→resume: soft-disconnect, reconnect, re-emit.
+        // Simulate background→resume: soft-disconnect, reconnect, shell re-open
+        // (which re-emits shell-ready). The one-shot must suppress the re-fire.
         await emitState(SshSessionState.softDisconnected);
         await emitState(SshSessionState.reconnecting);
         await emitState(SshSessionState.connected);
+        await emitShellReady();
 
         expect(sentInputs, [
           'echo hi\n',
@@ -101,6 +123,7 @@ void main() {
       runner.arm(sessionId: sid, proxy: proxy, command: null);
 
       await emitState(SshSessionState.connected);
+      await emitShellReady();
       expect(sentInputs, isEmpty);
       expect(runner.hasFired(sid), isFalse);
     });
@@ -111,6 +134,7 @@ void main() {
       runner.arm(sessionId: sid, proxy: proxy, command: '  ls -la  ');
 
       await emitState(SshSessionState.connected);
+      await emitShellReady();
       expect(sentInputs, ['ls -la\n']);
     });
 


### PR DESCRIPTION
## Root cause (confirmed)

The run-on-connect / initial command (#558) reached some hosts but not others — the owner's slow "ra-server" profile dropped it and the command had to be typed manually.

- The UI `InitialCommandRunner.arm()` (`native/lib/state/sessions.dart`) fired the command via `proxy.sendInput` on the bare `connected` STATE transition.
- The task-side PTY shell opens ASYNCHRONOUSLY after `connected` (`native/lib/services/session_host.dart` `_ensureShell`).
- `_handleInput` only writes to `hosted.shell` when it is non-null; before the shell is wired it routes input to `appendScrollback` — i.e. the bytes are DROPPED, never sent to the remote.
- On a slow host the command's `sendInput` arrives before `_ensureShell` finishes, so the command vanishes. Fast hosts win the race → command lands. That is exactly the per-host inconsistency.

Arming is already centralized in `connect_form._connectWithParams`, through which ALL connect paths route (tap-to-connect, editor Save&connect, New session, reconnect). So the "missed arm on one path" theory was not the cause — but the tests now pin it.

## The fix: gate on shell-ready, not the state

- New task→UI `SshShellReadyEvent` (event kind `shellReady`), emitted by `_ensureShell` the instant the shell transport is attached and its output sub is wired. Re-emitted on every (re)open.
- `SshSessionProxy` exposes a `shellReady` stream tick.
- `InitialCommandRunner.arm` now listens on `shellReady` instead of the `connected` state. The one-shot `_fired` guard is preserved so a #551 reconnect shell re-open cannot re-run the command. The "already connected at arm time" guard (dedup re-activate of a live session) is kept.

No fixed delay, no polling — a single deterministic event.

## Red → green race test

`native/test/services/initial_command_shell_ready_test.dart` wires a real `SessionHost` + `InMemoryGatewayPair` with a fake `HostShellOpener` whose open is DELAYED 80ms relative to `connected`, plus a real proxy + `InitialCommandRunner`. It asserts the initial command reaches the LIVE shell (its `send`), not scrollback.

- RED on the old `connected`-gated runner: the command fired during the delay window, before the shell existed → dropped to scrollback (`Expected 'tmux a\n', Actual ''`).
- GREEN after the fix: the command lands on the shell after shell-ready.

A second case proves the command does NOT re-run when the shell re-opens on reconnect (one-shot). `native/test/state/initial_command_runner_test.dart` was updated to drive shell-ready and now asserts the command does NOT fire on bare `connected`.

## Connect paths that arm

All of them — arming is centralized in `_connectWithParams`, exercised by `_connectFromProfile` (tap), `_newConnection` / editor Save&connect, and the New session route. Reconnect re-opens the shell (re-emits shell-ready) but the one-shot guard suppresses a re-fire.

## Device

`native/integration_test/initial_command_smoke_test.dart` connects with `echo <marker>` as the initial command and asserts the marker appears in shell output (command ran on its own, never typed). The emulator's test-sshd is a FAST host, so this is a regression guard that the command fires at all on the new shell-ready path — NOT a slow-host proof.

The owner's real failing case is ra-server (a genuinely slow host), which the agent cannot reach. Please device-validate against ra-server AND a fast host before merge. Emulator integration suite (#589) is also required before merge (this touches the session state machine / IPC).

native-fast-gate: analyze clean, 345 tests pass.

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)