### PR TITLE
fix(#616): per-session font/theme tracks global default until customized

### DIFF
--- a/native/lib/state/ui_prefs_providers.dart
+++ b/native/lib/state/ui_prefs_providers.dart
@@ -870,23 +870,34 @@ final sessionAppearanceProvider =
       SessionAppearanceNotifier.new,
     );
 
-/// Per-session palette index. Falls back to the current default for an
-/// un-customized session. Rebuilds when that session's entry changes.
+/// Per-session palette index. Falls back to the current GLOBAL default for an
+/// un-customized session. Rebuilds when that session's entry changes AND when
+/// the global default changes (#616): a session WITHOUT its own override must
+/// track the global default — most importantly when the persisted default
+/// hydrates from SharedPreferences asynchronously, AFTER the terminal first
+/// rendered. Watching [terminalThemeProvider] (not just reading it via the
+/// notifier's `_default`) is what makes that rebuild happen. Once the session
+/// HAS an entry in the map, that entry wins and the global no longer leaks in.
 final sessionThemeProvider = Provider.family<int, String>((ref, sessionId) {
   ref.watch(sessionAppearanceProvider);
+  ref.watch(terminalThemeProvider); // rebuild on global-default change (#616)
   return ref
       .read(sessionAppearanceProvider.notifier)
       .appearanceOf(sessionId)
       .themeIndex;
 });
 
-/// Per-session font size. Falls back to the current default for an
-/// un-customized session.
+/// Per-session font size. Falls back to the current GLOBAL default for an
+/// un-customized session, and tracks the global default until the session is
+/// customized (#616) — see [sessionThemeProvider] for the rationale. Watching
+/// [fontSizeProvider] makes an un-customized session pick up the global default
+/// the moment it hydrates / changes.
 final sessionFontSizeProvider = Provider.family<double, String>((
   ref,
   sessionId,
 ) {
   ref.watch(sessionAppearanceProvider);
+  ref.watch(fontSizeProvider); // rebuild on global-default change (#616)
   return ref
       .read(sessionAppearanceProvider.notifier)
       .appearanceOf(sessionId)

--- a/native/test/state/per_session_appearance_test.dart
+++ b/native/test/state/per_session_appearance_test.dart
@@ -182,5 +182,59 @@ void main() {
       expect(c.read(sessionFontSizeProvider(b.id)), fontSizeDefault);
       expect(c.read(sessionThemeProvider(b.id)), terminalThemeDefault);
     });
+
+    // #616: the global default can change AFTER a session's terminal first
+    // reads its per-session font — most importantly when the persisted default
+    // hydrates from SharedPreferences asynchronously on a real device (the test
+    // harness mocks prefs synchronously to empty, so this never reproduced
+    // headlessly before). An un-customized session must TRACK the global
+    // default: the family provider has to rebuild when the global notifier
+    // changes, not just when the per-session map changes. On the old code these
+    // are RED — the family providers only `watch` the map and `read` the
+    // globals, so they never rebuild on a global change.
+    test('an un-customized session tracks a later global font-size change', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      expect(c.read(sessionFontSizeProvider(a.id)), fontSizeDefault);
+
+      // Global default changes (e.g. async prefs hydration / a future global
+      // settings control). The session has no override, so it must follow.
+      c.read(fontSizeProvider.notifier).set(20);
+      expect(
+        c.read(sessionFontSizeProvider(a.id)),
+        20,
+        reason: 'an un-customized session must reflect the new global default',
+      );
+
+      // Once the session HAS its own override, the global no longer leaks in.
+      c.read(sessionAppearanceProvider.notifier).setFontSize(a.id, 11);
+      c.read(fontSizeProvider.notifier).set(24);
+      expect(
+        c.read(sessionFontSizeProvider(a.id)),
+        11,
+        reason: 'a per-session override pins the value against global changes',
+      );
+    });
+
+    test('an un-customized session tracks a later global theme change', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      expect(c.read(sessionThemeProvider(a.id)), terminalThemeDefault);
+
+      c.read(terminalThemeProvider.notifier).set(1);
+      expect(
+        c.read(sessionThemeProvider(a.id)),
+        1,
+        reason: 'an un-customized session must reflect the new global theme',
+      );
+
+      c.read(sessionAppearanceProvider.notifier).setTheme(a.id, 0);
+      c.read(terminalThemeProvider.notifier).set(2);
+      expect(
+        c.read(sessionThemeProvider(a.id)),
+        0,
+        reason: 'a per-session override pins the value against global changes',
+      );
+    });
   });
 }

--- a/native/test/widget/terminal_font_apply_test.dart
+++ b/native/test/widget/terminal_font_apply_test.dart
@@ -1,0 +1,173 @@
+// Per-session font size must APPLY to the rendered terminal (#616).
+//
+// The per-session model + the session-menu stepper are already covered by
+// per_session_appearance_test.dart and session_menu_appearance_test.dart. The
+// device bug (#616 — "adjusted font size several times, not persisting per
+// terminal") is at the RENDER layer: stepping the active session's font must
+// actually reach the live `TerminalView` so the glyphs resize, and must NOT
+// resize a sibling session's terminal (per-session isolation at the widget).
+//
+// These render-layer assertions are the gap. They read the `TerminalView` that
+// `_SessionTerminalBody` builds for a given session and assert its
+// `textStyle.fontSize`.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_providers.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/ui/terminal_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xterm/xterm.dart';
+
+import '../support/fake_ssh_shell_transport.dart';
+
+ProviderContainer _makeContainer(FakeSshShellTransport transport) {
+  final pair = InMemoryGatewayPair();
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      sshShellOpenerProvider.overrideWithValue(
+        (ref, sessionId, terminal) async => transport,
+      ),
+    ],
+  );
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  addTearDown(container.dispose);
+  return container;
+}
+
+SessionEntry _add(ProviderContainer c, String host) {
+  return c
+      .read(sessionsProvider.notifier)
+      .addOrActivate(
+        SshConnectParams(
+          host: host,
+          port: 22,
+          username: 'u',
+          auth: const SshAuth.password('p'),
+        ),
+      );
+}
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 8}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+/// The `fontSize` the `TerminalView` for [sessionId] is currently rendering.
+/// `skipOffstage: false` because inactive sessions live offstage in the
+/// terminal screen's `IndexedStack`.
+double _terminalFontSize(WidgetTester tester, String sessionId) {
+  final view = tester.widget<TerminalView>(
+    find.byKey(Key('terminal-view-$sessionId'), skipOffstage: false),
+  );
+  return view.textStyle.fontSize;
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('stepping the active session font resizes its TerminalView', (
+    tester,
+  ) async {
+    final transport = FakeSshShellTransport();
+    addTearDown(transport.close);
+    final container = _makeContainer(transport);
+    final a = _add(container, 'host-a');
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: TerminalScreen()),
+      ),
+    );
+    await _pumpFrames(tester);
+
+    expect(_terminalFontSize(tester, a.id), fontSizeDefault);
+
+    // Step the active session's font up twice via the notifier (the same call
+    // the session-menu stepper makes).
+    container
+        .read(sessionAppearanceProvider.notifier)
+        .adjustFontSize(a.id, kFontSizeStep);
+    container
+        .read(sessionAppearanceProvider.notifier)
+        .adjustFontSize(a.id, kFontSizeStep);
+    await _pumpFrames(tester);
+
+    expect(
+      _terminalFontSize(tester, a.id),
+      fontSizeDefault + 2 * kFontSizeStep,
+      reason: 'the live terminal must reflect the per-session font change',
+    );
+  });
+
+  testWidgets('resizing one session does NOT resize the other terminal', (
+    tester,
+  ) async {
+    final transport = FakeSshShellTransport();
+    addTearDown(transport.close);
+    final container = _makeContainer(transport);
+    final a = _add(container, 'host-a');
+    final b = _add(container, 'host-b'); // b is active
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: TerminalScreen()),
+      ),
+    );
+    await _pumpFrames(tester);
+
+    container.read(sessionAppearanceProvider.notifier).setFontSize(b.id, 22);
+    await _pumpFrames(tester);
+
+    expect(_terminalFontSize(tester, b.id), 22);
+    expect(
+      _terminalFontSize(tester, a.id),
+      fontSizeDefault,
+      reason: 'sibling session terminal font must be untouched',
+    );
+  });
+
+  testWidgets('a freshly-added session terminal starts from the default', (
+    tester,
+  ) async {
+    final transport = FakeSshShellTransport();
+    addTearDown(transport.close);
+    final container = _makeContainer(transport);
+    final a = _add(container, 'host-a');
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: TerminalScreen()),
+      ),
+    );
+    await _pumpFrames(tester);
+
+    // Shrink session A.
+    container.read(sessionAppearanceProvider.notifier).setFontSize(a.id, 26);
+    await _pumpFrames(tester);
+    expect(_terminalFontSize(tester, a.id), 26);
+
+    // A new session must render at the default, not A's override.
+    final b = _add(container, 'host-b');
+    await _pumpFrames(tester);
+    expect(
+      _terminalFontSize(tester, b.id),
+      fontSizeDefault,
+      reason: 'a new session terminal starts from the global default',
+    );
+  });
+}


### PR DESCRIPTION
## #616 — per-session font size not persisting / not applying

### Root cause
The per-session `.family` providers (`sessionThemeProvider` /
`sessionFontSizeProvider`) fall back to the GLOBAL default for an un-customized
session, but they resolved that default via `ref.read` (inside the notifier's
`_default`) while only `ref.watch`-ing the per-session appearance map. So an
un-customized session **never rebuilt when the global default changed** — most
importantly when the persisted global default hydrates from `SharedPreferences`
**asynchronously**, after the terminal first rendered.

On device this means: launch with a saved default → the first session paints at
the hardcoded `13.0` and never picks up the hydrated default, so the owner's
adjustments appear not to stick "per terminal."

This never reproduced headlessly because the test harness mocks
`SharedPreferences` synchronously to empty — the global default was always
`13.0` at read time, so the missing dependency was invisible.

Ruled out (verified correct at every layer): the menu stepper's active-session
resolution, the `_SessionTerminalBody` watch + `TerminalView` rebuild, and
xterm 4.0.0 internals (the painter recomputes `cellSize`, clears the paragraph
cache, and calls `markNeedsLayout` on a `textStyle` change; `TerminalStyle` has
identity equality so a rebuilt style always applies).

### Fix
`sessionThemeProvider` / `sessionFontSizeProvider` now also
`ref.watch(terminalThemeProvider)` / `ref.watch(fontSizeProvider)`. An
un-customized session tracks the global default (including async hydration);
once a session has its own override, that entry wins and the global no longer
leaks in — per-session isolation preserved. +6 lines of product code, scoped to
`native/lib/state/ui_prefs_providers.dart`.

### Tests (red → green)
- `native/test/state/per_session_appearance_test.dart` — two RED-first tests:
  an un-customized session tracks a later global font/theme change; a
  per-session override pins the value against subsequent global changes.
- `native/test/widget/terminal_font_apply_test.dart` (NEW) — render-layer
  regression: asserts the live `TerminalView.textStyle.fontSize` applies the
  per-session font, isolates siblings (offstage in the `IndexedStack`), and a
  new session terminal starts from the default. Closes the headless gap — the
  prior suite only asserted provider state, never the rendered widget.

`scripts/native-fast-gate.sh` passes (analyze clean + full unit suite green).

### Device validation REQUIRED before merge
This is a `device`-labelled bug and the failure mode is device-class (async
prefs hydration). The headless red→green proves the logic, but the VISIBLE
resize must be validated on the emulator/device — please run the appearance
flow on-device (adjust the per-session font several times; confirm the terminal
glyphs resize and the value sticks per terminal across session switches). Not
device-verified by this agent.

Closes #616