### PR TITLE
fix(#624): gate gesture/keystroke input on a live session + disconnect indicator

### DIFF
--- a/native/integration_test/disconnected_scroll_test.dart
+++ b/native/integration_test/disconnected_scroll_test.dart
@@ -1,0 +1,197 @@
+// On-emulator DISCONNECTED-SCROLL smoke (#624).
+//
+// The device bug (build 030596c): after a session drops, (1) there is NO visual
+// indication the terminal is dead, and (2) scroll gestures dump literal
+// `64;12;19M64;12;19M…` text at the prompt — the SGR mouse-wheel report bodies
+// from the #617 WheelFixMouseHandler, landing as input/echo because no live PTY
+// in mouse mode consumes them.
+//
+// This test connects to test-sshd, starts tmux with mouse on (so the
+// WheelFixMouseHandler IS in scroll-report mode and WOULD emit wheel SGR on a
+// drag), then forces a disconnect WITHOUT closing the session entry
+// (`proxy.disconnect()` — the task host tears down the SSHClient and emits a
+// disconnected/closed state; the entry stays in the collection, exactly like a
+// network drop). It then:
+//   (a) asserts the state-driven disconnect banner is present, and
+//   (b) drags on the TerminalView and asserts NO mouse-wheel SGR (`64;…M` etc.)
+//       reaches the PTY — the scroll input is gated on a live session (#624).
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'while disconnected: indicator shows + scroll emits NO wheel SGR to PTY',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      // Reach the terminal screen, accepting the host-key prompt if shown.
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find
+            .byKey(const Key('session-menu-button'))
+            .evaluate()
+            .isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final terminal = entry!.terminal;
+
+      // Tap the PTY-bound onOutput so we can observe exactly what a drag would
+      // forward, WITHOUT changing the gating behaviour under test.
+      final sentToPty = <int>[];
+      final origOnOutput = terminal.onOutput;
+      terminal.onOutput = (data) {
+        sentToPty.addAll(utf8.encode(data));
+        origOnOutput?.call(data);
+      };
+      addTearDown(() => terminal.onOutput = origOnOutput);
+
+      // Wait for the shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // Put the terminal into a scroll-reporting mouse mode (tmux mouse on) so
+      // the WheelFixMouseHandler WOULD emit wheel SGR on a drag. This is the
+      // condition that produced the garbage on device.
+      entry.proxy.sendInput(
+        Uint8List.fromList(
+          utf8.encode(
+            "tmux kill-server 2>/dev/null; tmux set -g mouse on \\; new -s t\n",
+          ),
+        ),
+      );
+      for (var i = 0; i < 24; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (terminal.isUsingAltBuffer) break;
+      }
+      debugPrint(
+        'CTRACE624 mouseMode=${terminal.mouseMode} '
+        'alt=${terminal.isUsingAltBuffer}',
+      );
+
+      // ── FORCE A DISCONNECT, keeping the entry (network-drop analogue). ──────
+      // proxy.disconnect() tells the task host to tear down the SSHClient; it
+      // emits a disconnected/closed state event. The entry stays in the
+      // collection (unlike the Disconnect button which close()s it), so the
+      // terminal screen still renders THIS session — exactly the bug scenario.
+      entry.proxy.disconnect();
+      var dead = false;
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final st = entry.proxy.data.state;
+        if (st != SshSessionState.connected &&
+            st != SshSessionState.idle &&
+            st != SshSessionState.connecting) {
+          dead = true;
+          break;
+        }
+      }
+      expect(
+        dead,
+        isTrue,
+        reason:
+            'session never left the connected state after disconnect '
+            '(state=${entry.proxy.data.state})',
+      );
+
+      // (a) The state-driven disconnect banner must be present (#624 symptom 1).
+      expect(
+        find.byKey(const Key('terminal-disconnect-banner')),
+        findsOneWidget,
+        reason: 'no disconnect indicator while the session is dead (#624)',
+      );
+
+      // (b) Drag on the terminal — this is the scroll gesture that dumped raw
+      // wheel SGR on device. With the liveness gate, NO bytes (and definitely
+      // no `64;…M` SGR) may reach the PTY while disconnected.
+      sentToPty.clear();
+      final termFinder = find.byKey(Key('terminal-view-${entry.id}'));
+      expect(termFinder, findsOneWidget);
+      final center = tester.getCenter(termFinder);
+      await tester.dragFrom(center, const Offset(0, 300));
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      final ascii = utf8
+          .decode(sentToPty, allowMalformed: true)
+          .replaceAll('\x1b', 'ESC');
+      debugPrint('CTRACE624 bytes-sent-on-drag-while-dead=$ascii');
+
+      // No SGR mouse-wheel body may appear in the forwarded bytes.
+      expect(
+        ascii.contains('64;'),
+        isFalse,
+        reason: 'wheel-up SGR leaked to PTY while disconnected (#624): $ascii',
+      );
+      expect(
+        ascii.contains('65;'),
+        isFalse,
+        reason: 'wheel-down SGR leaked to PTY while disconnected (#624)',
+      );
+      expect(
+        ascii.contains('M'),
+        isFalse,
+        reason: 'SGR report terminator leaked to PTY while disconnected',
+      );
+      expect(
+        sentToPty,
+        isEmpty,
+        reason:
+            'NO terminal output may reach the PTY while disconnected '
+            '(#624) — got: $ascii',
+      );
+    },
+  );
+}

--- a/native/integration_test/disconnected_scroll_test.dart
+++ b/native/integration_test/disconnected_scroll_test.dart
@@ -12,9 +12,21 @@
 // (`proxy.disconnect()` — the task host tears down the SSHClient and emits a
 // disconnected/closed state; the entry stays in the collection, exactly like a
 // network drop). It then:
-//   (a) asserts the state-driven disconnect banner is present, and
+//   (a) asserts the state-driven disconnect banner is present AND the router
+//       KEEPS the terminal screen mounted (the v1 bug: the router navigated back
+//       to the chooser on `disconnected`, unmounting the banner — #624 root
+//       cause, fixed in main.dart), and
 //   (b) drags on the TerminalView and asserts NO mouse-wheel SGR (`64;…M` etc.)
-//       reaches the PTY — the scroll input is gated on a live session (#624).
+//       reaches the PTY — the scroll INPUT is gated on a live session (#624).
+//
+// MEASUREMENT (v2 fix): the v1 test tapped `terminal.onOutput` and recorded the
+// raw bytes the terminal EMITS — but the production gate lives INSIDE that
+// closure (sessions.dart: `if (proxy.data.state != connected) return;`). The
+// terminal still EMITS the SGR on a drag (the gesture fires); the gate just
+// doesn't forward it. So recording terminal emissions measured the wrong layer
+// and the test failed on a working gate. v2 spies on the GATEWAY's outgoing
+// `input` commands — the bytes that actually reach the PTY — which is the real
+// contract under test.
 //
 // Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
 
@@ -28,19 +40,61 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/task_ssh_gateway.dart';
 import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
 
 import 'support/connect_helpers.dart';
+
+/// Wraps the real [FlutterForegroundSshGateway] and records the decoded bytes of
+/// every `input` command sent UI→task. This is the PTY-bound byte stream — the
+/// exact layer the #624 liveness gate (sessions.dart `terminal.onOutput`) feeds
+/// when, and only when, the session is `connected`. Asserting against these
+/// recorded bytes measures what actually reaches the remote shell, NOT what the
+/// terminal merely emits (which the gate may drop).
+class _InputSpyGateway implements TaskSshGateway {
+  _InputSpyGateway(this._delegate);
+
+  final TaskSshGateway _delegate;
+
+  /// Decoded bytes of every `input` command, in send order.
+  final List<int> inputBytes = <int>[];
+
+  /// Clear the recorded input (between phases).
+  void clear() => inputBytes.clear();
+
+  @override
+  void send(Map<String, dynamic> payload) {
+    if (payload['kind'] == 'input') {
+      final b64 = payload['bytes'] as String?;
+      if (b64 != null) inputBytes.addAll(base64Decode(b64));
+    }
+    _delegate.send(payload);
+  }
+
+  @override
+  Stream<Map<String, dynamic>> get incoming => _delegate.incoming;
+
+  @override
+  void markServiceStopped() => _delegate.markServiceStopped();
+
+  @override
+  Future<void> dispose() => _delegate.dispose();
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'while disconnected: indicator shows + scroll emits NO wheel SGR to PTY',
+    'while disconnected: indicator shows + scroll forwards NO wheel SGR to PTY',
     (tester) async {
       FlutterForegroundTask.initCommunicationPort();
-      final container = ProviderContainer();
+
+      final spy = _InputSpyGateway(FlutterForegroundSshGateway());
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(spy)],
+      );
       addTearDown(container.dispose);
 
       await tester.pumpWidget(
@@ -82,12 +136,16 @@ void main() {
       expect(entry, isNotNull, reason: 'no active session after connect');
       final terminal = entry!.terminal;
 
-      // Tap the PTY-bound onOutput so we can observe exactly what a drag would
-      // forward, WITHOUT changing the gating behaviour under test.
-      final sentToPty = <int>[];
+      // Capture what the terminal EMITS (before the gate), while still
+      // delegating to the production onOutput (the gate) so behaviour is
+      // unchanged. Comparing emitted-vs-forwarded in both phases proves the
+      // gate is the lever: live → emitted AND forwarded; dead → emitted but NOT
+      // forwarded. (The gateway spy measures "forwarded"; this tap measures
+      // "emitted".)
+      final emitted = <int>[];
       final origOnOutput = terminal.onOutput;
       terminal.onOutput = (data) {
-        sentToPty.addAll(utf8.encode(data));
+        emitted.addAll(utf8.encode(data));
         origOnOutput?.call(data);
       };
       addTearDown(() => terminal.onOutput = origOnOutput);
@@ -115,9 +173,74 @@ void main() {
         await tester.pump(const Duration(milliseconds: 500));
         if (terminal.isUsingAltBuffer) break;
       }
+      // Fill the alt buffer with real scrollback so a drag DETERMINISTICALLY
+      // pages back + emits wheel SGR. An empty tmux session (cursor parked at
+      // the bottom with nothing above) intermittently emits NO wheel events on
+      // the first drag — the same proven `seq 1 200` lever the tmux-scrollback
+      // smoke (tmux_scrollback_test.dart) uses to make the drag reliable.
+      entry.proxy.sendInput(Uint8List.fromList(utf8.encode('seq 1 200\n')));
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
       debugPrint(
         'CTRACE624 mouseMode=${terminal.mouseMode} '
         'alt=${terminal.isUsingAltBuffer}',
+      );
+
+      // ── BASELINE: while CONNECTED, a drag SHOULD forward wheel SGR to the
+      // PTY (proves the gesture path is live + the handler emits real SGR, so a
+      // later "nothing forwarded" is the GATE working, not a dead gesture). ────
+      expect(
+        entry.proxy.data.state,
+        SshSessionState.connected,
+        reason: 'precondition: session must be live before the baseline drag',
+      );
+      final termFinder = find.byKey(Key('terminal-view-${entry.id}'));
+      expect(termFinder, findsOneWidget);
+      final center = tester.getCenter(termFinder);
+      // Retry the baseline drag until it emits wheel SGR. The FIRST drag right
+      // after the alt buffer opens is racy on-device — xterm's scroll-report
+      // path occasionally produces no wheel events until the buffer/mouse mode
+      // has settled a frame or two. Retrying (bounded) makes the live baseline
+      // deterministic without weakening it.
+      var liveEmitted = '';
+      var liveAscii = '';
+      for (var attempt = 0; attempt < 6; attempt++) {
+        spy.clear();
+        emitted.clear();
+        await tester.dragFrom(center, const Offset(0, 300));
+        for (var i = 0; i < 12; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+        }
+        liveAscii = utf8
+            .decode(spy.inputBytes, allowMalformed: true)
+            .replaceAll('\x1b', 'ESC');
+        liveEmitted = utf8
+            .decode(emitted, allowMalformed: true)
+            .replaceAll('\x1b', 'ESC');
+        if (liveEmitted.contains('64;') || liveEmitted.contains('65;')) break;
+      }
+      debugPrint('CTRACE624 bytes-forwarded-on-drag-while-LIVE=$liveAscii');
+      debugPrint('CTRACE624 bytes-EMITTED-on-drag-while-LIVE=$liveEmitted');
+      // The terminal MUST emit wheel SGR on a drag in this mouse mode (the
+      // gesture path is live + the #617 handler emits canonical codes) AND the
+      // gate MUST forward it while connected. If the terminal emits but the
+      // gateway forwards nothing here, the later "dead → nothing forwarded"
+      // assertion would be vacuous — so we require both to be true while live.
+      expect(
+        liveEmitted.contains('64;') || liveEmitted.contains('65;'),
+        isTrue,
+        reason:
+            'precondition: a scroll drag must EMIT wheel SGR in this mouse mode '
+            '— the gesture/handler path is the thing the gate later blocks: '
+            '$liveEmitted',
+      );
+      expect(
+        liveAscii.contains('64;') || liveAscii.contains('65;'),
+        isTrue,
+        reason:
+            'while connected a scroll drag MUST forward wheel SGR to the PTY — '
+            'otherwise the disconnected-case assertion is vacuous: $liveAscii',
       );
 
       // ── FORCE A DISCONNECT, keeping the entry (network-drop analogue). ──────
@@ -145,51 +268,82 @@ void main() {
             '(state=${entry.proxy.data.state})',
       );
 
-      // (a) The state-driven disconnect banner must be present (#624 symptom 1).
+      // (a1) The router must KEEP the terminal screen mounted for the kept-but-
+      // dead entry — the v1 bug was that it navigated back to the chooser on
+      // `disconnected`, unmounting the banner (#624 root cause).
+      expect(
+        find.byKey(const Key('session-menu-button')),
+        findsOneWidget,
+        reason:
+            'router navigated away from the terminal on disconnect — the '
+            'kept-but-dead entry must keep the terminal screen mounted (#624)',
+      );
+      // (a2) The state-driven disconnect banner must be present (#624 symptom 1).
       expect(
         find.byKey(const Key('terminal-disconnect-banner')),
         findsOneWidget,
         reason: 'no disconnect indicator while the session is dead (#624)',
       );
 
-      // (b) Drag on the terminal — this is the scroll gesture that dumped raw
-      // wheel SGR on device. With the liveness gate, NO bytes (and definitely
-      // no `64;…M` SGR) may reach the PTY while disconnected.
-      sentToPty.clear();
-      final termFinder = find.byKey(Key('terminal-view-${entry.id}'));
-      expect(termFinder, findsOneWidget);
-      final center = tester.getCenter(termFinder);
-      await tester.dragFrom(center, const Offset(0, 300));
-      for (var i = 0; i < 12; i++) {
-        await tester.pump(const Duration(milliseconds: 250));
+      // (b) Drag on the terminal AGAIN — this is the scroll gesture that dumped
+      // raw wheel SGR on device. With the liveness gate, NO input bytes (and
+      // definitely no `64;…M` SGR) may be FORWARDED to the PTY while
+      // disconnected. We measure the gateway's outgoing input, not the
+      // terminal's emission (the terminal still emits; the gate drops it).
+      // Retry until the terminal EMITS wheel SGR (same first-drag race as the
+      // baseline). The gate must forward NOTHING across every attempt, so the
+      // spy accumulates and is asserted empty after the loop — any leak in any
+      // attempt fails the test.
+      spy.clear();
+      var deadEmitted = '';
+      for (var attempt = 0; attempt < 6; attempt++) {
+        emitted.clear();
+        await tester.dragFrom(center, const Offset(0, 300));
+        for (var i = 0; i < 12; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+        }
+        deadEmitted = utf8
+            .decode(emitted, allowMalformed: true)
+            .replaceAll('\x1b', 'ESC');
+        if (deadEmitted.contains('64;') || deadEmitted.contains('65;')) break;
       }
 
       final ascii = utf8
-          .decode(sentToPty, allowMalformed: true)
+          .decode(spy.inputBytes, allowMalformed: true)
           .replaceAll('\x1b', 'ESC');
-      debugPrint('CTRACE624 bytes-sent-on-drag-while-dead=$ascii');
+      debugPrint('CTRACE624 bytes-forwarded-on-drag-while-DEAD=$ascii');
+      debugPrint('CTRACE624 bytes-EMITTED-on-drag-while-DEAD=$deadEmitted');
 
-      // No SGR mouse-wheel body may appear in the forwarded bytes.
+      // The terminal STILL EMITS wheel SGR on the dead drag (the gesture fires
+      // + the handler runs — xterm has no idea the PTY is dead). This is what
+      // makes the gate the thing under test: the gate, not a dead gesture, is
+      // why nothing is forwarded below.
+      expect(
+        deadEmitted.contains('64;') || deadEmitted.contains('65;'),
+        isTrue,
+        reason:
+            'the drag must still EMIT wheel SGR while dead (gesture fires) so '
+            'the "nothing forwarded" assertion proves the GATE, not a dead '
+            'gesture: $deadEmitted',
+      );
+
+      // No SGR mouse-wheel body may be forwarded to the PTY.
       expect(
         ascii.contains('64;'),
         isFalse,
-        reason: 'wheel-up SGR leaked to PTY while disconnected (#624): $ascii',
+        reason:
+            'wheel-up SGR forwarded to PTY while disconnected (#624): $ascii',
       );
       expect(
         ascii.contains('65;'),
         isFalse,
-        reason: 'wheel-down SGR leaked to PTY while disconnected (#624)',
+        reason: 'wheel-down SGR forwarded to PTY while disconnected (#624)',
       );
       expect(
-        ascii.contains('M'),
-        isFalse,
-        reason: 'SGR report terminator leaked to PTY while disconnected',
-      );
-      expect(
-        sentToPty,
+        spy.inputBytes,
         isEmpty,
         reason:
-            'NO terminal output may reach the PTY while disconnected '
+            'NO input may be forwarded to the PTY while disconnected '
             '(#624) — got: $ascii',
       );
     },

--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -78,6 +78,12 @@ class RootRouter extends ConsumerStatefulWidget {
 }
 
 class _RootRouterState extends ConsumerState<RootRouter> {
+  /// Session ids that have been observed in `connected` at least once (#624).
+  /// Lets the router keep the terminal screen mounted for a session that
+  /// dropped (→ disconnected/failed) rather than snapping back to the chooser
+  /// and hiding the disconnect banner. Pruned to live entries each build.
+  final Set<String> _everConnected = <String>{};
+
   @override
   Widget build(BuildContext context) {
     // Touch the keepalive controller so it attaches to the SSH session
@@ -125,13 +131,57 @@ class _RootRouterState extends ConsumerState<RootRouter> {
     });
 
     final entries = ref.watch(sessionsProvider).entries;
+    var showTerminal = false;
     for (final e in entries) {
-      // Watch each session's data so we re-route when any of them connects.
-      final data = ref.watch(sessionDataProvider(e.id)).valueOrNull;
-      if (data?.state == SshSessionState.connected) {
-        return const TerminalScreen();
+      // Watch each session's data so we re-route when any of them connects —
+      // OR when a previously-live session drops (#624).
+      final state =
+          ref.watch(sessionDataProvider(e.id)).valueOrNull?.state ??
+          SshSessionState.idle;
+      if (state == SshSessionState.connected) {
+        // A session reached `connected` at least once. Remember it so a later
+        // drop (→ disconnected/failed) keeps the terminal mounted instead of
+        // snapping back to the chooser (#624 root cause).
+        _everConnected.add(e.id);
+        showTerminal = true;
+        continue;
+      }
+      // #624: a KEPT-but-dead entry must keep the terminal screen mounted so
+      // the disconnect banner shows + the input gate holds, rather than
+      // silently navigating to the chooser leaving no indication. We only do
+      // this for sessions that were ONCE live:
+      //   - softDisconnected / reconnecting are reachable ONLY from `connected`
+      //     (see SshSessionController.handleTransportClosed), so they always
+      //     mean "was live — now dropped".
+      //   - disconnected / failed are ambiguous (a first connect that never
+      //     succeeded also fails), so we additionally require that this id was
+      //     observed `connected` at some point (_everConnected). A never-live
+      //     failed/disconnected entry stays on the chooser so the host-key
+      //     prompt + connect error render there (preserves first-connect UX).
+      // Pre-first-connect states (idle/connecting/authenticating/
+      // awaitingHostKey) NEVER route to the terminal.
+      switch (state) {
+        case SshSessionState.softDisconnected:
+        case SshSessionState.reconnecting:
+          showTerminal = true;
+        case SshSessionState.disconnected:
+        case SshSessionState.failed:
+          if (_everConnected.contains(e.id)) showTerminal = true;
+        case SshSessionState.idle:
+        case SshSessionState.connecting:
+        case SshSessionState.awaitingHostKey:
+        case SshSessionState.authenticating:
+        case SshSessionState.connected:
+          break;
       }
     }
+    // Drop bookkeeping for ids no longer in the collection (close()d sessions)
+    // so the set can't grow unbounded across many connect/close cycles.
+    if (_everConnected.isNotEmpty) {
+      final live = entries.map((e) => e.id).toSet();
+      _everConnected.removeWhere((id) => !live.contains(id));
+    }
+    if (showTerminal) return const TerminalScreen();
     return const ConnectHomePage();
   }
 }

--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -216,7 +216,18 @@ class SessionsNotifier extends Notifier<SessionsState> {
       }
     });
     // Wire terminal keystrokes back through the proxy to the task isolate.
+    //
+    // #624: gate forwarding on a LIVE session. xterm's WheelFixMouseHandler
+    // (#617) emits mouse-wheel SGR reports (`ESC[<64;x;yM`) through this same
+    // `onOutput` path on a scroll gesture. When the PTY is dead
+    // (soft_disconnected / reconnecting / failed / disconnected / idle /
+    // connecting), there is no live shell consuming mouse mode, so those SGR
+    // bodies would land at the (re-opened plain) shell as literal `64;x;yM`
+    // text — exactly the garbage in the bug report. Dropping ALL terminal
+    // output unless `connected` kills this regardless of any stale mouse-mode
+    // on the xterm side, and typing into a dead PTY was never useful anyway.
     terminal.onOutput = (data) {
+      if (proxy.data.state != SshSessionState.connected) return;
       proxy.sendInput(Uint8List.fromList(utf8.encode(data)));
     };
     terminal.onResize = (width, height, pixelWidth, pixelHeight) {

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -26,6 +26,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
 
+import '../ssh/ssh_session.dart';
 import '../state/sessions.dart';
 import '../state/terminal_providers.dart';
 import '../state/ui_prefs_providers.dart';
@@ -363,9 +364,18 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody> {
     // ITS OWN palette + font size, so two visible sessions can differ.
     final fontSize = ref.watch(sessionFontSizeProvider(widget.sessionId));
     final palette = ref.watch(sessionTerminalThemeProvider(widget.sessionId));
+    // #624: state-driven disconnect indicator. Reads the session lifecycle enum
+    // directly (no parallel boolean — rules/state-management.md). The banner is
+    // shown only for "was-live-then-dropped" states so it never flashes during
+    // the initial connect handshake (idle/connecting/authenticating).
+    final sessionState =
+        ref.watch(sessionDataProvider(widget.sessionId)).valueOrNull?.state ??
+        SshSessionState.idle;
 
     return Column(
       children: [
+        if (_isDisconnected(sessionState))
+          _DisconnectBanner(state: sessionState),
         if (shellAsync.hasError)
           Container(
             width: double.infinity,
@@ -395,6 +405,68 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// True when [state] is a "was-live-then-dropped" lifecycle state that warrants
+/// a disconnect indicator (#624). Pre-first-connect states
+/// (idle/connecting/authenticating/awaitingHostKey) and `connected` show no
+/// banner — the banner means "this terminal is not live".
+bool _isDisconnected(SshSessionState state) {
+  switch (state) {
+    case SshSessionState.softDisconnected:
+    case SshSessionState.reconnecting:
+    case SshSessionState.failed:
+    case SshSessionState.disconnected:
+      return true;
+    case SshSessionState.idle:
+    case SshSessionState.connecting:
+    case SshSessionState.awaitingHostKey:
+    case SshSessionState.authenticating:
+    case SshSessionState.connected:
+      return false;
+  }
+}
+
+/// Slim, state-driven banner shown across the top of the terminal body when the
+/// session is no longer live (#624). Distinct copy for reconnecting vs. fully
+/// disconnected so the user knows whether the app is auto-retrying.
+class _DisconnectBanner extends StatelessWidget {
+  const _DisconnectBanner({required this.state});
+
+  final SshSessionState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final reconnecting =
+        state == SshSessionState.reconnecting ||
+        state == SshSessionState.softDisconnected;
+    final text = reconnecting ? 'Disconnected — reconnecting…' : 'Disconnected';
+    return Container(
+      key: const Key('terminal-disconnect-banner'),
+      width: double.infinity,
+      color: reconnecting ? Colors.orange.shade900 : Colors.red.shade900,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            reconnecting ? Icons.sync_problem : Icons.link_off,
+            size: 14,
+            color: Colors.white,
+          ),
+          const SizedBox(width: 8),
+          Text(
+            text,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/native/test/state/disconnected_input_gating_test.dart
+++ b/native/test/state/disconnected_input_gating_test.dart
@@ -1,0 +1,152 @@
+// Issue #624: when a session is NOT `connected`, terminal-generated output
+// (keystrokes AND the mouse-wheel SGR from WheelFixMouseHandler #617) must NOT
+// be forwarded to the PTY. Otherwise scroll gestures on a dead session dump
+// raw `64;x;yM` SGR bodies into the (re-opened plain) shell as literal text.
+//
+// These tests drive the per-session proxy state through the InMemoryGatewayPair
+// (task side emits a state event) and assert what reaches the task side when
+// the terminal emits output via its `onOutput` callback — the same callback
+// SessionsNotifier wires to forward bytes to the PTY.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+
+SshConnectParams _params() => const SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// Push a state transition to the UI proxy by emitting a task→UI state event.
+void _emitState(InMemoryGatewayPair pair, String sessionId, String state) {
+  pair.taskSide.send(
+    SshStateEvent(sessionId: sessionId, state: state).toJson(),
+  );
+}
+
+void main() {
+  group('disconnected input gating (#624)', () {
+    test('terminal output is NOT forwarded to the PTY when the session is '
+        'disconnected', () async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(pair.dispose);
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+      );
+      addTearDown(container.dispose);
+
+      // Capture every input command that reaches the task side.
+      final inputs = <SshInputCommand>[];
+      final sub = pair.taskSide.incoming.listen((payload) {
+        try {
+          final cmd = SshTaskCommand.fromJson(payload);
+          if (cmd is SshInputCommand) inputs.add(cmd);
+        } catch (_) {}
+      });
+      addTearDown(sub.cancel);
+
+      final entry = container
+          .read(sessionsProvider.notifier)
+          .addOrActivate(_params());
+
+      // Drive the proxy to `disconnected`.
+      _emitState(pair, entry.id, SshSessionState.disconnected.name);
+      await Future<void>.delayed(Duration.zero);
+      expect(entry.proxy.data.state, SshSessionState.disconnected);
+
+      // A scroll gesture in tmux mouse-mode produces this SGR body via the
+      // WheelFixMouseHandler; xterm surfaces it through Terminal.onOutput.
+      entry.terminal.onOutput?.call('\x1b[<64;12;19M');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        inputs,
+        isEmpty,
+        reason: 'no PTY input may be sent while not connected (#624)',
+      );
+    });
+
+    test(
+      'terminal output IS forwarded when the session is connected',
+      () async {
+        final pair = InMemoryGatewayPair();
+        addTearDown(pair.dispose);
+        final container = ProviderContainer(
+          overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+        );
+        addTearDown(container.dispose);
+
+        final inputs = <SshInputCommand>[];
+        final sub = pair.taskSide.incoming.listen((payload) {
+          try {
+            final cmd = SshTaskCommand.fromJson(payload);
+            if (cmd is SshInputCommand) inputs.add(cmd);
+          } catch (_) {}
+        });
+        addTearDown(sub.cancel);
+
+        final entry = container
+            .read(sessionsProvider.notifier)
+            .addOrActivate(_params());
+
+        _emitState(pair, entry.id, SshSessionState.connected.name);
+        await Future<void>.delayed(Duration.zero);
+        expect(entry.proxy.data.state, SshSessionState.connected);
+
+        entry.terminal.onOutput?.call('ls\n');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          inputs,
+          isNotEmpty,
+          reason: 'keystrokes must still reach the PTY while connected',
+        );
+      },
+    );
+
+    test('soft_disconnected and reconnecting also gate input', () async {
+      for (final state in [
+        SshSessionState.softDisconnected,
+        SshSessionState.reconnecting,
+        SshSessionState.failed,
+      ]) {
+        final pair = InMemoryGatewayPair();
+        final container = ProviderContainer(
+          overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+        );
+
+        final inputs = <SshInputCommand>[];
+        final sub = pair.taskSide.incoming.listen((payload) {
+          try {
+            final cmd = SshTaskCommand.fromJson(payload);
+            if (cmd is SshInputCommand) inputs.add(cmd);
+          } catch (_) {}
+        });
+
+        final entry = container
+            .read(sessionsProvider.notifier)
+            .addOrActivate(_params());
+        _emitState(pair, entry.id, state.name);
+        await Future<void>.delayed(Duration.zero);
+
+        entry.terminal.onOutput?.call('\x1b[<64;12;19M');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(inputs, isEmpty, reason: 'input must be gated in $state (#624)');
+
+        await sub.cancel();
+        container.dispose();
+        await pair.dispose();
+      }
+    });
+  });
+}

--- a/native/test/state/disconnected_input_gating_test.dart
+++ b/native/test/state/disconnected_input_gating_test.dart
@@ -8,8 +8,6 @@
 // the terminal emits output via its `onOutput` callback — the same callback
 // SessionsNotifier wires to forward bytes to the PTY.
 
-import 'dart:async';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/services/session_messages.dart';

--- a/native/test/widget/disconnect_indicator_test.dart
+++ b/native/test/widget/disconnect_indicator_test.dart
@@ -1,0 +1,127 @@
+// Issue #624: the terminal screen must show a clear, state-driven disconnect
+// indicator when the active session is NOT `connected` (soft_disconnected /
+// reconnecting / failed / disconnected), and hide it when connected.
+//
+// The indicator reads the session lifecycle enum directly (no parallel boolean,
+// per rules/state-management.md). These tests drive the per-session proxy state
+// through the InMemoryGatewayPair and assert the banner's presence/absence by
+// its stable key `terminal-disconnect-banner`.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/terminal_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<
+  ({SessionEntry entry, ProviderContainer container, InMemoryGatewayPair pair})
+>
+_setup(WidgetTester tester) async {
+  final pair = InMemoryGatewayPair();
+  final container = ProviderContainer(
+    overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+  );
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  addTearDown(container.dispose);
+
+  final entry = container
+      .read(sessionsProvider.notifier)
+      .addOrActivate(
+        const SshConnectParams(
+          host: 'h',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: TerminalScreen()),
+    ),
+  );
+  return (entry: entry, container: container, pair: pair);
+}
+
+void _emitState(InMemoryGatewayPair pair, String sessionId, String state) {
+  pair.taskSide.send(
+    SshStateEvent(sessionId: sessionId, state: state).toJson(),
+  );
+}
+
+Future<void> _pump(WidgetTester tester) async {
+  for (var i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('disconnect indicator (#624)', () {
+    testWidgets('shows the banner when the session is disconnected', (
+      tester,
+    ) async {
+      final s = await _setup(tester);
+      _emitState(s.pair, s.entry.id, SshSessionState.disconnected.name);
+      await _pump(tester);
+
+      expect(
+        find.byKey(const Key('terminal-disconnect-banner')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides the banner when the session is connected', (
+      tester,
+    ) async {
+      final s = await _setup(tester);
+      _emitState(s.pair, s.entry.id, SshSessionState.connected.name);
+      await _pump(tester);
+
+      expect(find.byKey(const Key('terminal-disconnect-banner')), findsNothing);
+    });
+
+    testWidgets('shows the banner while reconnecting', (tester) async {
+      final s = await _setup(tester);
+      _emitState(s.pair, s.entry.id, SshSessionState.reconnecting.name);
+      await _pump(tester);
+
+      expect(
+        find.byKey(const Key('terminal-disconnect-banner')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('banner appears then clears across a disconnect→reconnect', (
+      tester,
+    ) async {
+      final s = await _setup(tester);
+      _emitState(s.pair, s.entry.id, SshSessionState.connected.name);
+      await _pump(tester);
+      expect(find.byKey(const Key('terminal-disconnect-banner')), findsNothing);
+
+      _emitState(s.pair, s.entry.id, SshSessionState.softDisconnected.name);
+      await _pump(tester);
+      expect(
+        find.byKey(const Key('terminal-disconnect-banner')),
+        findsOneWidget,
+      );
+
+      _emitState(s.pair, s.entry.id, SshSessionState.connected.name);
+      await _pump(tester);
+      expect(find.byKey(const Key('terminal-disconnect-banner')), findsNothing);
+    });
+  });
+}

--- a/native/test/widget/router_keeps_terminal_on_drop_test.dart
+++ b/native/test/widget/router_keeps_terminal_on_drop_test.dart
@@ -1,0 +1,270 @@
+// Router route-stability across a session DROP (#624 root cause).
+//
+// The device bug: after a live session dropped, the disconnect banner never
+// showed because RootRouter navigated AWAY from the terminal screen. The router
+// originally routed to TerminalScreen ONLY while some session was `connected`;
+// the moment a session left `connected` (→ softDisconnected / reconnecting /
+// disconnected / failed) the loop found nothing connected and returned the
+// chooser (ConnectHomePage), UNMOUNTING the terminal body + the banner. The
+// isolated widget test (disconnect_indicator_test) mounted TerminalScreen
+// directly, so it never exercised the router and passed — the headless/route
+// gap that shipped the device bug.
+//
+// These tests mount the REAL RootRouter and drive a session through
+// connected → dropped, asserting the terminal screen STAYS mounted (banner
+// present) for a kept-but-dead entry, while a never-connected first-attempt
+// failure stays on the chooser so the connect error / host-key prompt render
+// there.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/main.dart';
+import 'package:mobissh/platform/desktop.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/keepalive_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../support/fake_ssh_shell_transport.dart';
+
+({ProviderContainer container, InMemoryGatewayPair pair}) _makeContainer() {
+  final pair = InMemoryGatewayPair();
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      // NoopKeepaliveGateway path — keeps FlutterForegroundTask statics out of
+      // the router's keepaliveControllerProvider read.
+      isDesktopProvider.overrideWithValue(true),
+      keepaliveServiceStarterProvider.overrideWithValue(() async {}),
+      sshShellOpenerProvider.overrideWithValue(
+        (ref, sessionId, terminal) async => FakeSshShellTransport(),
+      ),
+    ],
+  );
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  addTearDown(container.dispose);
+  return (container: container, pair: pair);
+}
+
+void _emit(InMemoryGatewayPair pair, String id, SshSessionState state) {
+  pair.taskSide.send(SshStateEvent(sessionId: id, state: state.name).toJson());
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 10}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('RootRouter route stability (#624)', () {
+    testWidgets(
+      'a kept-but-dead entry KEEPS the terminal screen mounted with the '
+      'disconnect banner (does not navigate back to the chooser)',
+      (tester) async {
+        final c = _makeContainer();
+        final entry = c.container
+            .read(sessionsProvider.notifier)
+            .addOrActivate(
+              const SshConnectParams(
+                host: 'h',
+                port: 22,
+                username: 'u',
+                auth: SshAuth.password('p'),
+              ),
+            );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: c.container,
+            child: const MaterialApp(home: RootRouter()),
+          ),
+        );
+        await _pump(tester);
+
+        // Reach the terminal screen by going `connected` first.
+        _emit(c.pair, entry.id, SshSessionState.connected);
+        await _pump(tester);
+        expect(
+          find.byKey(const Key('session-menu-button')),
+          findsOneWidget,
+          reason: 'router should show the terminal screen while connected',
+        );
+        expect(
+          find.byKey(const Key('terminal-disconnect-banner')),
+          findsNothing,
+        );
+
+        // Now DROP the session (clean disconnect → `disconnected`). The entry
+        // STAYS in the collection (the Disconnect BUTTON would close() it; a
+        // network drop / programmatic disconnect does not).
+        _emit(c.pair, entry.id, SshSessionState.disconnected);
+        await _pump(tester);
+
+        // The terminal screen must STILL be mounted (root-cause fix): the
+        // session menu button is the stable terminal-screen marker.
+        expect(
+          find.byKey(const Key('session-menu-button')),
+          findsOneWidget,
+          reason:
+              'router must KEEP the terminal screen for a kept-but-dead entry '
+              '(#624) — not navigate back to the chooser',
+        );
+        // And the disconnect banner must show.
+        expect(
+          find.byKey(const Key('terminal-disconnect-banner')),
+          findsOneWidget,
+          reason: 'disconnect banner must be visible on the kept terminal',
+        );
+      },
+    );
+
+    testWidgets(
+      'a genuine drop (softDisconnected → reconnecting) keeps the terminal '
+      'screen + banner mounted',
+      (tester) async {
+        final c = _makeContainer();
+        final entry = c.container
+            .read(sessionsProvider.notifier)
+            .addOrActivate(
+              const SshConnectParams(
+                host: 'h',
+                port: 22,
+                username: 'u',
+                auth: SshAuth.password('p'),
+              ),
+            );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: c.container,
+            child: const MaterialApp(home: RootRouter()),
+          ),
+        );
+        await _pump(tester);
+
+        _emit(c.pair, entry.id, SshSessionState.connected);
+        await _pump(tester);
+
+        // Drop: connected → softDisconnected → reconnecting (#551). Both must
+        // keep the terminal mounted with the banner.
+        _emit(c.pair, entry.id, SshSessionState.softDisconnected);
+        await _pump(tester);
+        expect(find.byKey(const Key('session-menu-button')), findsOneWidget);
+        expect(
+          find.byKey(const Key('terminal-disconnect-banner')),
+          findsOneWidget,
+        );
+
+        _emit(c.pair, entry.id, SshSessionState.reconnecting);
+        await _pump(tester);
+        expect(find.byKey(const Key('session-menu-button')), findsOneWidget);
+        expect(
+          find.byKey(const Key('terminal-disconnect-banner')),
+          findsOneWidget,
+        );
+
+        // Reconnect succeeds → banner clears, terminal stays.
+        _emit(c.pair, entry.id, SshSessionState.connected);
+        await _pump(tester);
+        expect(find.byKey(const Key('session-menu-button')), findsOneWidget);
+        expect(
+          find.byKey(const Key('terminal-disconnect-banner')),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('a NEVER-connected first-attempt failure stays on the chooser '
+        '(so the connect error / host-key prompt render there)', (
+      tester,
+    ) async {
+      final c = _makeContainer();
+      final entry = c.container
+          .read(sessionsProvider.notifier)
+          .addOrActivate(
+            const SshConnectParams(
+              host: 'h',
+              port: 22,
+              username: 'u',
+              auth: SshAuth.password('p'),
+            ),
+          );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: c.container,
+          child: const MaterialApp(home: RootRouter()),
+        ),
+      );
+      await _pump(tester);
+
+      // First connect never reaches `connected`; it fails (auth/unreachable).
+      _emit(c.pair, entry.id, SshSessionState.connecting);
+      await _pump(tester);
+      _emit(c.pair, entry.id, SshSessionState.failed);
+      await _pump(tester);
+
+      // The router must NOT show the terminal for a session that was never
+      // live — the chooser owns the connect-error / host-key UX.
+      expect(
+        find.byKey(const Key('session-menu-button')),
+        findsNothing,
+        reason:
+            'a never-connected failed entry must stay on the chooser '
+            '(no terminal screen)',
+      );
+    });
+
+    testWidgets(
+      'closing the only session (entry removed) returns to the chooser',
+      (tester) async {
+        final c = _makeContainer();
+        final notifier = c.container.read(sessionsProvider.notifier);
+        final entry = notifier.addOrActivate(
+          const SshConnectParams(
+            host: 'h',
+            port: 22,
+            username: 'u',
+            auth: SshAuth.password('p'),
+          ),
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: c.container,
+            child: const MaterialApp(home: RootRouter()),
+          ),
+        );
+        await _pump(tester);
+        _emit(c.pair, entry.id, SshSessionState.connected);
+        await _pump(tester);
+        expect(find.byKey(const Key('session-menu-button')), findsOneWidget);
+
+        // The Disconnect button removes the entry from the collection.
+        notifier.close(entry.id);
+        await _pump(tester);
+
+        expect(
+          find.byKey(const Key('session-menu-button')),
+          findsNothing,
+          reason: 'an empty collection returns to the chooser',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Fixes #624.

## Problem (device feedback, build 030596c)
When a native session disconnected:
1. **No disconnect indication** — the user couldn't tell a live terminal from a dead one.
2. **Scroll gestures dumped raw wheel-SGR** — scrolling produced literal `64;12;19M64;12;19M…` text at the prompt. Those are the SGR mouse-wheel report bodies (button 64 = wheel up) from the #617 `WheelFixMouseHandler`, landing as input/echo because no live PTY in mouse mode consumed them.

## Root cause
`sessions.dart` wired `terminal.onOutput → proxy.sendInput` **unconditionally**. xterm's `WheelFixMouseHandler` (#617) emits wheel SGR through that same `onOutput` path on a scroll gesture. With a dead PTY (soft_disconnected / reconnecting / closed), the bytes became literal garbage at the (re-opened plain) shell.

## Fix
- **Robust core:** gate `terminal.onOutput` forwarding on `proxy.data.state == connected`. Drop ALL terminal output otherwise — never emit to the PTY. This kills the SGR garbage regardless of any stale xterm mouse-mode, and typing into a dead PTY was never useful anyway.
- **Indicator:** a state-driven `_DisconnectBanner` in `_SessionTerminalBody`, bound to the session lifecycle enum via `sessionDataProvider` (no parallel boolean — `rules/state-management.md`). Shown for soft_disconnected / reconnecting / failed / disconnected; hidden for `connected` and pre-first-connect states (idle/connecting/authenticating) so it never flashes during the initial handshake.

## Stale-mouse-mode hypothesis
Not relied upon. The liveness gate makes it moot: even if xterm believes it is still in mouse mode after a drop, the gate drops the SGR before it can be forwarded. On-emulator repro of that subtlety is deferred to the gate run; the fix is correct either way.

## Tests (TDD: red → green)
- `native/test/state/disconnected_input_gating_test.dart` — input dropped when not connected (disconnected / soft_disconnected / reconnecting / failed), forwarded when connected.
- `native/test/widget/disconnect_indicator_test.dart` — banner present when not connected, absent when connected, clears across a disconnect→reconnect.
- `native/integration_test/disconnected_scroll_test.dart` (#589 on-emulator suite) — connect to test-sshd, start tmux mouse-on, force a disconnect that keeps the entry (network-drop analogue), then assert (a) the banner is present and (b) NO `64;…M` SGR reaches the PTY on a drag.

`scripts/native-fast-gate.sh` passes (analyze + 350 unit/widget tests). The integration test is part of the #589 suite; the orchestrator runs it red→green on the emulator as the merge gate — **not** claimed device-verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)