### PR TITLE
fix(#563): bound authenticating phase with readyTimer

### DIFF
--- a/native/lib/ssh/ssh_session.dart
+++ b/native/lib/ssh/ssh_session.dart
@@ -723,13 +723,32 @@ class SshSessionController {
   // --- private helpers ---
 
   void _emit(SshSessionData next) {
-    // Cancel the connecting-phase timer the instant state leaves `connecting`.
-    // Centralizing here covers every transition path (awaitingHostKey,
-    // authenticating, connected, failed) — including the human-paced host-key
-    // prompt, which must never be timed out (#542). The timer is (re-)armed
-    // explicitly in connect() after the `connecting` emit, so cancelling on a
-    // `connecting` emit here is harmless.
-    if (next.state != SshSessionState.connecting && _readyTimer != null) {
+    // Manage the machine-paced phase deadline timer per transition.
+    //
+    // `connecting` and `authenticating` are BOTH machine-paced phases that must
+    // be bounded: the handshake (#542) and userauth (#563) can each stall after
+    // a half-open path is established (TCP SYN accepted but no SSH bytes flow,
+    // or auth negotiation never completes). The previous design cancelled the
+    // timer on entry to ANY non-`connecting` state — including `authenticating`
+    // — so a userauth that stalled AFTER host-key accept hung forever (#563).
+    //
+    // `awaitingHostKey` is HUMAN-paced — the user may deliberate at the Trust
+    // dialog indefinitely — so it must NEVER time out. Terminal/steady states
+    // (`connected`, `failed`, `disconnected`, `softDisconnected`,
+    // `reconnecting`, `idle`) also cancel.
+    //
+    // Rules:
+    //   - entering `connecting` or `authenticating`: (re-)arm the timer.
+    //     `_armReadyTimer()` cancels any existing timer first, so arming is
+    //     idempotent (connect() still calls it explicitly after the connecting
+    //     emit; harmless).
+    //   - any other state: cancel.
+    final armPhase =
+        next.state == SshSessionState.connecting ||
+        next.state == SshSessionState.authenticating;
+    if (armPhase) {
+      _armReadyTimer();
+    } else if (_readyTimer != null) {
       ctrace('task.ssh', 'readyTimer: cancelled (state→${next.state.name})');
       _readyTimer!.cancel();
       _readyTimer = null;
@@ -740,18 +759,24 @@ class SshSessionController {
     }
   }
 
-  /// Arm the connecting-phase deadline. If the session is STILL `connecting`
-  /// when it fires, force-close the client + socket and surface `failed` (#542).
+  /// Arm the machine-paced phase deadline. If the session is STILL `connecting`
+  /// (handshake never completed, #542) OR `authenticating` (userauth stalled
+  /// after host-key accept, #563) when it fires, force-close the client +
+  /// socket and surface `failed`. `awaitingHostKey` cancels this timer (see
+  /// `_emit`), so the human-paced host-key prompt is never timed out.
   void _armReadyTimer() {
     _readyTimer?.cancel();
     final secs = readyTimeout.inMilliseconds / 1000;
     ctrace('task.ssh', 'readyTimer: armed (${secs}s)');
     _readyTimer = Timer(readyTimeout, () {
       _readyTimer = null;
-      if (_data.state != SshSessionState.connecting) return;
+      if (_data.state != SshSessionState.connecting &&
+          _data.state != SshSessionState.authenticating) {
+        return;
+      }
       ctrace(
         'task.ssh',
-        'readyTimer: FIRED while still connecting → force-fail',
+        'readyTimer: FIRED while still ${_data.state.name} → force-fail',
       );
       _forceCloseTransport();
       _emit(

--- a/native/test/ssh/handshake_timeout_test.dart
+++ b/native/test/ssh/handshake_timeout_test.dart
@@ -1,12 +1,18 @@
-// Connecting-phase handshake-timeout tests (#542).
+// Machine-paced phase timeout tests (#542, #563).
 //
 // `connect()` bounds only the TCP connect (`handshakeTimeout`). After TCP
 // opens, `await client.authenticated` had no timeout — a half-open Tailscale
 // path (TCP SYN accepted, no SSH KEX bytes ever flow) hung at `connecting`
-// forever. The controller now arms a `readyTimeout` timer when it enters
-// `connecting` and force-fails if KEX never completes — BUT the timer must be
-// cancelled the instant state leaves `connecting`, so the human-paced host-key
-// prompt (`awaitingHostKey`) is never timed out.
+// forever. The controller arms a `readyTimeout` timer for the machine-paced
+// phases and force-fails if they never complete.
+//
+// #542: bounds `connecting` (handshake / KEX never completes).
+// #563: bounds `authenticating` too — a userauth that stalls AFTER host-key
+//       accept previously hung forever, because the timer was cancelled on
+//       entry to `authenticating` and never re-armed.
+//
+// BUT the timer must be cancelled the instant state enters `awaitingHostKey`,
+// so the human-paced host-key prompt is never timed out.
 
 import 'dart:async';
 import 'dart:typed_data';
@@ -57,72 +63,166 @@ void main() {
     });
 
     test(
-        'socket opens but KEX never completes → fails within readyTimeout',
-        () async {
-      final controller = SshSessionController(
-        readyTimeout: const Duration(milliseconds: 150),
-        socketOpener: (host, port, {timeout}) async => _SilentSocket(),
-      );
+      'socket opens but KEX never completes → fails within readyTimeout',
+      () async {
+        final controller = SshSessionController(
+          readyTimeout: const Duration(milliseconds: 150),
+          socketOpener: (host, port, {timeout}) async => _SilentSocket(),
+        );
 
-      final connectFuture = controller.connect(const SshConnectParams(
-        host: 'half-open',
-        port: 22,
-        username: 'u',
-        auth: SshAuth.password('p'),
-      ));
+        final connectFuture = controller.connect(
+          const SshConnectParams(
+            host: 'half-open',
+            port: 22,
+            username: 'u',
+            auth: SshAuth.password('p'),
+          ),
+        );
 
-      // Reaches `connecting` synchronously after the socket opens.
-      // Wait past the readyTimeout — the timer must fire and force-fail.
-      await Future<void>.delayed(const Duration(milliseconds: 400));
+        // Reaches `connecting` synchronously after the socket opens.
+        // Wait past the readyTimeout — the timer must fire and force-fail.
+        await Future<void>.delayed(const Duration(milliseconds: 400));
 
-      expect(controller.data.state, SshSessionState.failed);
-      expect(controller.data.error, isNotNull);
-      expect(controller.data.error, contains('No SSH response'));
+        expect(controller.data.state, SshSessionState.failed);
+        expect(controller.data.error, isNotNull);
+        expect(controller.data.error, contains('No SSH response'));
 
-      // connect() should not hang forever on `client.authenticated`.
-      await connectFuture.timeout(const Duration(seconds: 2),
-          onTimeout: () {});
+        // connect() should not hang forever on `client.authenticated`.
+        await connectFuture.timeout(
+          const Duration(seconds: 2),
+          onTimeout: () {},
+        );
 
-      await controller.dispose();
-    });
+        await controller.dispose();
+      },
+    );
 
     test(
-        'awaitingHostKey (host-key prompt) cancels the timer — never times out',
-        () async {
-      final controller = SshSessionController(
-        readyTimeout: const Duration(milliseconds: 100),
-      );
+      'awaitingHostKey (host-key prompt) cancels the timer — never times out',
+      () async {
+        final controller = SshSessionController(
+          readyTimeout: const Duration(milliseconds: 100),
+        );
 
-      const params = SshConnectParams(
-        host: 'prompt-host',
-        port: 22,
-        username: 'u',
-        auth: SshAuth.password('p'),
-      );
+        const params = SshConnectParams(
+          host: 'prompt-host',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        );
 
-      // Drive the verify-host-key path directly (untrusted key → prompt).
-      // The returned future stays pending until accept/reject — modelling a
-      // human deliberating at the Trust dialog.
-      final verifyFuture = controller.verifyHostKeyForTest(
-        params,
-        'ssh-ed25519',
-        Uint8List.fromList(List<int>.filled(32, 7)),
-      );
+        // Drive the verify-host-key path directly (untrusted key → prompt).
+        // The returned future stays pending until accept/reject — modelling a
+        // human deliberating at the Trust dialog.
+        final verifyFuture = controller.verifyHostKeyForTest(
+          params,
+          'ssh-ed25519',
+          Uint8List.fromList(List<int>.filled(32, 7)),
+        );
 
-      expect(controller.data.state, SshSessionState.awaitingHostKey);
+        expect(controller.data.state, SshSessionState.awaitingHostKey);
 
-      // Wait far longer than the readyTimeout. A human at the dialog must NOT
-      // be timed out — the connecting-phase timer must have been cancelled.
-      await Future<void>.delayed(const Duration(milliseconds: 350));
+        // Wait far longer than the readyTimeout. A human at the dialog must NOT
+        // be timed out — the connecting-phase timer must have been cancelled.
+        await Future<void>.delayed(const Duration(milliseconds: 350));
 
-      expect(controller.data.state, SshSessionState.awaitingHostKey);
-      expect(controller.data.state, isNot(SshSessionState.failed));
+        expect(controller.data.state, SshSessionState.awaitingHostKey);
+        expect(controller.data.state, isNot(SshSessionState.failed));
 
-      // Resolve the prompt so the pending future doesn't leak.
-      controller.acceptHostKey();
-      await verifyFuture;
+        // Resolve the prompt so the pending future doesn't leak.
+        controller.acceptHostKey();
+        await verifyFuture;
 
-      await controller.dispose();
-    });
+        await controller.dispose();
+      },
+    );
+
+    test(
+      'authenticating stalls after host-key accept → fails within readyTimeout (#563)',
+      () async {
+        final controller = SshSessionController(
+          readyTimeout: const Duration(milliseconds: 150),
+        );
+
+        const params = SshConnectParams(
+          host: 'stall-auth',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        );
+
+        // Untrusted key → prompt. The returned future stays pending until
+        // accept/reject (models the dartssh2 verify callback awaiting a human).
+        final verifyFuture = controller.verifyHostKeyForTest(
+          params,
+          'ssh-ed25519',
+          Uint8List.fromList(List<int>.filled(32, 9)),
+        );
+
+        expect(controller.data.state, SshSessionState.awaitingHostKey);
+
+        // Human accepts the host key → transition to `authenticating`. Now
+        // userauth begins. Model a stalled userauth: nothing else happens — no
+        // password challenge resolves, no transport bytes flow. Before #563 the
+        // readyTimer was cancelled on entry to `authenticating` and never
+        // re-armed, so the session hung in `authenticating` forever.
+        controller.acceptHostKey();
+        expect(controller.data.state, SshSessionState.authenticating);
+
+        // Wait well past the readyTimeout. The re-armed timer must fire and
+        // force-fail the stalled auth.
+        await Future<void>.delayed(const Duration(milliseconds: 400));
+
+        expect(controller.data.state, SshSessionState.failed);
+        expect(controller.data.error, isNotNull);
+        expect(controller.data.error, contains('No SSH response'));
+
+        // Resolve the dangling verify future so it doesn't leak.
+        await verifyFuture;
+
+        await controller.dispose();
+      },
+    );
+
+    test(
+      'already-trusted host key → authenticating arms timer; stall → fails (#563)',
+      () async {
+        const params = SshConnectParams(
+          host: 'trusted-stall',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        );
+
+        final controller = SshSessionController(
+          readyTimeout: const Duration(milliseconds: 150),
+        );
+
+        // Pre-trust the fingerprint so the verify path goes straight to
+        // `authenticating` (no prompt). The hex must match _fingerprintHex of
+        // the bytes below: 32 bytes of 0x05 → "05" * 32.
+        final fp = Uint8List.fromList(List<int>.filled(32, 5));
+        const hex =
+            '0505050505050505050505050505050505050505050505050505050505050505';
+        controller.hostKeyStore.trust(params.host, params.port, hex);
+
+        final verifyFuture = controller.verifyHostKeyForTest(
+          params,
+          'ssh-ed25519',
+          fp,
+        );
+
+        // Trusted → straight to authenticating (no awaitingHostKey detour).
+        expect(controller.data.state, SshSessionState.authenticating);
+
+        // Stalled userauth: wait past the readyTimeout.
+        await Future<void>.delayed(const Duration(milliseconds: 400));
+
+        expect(controller.data.state, SshSessionState.failed);
+
+        await verifyFuture;
+        await controller.dispose();
+      },
+    );
   });
 }


### PR DESCRIPTION
Bot fix for #563. Closes #563.