### PR TITLE
feat(#570): rich-text stream parser (Part A: parser core)

### DIFF
--- a/native/lib/terminal/session_stream_parser.dart
+++ b/native/lib/terminal/session_stream_parser.dart
@@ -1,0 +1,215 @@
+// Per-session rich-text stream parser (#570, Part A — parser core only).
+//
+// `SessionStreamParser` sits on a session's LOGICAL (decoded) text stream — it
+// is fed chunks of terminal output, NOT per-rendered-line — and detects
+// "rich" runs the UI can later make tappable:
+//   - full URLs (a robust default matcher), and
+//   - any number of caller-supplied token matchers (e.g. `/remote/path`,
+//     `#hashid`).
+//
+// Why the LOGICAL stream and not rendered lines: a long URL the terminal
+// SOFT-WRAPS across several display rows is a single contiguous run of
+// characters in the logical stream, so it is detected as ONE match. Likewise a
+// URL/token split across two fed chunks is coalesced. Matches carry the matched
+// TEXT plus session-ABSOLUTE logical offsets (`start`/`end`) so a later UI
+// layer (Part B) can map them onto rendered cells.
+//
+// Scalability: the parser keeps a bounded rolling buffer. After each feed it
+// scans only the region up to the last "safe boundary" (the last whitespace /
+// newline — no in-flight token can straddle it) and retains only the tail after
+// that boundary for the next feed. This makes the work per feed O(new bytes +
+// pending-tail), not O(total-history), so it stays cheap across large
+// scrollback. The retained tail is additionally capped at [maxBufferChars]; a
+// single unterminated token longer than that cap will not be matched (a token
+// with no whitespace/newline for thousands of characters is not a real link).
+//
+// Coordination with #575 (SessionSignalDetector): that detector scans RAW BYTES
+// for OSC-9 / BEL escape sequences (a control-byte domain). This parser scans
+// DECODED logical text (a different domain). They are complementary, but #575's
+// own note says the shared parser "can grow from this seam". The extension seam
+// here is the pluggable [RichTextMatcher] list + the typed [StreamMatch] /
+// [StreamMatchKind] taxonomy: an OSC/bell text-side consumer could be added as
+// another matcher kind without changing the scan loop. That is NOT implemented
+// here (it belongs to #575).
+//
+// This module is PURE (no Flutter, no I/O) and is exercised entirely by
+// `test/terminal/session_stream_parser_test.dart` in the fast unit gate. Wiring
+// it into the session output path (sessions.dart / session_host.dart) and the
+// tap UI (terminal_screen.dart) is Part B — out of scope here. App-level config
+// for the regex set (Part B / settings) would simply be passed as
+// [extraMatchers] at construction, one parser per session.
+
+/// The category of a detected run. URLs are first-class; everything a caller
+/// configures is [custom]. The enum is the extension point for #575
+/// (OSC/bell) and any future rich-text kind.
+enum StreamMatchKind { url, custom }
+
+/// A detected rich-text run in the logical stream.
+class StreamMatch {
+  const StreamMatch({
+    required this.kind,
+    required this.text,
+    required this.start,
+    required this.end,
+  });
+
+  /// What kind of run this is.
+  final StreamMatchKind kind;
+
+  /// The exact matched substring of the logical stream.
+  final String text;
+
+  /// Session-absolute start offset (inclusive) into the full logical stream the
+  /// parser has been fed since construction.
+  final int start;
+
+  /// Session-absolute end offset (exclusive). `end - start == text.length`.
+  final int end;
+
+  @override
+  String toString() => 'StreamMatch($kind, "$text", $start..$end)';
+}
+
+/// A pluggable matcher: a [RegExp] plus the [StreamMatchKind] its hits emit.
+///
+/// Matchers are applied to the same scanned region in order; the parser emits
+/// every non-overlapping hit each matcher finds. Keeping matchers as plain data
+/// is the seam that lets #575 add an OSC/bell matcher later without touching the
+/// scan loop. (Named `RichTextMatcher`, not `StreamMatcher`, to avoid colliding
+/// with `package:matcher`'s `StreamMatcher` in test files.)
+class RichTextMatcher {
+  const RichTextMatcher({required this.kind, required this.pattern});
+
+  /// Kind emitted for hits of [pattern].
+  final StreamMatchKind kind;
+
+  /// The pattern to search for within the scanned region.
+  final RegExp pattern;
+}
+
+/// Default robust-ish URL matcher: an http/https scheme followed by a run of
+/// URL-legal characters, stopping before trailing sentence punctuation. It does
+/// not try to be an RFC parser — it errs toward what a human would tap.
+final RegExp _defaultUrlPattern = RegExp(
+  // scheme://  then one-or-more URL chars, then a final URL char that is not
+  // trailing punctuation (so "page." captures "page", not "page.").
+  r'https?://[^\s<>"'
+  "'"
+  r']*[^\s<>"'
+  "'"
+  r'.,;:!?)\]}]',
+  caseSensitive: false,
+);
+
+/// Consumes a session's logical text stream and emits [StreamMatch]es.
+///
+/// One instance per session by construction. Not thread-safe; feed from a single
+/// sequence of calls (the session's output handler).
+class SessionStreamParser {
+  SessionStreamParser({
+    required this.onMatch,
+    List<RichTextMatcher>? extraMatchers,
+    this.maxBufferChars = 8192,
+  }) : _matchers = [
+         RichTextMatcher(
+           kind: StreamMatchKind.url,
+           pattern: _defaultUrlPattern,
+         ),
+         ...?extraMatchers,
+       ];
+
+  /// Invoked once per detected match, in stream order.
+  final void Function(StreamMatch match) onMatch;
+
+  /// Upper bound on the retained rolling-buffer length. A pending (unterminated)
+  /// token longer than this will not be matched. Default 8192 chars.
+  final int maxBufferChars;
+
+  final List<RichTextMatcher> _matchers;
+
+  /// The rolling buffer: the not-yet-finalized tail of the logical stream.
+  final StringBuffer _bufBuilder = StringBuffer();
+  String _buf = '';
+
+  /// Number of logical characters that have been finalized (scanned + dropped)
+  /// before the current buffer. Absolute offset of `_buf[i]` is `_dropped + i`.
+  int _dropped = 0;
+
+  /// Current rolling-buffer length (for tests / introspection).
+  int get bufferLength => _buf.length;
+
+  /// Feed a chunk of LOGICAL (decoded) terminal output. Emits zero or more
+  /// matches for any token that becomes complete with this chunk.
+  void feed(String chunk) {
+    if (chunk.isEmpty) return;
+    _bufBuilder.write(chunk);
+    _buf = _bufBuilder.toString();
+
+    // Everything up to and including the last whitespace/newline is "safe":
+    // no token can straddle a whitespace boundary, so any match wholly inside
+    // that region is final. The tail after it may still be a partial token, so
+    // we keep it for the next feed (coalescing).
+    final safeEnd = _lastSafeBoundary(_buf);
+    if (safeEnd > 0) {
+      _scanRegion(0, safeEnd);
+      _advance(safeEnd);
+    }
+
+    // Guard the retained tail against unbounded growth. If the tail (a single
+    // run with no whitespace) exceeds the cap, drop its oldest characters.
+    if (_buf.length > maxBufferChars) {
+      _advance(_buf.length - maxBufferChars);
+    }
+  }
+
+  /// Drop `count` characters from the front of the buffer, bumping the absolute
+  /// offset base. Rebuilds the buffer compactly.
+  void _advance(int count) {
+    if (count <= 0) return;
+    _dropped += count;
+    _buf = _buf.substring(count);
+    _bufBuilder
+      ..clear()
+      ..write(_buf);
+  }
+
+  /// Index just past the last whitespace character in [s], i.e. the end of the
+  /// region in which every token is guaranteed complete. Returns 0 if [s] has
+  /// no whitespace (the whole thing is one in-flight run).
+  int _lastSafeBoundary(String s) {
+    for (var i = s.length - 1; i >= 0; i--) {
+      if (_isWhitespace(s.codeUnitAt(i))) return i + 1;
+    }
+    return 0;
+  }
+
+  bool _isWhitespace(int c) =>
+      c == 0x20 || // space
+      c == 0x09 || // tab
+      c == 0x0a || // LF
+      c == 0x0d || // CR
+      c == 0x0c || // FF
+      c == 0x0b; // VT
+
+  /// Run every matcher over `_buf[start..end)` and emit hits with absolute
+  /// offsets.
+  void _scanRegion(int start, int end) {
+    if (end <= start) return;
+    final region = _buf.substring(start, end);
+    final base = _dropped + start;
+    for (final matcher in _matchers) {
+      for (final m in matcher.pattern.allMatches(region)) {
+        final matchText = m.group(0);
+        if (matchText == null || matchText.isEmpty) continue;
+        onMatch(
+          StreamMatch(
+            kind: matcher.kind,
+            text: matchText,
+            start: base + m.start,
+            end: base + m.end,
+          ),
+        );
+      }
+    }
+  }
+}

--- a/native/test/terminal/session_stream_parser_test.dart
+++ b/native/test/terminal/session_stream_parser_test.dart
@@ -1,0 +1,269 @@
+// Unit tests for the per-session rich-text stream parser (#570, Part A).
+//
+// `SessionStreamParser` consumes a session's LOGICAL (decoded) text stream —
+// chunks of terminal output, NOT per-rendered-line — and detects:
+//   - full URLs (robust regex)
+//   - a configurable set of additional token regexes (e.g. `/remote/path`,
+//     `#hashid`).
+// It returns typed `StreamMatch`es carrying the matched TEXT and stable,
+// session-absolute logical OFFSETS so a later UI layer can map them to rendered
+// cells. Because the parser sits on the logical stream, a URL that WRAPS across
+// rendered terminal lines is a single contiguous run of characters here and is
+// detected as one match. URLs/tokens split across two fed chunks are coalesced.
+//
+// Part A is the pure parser + tests only — no session wiring, no UI. The parser
+// is structured with a pluggable matcher list so #575's OSC/bell consumer can
+// ride the same scan later; that extension is NOT implemented here.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/terminal/session_stream_parser.dart';
+
+void main() {
+  group('URL detection (default config)', () {
+    test('a single URL in one chunk is detected with correct text', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('see https://example.com/path?q=1 for details\n');
+      expect(matches, hasLength(1));
+      expect(matches.first.kind, StreamMatchKind.url);
+      expect(matches.first.text, 'https://example.com/path?q=1');
+    });
+
+    test('match offsets are session-absolute and slice back to the URL', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      const text = 'go to http://a.test/x now';
+      p.feed(text);
+      final m = matches.single;
+      // Offsets index into the full logical stream the parser has seen.
+      expect(text.substring(m.start, m.end), m.text);
+      expect(m.text, 'http://a.test/x');
+    });
+
+    test('multiple URLs in one chunk are all detected, in order', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('first https://one.example second http://two.example/y end\n');
+      expect(matches.map((m) => m.text).toList(), [
+        'https://one.example',
+        'http://two.example/y',
+      ]);
+    });
+
+    test('default config detects URLs with no caller-supplied regex', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('https://default.example/\n');
+      expect(matches.single.kind, StreamMatchKind.url);
+      expect(matches.single.text, 'https://default.example/');
+    });
+
+    test('trailing sentence punctuation is not captured into the URL', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('visit https://example.com/page.\n');
+      expect(matches.single.text, 'https://example.com/page');
+    });
+  });
+
+  group('wrap- and whitespace-margin awareness', () {
+    test('a URL surrounded by whitespace margins is detected cleanly', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('   \t https://margin.example/path   \t\n');
+      expect(matches.single.text, 'https://margin.example/path');
+    });
+
+    test(
+      'a URL that wraps across rendered lines is one contiguous logical match',
+      () {
+        // The terminal soft-wraps a long URL across two display rows, but the
+        // LOGICAL stream the parser sees has no break inside the URL. The
+        // caller is responsible for feeding logical (de-wrapped) text; here we
+        // assert the parser treats a contiguous run as a single URL even with
+        // line breaks BEFORE and AFTER it (the wrap margins).
+        final matches = <StreamMatch>[];
+        final p = SessionStreamParser(onMatch: matches.add);
+        p.feed('line one\nhttps://wrapped.example/a/very/long/path/segment\nx');
+        expect(
+          matches.single.text,
+          'https://wrapped.example/a/very/long/path/segment',
+        );
+      },
+    );
+
+    test('a newline inside the run terminates the URL (no swallowing)', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('https://example.com/a\nnotpartofurl\n');
+      expect(matches.single.text, 'https://example.com/a');
+    });
+  });
+
+  group('chunk-boundary coalescing', () {
+    test('a URL split across two feeds is detected once it completes', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('open https://split.examp');
+      // Nothing emitted yet — the token has not been terminated.
+      expect(matches, isEmpty);
+      p.feed('le.com/done end\n');
+      expect(matches, hasLength(1));
+      expect(matches.single.text, 'https://split.example.com/done');
+    });
+
+    test(
+      'offsets after a split feed are still absolute to the full stream',
+      () {
+        final matches = <StreamMatch>[];
+        final p = SessionStreamParser(onMatch: matches.add);
+        const a = 'prefix ';
+        const b = 'http://x.test/end ';
+        p.feed(a);
+        p.feed(b);
+        final m = matches.single;
+        expect(m.start, a.length);
+        expect(m.text, 'http://x.test/end');
+      },
+    );
+
+    test('the same span is never emitted twice across feeds', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('https://once.example/p ');
+      p.feed('more text with no url\n');
+      expect(matches, hasLength(1));
+    });
+  });
+
+  group('configurable token regexes', () {
+    test('a caller-supplied path regex detects /remote/path tokens', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(
+        onMatch: matches.add,
+        extraMatchers: [
+          RichTextMatcher(
+            kind: StreamMatchKind.custom,
+            pattern: RegExp(r'(?:/[\w.-]+)+'),
+          ),
+        ],
+      );
+      p.feed('cat /remote/path/to/file.txt\n');
+      final custom = matches.where((m) => m.kind == StreamMatchKind.custom);
+      expect(custom.map((m) => m.text), contains('/remote/path/to/file.txt'));
+    });
+
+    test('a caller-supplied hashid regex detects #id tokens', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(
+        onMatch: matches.add,
+        extraMatchers: [
+          RichTextMatcher(
+            kind: StreamMatchKind.custom,
+            pattern: RegExp(r'#[A-Za-z0-9_]+'),
+          ),
+        ],
+      );
+      p.feed('fixed in #abc123 and #def456 today\n');
+      expect(
+        matches
+            .where((m) => m.kind == StreamMatchKind.custom)
+            .map((m) => m.text)
+            .toList(),
+        ['#abc123', '#def456'],
+      );
+    });
+
+    test('URLs and custom tokens are both emitted from one stream', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(
+        onMatch: matches.add,
+        extraMatchers: [
+          RichTextMatcher(
+            kind: StreamMatchKind.custom,
+            pattern: RegExp(r'#[A-Za-z0-9_]+'),
+          ),
+        ],
+      );
+      p.feed('ref #t100 see https://both.example/p done\n');
+      expect(matches.any((m) => m.kind == StreamMatchKind.url), isTrue);
+      expect(matches.any((m) => m.kind == StreamMatchKind.custom), isTrue);
+    });
+  });
+
+  group('partial-then-completed tokens (no false matches)', () {
+    test('a custom token split across feeds is not emitted until complete', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(
+        onMatch: matches.add,
+        extraMatchers: [
+          RichTextMatcher(
+            kind: StreamMatchKind.custom,
+            pattern: RegExp(r'#[A-Za-z0-9_]+'),
+          ),
+        ],
+      );
+      p.feed('issue #ab');
+      // It LOOKS like a complete token, but more identifier chars may follow;
+      // we must not emit a truncated token that then keeps growing.
+      p.feed('c123 closed\n');
+      final custom = matches
+          .where((m) => m.kind == StreamMatchKind.custom)
+          .toList();
+      expect(custom, hasLength(1));
+      expect(custom.single.text, '#abc123');
+    });
+
+    test('a non-URL prefix that never completes does not emit', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add);
+      p.feed('this mentions http but no scheme://target here\n');
+      // "http" alone (no ://) is not a URL.
+      expect(matches.where((m) => m.kind == StreamMatchKind.url), isEmpty);
+    });
+  });
+
+  group('scalability / bounded buffer', () {
+    test(
+      'large scrollback feeds detect every URL without quadratic blowup',
+      () {
+        final matches = <StreamMatch>[];
+        final p = SessionStreamParser(onMatch: matches.add);
+        // Feed many lines, each with a URL, in many small chunks.
+        const lines = 2000;
+        for (var i = 0; i < lines; i++) {
+          p.feed('row $i https://host$i.example/p$i\n');
+        }
+        final urls = matches
+            .where((m) => m.kind == StreamMatchKind.url)
+            .toList();
+        expect(urls, hasLength(lines));
+        // Spot-check a late match's text to ensure offsets/coalescing held up.
+        expect(
+          urls.last.text,
+          'https://host${lines - 1}.example/p${lines - 1}',
+        );
+      },
+    );
+
+    test('internal buffer stays bounded across a long stream', () {
+      final p = SessionStreamParser(onMatch: (_) {}, maxBufferChars: 256);
+      for (var i = 0; i < 1000; i++) {
+        p.feed('a line of plain text number $i with no links at all\n');
+      }
+      // The rolling buffer must not grow unbounded with stream length.
+      expect(p.bufferLength, lessThanOrEqualTo(256));
+    });
+
+    test('absolute offset reflects total characters fed, not buffer size', () {
+      final matches = <StreamMatch>[];
+      final p = SessionStreamParser(onMatch: matches.add, maxBufferChars: 64);
+      final filler = 'x' * 500; // pushes past the buffer bound
+      p.feed('$filler https://late.example/p\n');
+      final m = matches.single;
+      // The URL starts right after the filler + one space.
+      expect(m.start, filler.length + 1);
+      expect(m.text, 'https://late.example/p');
+    });
+  });
+}


### PR DESCRIPTION
## #570 Part A — `SessionStreamParser` core (parser + tests only)

Implements the parser module for scalable rich-text detection in the terminal's
LOGICAL text stream. **No UI, no session wiring** — that is Part B (owned
elsewhere).

### What this adds
- `native/lib/terminal/session_stream_parser.dart` — pure, Flutter-free parser:
  - Consumes the LOGICAL (decoded) output stream in `feed(String chunk)` calls,
    not per-rendered-line, so a soft-wrapped URL is one contiguous match.
  - Detects full **URLs** (robust default matcher) plus any number of
    caller-supplied token regexes via `RichTextMatcher` (e.g. `/remote/path`,
    `#hashid`).
  - Emits typed `StreamMatch{kind, text, start, end}` with **session-absolute
    logical offsets** for a later UI layer to map to cells.
  - **Coalesces** tokens split across chunk boundaries; never emits a partial
    or a duplicate span.
  - **Bounded** rolling buffer (`maxBufferChars`, default 8192); per-feed work
    is O(new + tail), no history rescan. The "last whitespace = safe boundary"
    invariant gives coalescing, partial-suppression, dedup, and the bound at
    once.
- `native/test/terminal/session_stream_parser_test.dart` — 19 unit tests (run
  in the fast unit gate): URL detect, wrap/whitespace margins, multi-URL,
  cross-chunk split coalescing, configurable token regexes, no-false-partial,
  large-input/bounded-buffer, absolute offsets, no duplicate emit.

### Coordination with #575
#575 already shipped `SessionSignalDetector` (a raw-BYTE OSC9/BEL scanner — a
different domain). No existing parser to reuse, so this is the canonical one.
The extension seam #575's comment asked for is here: the pluggable
`RichTextMatcher` list + `StreamMatch`/`StreamMatchKind` taxonomy — an OSC/bell
text-side consumer can be added as another matcher kind without touching the
scan loop. **OSC/bell is NOT implemented here.**

### Part B (remains, not in this PR)
- Wire the parser into the session output path (sessions.dart / session_host.dart).
- `terminal_screen.dart` highlight/tap UI.
- Settings UI for the configurable regex set (config is accepted today via the
  `extraMatchers` constructor param, one parser per session).

Gate: `scripts/native-fast-gate.sh` green (369 tests; one unrelated
feedback-share widget flake confirmed passing in isolation). `dart format` clean.