### PR TITLE
fix(#614,#633,#634): compose-bar — hide on commit/submit, retain focus on resume, top thumb + copy/paste

### DIFF
--- a/native/lib/ui/compose_bar.dart
+++ b/native/lib/ui/compose_bar.dart
@@ -23,7 +23,11 @@
 // feedback_monochrome_icons_no_emoji).
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
+
+import '../state/lifecycle_providers.dart';
 
 /// Bracketed-paste wrappers (#599): a multi-line commit is wrapped so the
 /// remote TUI/shell treats it as a single paste rather than running each
@@ -41,7 +45,7 @@ const String _bracketedPasteEnd = '\x1b[201~';
 /// above the session bar.
 enum ComposeDock { top, bottom }
 
-class ComposeBar extends StatefulWidget {
+class ComposeBar extends ConsumerStatefulWidget {
   const ComposeBar({
     super.key,
     required this.terminal,
@@ -63,10 +67,10 @@ class ComposeBar extends StatefulWidget {
   final double bottomReserve;
 
   @override
-  State<ComposeBar> createState() => _ComposeBarState();
+  ConsumerState<ComposeBar> createState() => _ComposeBarState();
 }
 
-class _ComposeBarState extends State<ComposeBar> {
+class _ComposeBarState extends ConsumerState<ComposeBar> {
   final TextEditingController _controller = TextEditingController();
   final FocusNode _focusNode = FocusNode();
 
@@ -74,6 +78,12 @@ class _ComposeBarState extends State<ComposeBar> {
   /// while the keyboard is up (the common swipe/voice compose case). Double-tap
   /// the grip toggles top↔bottom.
   ComposeDock _dock = ComposeDock.top;
+
+  /// #633: whether the compose field held focus when the app was last paused.
+  /// On resume we re-`requestFocus()` only if this is true, so a background swap
+  /// (lock screen, app switcher) doesn't lose the keyboard mid-compose. If the
+  /// field wasn't focused at pause, resume leaves focus alone.
+  bool _hadFocusAtPause = false;
 
   @override
   void initState() {
@@ -88,6 +98,28 @@ class _ComposeBarState extends State<ComposeBar> {
     });
   }
 
+  /// #633: re-focus the compose field across an app-swap. The OS drops soft-
+  /// keyboard focus when the app is backgrounded; on resume we restore it (only
+  /// if the field was focused at pause) so the owner returns to a live field
+  /// with the keyboard up and the composed text intact. Mirrors the
+  /// auto-focus-on-open pattern (dc6f803). We do NOT touch the keyboard/
+  /// visualViewport handling (#610/#585) — just the FocusNode.
+  void _onLifecycle(AppLifecycleState? prev, AppLifecycleState next) {
+    if (next == AppLifecycleState.paused ||
+        next == AppLifecycleState.inactive) {
+      // Latch focus state at the moment we lose the foreground.
+      if (next == AppLifecycleState.paused) {
+        _hadFocusAtPause = _focusNode.hasFocus;
+      }
+    } else if (next == AppLifecycleState.resumed) {
+      if (_hadFocusAtPause) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _focusNode.requestFocus();
+        });
+      }
+    }
+  }
+
   @override
   void dispose() {
     _controller.removeListener(_onChanged);
@@ -100,7 +132,9 @@ class _ComposeBarState extends State<ComposeBar> {
 
   /// Send staged text, optionally followed by [trailing] ('\r' for submit).
   /// Multi-line text is bracketed-paste wrapped so embedded newlines don't each
-  /// fire Enter. Clears + keeps focus for the next swipe/voice phrase.
+  /// fire Enter. #614 (owner reversal): BOTH commit (trailing=='') and submit
+  /// (trailing=='\r') HIDE the panel afterward via [onClose], so the full
+  /// terminal is readable once composing is done.
   void _send({required String trailing}) {
     final text = _controller.text;
     if (text.isEmpty && trailing.isEmpty) return;
@@ -114,11 +148,41 @@ class _ComposeBarState extends State<ComposeBar> {
       widget.terminal.textInput(trailing);
     }
     _controller.clear();
-    _focusNode.requestFocus();
+    // #614: hide the panel after sending (both commit and submit).
+    widget.onClose();
   }
 
   void _clear() {
     _controller.clear();
+    _focusNode.requestFocus();
+  }
+
+  /// #634: copy the current compose text to the system clipboard (PWA parity —
+  /// mirrors the IME compose copy affordance). Keeps focus in the field.
+  void _copy() {
+    final text = _controller.text;
+    if (text.isEmpty) return;
+    Clipboard.setData(ClipboardData(text: text));
+    _focusNode.requestFocus();
+  }
+
+  /// #634: paste clipboard text into the compose field AT THE CURSOR (replacing
+  /// any selection), then move the caret to the end of the inserted text.
+  Future<void> _paste() async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    final pasted = data?.text;
+    if (pasted == null || pasted.isEmpty) return;
+    if (!mounted) return;
+    final value = _controller.value;
+    final sel = value.selection;
+    // Selection may be invalid (e.g. never focused); fall back to end-insert.
+    final start = sel.isValid ? sel.start : value.text.length;
+    final end = sel.isValid ? sel.end : value.text.length;
+    final newText = value.text.replaceRange(start, end, pasted);
+    _controller.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection.collapsed(offset: start + pasted.length),
+    );
     _focusNode.requestFocus();
   }
 
@@ -128,12 +192,17 @@ class _ComposeBarState extends State<ComposeBar> {
     final media = MediaQuery.of(context);
     final size = media.size;
 
+    // #633: re-focus the compose field across an app-swap (paused → resumed).
+    // ref.listen so the side effect fires on the transition, not every build.
+    ref.listen<AppLifecycleState>(lifecycleProvider, _onLifecycle);
+
     // Panel width: most of the screen, capped so it reads as a panel.
     final panelWidth = size.width - 24;
-    // Tall enough for the 4-button vertical action rail (close/clear/commit/
-    // submit) WITHOUT overflow — an overflowing Column under Clip.antiAlias
-    // clips the bottom buttons so their taps don't land.
-    const panelHeight = 196.0;
+    // Tall enough for the top drag bar + the 6-button vertical action rail
+    // (close/clear/copy/paste/commit/submit) WITHOUT overflow — an overflowing
+    // Column under Clip.antiAlias clips the bottom buttons so their taps don't
+    // land.
+    const panelHeight = 272.0;
     const margin = 12.0;
     final left = (size.width - panelWidth) / 2;
 
@@ -166,13 +235,15 @@ class _ComposeBarState extends State<ComposeBar> {
         clipBehavior: Clip.antiAlias,
         child: SizedBox(
           height: panelHeight,
-          child: Row(
+          child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // Dock grip (left edge): toggle the panel between the TOP and
-              // BOTTOM margin so the user can keep the terminal cursor visible.
-              // Double-tap or a vertical drag flips the dock; the anchor is
-              // always a fixed margin (#610) — never free-floating off-screen.
+              // Dock grip (TOP edge, #634): a slim full-width bar so the text
+              // field reclaims the left margin and reads wider. Toggle the panel
+              // between the TOP and BOTTOM margin so the user can keep the
+              // terminal cursor visible. Double-tap or a vertical drag flips the
+              // dock; the anchor is always a fixed margin (#610) — never
+              // free-floating off-screen.
               GestureDetector(
                 key: const Key('compose-bar-drag'),
                 behavior: HitTestBehavior.opaque,
@@ -187,59 +258,71 @@ class _ComposeBarState extends State<ComposeBar> {
                       : ComposeDock.top;
                 }),
                 child: Container(
-                  width: 28,
+                  height: 24,
                   color: theme.colorScheme.surfaceContainerHighest,
+                  alignment: Alignment.center,
                   child: Icon(
-                    Icons.drag_indicator,
+                    Icons.drag_handle,
                     size: 18,
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
                 ),
               ),
-              // The editable — gets the width (buttons are a slim vertical rail).
+              // Field + action rail share the remaining height.
               Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(8, 8, 4, 8),
-                  child: TextField(
-                    key: const Key('compose-bar-input'),
-                    controller: _controller,
-                    focusNode: _focusNode,
-                    autofocus: true,
-                    // THE CRUX: composing/swipe/voice need these ENABLED.
-                    keyboardType: TextInputType.multiline,
-                    textInputAction: TextInputAction.newline,
-                    autocorrect: true,
-                    enableSuggestions: true,
-                    enableIMEPersonalizedLearning: true,
-                    expands: true,
-                    minLines: null,
-                    maxLines: null,
-                    textAlignVertical: TextAlignVertical.top,
-                    style: const TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 15,
-                    ),
-                    decoration: InputDecoration(
-                      isDense: true,
-                      hintText: 'Compose (swipe / voice / type)',
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(8),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    // The editable — gets the width (slim vertical button rail).
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(8, 8, 4, 8),
+                        child: TextField(
+                          key: const Key('compose-bar-input'),
+                          controller: _controller,
+                          focusNode: _focusNode,
+                          autofocus: true,
+                          // THE CRUX: composing/swipe/voice need these ENABLED.
+                          keyboardType: TextInputType.multiline,
+                          textInputAction: TextInputAction.newline,
+                          autocorrect: true,
+                          enableSuggestions: true,
+                          enableIMEPersonalizedLearning: true,
+                          expands: true,
+                          minLines: null,
+                          maxLines: null,
+                          textAlignVertical: TextAlignVertical.top,
+                          style: const TextStyle(
+                            fontFamily: 'monospace',
+                            fontSize: 15,
+                          ),
+                          decoration: InputDecoration(
+                            isDense: true,
+                            hintText: 'Compose (swipe / voice / type)',
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                              vertical: 8,
+                            ),
+                          ),
+                        ),
                       ),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 10,
-                        vertical: 8,
-                      ),
                     ),
-                  ),
+                    // Vertical action rail (#604/#634): close / clear / copy /
+                    // paste / commit / submit.
+                    _ActionRail(
+                      hasText: _controller.text.isNotEmpty,
+                      onClose: widget.onClose,
+                      onClear: _clear,
+                      onCopy: _copy,
+                      onPaste: _paste,
+                      onCommit: () => _send(trailing: ''),
+                      onSubmit: () => _send(trailing: '\r'),
+                    ),
+                  ],
                 ),
-              ),
-              // Vertical action rail (#604): close / clear / commit / submit.
-              _ActionRail(
-                hasText: _controller.text.isNotEmpty,
-                onClose: widget.onClose,
-                onClear: _clear,
-                onCommit: () => _send(trailing: ''),
-                onSubmit: () => _send(trailing: '\r'),
               ),
             ],
           ),
@@ -256,6 +339,8 @@ class _ActionRail extends StatelessWidget {
     required this.hasText,
     required this.onClose,
     required this.onClear,
+    required this.onCopy,
+    required this.onPaste,
     required this.onCommit,
     required this.onSubmit,
   });
@@ -263,6 +348,8 @@ class _ActionRail extends StatelessWidget {
   final bool hasText;
   final VoidCallback onClose;
   final VoidCallback onClear;
+  final VoidCallback onCopy;
+  final VoidCallback onPaste;
   final VoidCallback onCommit;
   final VoidCallback onSubmit;
 
@@ -289,6 +376,22 @@ class _ActionRail extends StatelessWidget {
             iconSize: 20,
             icon: const Icon(Icons.backspace_outlined),
             onPressed: hasText ? onClear : null,
+          ),
+          IconButton(
+            key: const Key('compose-bar-copy'),
+            tooltip: 'Copy compose text',
+            visualDensity: VisualDensity.compact,
+            iconSize: 20,
+            icon: const Icon(Icons.copy_outlined),
+            onPressed: hasText ? onCopy : null,
+          ),
+          IconButton(
+            key: const Key('compose-bar-paste'),
+            tooltip: 'Paste at cursor',
+            visualDensity: VisualDensity.compact,
+            iconSize: 20,
+            icon: const Icon(Icons.content_paste_outlined),
+            onPressed: onPaste,
           ),
           IconButton(
             key: const Key('compose-bar-commit'),

--- a/native/test/widget/compose_bar_test.dart
+++ b/native/test/widget/compose_bar_test.dart
@@ -1,4 +1,4 @@
-// Compose-bar (IME / swipe / voice surface) commit semantics (#599).
+// Compose-bar (IME / swipe / voice surface) semantics (#599, #614, #633, #634).
 //
 // The byte-level contract — the thing that matters for the owner's swipe+voice
 // goal — is what the bar SENDS to the terminal:
@@ -6,114 +6,350 @@
 //   - Submit (⏎): the text THEN a carriage return.
 //   - Multi-line text is bracketed-paste wrapped (\x1b[200~ … \x1b[201~) so the
 //     remote treats it as one paste, not N Enters.
-//   - The field clears after send (ready for the next phrase).
+// #614: BOTH commit AND submit now HIDE the panel (onClose) so the full terminal
+//   is readable after composing (owner reversal of the original #614 plan).
+// #634: drag thumb at the TOP edge; Copy/Paste pills in the action rail.
+// #633: best-effort — preview field re-focuses on app resume if it was focused
+//   at pause (true app-swap focus is device-only).
 // We capture `terminal.onOutput` (the exact pipe the keybar + IME use →
 // proxy.sendInput → PTY) and assert the bytes.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/lifecycle_providers.dart';
 import 'package:mobissh/ui/compose_bar.dart';
 import 'package:xterm/xterm.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<Terminal> pumpBar(WidgetTester tester, List<String> sink) async {
+  // ComposeBar is a ConsumerStatefulWidget (it listens to lifecycleProvider for
+  // #633), so it must be pumped inside a ProviderScope. Returns the container so
+  // tests can drive the lifecycle provider for #633.
+  Future<ProviderContainer> pumpBar(
+    WidgetTester tester,
+    List<String> sink, {
+    VoidCallback? onClose,
+  }) async {
     final terminal = Terminal();
     terminal.onOutput = sink.add;
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          // ComposeBar is a floating panel (returns a Positioned), so it must
-          // live inside a Stack (#604).
-          body: Stack(
-            children: [ComposeBar(terminal: terminal, onClose: () {})],
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            // ComposeBar is a floating panel (returns a Positioned), so it must
+            // live inside a Stack (#604).
+            body: Stack(
+              children: [
+                ComposeBar(terminal: terminal, onClose: onClose ?? () {}),
+              ],
+            ),
           ),
         ),
       ),
     );
     await tester.pump();
-    return terminal;
+    return container;
   }
 
-  testWidgets('commit (✓) sends text only — no Enter', (tester) async {
-    final sink = <String>[];
-    await pumpBar(tester, sink);
+  group('byte contract', () {
+    testWidgets('commit (✓) sends text only — no Enter', (tester) async {
+      final sink = <String>[];
+      await pumpBar(tester, sink);
 
-    await tester.enterText(
-      find.byKey(const Key('compose-bar-input')),
-      'ls -la',
-    );
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('compose-bar-commit')));
-    await tester.pump();
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'ls -la',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-commit')));
+      await tester.pump();
 
-    expect(sink.join(), 'ls -la');
-    expect(sink.join().contains('\r'), isFalse);
-    // Field cleared after send.
-    expect(
-      tester
+      expect(sink.join(), 'ls -la');
+      expect(sink.join().contains('\r'), isFalse);
+    });
+
+    testWidgets('submit (⏎) sends text then carriage return', (tester) async {
+      final sink = <String>[];
+      await pumpBar(tester, sink);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'echo hi',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-submit')));
+      await tester.pump();
+
+      expect(sink.join(), 'echo hi\r');
+    });
+
+    testWidgets('swipe-typed words with SPACES land intact', (tester) async {
+      final sink = <String>[];
+      await pumpBar(tester, sink);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'the quick brown fox',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-commit')));
+      await tester.pump();
+
+      expect(sink.join(), 'the quick brown fox');
+    });
+
+    testWidgets('multi-line commit is bracketed-paste wrapped', (tester) async {
+      final sink = <String>[];
+      await pumpBar(tester, sink);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'line1\nline2',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-commit')));
+      await tester.pump();
+
+      expect(sink.join(), '\x1b[200~line1\nline2\x1b[201~');
+    });
+
+    testWidgets('submit with empty field still sends Enter', (tester) async {
+      final sink = <String>[];
+      await pumpBar(tester, sink);
+
+      await tester.tap(find.byKey(const Key('compose-bar-submit')));
+      await tester.pump();
+
+      expect(sink.join(), '\r');
+    });
+  });
+
+  group('#614 — both commit and submit hide the panel', () {
+    testWidgets('commit (✓) hides the panel via onClose', (tester) async {
+      final sink = <String>[];
+      var closed = 0;
+      await pumpBar(tester, sink, onClose: () => closed++);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'ls -la',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-commit')));
+      await tester.pump();
+
+      expect(closed, 1, reason: 'commit must hide the panel (#614 reversal)');
+    });
+
+    testWidgets('submit (⏎) hides the panel via onClose', (tester) async {
+      final sink = <String>[];
+      var closed = 0;
+      await pumpBar(tester, sink, onClose: () => closed++);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'echo hi',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-submit')));
+      await tester.pump();
+
+      expect(closed, 1, reason: 'submit must hide the panel');
+    });
+
+    testWidgets('multi-line commit also hides the panel', (tester) async {
+      final sink = <String>[];
+      var closed = 0;
+      await pumpBar(tester, sink, onClose: () => closed++);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'line1\nline2',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-commit')));
+      await tester.pump();
+
+      expect(closed, 1);
+    });
+
+    testWidgets('empty commit does NOT close (nothing to send)', (
+      tester,
+    ) async {
+      final sink = <String>[];
+      var closed = 0;
+      await pumpBar(tester, sink, onClose: () => closed++);
+
+      // Commit is disabled when empty, so tapping does nothing; but if it were
+      // invoked, no send + no close.
+      await tester.tap(find.byKey(const Key('compose-bar-commit')));
+      await tester.pump();
+
+      expect(closed, 0);
+      expect(sink, isEmpty);
+    });
+  });
+
+  group('#634 — copy/paste pills + top thumb', () {
+    testWidgets('drag thumb renders at the top edge (above the field)', (
+      tester,
+    ) async {
+      await pumpBar(tester, <String>[]);
+
+      final grip = find.byKey(const Key('compose-bar-drag'));
+      final field = find.byKey(const Key('compose-bar-input'));
+      expect(grip, findsOneWidget);
+      expect(field, findsOneWidget);
+
+      final gripBox = tester.getRect(grip);
+      final fieldBox = tester.getRect(field);
+      expect(
+        gripBox.center.dy < fieldBox.top,
+        isTrue,
+        reason: 'grip must sit above the text field (top dock thumb)',
+      );
+    });
+
+    testWidgets('Copy pill copies the current compose text to the clipboard', (
+      tester,
+    ) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        );
+      });
+
+      await pumpBar(tester, <String>[]);
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'hello world',
+      );
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('compose-bar-copy')));
+      await tester.pump();
+
+      expect(clipboardText, 'hello world');
+    });
+
+    testWidgets('Paste pill inserts clipboard text at the cursor', (
+      tester,
+    ) async {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.getData') {
+            return <String, dynamic>{'text': 'PASTED'};
+          }
+          return null;
+        },
+      );
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        );
+      });
+
+      await pumpBar(tester, <String>[]);
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'abXY',
+      );
+      await tester.pump();
+
+      // Place cursor between "ab" and "XY".
+      final controller = tester
           .widget<TextField>(find.byKey(const Key('compose-bar-input')))
-          .controller
-          ?.text,
-      isEmpty,
-    );
+          .controller!;
+      controller.selection = const TextSelection.collapsed(offset: 2);
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('compose-bar-paste')));
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'abPASTEDXY');
+    });
   });
 
-  testWidgets('submit (⏎) sends text then carriage return', (tester) async {
-    final sink = <String>[];
-    await pumpBar(tester, sink);
+  group('#633 — re-focus on resume (best-effort; real swap is device-only)', () {
+    testWidgets('field regains focus on resume when it was focused at pause', (
+      tester,
+    ) async {
+      final container = await pumpBar(tester, <String>[]);
 
-    await tester.enterText(
-      find.byKey(const Key('compose-bar-input')),
-      'echo hi',
-    );
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('compose-bar-submit')));
-    await tester.pump();
+      // Field auto-focuses on open. Confirm.
+      final focusNode = tester
+          .widget<TextField>(find.byKey(const Key('compose-bar-input')))
+          .focusNode!;
+      expect(focusNode.hasFocus, isTrue);
 
-    expect(sink.join(), 'echo hi\r');
-  });
+      // Simulate background: provider goes paused. The bar records hasFocus.
+      container.read(lifecycleProvider.notifier).state =
+          AppLifecycleState.paused;
+      await tester.pump();
+      // Drop focus while paused (as the OS would).
+      focusNode.unfocus();
+      await tester.pump();
+      expect(focusNode.hasFocus, isFalse);
 
-  testWidgets('swipe-typed words with SPACES land intact', (tester) async {
-    // Simulates the owner's case: a multi-word phrase (as swipe/voice deliver
-    // it) committed in one go — spaces must survive.
-    final sink = <String>[];
-    await pumpBar(tester, sink);
+      // Resume: the bar must re-request focus (it was focused at pause).
+      container.read(lifecycleProvider.notifier).state =
+          AppLifecycleState.resumed;
+      await tester.pump();
+      await tester.pump(); // post-frame callback
 
-    await tester.enterText(
-      find.byKey(const Key('compose-bar-input')),
-      'the quick brown fox',
-    );
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('compose-bar-commit')));
-    await tester.pump();
+      expect(
+        focusNode.hasFocus,
+        isTrue,
+        reason: 'must re-focus on resume when focused at pause (#633)',
+      );
+    });
 
-    expect(sink.join(), 'the quick brown fox');
-  });
+    testWidgets('field does NOT grab focus on resume if it was not focused', (
+      tester,
+    ) async {
+      final container = await pumpBar(tester, <String>[]);
 
-  testWidgets('multi-line commit is bracketed-paste wrapped', (tester) async {
-    final sink = <String>[];
-    await pumpBar(tester, sink);
+      final focusNode = tester
+          .widget<TextField>(find.byKey(const Key('compose-bar-input')))
+          .focusNode!;
+      // Drop focus BEFORE pause so it is unfocused at pause time.
+      focusNode.unfocus();
+      await tester.pump();
+      expect(focusNode.hasFocus, isFalse);
 
-    await tester.enterText(
-      find.byKey(const Key('compose-bar-input')),
-      'line1\nline2',
-    );
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('compose-bar-commit')));
-    await tester.pump();
+      container.read(lifecycleProvider.notifier).state =
+          AppLifecycleState.paused;
+      await tester.pump();
 
-    expect(sink.join(), '\x1b[200~line1\nline2\x1b[201~');
-  });
+      container.read(lifecycleProvider.notifier).state =
+          AppLifecycleState.resumed;
+      await tester.pump();
+      await tester.pump();
 
-  testWidgets('submit with empty field still sends Enter', (tester) async {
-    final sink = <String>[];
-    await pumpBar(tester, sink);
-
-    await tester.tap(find.byKey(const Key('compose-bar-submit')));
-    await tester.pump();
-
-    expect(sink.join(), '\r');
+      expect(
+        focusNode.hasFocus,
+        isFalse,
+        reason: 'no re-focus when it was not focused at pause (#633)',
+      );
+    });
   });
 }


### PR DESCRIPTION
Closes #614, #633, #634

Three related compose-bar items (#604/#610 floating compose/preview panel), all in `native/lib/ui/compose_bar.dart`, shipped together with TDD.

## #614 (P0) — Enter AND Commit both hide the panel
Owner reversal: both actions now hide the modal so the full terminal is readable after composing. `_send()` calls `onClose()` after **both** commit (text-only, `trailing == ''`) and submit (text + Enter, `trailing == '\r'`), including the multiline bracketed-paste path. Removed the post-send `requestFocus()` (the panel is closing).

## #633 — preview field retains focus across app-swap
`ComposeBar` is now a `ConsumerStatefulWidget` that `ref.listen`s the `lifecycleProvider` (#525). It latches `_focusNode.hasFocus` at `paused` and re-`requestFocus()` (post-frame) at `resumed` **only if** it was focused at pause. If it was not focused at pause, resume leaves focus alone. No keyboard/visualViewport meddling (#610/#585) — just the FocusNode.

## #634 — top thumb + Copy/Paste pills (PWA parity)
- Drag/dock thumb moved from the left edge to a thin **full-width TOP bar**, so the text field reclaims the left margin (wider). Layout is now `Column[grip, Expanded(Row[field, rail])]`. Drag/double-tap dock toggle and the #610 fixed-margin anchor math are preserved (no off-screen regression).
- Added monochrome **Copy** (preview text → clipboard) and **Paste** (clipboard → preview at the cursor, replacing any selection) pills in the action rail, alongside close/clear/✓/⏎ (mirrors the PWA compose affordance, `src/modules/ime.ts`). `Icons.copy_outlined` / `Icons.content_paste_outlined` — theme-tinted, never emoji.
- `panelHeight` 196→272 to fit the 6-button rail without `Clip.antiAlias` tap-eating overflow.

## TDD
Rewrote `compose_bar_test.dart`: 7 new tests RED against prior behavior, green after. Covers #614 (commit + submit + multiline all close; empty commit does not), #634 (Copy copies, Paste inserts at cursor, thumb above field), #633 (re-focus on resume when focused at pause; no-op when not). 14/14 compose tests + native fast gate (395 tests) green.

## Device validation required
Focus / drag / keyboard behavior is device-y. The #633 test drives the lifecycle provider in headless — true app-swap focus restoration is device-only. Orchestrator device-gates before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)