### PR TITLE
fix(#638): compose Copy/Paste/Fix as inline pills, not in the whole-view rail

### DIFF
--- a/native/lib/ui/compose_bar.dart
+++ b/native/lib/ui/compose_bar.dart
@@ -28,6 +28,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
 
 import '../state/lifecycle_providers.dart';
+import '../util/terminal_copy_fixup.dart';
 
 /// Bracketed-paste wrappers (#599): a multi-line commit is wrapped so the
 /// remote TUI/shell treats it as a single paste rather than running each
@@ -157,8 +158,8 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
     _focusNode.requestFocus();
   }
 
-  /// #634: copy the current compose text to the system clipboard (PWA parity —
-  /// mirrors the IME compose copy affordance). Keeps focus in the field.
+  /// #638 (was #634): copy the current compose text to the system clipboard
+  /// (PWA parity — mirrors the IME compose Copy pill). Keeps focus in the field.
   void _copy() {
     final text = _controller.text;
     if (text.isEmpty) return;
@@ -166,8 +167,26 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
     _focusNode.requestFocus();
   }
 
-  /// #634: paste clipboard text into the compose field AT THE CURSOR (replacing
-  /// any selection), then move the caret to the end of the inserted text.
+  /// #638: "Fix" pill — collapse terminal soft-wrap artifacts in the staged
+  /// text into one clean line (PWA parity with `fixupTerminalCopy`). Used after
+  /// pasting a long URL/command that the terminal hard-wrapped with newline +
+  /// indent. Keeps the caret at the end and keeps focus.
+  void _fix() {
+    final cleaned = fixupTerminalCopy(_controller.text);
+    if (cleaned == _controller.text) {
+      _focusNode.requestFocus();
+      return;
+    }
+    _controller.value = TextEditingValue(
+      text: cleaned,
+      selection: TextSelection.collapsed(offset: cleaned.length),
+    );
+    _focusNode.requestFocus();
+  }
+
+  /// #638 (was #634): paste clipboard text into the compose field AT THE CURSOR
+  /// (replacing any selection), then move the caret to the end of the inserted
+  /// text.
   Future<void> _paste() async {
     final data = await Clipboard.getData(Clipboard.kTextPlain);
     final pasted = data?.text;
@@ -198,10 +217,10 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
 
     // Panel width: most of the screen, capped so it reads as a panel.
     final panelWidth = size.width - 24;
-    // Tall enough for the top drag bar + the 6-button vertical action rail
-    // (close/clear/copy/paste/commit/submit) WITHOUT overflow — an overflowing
-    // Column under Clip.antiAlias clips the bottom buttons so their taps don't
-    // land.
+    // Tall enough for the top drag bar + the inline pill row (Fix/Copy/Paste,
+    // #638) + the 4-button vertical action rail (close/clear/commit/submit)
+    // WITHOUT overflow — an overflowing Column under Clip.antiAlias clips the
+    // bottom buttons so their taps don't land.
     const panelHeight = 272.0;
     const margin = 12.0;
     final left = (size.width - panelWidth) / 2;
@@ -268,6 +287,17 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
                   ),
                 ),
               ),
+              // #638: inline TEXT-action pill row (Fix / Copy / Paste). These
+              // are TEXT actions on the staged content — distinct from the
+              // right rail's WHOLE-VIEW actions (close/clear/✓/⏎). Mirrors the
+              // PWA's `.ime-paste-overlay` chips (src/modules/ime.ts), same
+              // left→right order. Monochrome, theme-tinted (no emoji).
+              _PillRow(
+                hasText: _controller.text.isNotEmpty,
+                onFix: _fix,
+                onCopy: _copy,
+                onPaste: _paste,
+              ),
               // Field + action rail share the remaining height.
               Expanded(
                 child: Row(
@@ -310,14 +340,13 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
                         ),
                       ),
                     ),
-                    // Vertical action rail (#604/#634): close / clear / copy /
-                    // paste / commit / submit.
+                    // Vertical action rail (#604/#638): WHOLE-VIEW actions
+                    // only — close / clear / commit / submit. Text actions
+                    // (copy/paste/fix) moved to the inline pill row above.
                     _ActionRail(
                       hasText: _controller.text.isNotEmpty,
                       onClose: widget.onClose,
                       onClear: _clear,
-                      onCopy: _copy,
-                      onPaste: _paste,
                       onCommit: () => _send(trailing: ''),
                       onSubmit: () => _send(trailing: '\r'),
                     ),
@@ -332,15 +361,114 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
   }
 }
 
-/// Slim vertical button rail for the compose panel (#604). Stacking the actions
-/// keeps the editable wide for long composition. Monochrome theme-tinted icons.
+/// Inline TEXT-action pill row (#638). Mirrors the PWA's `.ime-paste-overlay`
+/// chips (src/modules/ime.ts) — same left→right order: Fix, Copy, Paste. These
+/// act on the staged TEXT (not the whole view), so they live as chips next to
+/// the field rather than in the right rail (owner: "the copy paste and fix are
+/// pills not cluttering up the right side for whole view actions"). Monochrome,
+/// theme-tinted — no emoji (memory: feedback_monochrome_icons_no_emoji).
+class _PillRow extends StatelessWidget {
+  const _PillRow({
+    required this.hasText,
+    required this.onFix,
+    required this.onCopy,
+    required this.onPaste,
+  });
+
+  final bool hasText;
+  final VoidCallback onFix;
+  final VoidCallback onCopy;
+  final VoidCallback onPaste;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      key: const Key('compose-bar-pills'),
+      padding: const EdgeInsets.fromLTRB(8, 6, 8, 0),
+      child: Row(
+        children: [
+          _Pill(
+            buttonKey: const Key('compose-bar-fix'),
+            icon: Icons.auto_fix_high_outlined,
+            label: 'Fix',
+            tooltip: 'Collapse terminal soft-wraps into one line',
+            onPressed: hasText ? onFix : null,
+          ),
+          const SizedBox(width: 6),
+          _Pill(
+            buttonKey: const Key('compose-bar-copy'),
+            icon: Icons.copy_outlined,
+            label: 'Copy',
+            tooltip: 'Copy compose text',
+            onPressed: hasText ? onCopy : null,
+          ),
+          const SizedBox(width: 6),
+          _Pill(
+            buttonKey: const Key('compose-bar-paste'),
+            icon: Icons.content_paste_outlined,
+            label: 'Paste',
+            tooltip: 'Paste at cursor',
+            onPressed: onPaste,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single chip-style text-action pill (#638). Tonal, compact, monochrome —
+/// reads as a secondary affordance, not a primary button.
+class _Pill extends StatelessWidget {
+  const _Pill({
+    required this.buttonKey,
+    required this.icon,
+    required this.label,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  final Key buttonKey;
+  final IconData icon;
+  final String label;
+  final String tooltip;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Tooltip(
+      message: tooltip,
+      child: TextButton.icon(
+        key: buttonKey,
+        onPressed: onPressed,
+        icon: Icon(icon, size: 16),
+        label: Text(label),
+        style: TextButton.styleFrom(
+          visualDensity: VisualDensity.compact,
+          foregroundColor: theme.colorScheme.onSurfaceVariant,
+          backgroundColor: theme.colorScheme.surfaceContainerHighest,
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+          minimumSize: const Size(0, 32),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          textStyle: const TextStyle(fontSize: 12),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Slim vertical button rail for the compose panel (#604/#638). WHOLE-VIEW
+/// actions only — close / clear / commit / submit. Text actions live in the
+/// pill row. Stacking keeps the editable wide for long composition. Monochrome
+/// theme-tinted icons.
 class _ActionRail extends StatelessWidget {
   const _ActionRail({
     required this.hasText,
     required this.onClose,
     required this.onClear,
-    required this.onCopy,
-    required this.onPaste,
     required this.onCommit,
     required this.onSubmit,
   });
@@ -348,8 +476,6 @@ class _ActionRail extends StatelessWidget {
   final bool hasText;
   final VoidCallback onClose;
   final VoidCallback onClear;
-  final VoidCallback onCopy;
-  final VoidCallback onPaste;
   final VoidCallback onCommit;
   final VoidCallback onSubmit;
 
@@ -357,6 +483,7 @@ class _ActionRail extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
+      key: const Key('compose-bar-rail'),
       padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -376,22 +503,6 @@ class _ActionRail extends StatelessWidget {
             iconSize: 20,
             icon: const Icon(Icons.backspace_outlined),
             onPressed: hasText ? onClear : null,
-          ),
-          IconButton(
-            key: const Key('compose-bar-copy'),
-            tooltip: 'Copy compose text',
-            visualDensity: VisualDensity.compact,
-            iconSize: 20,
-            icon: const Icon(Icons.copy_outlined),
-            onPressed: hasText ? onCopy : null,
-          ),
-          IconButton(
-            key: const Key('compose-bar-paste'),
-            tooltip: 'Paste at cursor',
-            visualDensity: VisualDensity.compact,
-            iconSize: 20,
-            icon: const Icon(Icons.content_paste_outlined),
-            onPressed: onPaste,
           ),
           IconButton(
             key: const Key('compose-bar-commit'),

--- a/native/lib/util/terminal_copy_fixup.dart
+++ b/native/lib/util/terminal_copy_fixup.dart
@@ -1,0 +1,72 @@
+// Terminal-copy fixup — Dart port of the PWA's `fixupTerminalCopy`
+// (src/modules/ime-fixup.ts). Backs the compose "Fix" pill (#638).
+//
+// Round-trips text copied out of the terminal — where xterm soft-wraps long
+// URLs / commands / API keys with a newline + indent (or a bare newline) — back
+// into one clean, executable line. Deterministic; no semantic guessing.
+//
+// Heuristics (mirror the PWA exactly so behavior matches on both platforms):
+//   - CR / CRLF normalize to `\n`.
+//   - Trailing whitespace before a newline is trimmed.
+//   - A newline (optionally followed by indent) between two words collapses:
+//       * to NOTHING if either adjacent word contains URL/path punctuation
+//         (a single token was wrapped mid-string), or
+//       * to a single SPACE otherwise (wrapped prose).
+//   - Genuine paragraph breaks (`\n{2,}`) are preserved as a single `\n`.
+//   - Leading / trailing whitespace is trimmed.
+
+/// URL/path punctuation that strongly signals "this run of non-whitespace is a
+/// single token, not prose". Excludes `-` (too ambiguous — shell flags).
+final RegExp _tokenPunct = RegExp(r'[/:?#&=%+._~]');
+
+final RegExp _crlf = RegExp(r'\r\n?');
+final RegExp _trailingWs = RegExp(r'[ \t]+\n');
+final RegExp _paragraphs = RegExp(r'\n{2,}');
+// A word, a newline + optional indent, then another word.
+final RegExp _softWrap = RegExp(r'(\S+)\n[ \t]*(\S+)');
+final RegExp _remainingNl = RegExp(r'\n[ \t]*');
+
+/// Collapse common terminal-copy soft-wrap artifacts into one clean line while
+/// preserving genuine paragraph breaks. Pure function — safe to unit test.
+String fixupTerminalCopy(String input) {
+  // 1. Normalize line endings.
+  var s = input.replaceAll(_crlf, '\n');
+  // 2. Trim trailing whitespace so soft-wrap detection sees the real boundary.
+  s = s.replaceAll(_trailingWs, '\n');
+  // 3. Preserve genuine paragraph breaks behind a control-char placeholder
+  //    (U+0001, like the PWA) so the soft-wrap collapse leaves them alone;
+  //    restored in step 6.
+  final para = String.fromCharCode(1);
+  s = s.replaceAll(_paragraphs, para);
+  // 4. Token-aware soft-wrap collapse. Non-overlapping left-to-right (matches
+  //    JS's global regex-replace), so a shared boundary word is consumed once.
+  s = _collapseSoftWraps(s);
+  // 5. Any remaining `\n` (wrap at doc start/end with no surrounding word)
+  //    collapses to nothing.
+  s = s.replaceAll(_remainingNl, '');
+  // 6. Restore paragraph breaks.
+  s = s.replaceAll(para, '\n');
+  // 7. Trim outer whitespace (prompt indent / trailing newline).
+  return s.trim();
+}
+
+/// Equivalent of JS `String.replace(/(\S+)\n[ \t]*(\S+)/g, fn)`: non-overlapping
+/// left-to-right replacement. After a match, scanning resumes at the end of the
+/// replacement, so a shared boundary word is not re-consumed.
+String _collapseSoftWraps(String s) {
+  final buf = StringBuffer();
+  var last = 0;
+  for (final m in _softWrap.allMatches(s)) {
+    if (m.start < last) continue; // overlaps a prior consumed match
+    buf.write(s.substring(last, m.start));
+    final prev = m.group(1)!;
+    final next = m.group(2)!;
+    final isToken = _tokenPunct.hasMatch(prev) || _tokenPunct.hasMatch(next);
+    buf.write(prev);
+    buf.write(isToken ? '' : ' ');
+    buf.write(next);
+    last = m.end;
+  }
+  buf.write(s.substring(last));
+  return buf.toString();
+}

--- a/native/test/util/terminal_copy_fixup_test.dart
+++ b/native/test/util/terminal_copy_fixup_test.dart
@@ -1,0 +1,48 @@
+// Unit tests for fixupTerminalCopy — the "Fix" pill behavior (#638).
+// Mirrors the PWA's ime-fixup semantics: collapse terminal soft-wrap artifacts
+// into one clean line, preserve genuine paragraph breaks, token-aware joins.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/util/terminal_copy_fixup.dart';
+
+void main() {
+  group('fixupTerminalCopy', () {
+    test('joins a URL wrapped mid-token with NO separator', () {
+      // xterm hard-wrapped a long URL; the join must be lossless.
+      const wrapped = 'https://example.com/very/long/\n    path?query=value';
+      expect(
+        fixupTerminalCopy(wrapped),
+        'https://example.com/very/long/path?query=value',
+      );
+    });
+
+    test('joins wrapped prose with a single space', () {
+      const wrapped = 'the quick brown\n    fox jumps';
+      expect(fixupTerminalCopy(wrapped), 'the quick brown fox jumps');
+    });
+
+    test('preserves a genuine paragraph break (blank line)', () {
+      const text = 'first line\n\nsecond line';
+      expect(fixupTerminalCopy(text), 'first line\nsecond line');
+    });
+
+    test('normalizes CRLF and trims trailing whitespace', () {
+      const text = 'echo hello   \r\n    world';
+      expect(fixupTerminalCopy(text), 'echo hello world');
+    });
+
+    test('trims leading prompt indent and trailing newline', () {
+      const text = '   ls -la\n';
+      expect(fixupTerminalCopy(text), 'ls -la');
+    });
+
+    test('leaves an already-clean single line unchanged', () {
+      const text = 'git status';
+      expect(fixupTerminalCopy(text), 'git status');
+    });
+
+    test('empty input stays empty', () {
+      expect(fixupTerminalCopy(''), '');
+    });
+  });
+}

--- a/native/test/widget/compose_bar_test.dart
+++ b/native/test/widget/compose_bar_test.dart
@@ -1,4 +1,4 @@
-// Compose-bar (IME / swipe / voice surface) semantics (#599, #614, #633, #634).
+// Compose-bar (IME / swipe / voice surface) semantics (#599, #614, #633, #638).
 //
 // The byte-level contract — the thing that matters for the owner's swipe+voice
 // goal — is what the bar SENDS to the terminal:
@@ -8,7 +8,8 @@
 //     remote treats it as one paste, not N Enters.
 // #614: BOTH commit AND submit now HIDE the panel (onClose) so the full terminal
 //   is readable after composing (owner reversal of the original #614 plan).
-// #634: drag thumb at the TOP edge; Copy/Paste pills in the action rail.
+// #638 (corrects #634): drag thumb at the TOP edge; Copy/Paste/Fix are inline
+//   text-action PILLS — the right rail holds only whole-view actions.
 // #633: best-effort — preview field re-focuses on app resume if it was focused
 //   at pause (true app-swap focus is device-only).
 // We capture `terminal.onOutput` (the exact pipe the keybar + IME use →
@@ -196,7 +197,7 @@ void main() {
     });
   });
 
-  group('#634 — copy/paste pills + top thumb', () {
+  group('#638 — copy/paste/fix are inline pills, NOT in the right rail', () {
     testWidgets('drag thumb renders at the top edge (above the field)', (
       tester,
     ) async {
@@ -214,6 +215,83 @@ void main() {
         isTrue,
         reason: 'grip must sit above the text field (top dock thumb)',
       );
+    });
+
+    testWidgets(
+      'right rail keeps ONLY whole-view actions (no copy/paste/fix)',
+      (tester) async {
+        await pumpBar(tester, <String>[]);
+
+        // The rail must still carry the whole-view actions.
+        expect(find.byKey(const Key('compose-bar-close')), findsOneWidget);
+        expect(find.byKey(const Key('compose-bar-clear')), findsOneWidget);
+        expect(find.byKey(const Key('compose-bar-commit')), findsOneWidget);
+        expect(find.byKey(const Key('compose-bar-submit')), findsOneWidget);
+
+        // The text actions must NOT live inside the rail any more — they belong
+        // to the pill row. Assert no rail descendant owns those keys.
+        expect(
+          find.descendant(
+            of: find.byKey(const Key('compose-bar-rail')),
+            matching: find.byKey(const Key('compose-bar-copy')),
+          ),
+          findsNothing,
+        );
+        expect(
+          find.descendant(
+            of: find.byKey(const Key('compose-bar-rail')),
+            matching: find.byKey(const Key('compose-bar-paste')),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('inline pill row carries Copy, Paste and Fix', (tester) async {
+      await pumpBar(tester, <String>[]);
+
+      final pillRow = find.byKey(const Key('compose-bar-pills'));
+      expect(pillRow, findsOneWidget);
+
+      expect(
+        find.descendant(
+          of: pillRow,
+          matching: find.byKey(const Key('compose-bar-copy')),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: pillRow,
+          matching: find.byKey(const Key('compose-bar-paste')),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: pillRow,
+          matching: find.byKey(const Key('compose-bar-fix')),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Fix pill collapses terminal soft-wrap into one clean line', (
+      tester,
+    ) async {
+      await pumpBar(tester, <String>[]);
+
+      final controller = tester
+          .widget<TextField>(find.byKey(const Key('compose-bar-input')))
+          .controller!;
+      // A URL hard-wrapped by the terminal (newline + indent mid-token).
+      controller.text = 'https://example.com/long/\n    path?q=1';
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('compose-bar-fix')));
+      await tester.pump();
+
+      expect(controller.text, 'https://example.com/long/path?q=1');
     });
 
     testWidgets('Copy pill copies the current compose text to the clipboard', (


### PR DESCRIPTION
## What
Corrects #634: moves compose **Copy / Paste / Fix** out of the right-side
vertical action rail and into an inline chip **pill row**. The rail is for
WHOLE-VIEW actions only.

Owner (2026-06-02): "the copy paste and fix are pills not cluttering up the
right side for whole view actions."

## Changes
- `native/lib/ui/compose_bar.dart`
  - Right rail (`compose-bar-rail`) now holds ONLY whole-view actions:
    close / clear / ✓ commit / ⏎ submit. The #634 top drag thumb is kept.
  - New `_PillRow` (`compose-bar-pills`) under the drag grip: **Fix, Copy, Paste**
    chips — same left→right order as the PWA's `.ime-paste-overlay`. Tonal,
    monochrome `TextButton.icon`, no emoji.
  - New `_fix()` action.
- `native/lib/util/terminal_copy_fixup.dart` (NEW) — Dart port of the PWA's
  `fixupTerminalCopy` (src/modules/ime-fixup.ts).

## What the "Fix" pill does (taken from the PWA, not invented)
The PWA's `#imeFixupBtn` runs `fixupTerminalCopy`: it round-trips text copied
out of the terminal — where xterm hard-wraps long URLs/commands with `\n` +
indent — back into one clean executable line. Token-aware (URL/path punctuation
joins losslessly, wrapped prose joins with a single space), preserves genuine
paragraph breaks, trims. Ported verbatim to Dart; no owner clarification needed.

## Tests (TDD)
- `native/test/util/terminal_copy_fixup_test.dart` (NEW): URL join, prose join,
  paragraph preservation, CRLF/trailing-ws, trim, no-op, empty.
- `native/test/widget/compose_bar_test.dart`: rail has NO copy/paste; pill row
  carries copy/paste/fix; Fix collapses soft-wrap. Existing Copy/Paste behavior
  tests reuse the same keys (now on the pills) and still pass.
- `scripts/native-fast-gate.sh`: analyze clean, all unit tests green. `dart format` applied.

## Device validation
Pill layout + touch targets are for orchestrator screenshot validation on the
emulator — not claimed device-verified from headless.

## Scope
Touched only `compose_bar.dart` (+ new util) and their tests. Did NOT touch
`terminal_screen.dart` / `session_host.dart` (the #625/#600 layout agent owns those).

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)