### PR TITLE
fix(#625,#600): terminal re-measures on font-load + viewport change — fill + reflow

### DIFF
--- a/native/integration_test/terminal_layout_fill_test.dart
+++ b/native/integration_test/terminal_layout_fill_test.dart
@@ -1,0 +1,206 @@
+// On-emulator TERMINAL-LAYOUT / RESIZE smoke (#625 + #600).
+//
+// The device bugs (build 030596c):
+//   #625 — on FIRST connect the terminal does NOT fill the screen: a dead
+//          vertical gap sits between the last terminal line and the keybar. The
+//          terminal locked in cols/rows for a stale (fallback-font) cell size on
+//          the first layout and never re-measured.
+//   #600 — terminal layout breaks on viewport changes (keyboard show/hide,
+//          keybar toggle, rotation, reconnect) "more than the PWA": the PTY size
+//          is not re-sent on every rendered-size change, so the server's idea of
+//          cols/rows diverges from what's rendered.
+//
+// Headless widget tests CANNOT reproduce these — test fonts are preloaded before
+// the first frame, so xterm always measures the correct cell size and always
+// re-fits. This test runs on the REAL emulator (real font load + real layout)
+// and asserts the device contract:
+//   1. After connect, the terminal FILLS the tall emulator viewport — many more
+//      than the default 24 rows (no dead gap, #625).
+//   2. Changing the available height (keybar toggle, the same lever every
+//      viewport change pulls) REFLOWS the terminal AND sends a NEW PTY resize to
+//      the task host with the new rows (#600). The PWA does exactly this
+//      (fitAddon.fit() + ws.send(resize)) on every viewport change.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+
+import 'support/connect_helpers.dart';
+
+/// One captured PTY resize command (cols x rows) sent UI→task.
+class _Resize {
+  const _Resize(this.cols, this.rows);
+  final int cols;
+  final int rows;
+  @override
+  String toString() => '${cols}x$rows';
+}
+
+/// Wraps the real gateway and records every `resize` command sent UI→task —
+/// the exact signal that re-sizes the remote PTY (session_host.dart →
+/// `shell.resize`). Lets the test prove the server is TOLD the new size on a
+/// viewport change, not just that the local widget reflowed.
+class _ResizeSpyGateway implements TaskSshGateway {
+  _ResizeSpyGateway(this._delegate);
+
+  final TaskSshGateway _delegate;
+  final List<_Resize> resizes = <_Resize>[];
+
+  void clear() => resizes.clear();
+
+  @override
+  void send(Map<String, dynamic> payload) {
+    if (payload['kind'] == 'resize') {
+      resizes.add(_Resize(payload['cols'] as int, payload['rows'] as int));
+    }
+    _delegate.send(payload);
+  }
+
+  @override
+  Stream<Map<String, dynamic>> get incoming => _delegate.incoming;
+
+  @override
+  void markServiceStopped() => _delegate.markServiceStopped();
+
+  @override
+  Future<void> dispose() => _delegate.dispose();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'terminal fills on first connect (no dead gap) and reflows + re-sends '
+    'PTY resize on a viewport change',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final spy = _ResizeSpyGateway(FlutterForegroundSshGateway());
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(spy)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      // Reach the terminal screen, accepting the host-key prompt if shown.
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find
+            .byKey(const Key('session-menu-button'))
+            .evaluate()
+            .isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final terminal = entry!.terminal;
+
+      // Let the first connect + first frame + font load settle.
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      // ── (1) #625 — the terminal FILLS the viewport on first connect. ──────
+      // The default Terminal is 80x24. On a phone-class emulator screen the
+      // terminal must fit MANY more than 24 rows. A terminal stuck at ~24 rows
+      // is the dead-gap bug. We use a conservative floor (> 30) so the assertion
+      // is robust across emulator densities while still failing the stuck-at-24
+      // regression.
+      final firstRows = terminal.viewHeight;
+      debugPrint('LAYOUT625 firstFill ${terminal.viewWidth}x$firstRows');
+      expect(
+        firstRows,
+        greaterThan(30),
+        reason:
+            'terminal did not fill the viewport on first connect — only '
+            '$firstRows rows. This is the #625 dead-gap (stale first-frame '
+            'size that never re-measured).',
+      );
+
+      // A resize matching the rendered size must have reached the host.
+      expect(
+        spy.resizes,
+        isNotEmpty,
+        reason: 'no PTY resize was ever sent to the host',
+      );
+      expect(
+        spy.resizes.last.rows,
+        firstRows,
+        reason:
+            'the last PTY resize ${spy.resizes.last} disagrees with the '
+            'rendered $firstRows rows — server/client size diverged (#600)',
+      );
+
+      // ── (2) #600 — a viewport change REFLOWS + re-sends the PTY size. ─────
+      // Toggling the keybar OFF frees ~one keybar of height; the terminal must
+      // grow (more rows) AND a fresh resize must reach the host. This is the
+      // same lever every viewport change pulls (keyboard show/hide, rotation).
+      spy.clear();
+      container.read(keybarVisibleProvider.notifier).toggle();
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      final grownRows = terminal.viewHeight;
+      debugPrint(
+        'LAYOUT600 afterKeybarToggle ${terminal.viewWidth}x$grownRows',
+      );
+      expect(
+        grownRows,
+        greaterThan(firstRows),
+        reason:
+            'hiding the keybar did not reflow the terminal (still $grownRows '
+            'rows vs $firstRows) — viewport change did not re-fit (#600)',
+      );
+      expect(
+        spy.resizes,
+        isNotEmpty,
+        reason:
+            'viewport change reflowed the widget but sent NO PTY resize — the '
+            'server now disagrees with the rendered size (#600)',
+      );
+      expect(
+        spy.resizes.last.rows,
+        grownRows,
+        reason:
+            'the resize sent after the viewport change (${spy.resizes.last}) '
+            'disagrees with the rendered $grownRows rows (#600)',
+      );
+    },
+  );
+}

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -345,13 +345,98 @@ class _SessionTerminalBody extends ConsumerStatefulWidget {
       _SessionTerminalBodyState();
 }
 
-class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody> {
+class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
+    with WidgetsBindingObserver {
   /// Passed to TerminalView so we own the scrollback Scrollable (#605). Having
   /// an explicit controller also lets future work jump-to-bottom on new output.
   final ScrollController _scrollController = ScrollController();
 
   @override
+  void initState() {
+    super.initState();
+    // #625/#600 — terminal layout/resize correctness.
+    //
+    // xterm.dart's `RenderTerminal.performLayout` computes cols/rows from
+    // `constraints.biggest / cellSize`, but ONLY inside `performLayout`. On the
+    // device's FIRST connect the very first layout can run before the bundled
+    // JetBrainsMono asset font has settled, so the cell size is measured from
+    // the platform-monospace fallback. The terminal locks in cols/rows for the
+    // WRONG cell size and never re-measures on its own (the constraints don't
+    // change), so the rendered content fills fewer rows than the viewport —
+    // the dead vertical gap above the keybar (#625). It "settles" after any
+    // later relayout (keyboard / rotation / keybar toggle) because that re-runs
+    // `performLayout` with the now-correct cached cellSize.
+    //
+    // The PWA's terminal (`src/modules/terminal.ts`, the UX spec) is more
+    // stable precisely because it RE-FITS explicitly on every viewport/font
+    // change (`fitAddon.fit()` on `fonts.ready`, `loadingdone`, visualViewport
+    // resize) and re-sends the PTY size. We mirror that here: force xterm to
+    // re-measure after the first frame and whenever the available fonts change,
+    // so the rendered size — and therefore the PTY `resize` that
+    // `Terminal.onResize` sends (see sessions.dart) — tracks reality.
+    WidgetsBinding.instance.addObserver(this);
+    PaintingBinding.instance.systemFonts.addListener(_forceRemeasure);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _forceRemeasure());
+  }
+
+  /// Force the xterm `TerminalView` to re-run layout so it recomputes cols/rows
+  /// from the current rendered cell size. A no-op cost when nothing changed:
+  /// `markNeedsLayout` only re-measures, and `Terminal.onResize` fires (→
+  /// `proxy.sendResize`) ONLY when cols/rows actually differ. Deferred to a
+  /// post-frame callback so it is safe to call from layout-phase notifications
+  /// (`systemFonts`, metrics changes).
+  void _forceRemeasure() {
+    if (!mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      // The `terminal-view-$id` ValueKey is kept for test addressing, so we
+      // can't also hang a `GlobalKey<TerminalViewState>` on the TerminalView.
+      // Locate its state by descending our own element subtree instead.
+      final state = _findTerminalViewState();
+      if (state == null) return;
+      // `renderTerminal` throws if the viewport hasn't laid out yet; a render
+      // box detached mid-frame would also reject `markNeedsLayout`. Either way
+      // the next settle/remeasure recovers, so swallow.
+      try {
+        final ro = state.renderTerminal;
+        if (ro.attached) ro.markNeedsLayout();
+      } catch (_) {
+        /* not laid out yet — a later remeasure handles it */
+      }
+    });
+  }
+
+  /// Walk this body's element subtree to find the xterm [TerminalViewState].
+  /// Returns null before the first build or if the TerminalView isn't mounted
+  /// (e.g. an offstage IndexedStack child that hasn't laid out yet).
+  TerminalViewState? _findTerminalViewState() {
+    TerminalViewState? found;
+    void visit(Element el) {
+      if (found != null) return;
+      if (el is StatefulElement && el.state is TerminalViewState) {
+        found = el.state as TerminalViewState;
+        return;
+      }
+      el.visitChildren(visit);
+    }
+
+    (context as Element).visitChildren(visit);
+    return found;
+  }
+
+  /// Keyboard show/hide and rotation change the available terminal height. The
+  /// Scaffold relayout already re-fits xterm in most cases, but we re-measure
+  /// explicitly so a viewport change can never leave the PTY size stale vs. the
+  /// rendered size (#600). Mirrors the PWA's visualViewport resize → re-fit.
+  @override
+  void didChangeMetrics() {
+    _forceRemeasure();
+  }
+
+  @override
   void dispose() {
+    PaintingBinding.instance.systemFonts.removeListener(_forceRemeasure);
+    WidgetsBinding.instance.removeObserver(this);
     _scrollController.dispose();
     super.dispose();
   }

--- a/native/test/widget/terminal_remeasure_test.dart
+++ b/native/test/widget/terminal_remeasure_test.dart
@@ -1,0 +1,182 @@
+// Widget tests for the terminal re-measure path (#625 / #600).
+//
+// Root cause (device): xterm.dart computes cols/rows from `cellSize` ONLY
+// inside `RenderTerminal.performLayout`. On a real device's first connect the
+// first layout can run before the bundled JetBrainsMono asset font has settled,
+// so the terminal locks in cols/rows for the fallback font's cell size and
+// never re-measures (constraints don't change) — the dead gap above the keybar.
+//
+// A headless harness can't reproduce the asset-font race: test fonts are
+// preloaded before the first frame, so xterm always measures the correct cell
+// size on the first layout (the "fills the viewport" test below confirms that
+// baseline). What the harness CAN lock in is the fix's WIRING — that the body
+// registers a system-fonts listener and a WidgetsBindingObserver while mounted
+// and tears both down on dispose, so a font-load / metrics change on device
+// forces the re-measure. The on-emulator integration test
+// (`terminal_layout_fill_test.dart`) is the real device gate for the re-fit.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_providers.dart';
+import 'package:mobissh/ui/terminal_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xterm/xterm.dart';
+
+import '../support/fake_ssh_shell_transport.dart';
+
+Future<({SessionEntry entry, ProviderContainer container})> _setup(
+  WidgetTester tester,
+  FakeSshShellTransport transport,
+) async {
+  final pair = InMemoryGatewayPair();
+  addTearDown(() async => pair.dispose());
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      sshShellOpenerProvider.overrideWithValue(
+        (ref, sessionId, terminal) async => transport,
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  final entry = container
+      .read(sessionsProvider.notifier)
+      .addOrActivate(
+        const SshConnectParams(
+          host: 'h',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: TerminalScreen()),
+    ),
+  );
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  return (entry: entry, container: container);
+}
+
+/// Deliver the platform `fontsChange` system message — the same signal Flutter
+/// raises when an asset font finishes loading. Drives both xterm's own relayout
+/// mixin and the body's `systemFonts` listener.
+Future<void> _fireFontsChange(WidgetTester tester) async {
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    'flutter/system',
+    const JSONMessageCodec().encodeMessage(<String, dynamic>{
+      'type': 'fontsChange',
+    }),
+    (_) {},
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('terminal re-measure (#625/#600)', () {
+    testWidgets(
+      'fills the viewport on first layout — more than the default 24 rows',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final s = await _setup(tester, transport);
+
+        // The default Terminal is 80x24. On the (large) test surface it must
+        // fit MORE than 24 rows — i.e. the terminal filled the available
+        // height rather than leaving a dead gap (#625 baseline).
+        expect(
+          s.entry.terminal.viewHeight,
+          greaterThan(24),
+          reason: 'terminal did not fill the viewport on first layout (#625)',
+        );
+      },
+    );
+
+    testWidgets(
+      'a fonts-change while mounted re-measures without throwing and the '
+      'terminal stays filled (#625/#600)',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final s = await _setup(tester, transport);
+
+        final fitted = s.entry.terminal.viewHeight;
+        expect(fitted, greaterThan(24));
+
+        // Fire the platform fonts-change (the asset font finishing load on
+        // device). The body's listener forces a re-measure; on the stable
+        // test font the fitted size is unchanged, but the path must run
+        // cleanly and the terminal must remain filled (no regression to 24).
+        await _fireFontsChange(tester);
+        for (var i = 0; i < 6; i++) {
+          await tester.pump(const Duration(milliseconds: 50));
+        }
+
+        expect(s.entry.terminal.viewHeight, fitted);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'a metrics change re-measures without throwing and stays filled (#600)',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final s = await _setup(tester, transport);
+
+        final fitted = s.entry.terminal.viewHeight;
+        expect(fitted, greaterThan(24));
+
+        tester.binding.handleMetricsChanged();
+        for (var i = 0; i < 6; i++) {
+          await tester.pump(const Duration(milliseconds: 50));
+        }
+
+        expect(s.entry.terminal.viewHeight, fitted);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      're-measure wiring is torn down when the session body unmounts',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final s = await _setup(tester, transport);
+
+        // Replace the whole tree so the terminal body is disposed.
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // After dispose, a fonts-change must NOT touch the (gone) terminal.
+        // The body's listener is removed, so this is a no-op that must not
+        // throw. The previously-active session's terminal stays untouched.
+        final before = s.entry.terminal.viewHeight;
+        await _fireFontsChange(tester);
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(s.entry.terminal.viewHeight, before);
+        expect(tester.takeException(), isNull);
+      },
+    );
+  });
+
+  // Keep TerminalView referenced so a refactor that drops the addressable
+  // `terminal-view-$id` key is caught alongside these tests.
+  test('TerminalView type is referenced', () {
+    expect(TerminalView, isNotNull);
+  });
+}


### PR DESCRIPTION
## What

Fixes the terminal layout/resize correctness bugs (shared sizing root cause):

- **#625** — on first connect the terminal leaves a dead vertical gap between the last line and the keybar (not filling the screen).
- **#600** — terminal layout breaks on viewport changes (keyboard show/hide, keybar toggle, rotation, reconnect) "more than the PWA".

## Root cause

xterm.dart 4.0.0 `RenderTerminal.performLayout` computes cols/rows from `constraints.biggest / cellSize`, and **only** inside `performLayout`. On a device's first connect the first layout can run before the bundled `JetBrainsMono` asset font has settled, so the cell size is measured from the platform-monospace fallback. The terminal locks in cols/rows for the wrong cell size and never re-measures (the constraint doesn't change) — fewer rendered rows than the viewport → the dead gap. It "settles" after any later relayout because that re-runs `performLayout` with the now-correct cached cellSize.

## Fix

Mirror the PWA's proven fit-on-viewport/font-change loop (`src/modules/terminal.ts` — `fitAddon.fit()` on `fonts.ready` / `loadingdone` / visualViewport resize). `TerminalScreen`'s session body (`native/lib/ui/terminal_screen.dart`) now forces an xterm re-measure (`renderTerminal.markNeedsLayout()`):

- after the first frame (post-frame callback),
- on `PaintingBinding.instance.systemFonts` changes (asset font load),
- on `didChangeMetrics` (keyboard show/hide, rotation).

`Terminal.onResize` (in `sessions.dart`) then re-sends the PTY resize **only when cols/rows actually change**, so the server's idea of the size tracks what's rendered. `session_host.dart`'s resize path (`SshResizeCommand` → `shell.resize`) was reviewed and is correct — left unchanged. `compose_bar.dart` / `keybar.dart` untouched.

## Tests

- Widget regression guards (`terminal_remeasure_test.dart`): terminal fills the viewport on first layout, a fonts-change / metrics-change re-measures without throwing and stays filled, and the re-measure wiring is torn down on unmount.
- On-emulator integration test (`terminal_layout_fill_test.dart`, run via `scripts/native-connect-test.sh`): connects, asserts the terminal fills (45 rows on first connect, not stuck at 24), toggles the keybar, and asserts the terminal reflows (48 rows) **and** a new PTY resize reaches the host.

## Device validation note

The dev emulator does **not** reproduce the owner's specific first-connect gap — xterm's own font-change relayout already handles it there, so the integration test is green both with and without the fix on this emulator (a valid regression guard, not a red→green proof of the owner's race). The fix is a low-risk belt-and-suspenders that mirrors the PWA and can only help that race. **Final validation is on the owner's device.**

## #615 hand-off

`bottomReserve: 48 + (keybarVisible ? 96 : 0)` in `terminal_screen.dart` (compose-bar overlay reserve) is **not** the gap cause and was left as-is. The `48` (session bar) / `96` (keybar) magic numbers should be centralized when #615 does the chrome-shrink pass.

Closes #625, #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)