### PR TITLE
ux(#615): shrink session bar + keybar ~25%, lighter outlines, fit Home/End, smaller ESC

### DIFF
--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -22,6 +22,30 @@ import 'package:xterm/xterm.dart';
 
 import '../state/sessions.dart';
 
+/// Bottom-chrome sizing (#615). The keybar was shrunk ~25% vertically to give
+/// the terminal more real estate. These are the single source of truth for the
+/// button geometry AND the vertical space the bar occupies — the latter
+/// ([kKeybarReserve]) is consumed by the compose bar's bottom reserve in
+/// terminal_screen.dart so a docked compose panel always clears the chrome.
+///
+/// Old values (pre-#615): minWidth 48, minHeight 44, icon 18, label 14,
+/// reserve ≈ 96. The ~25% reduction lands the height around 33 and the reserve
+/// around 72.
+const double kKeybarButtonMinWidth = 44;
+const double kKeybarButtonMinHeight = 33;
+const double kKeybarIconSize = 14;
+const double kKeybarLabelFontSize = 12;
+
+/// "ESC" is the widest text label; scaling it down lets it share the normal
+/// button min width instead of bulging the bar (#615). Still monochrome text —
+/// no glyph that could be mistaken for Enter.
+const double kKeybarEscFontSize = 10;
+
+/// Vertical space (logical px) the keybar occupies, used as the compose-bar
+/// bottom reserve. Button height + the 4px top/bottom scroll-view padding,
+/// rounded for a small safety margin. ~25% smaller than the old hardcoded 96.
+const double kKeybarReserve = 72;
+
 /// One key on the bar. Renders [label] text, OR [icon] (a monochrome
 /// theme-tinted Material icon) when set — never an emoji.
 class KeybarKey {
@@ -124,7 +148,8 @@ class Keybar extends ConsumerWidget {
         // target. Each button has a comfortable min width.
         child: SingleChildScrollView(
           scrollDirection: Axis.horizontal,
-          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+          // #615: tighter vertical padding (was 4) to shrink the strip ~25%.
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 3),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -165,29 +190,44 @@ class _KeybarButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    // #615: ESC is the widest text key; render it at a smaller font so it fits
+    // the shared normal button width instead of bulging the bar. Still plain
+    // monochrome text (no Enter-ish glyph).
+    final bool isEsc = keyData.id == 'keyEsc';
     // Monochrome icon (theme-tinted) when set, else the label glyph/text.
     // Never an emoji — see memory feedback_monochrome_icons_no_emoji.
     final Widget child = keyData.icon != null
         ? Icon(
             keyData.icon,
-            size: 18,
+            size: kKeybarIconSize,
             color: theme.colorScheme.onSurface,
             semanticLabel: keyData.label,
           )
         : Text(
             keyData.label,
-            style: const TextStyle(fontSize: 14, fontFamily: 'monospace'),
+            style: TextStyle(
+              fontSize: isEsc ? kKeybarEscFontSize : kKeybarLabelFontSize,
+              fontFamily: 'monospace',
+            ),
             overflow: TextOverflow.ellipsis,
           );
     return OutlinedButton(
       key: Key('keybar-btn-${keyData.id}'),
       onPressed: () => _onTap(context),
       style: OutlinedButton.styleFrom(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        // Touch-friendly: a comfortable min width/height per key (≥44px tall
-        // tap target) instead of squeezing N keys to fit the viewport width.
-        minimumSize: const Size(48, 44),
+        // #615: tighter padding for the ~25% shrink. Still a touch-friendly
+        // tap target via minimumSize below.
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        // Every key shares the same min width so the bar stays even — ESC no
+        // longer bulges (its smaller font fits this width).
+        minimumSize: const Size(kKeybarButtonMinWidth, kKeybarButtonMinHeight),
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        // #615: lighter outline — thinner, lower-opacity border so the bar
+        // reads as a quiet strip rather than a grid of boxes.
+        side: BorderSide(
+          color: theme.colorScheme.outline.withValues(alpha: 0.4),
+          width: 0.5,
+        ),
         // Squarer look matching the PWA keybar — subtle rounding, not pill.
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(6)),

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -39,6 +39,12 @@ import 'session_menu.dart';
 /// a small horizontal wobble during a tap doesn't switch sessions.
 const double kSessionSwipeThreshold = 50;
 
+/// Vertical space (logical px) the bottom session bar occupies (#615). Single
+/// source of truth shared by the compose-bar bottom reserve so a docked compose
+/// panel always clears the bar. ~25% smaller than the old hardcoded 48 — the
+/// bar's row padding was tightened to match (see `_SessionBar`).
+const double kSessionBarReserve = 36;
+
 /// Bundled monospace family declared in `pubspec.yaml` (#552). The xterm
 /// `TerminalStyle.fontFamilyFallback` (platform monospace) covers glyphs the
 /// bundled face is missing, so this stays robust even if the asset is absent.
@@ -131,8 +137,12 @@ class TerminalScreen extends ConsumerWidget {
                 key: ValueKey('compose-bar-${activeEntry.id}'),
                 terminal: activeEntry.terminal,
                 // Reserve the bottom chrome so a bottom-docked panel never hides
-                // the session bar (#610). Session bar ≈ 48; keybar ≈ 96 when on.
-                bottomReserve: 48 + (keybarVisible ? 96 : 0),
+                // the session bar (#610). Heights are centralized constants
+                // (#615): kSessionBarReserve (session bar) + kKeybarReserve
+                // (keybar, only when visible). Update those — not magic numbers
+                // here — when the chrome height changes.
+                bottomReserve:
+                    kSessionBarReserve + (keybarVisible ? kKeybarReserve : 0),
                 onClose: () =>
                     ref.read(composeBarVisibleProvider.notifier).set(false),
               ),
@@ -243,9 +253,11 @@ class _SessionBarState extends State<_SessionBar> {
                 );
               },
               child: Padding(
+                // #615: vertical padding trimmed (was 8) to shrink the bar
+                // ~25%. Pairs with the smaller compose toggle icon below.
                 padding: const EdgeInsets.symmetric(
                   horizontal: 12,
-                  vertical: 8,
+                  vertical: 5,
                 ),
                 child: Row(
                   key: const Key('session-menu-button'),
@@ -277,7 +289,12 @@ class _SessionBarState extends State<_SessionBar> {
                 : 'Compose (swipe / voice)',
             isSelected: widget.composeOn,
             color: widget.composeOn ? theme.colorScheme.primary : null,
-            icon: const Icon(Icons.edit_note_outlined, size: 20),
+            // #615: tighter visual density so the IconButton's default 48px
+            // tap box doesn't set the bar height; the row padding now drives it.
+            visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints(minWidth: 36, minHeight: 28),
+            padding: EdgeInsets.zero,
+            icon: const Icon(Icons.edit_note_outlined, size: 18),
             onPressed: widget.onToggleCompose,
           ),
         ],

--- a/native/test/widget/keybar_test.dart
+++ b/native/test/widget/keybar_test.dart
@@ -81,6 +81,14 @@ void main() {
       }
     });
 
+    test('default set includes BOTH Home and End (#615)', () {
+      // #615: Home and End must be on the DEFAULT bar so they're reachable
+      // without scrolling once the keys are shrunk to fit a phone width.
+      final ids = kDefaultKeybarKeys.map((k) => k.id).toList();
+      expect(ids, contains('keyHome'));
+      expect(ids, contains('keyEnd'));
+    });
+
     test('all four arrows use the monochrome icon path (icon != null)', () {
       final arrows = kDefaultKeybarKeys
           .where(
@@ -97,6 +105,25 @@ void main() {
               'a unicode glyph that the platform colorizes inconsistently',
         );
       }
+    });
+  });
+
+  group('keybar sizing (#615 — shrink ~25%, lighter outline)', () {
+    test('button min height is reduced ~25% from the old 44px tap target', () {
+      // Old default min height was 44. A ~25% shrink lands around 33 (±2).
+      expect(kKeybarButtonMinHeight, lessThanOrEqualTo(35));
+      expect(kKeybarButtonMinHeight, greaterThanOrEqualTo(31));
+    });
+
+    test('icon + label font sizes are reduced from the old 18 / 14', () {
+      expect(kKeybarIconSize, lessThan(18));
+      expect(kKeybarLabelFontSize, lessThan(14));
+    });
+
+    test('keybar reserve height is reduced ~25% from the old 96px', () {
+      // The compose-bar bottomReserve used a hardcoded 96 for the keybar.
+      expect(kKeybarReserve, lessThanOrEqualTo(76));
+      expect(kKeybarReserve, greaterThanOrEqualTo(64));
     });
   });
 
@@ -136,6 +163,56 @@ void main() {
 
       expect(find.byKey(const Key('keybar')), findsOneWidget);
     });
+
+    testWidgets(
+      'ESC renders at a normal button width — same minWidth as a normal key '
+      '(#615)',
+      (tester) async {
+        final pair = InMemoryGatewayPair();
+        addTearDown(() async {
+          await pair.dispose();
+        });
+        final container = ProviderContainer(
+          overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+        );
+        addTearDown(container.dispose);
+
+        final entry = container
+            .read(sessionsProvider.notifier)
+            .addOrActivate(
+              const SshConnectParams(
+                host: 'h',
+                port: 22,
+                username: 'u',
+                auth: SshAuth.password('p'),
+              ),
+            );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(
+              home: Scaffold(body: Keybar(activeEntry: entry)),
+            ),
+          ),
+        );
+        await _pumpFrames(tester);
+
+        OutlinedButton buttonFor(String id) =>
+            tester.widget<OutlinedButton>(find.byKey(Key('keybar-btn-$id')));
+
+        Size? minSizeOf(OutlinedButton b) =>
+            b.style?.minimumSize?.resolve(<WidgetState>{});
+
+        final escMin = minSizeOf(buttonFor('keyEsc'));
+        final normalMin = minSizeOf(buttonFor('keyPipe'));
+        expect(escMin, isNotNull);
+        expect(normalMin, isNotNull);
+        // ESC must not be wider than a normal key — it used to be the widest
+        // text key. Same min width keeps the bar even.
+        expect(escMin!.width, equals(normalMin!.width));
+      },
+    );
 
     testWidgets(
       'tapping a key writes its byte sequence to the terminal',

--- a/native/test/widget/terminal_screen_widget_test.dart
+++ b/native/test/widget/terminal_screen_widget_test.dart
@@ -76,6 +76,14 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
+  group('bottom-chrome reserve constants (#615)', () {
+    test('session bar reserve is reduced ~25% from the old 48px', () {
+      // The compose-bar bottomReserve used a hardcoded 48 for the session bar.
+      expect(kSessionBarReserve, lessThanOrEqualTo(40));
+      expect(kSessionBarReserve, greaterThanOrEqualTo(32));
+    });
+  });
+
   group('TerminalScreen', () {
     testWidgets('renders a TerminalView', (tester) async {
       final transport = FakeSshShellTransport();


### PR DESCRIPTION
Bot fix for #615. Closes #615.