### PR TITLE
fix(#643): profile chooser fills the screen

### DIFF
--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -226,7 +226,10 @@ class _ConnectHomePageState extends State<ConnectHomePage> {
         child: IndexedStack(
           index: _index,
           children: const [
-            SingleChildScrollView(child: ConnectForm()),
+            // #643: NO SingleChildScrollView — the chooser fills the body so
+            // its profile list expands and scrolls internally. IndexedStack
+            // gives ConnectForm a bounded height (its Expanded needs that).
+            ConnectForm(),
             SettingsScreen(),
             DiagnosticsScreen(),
           ],

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -87,14 +87,29 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       }
     });
 
+    // #643: the chooser FILLS the screen. The saved-profile list goes in an
+    // `Expanded` so it takes all the vertical room above the actions (it
+    // scrolls within that full height); "New connection" + "Import from PWA"
+    // pin directly below the full-height list. Previously the list was capped
+    // at 220px and the whole Column was wrapped in a SingleChildScrollView at
+    // both call sites, so it collapsed to the top ~40% with a blank band below.
+    // This widget now needs a BOUNDED height (it no longer lives inside a
+    // SingleChildScrollView) — its hosts (ConnectHomePage / NewSessionPage)
+    // give it the full screen height.
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           // Saved profiles: tap a row = connect, pencil = edit. Empty-state
-          // hint nudges Import when the user has none yet.
-          ProfileList(onConnect: _connectFromProfile, onEdit: _editProfile),
+          // hint nudges Import when the user has none yet. Expanded so the list
+          // uses the available height and scrolls internally (#643).
+          Expanded(
+            child: ProfileList(
+              onConnect: _connectFromProfile,
+              onEdit: _editProfile,
+            ),
+          ),
           const SizedBox(height: 4),
           // The single "New" affordance: opens the editor in create mode. The
           // editor is the ad-hoc / new-connection entry now that the inline
@@ -106,8 +121,8 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
             label: Text(_busy ? 'Connecting…' : 'New connection'),
           ),
           const SizedBox(height: 4),
-          // Slim secondary access: Import-from-PWA. Settings + Diagnostics stay
-          // below as compact disclosures — not a wall of fields.
+          // Slim secondary access: Import-from-PWA. Settings + Diagnostics live
+          // on the home bottom nav (#611 Part A), not here.
           Align(
             alignment: Alignment.centerRight,
             child: TextButton.icon(
@@ -398,11 +413,10 @@ class NewSessionPage extends StatelessWidget {
     return Scaffold(
       key: const Key('new-session-page'),
       appBar: AppBar(title: const Text('New session')),
-      body: const SafeArea(
-        child: SingleChildScrollView(
-          child: ConnectForm(key: Key('new-session-form')),
-        ),
-      ),
+      // #643: NO SingleChildScrollView — the chooser fills the page height so
+      // its profile list expands and scrolls internally instead of collapsing
+      // to the top with a blank band below.
+      body: const SafeArea(child: ConnectForm(key: Key('new-session-form'))),
     );
   }
 }

--- a/native/lib/ui/profile_list.dart
+++ b/native/lib/ui/profile_list.dart
@@ -70,11 +70,14 @@ class ProfileList extends ConsumerWidget {
                 style: Theme.of(context).textTheme.titleSmall,
               ),
             ),
-            // Constrain so a giant list doesn't push the form off-screen.
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: 220),
+            // #643: the list FILLS the available height instead of a fixed
+            // 220px cap that left ~60% of the screen blank below. `Expanded`
+            // takes whatever vertical room the parent gives (the chooser places
+            // ProfileList in its own Expanded), and the ListView scrolls within
+            // that full height when there are more profiles than fit. No
+            // `shrinkWrap` — the list gets a bounded height from the Expanded.
+            Expanded(
               child: ListView.builder(
-                shrinkWrap: true,
                 itemCount: profiles.length,
                 itemBuilder: (context, i) {
                   final p = profiles[i];
@@ -86,7 +89,7 @@ class ProfileList extends ConsumerWidget {
                 },
               ),
             ),
-            const Divider(),
+            const Divider(height: 1),
           ],
         );
       },

--- a/native/test/widget/connect_applies_font_size_test.dart
+++ b/native/test/widget/connect_applies_font_size_test.dart
@@ -48,7 +48,7 @@ Future<ProviderContainer> _pump(
     UncontrolledProviderScope(
       container: container,
       child: const MaterialApp(
-        home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+        home: Scaffold(body: ConnectForm()),
       ),
     ),
   );

--- a/native/test/widget/connect_applies_theme_test.dart
+++ b/native/test/widget/connect_applies_theme_test.dart
@@ -53,7 +53,7 @@ Future<ProviderContainer> _pump(
     UncontrolledProviderScope(
       container: container,
       child: const MaterialApp(
-        home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+        home: Scaffold(body: ConnectForm()),
       ),
     ),
   );

--- a/native/test/widget/import_upsert_authtype_test.dart
+++ b/native/test/widget/import_upsert_authtype_test.dart
@@ -112,7 +112,7 @@ void main() {
         UncontrolledProviderScope(
           container: container,
           child: const MaterialApp(
-            home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+            home: Scaffold(body: ConnectForm()),
           ),
         ),
       );

--- a/native/test/widget/profile_chooser_fill_test.dart
+++ b/native/test/widget/profile_chooser_fill_test.dart
@@ -1,0 +1,286 @@
+// Widget tests for #643: the profile CHOOSER must FILL the available vertical
+// height instead of collapsing to the top ~40% with a large blank band below.
+//
+// Bug (reported 3×): "Saved Profiles" + a list cut off after ~4 entries +
+// "New connection" + "Import from PWA" crammed into the top; ~60% blank below.
+//
+// Root cause: the list was capped (ConstrainedBox maxHeight:220) AND both call
+// sites wrapped ConnectForm in a SingleChildScrollView, giving the Column
+// unbounded height so it shrank to content.
+//
+// Contract locked here:
+//   1. With a tall viewport + many profiles, the saved-profiles ListView fills
+//      the available height (its painted height is far taller than the old 220
+//      cap, and tracks the viewport) — it is NOT pinned to a small fixed box.
+//   2. "New connection" + "Import from PWA" remain present (below the list).
+//   3. With many profiles the list scrolls within its area (it is scrollable),
+//      and the action buttons stay visible (not pushed off-screen).
+//   4. The #611-A bottom nav still exposes Settings + Diagnostics.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/main.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/connect_form.dart';
+
+ProviderContainer _container({
+  required ProfilesStore store,
+  required SecretsStore secrets,
+  required InMemoryGatewayPair pair,
+}) {
+  return ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      profilesStoreProvider.overrideWithValue(store),
+      secretsStoreProvider.overrideWithValue(secrets),
+    ],
+  );
+}
+
+Future<void> _seedManyProfiles(ProfilesStore store, int n) async {
+  await store.save(<SavedProfile>[
+    for (var i = 0; i < n; i++)
+      SavedProfile(
+        title: 'Box $i',
+        host: 'box$i.example',
+        port: 22,
+        username: 'user$i',
+      ),
+  ]);
+}
+
+/// Painted height of the saved-profiles ListView (the scrollable that holds the
+/// tiles). Used to assert the list FILLS the viewport rather than the old fixed
+/// 220px cap.
+double _listHeight(WidgetTester tester) {
+  final listFinder = find.descendant(
+    of: find.byKey(const Key('profile-list-populated')),
+    matching: find.byType(Scrollable),
+  );
+  expect(listFinder, findsOneWidget);
+  return tester.getSize(listFinder).height;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets(
+    'saved-profiles list fills the available height on the home chooser '
+    '(not the old fixed 220 cap)',
+    (tester) async {
+      // Tall viewport so there is plenty of vertical room to fill.
+      tester.view.physicalSize = const Size(1000, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final store = ProfilesStore();
+      await _seedManyProfiles(store, 30);
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async => pair.dispose());
+      final container = _container(store: store, secrets: secrets, pair: pair);
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: ConnectHomePage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The list must take far more than the old 220px cap — it should fill the
+      // tall viewport (minus app bar, buttons, bottom nav). 600px is a
+      // conservative floor that the old fixed cap could never reach.
+      final h = _listHeight(tester);
+      expect(
+        h,
+        greaterThan(600),
+        reason:
+            'profile list should fill the screen height, was $h (old cap 220)',
+      );
+
+      // Actions remain present below the list.
+      expect(find.byKey(const Key('new-connection')), findsOneWidget);
+      expect(
+        find.byKey(const Key('open-import-profiles-dialog')),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'list height tracks the viewport — taller screen => taller list',
+    (tester) async {
+      Future<double> measureAt(Size size) async {
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1.0;
+
+        final store = ProfilesStore();
+        await _seedManyProfiles(store, 30);
+        final secrets = SecretsStore(backend: InMemorySecretsBackend());
+        final pair = InMemoryGatewayPair();
+        final container = _container(
+          store: store,
+          secrets: secrets,
+          pair: pair,
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: ConnectHomePage()),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final h = _listHeight(tester);
+        pair.dispose();
+        container.dispose();
+        return h;
+      }
+
+      final short = await measureAt(const Size(1000, 1400));
+      final tall = await measureAt(const Size(1000, 2600));
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+
+      // A fixed-height box would give identical heights; a filling list grows.
+      expect(
+        tall,
+        greaterThan(short + 400),
+        reason:
+            'list height must track the viewport (filled), '
+            'short=$short tall=$tall',
+      );
+    },
+  );
+
+  testWidgets(
+    'with many profiles the list scrolls and the actions stay visible',
+    (tester) async {
+      tester.view.physicalSize = const Size(1000, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final store = ProfilesStore();
+      await _seedManyProfiles(store, 40);
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async => pair.dispose());
+      final container = _container(store: store, secrets: secrets, pair: pair);
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: ConnectHomePage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Actions visible even with 40 profiles (the list scrolls internally,
+      // it does not push the buttons off-screen).
+      expect(find.byKey(const Key('new-connection')), findsOneWidget);
+      expect(
+        find.byKey(const Key('open-import-profiles-dialog')),
+        findsOneWidget,
+      );
+
+      // The list is scrollable: not all 40 tiles are laid out at once (a fixed
+      // non-scrolling Column would build them all). Scroll it and confirm a
+      // later tile can be revealed.
+      final listFinder = find.descendant(
+        of: find.byKey(const Key('profile-list-populated')),
+        matching: find.byType(Scrollable),
+      );
+      await tester.drag(listFinder, const Offset(0, -1200));
+      await tester.pumpAndSettle();
+      // After scrolling, the actions are STILL visible (they live outside the
+      // scrollable, pinned below it).
+      expect(find.byKey(const Key('new-connection')), findsOneWidget);
+    },
+  );
+
+  testWidgets('NewSessionPage chooser also fills (same widget, pushed route)', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1000, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store = ProfilesStore();
+    await _seedManyProfiles(store, 30);
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    final container = _container(store: store, secrets: secrets, pair: pair);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: NewSessionPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final h = _listHeight(tester);
+    expect(
+      h,
+      greaterThan(600),
+      reason: 'New session chooser list should fill too, was $h',
+    );
+    expect(find.byKey(const Key('new-connection')), findsOneWidget);
+    expect(
+      find.byKey(const Key('open-import-profiles-dialog')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('#611-A bottom nav still exposes Settings + Diagnostics', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1000, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    final container = _container(store: store, secrets: secrets, pair: pair);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: ConnectHomePage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('home-bottom-nav')), findsOneWidget);
+    expect(find.byKey(const Key('home-nav-settings')), findsOneWidget);
+    expect(find.byKey(const Key('home-nav-diagnostics')), findsOneWidget);
+
+    // Settings destination opens its own view.
+    await tester.tap(find.byKey(const Key('home-nav-settings')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('settings-section')), findsOneWidget);
+  });
+}

--- a/native/test/widget/profile_chooser_test.dart
+++ b/native/test/widget/profile_chooser_test.dart
@@ -70,7 +70,7 @@ void main() {
       UncontrolledProviderScope(
         container: container,
         child: const MaterialApp(
-          home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+          home: Scaffold(body: ConnectForm()),
         ),
       ),
     );
@@ -123,7 +123,7 @@ void main() {
       UncontrolledProviderScope(
         container: container,
         child: const MaterialApp(
-          home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+          home: Scaffold(body: ConnectForm()),
         ),
       ),
     );
@@ -176,7 +176,7 @@ void main() {
       UncontrolledProviderScope(
         container: container,
         child: const MaterialApp(
-          home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+          home: Scaffold(body: ConnectForm()),
         ),
       ),
     );

--- a/native/test/widget/profile_tap_connect_test.dart
+++ b/native/test/widget/profile_tap_connect_test.dart
@@ -75,7 +75,7 @@ void main() {
         UncontrolledProviderScope(
           container: container,
           child: const MaterialApp(
-            home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+            home: Scaffold(body: ConnectForm()),
           ),
         ),
       );
@@ -137,7 +137,7 @@ void main() {
         UncontrolledProviderScope(
           container: container,
           child: const MaterialApp(
-            home: Scaffold(body: SingleChildScrollView(child: ConnectForm())),
+            home: Scaffold(body: ConnectForm()),
           ),
         ),
       );


### PR DESCRIPTION
Bot fix for #643. Closes #643.