### PR TITLE
fix(#648): surface connect error on unreachable host

### DIFF
--- a/native/lib/ui/connect_error_dialog.dart
+++ b/native/lib/ui/connect_error_dialog.dart
@@ -1,0 +1,57 @@
+// Connect-error dialog (#648).
+//
+// When a connect attempt ends in `SshSessionState.failed` BEFORE the session
+// ever reached `connected` (unreachable host, refused, no route, half-open path
+// that hit the readyTimeout, bad key, rejected host key, auth failure), the user
+// must see a clear error with the reason and a way forward — never a silent
+// spinner or a no-op. Mirrors `showHostKeyDialog` (showDialog + AlertDialog) so
+// the chooser surfaces failures the same way it surfaces host-key prompts.
+//
+// Returns `true` if the user chose "Retry" (caller should re-dispatch connect),
+// `false`/null if the user dismissed with "Back".
+
+import 'package:flutter/material.dart';
+
+/// Show a modal explaining why a connect attempt failed.
+///
+/// [reason] is the controller's `SshSessionData.error` string (e.g.
+/// "TCP connect failed: ...", "No SSH response in 25s — host may be unreachable
+/// or asleep", "Authentication failed: ..."). [target] is an optional
+/// "host:port" label shown above the reason.
+Future<bool> showConnectErrorDialog(
+  BuildContext context, {
+  required String reason,
+  String? target,
+}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      key: const Key('connect-error-dialog'),
+      title: const Text('Connection failed'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (target != null && target.isNotEmpty) ...[
+            Text(target, style: const TextStyle(fontWeight: FontWeight.w600)),
+            const SizedBox(height: 12),
+          ],
+          Text(reason),
+        ],
+      ),
+      actions: [
+        TextButton(
+          key: const Key('connect-error-back'),
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: const Text('Back'),
+        ),
+        FilledButton(
+          key: const Key('connect-error-retry'),
+          onPressed: () => Navigator.of(ctx).pop(true),
+          child: const Text('Retry'),
+        ),
+      ],
+    ),
+  );
+  return result ?? false;
+}

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -35,6 +35,7 @@ import '../state/profiles_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
+import 'connect_error_dialog.dart';
 import 'host_key_dialog.dart';
 import 'import_profiles_dialog.dart';
 import 'profile_editor.dart';
@@ -56,6 +57,16 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
   /// pending timer or the awaiter hangs forever).
   StreamSubscription<SshSessionData>? _connectedSub;
   Completer<bool>? _connectedCompleter;
+
+  /// True while the connect-error dialog (#648) is open, so the `failed`-state
+  /// listener doesn't stack a second dialog on a re-emit of the same failure.
+  bool _errorDialogOpen = false;
+
+  /// The params (and display title) of the most recent connect dispatch, so the
+  /// connect-error dialog's "Retry" can re-attempt the SAME connection without
+  /// re-walking the profile/credential resolution (#648).
+  SshConnectParams? _lastConnectParams;
+  String? _lastConnectTitle;
 
   @override
   void dispose() {
@@ -84,6 +95,22 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       final prevPending = prev?.valueOrNull?.pendingHostKey;
       if (pending != null && prevPending == null) {
         _handleHostKeyPrompt(pending);
+      }
+
+      // #648: surface a connect FAILURE. An unreachable host (down / bad host /
+      // wrong port → TCP refused, no route, or the half-open path that hit the
+      // readyTimeout), a rejected host key, a bad key, or an auth failure all
+      // land the active session in `failed`. The router keeps THIS chooser
+      // mounted on a never-live `failed` precisely so the connect error renders
+      // here (main.dart RootRouter) — but nothing rendered it. Show a clear
+      // dialog with the reason + Back/Retry instead of a silent spinner/no-op.
+      // Only fire on the TRANSITION into `failed` (prev != failed) so a re-emit
+      // doesn't stack dialogs.
+      final nextState = next.valueOrNull?.state;
+      final prevState = prev?.valueOrNull?.state;
+      if (nextState == SshSessionState.failed &&
+          prevState != SshSessionState.failed) {
+        _handleConnectFailure(next.valueOrNull);
       }
     });
 
@@ -171,6 +198,11 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     // Captured before the async gap so we can pop a pushed "New session" route
     // after dispatching connect without touching `context` post-await.
     final navigator = Navigator.of(context);
+
+    // Remember the params so the connect-error dialog's "Retry" can re-attempt
+    // this exact connection without re-resolving the profile/credential (#648).
+    _lastConnectParams = params;
+    _lastConnectTitle = title;
 
     setState(() => _busy = true);
     try {
@@ -383,6 +415,49 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
         ? 'Imported ${parts.join(', ')}'
         : 'No profiles imported.';
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  /// #648: surface a connect failure as a clear, dismissable error dialog with
+  /// the reason + Back/Retry. Called on the transition into `failed`. "Retry"
+  /// re-dispatches the last connect params to the active session; "Back" just
+  /// dismisses (the user stays on the chooser, not a silent spinner).
+  Future<void> _handleConnectFailure(SshSessionData? data) async {
+    if (_errorDialogOpen) return;
+    final reason = (data?.error?.trim().isNotEmpty ?? false)
+        ? data!.error!.trim()
+        : 'The connection could not be established.';
+    final host = data?.host;
+    final port = data?.port;
+    final target = (host != null && host.isNotEmpty)
+        ? (port != null ? '$host:$port' : host)
+        : null;
+    ctrace('ui.chooser', 'connectFailure: surfacing error "$reason"');
+    _errorDialogOpen = true;
+    bool retry = false;
+    try {
+      retry = await showConnectErrorDialog(
+        context,
+        reason: reason,
+        target: target,
+      );
+    } finally {
+      _errorDialogOpen = false;
+    }
+    if (!mounted || !retry) return;
+
+    // Retry: re-attempt the SAME connection. Reuse the cached params so we
+    // don't re-walk profile/credential resolution. The active proxy is the one
+    // that just failed; re-dispatch connect through it.
+    final params = _lastConnectParams;
+    if (params == null) return;
+    ctrace('ui.chooser', 'connectFailure: RETRY ${params.host}:${params.port}');
+    final proxy = ref.read(sshSessionProxyProvider);
+    setState(() => _busy = true);
+    try {
+      await proxy.connect(params, title: _lastConnectTitle);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
   }
 
   Future<void> _handleHostKeyPrompt(PendingHostKey pending) async {

--- a/native/test/ssh/handshake_timeout_test.dart
+++ b/native/test/ssh/handshake_timeout_test.dart
@@ -98,6 +98,47 @@ void main() {
     );
 
     test(
+      'unreachable host (TCP connect refused) → failed within readyTimeout (#648)',
+      () async {
+        // Connecting to an unreachable host (down / wrong port → ECONNREFUSED,
+        // bad host → no route) must deterministically reach `failed` with a
+        // meaningful error, never a silent indefinite hang. The TCP connect
+        // itself throws; the controller surfaces `failed` immediately, well
+        // within the readyTimeout bound.
+        final controller = SshSessionController(
+          readyTimeout: const Duration(milliseconds: 200),
+          socketOpener: (host, port, {timeout}) async {
+            throw Exception(
+              'Connection refused (errno = 111) — no route to host',
+            );
+          },
+        );
+
+        final connectFuture = controller.connect(
+          const SshConnectParams(
+            host: 'down.example',
+            port: 22,
+            username: 'u',
+            auth: SshAuth.password('p'),
+          ),
+        );
+
+        // Resolves fast (TCP throw) — assert it completes inside the bound and
+        // the state is `failed` with a non-empty error.
+        await connectFuture.timeout(
+          const Duration(milliseconds: 150),
+          onTimeout: () {},
+        );
+
+        expect(controller.data.state, SshSessionState.failed);
+        expect(controller.data.error, isNotNull);
+        expect(controller.data.error, contains('TCP connect failed'));
+
+        await controller.dispose();
+      },
+    );
+
+    test(
       'awaitingHostKey (host-key prompt) cancels the timer — never times out',
       () async {
         final controller = SshSessionController(

--- a/native/test/widget/connect_error_surfaced_test.dart
+++ b/native/test/widget/connect_error_surfaced_test.dart
@@ -1,0 +1,181 @@
+// Widget test: a connect that ends in `failed` SURFACES a visible error (#648).
+//
+// Bug: connecting to an unreachable host gave no error and no feedback — the
+// session reached `SshSessionState.failed` (controller is bounded by the
+// readyTimeout / TCP-connect throw) but the chooser never rendered the failure.
+// The router keeps the chooser mounted on a never-live `failed` precisely so the
+// "connect error renders there", but the chooser only listened for host-key
+// prompts.
+//
+// This test drives a profile tap → connect, then pushes a `failed` state event
+// from the task side (modelling an unreachable host the controller force-failed)
+// and asserts the connect-error dialog appears with the reason — NOT a silent
+// hang.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/connect_form.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets(
+    'connect that reaches `failed` surfaces a visible error dialog with the reason',
+    (tester) async {
+      // Seed a password profile + its vault secret so the tap connects.
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('vault-1', <String, Object?>{'password': 'pw'});
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Unreachable',
+          host: 'down.example',
+          port: 22,
+          username: 'alice',
+          authType: 'password',
+          vaultId: 'vault-1',
+        ),
+      ]);
+
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async {
+        await pair.dispose();
+      });
+      final container = ProviderContainer(
+        overrides: [
+          taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+          profilesStoreProvider.overrideWithValue(store),
+          secretsStoreProvider.overrideWithValue(secrets),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: Scaffold(body: ConnectForm())),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the profile row → connect (creates the session entry).
+      await tester.tap(
+        find.byKey(const Key('profile-tile-down.example:22:alice')),
+      );
+      await _pumpFrames(tester, count: 20);
+
+      final entry = container.read(sessionsProvider).entries.first;
+
+      // The controller would deterministically force-fail an unreachable host
+      // within the readyTimeout. Model that terminal event from the task side.
+      const reason =
+          'No SSH response in 25s — host may be unreachable or asleep';
+      pair.taskSide.send(
+        SshStateEvent(
+          sessionId: entry.id,
+          state: SshSessionState.failed.name,
+          error: reason,
+          host: 'down.example',
+          port: 22,
+          username: 'alice',
+        ).toJson(),
+      );
+      await _pumpFrames(tester, count: 20);
+
+      // The failure must be SURFACED — a visible dialog with the reason, not a
+      // silent spinner.
+      expect(
+        find.byKey(const Key('connect-error-dialog')),
+        findsOneWidget,
+        reason: 'a failed connect must surface a visible error, not hang',
+      );
+      expect(find.textContaining('unreachable'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping Back on the connect-error dialog dismisses it (no hang)',
+    (tester) async {
+      final store = ProfilesStore();
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      await secrets.write('vault-1', <String, Object?>{'password': 'pw'});
+      await store.save(<SavedProfile>[
+        SavedProfile(
+          title: 'Refused',
+          host: 'refused.example',
+          port: 22,
+          username: 'bob',
+          authType: 'password',
+          vaultId: 'vault-1',
+        ),
+      ]);
+
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async {
+        await pair.dispose();
+      });
+      final container = ProviderContainer(
+        overrides: [
+          taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+          profilesStoreProvider.overrideWithValue(store),
+          secretsStoreProvider.overrideWithValue(secrets),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: Scaffold(body: ConnectForm())),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const Key('profile-tile-refused.example:22:bob')),
+      );
+      await _pumpFrames(tester, count: 20);
+
+      final entry = container.read(sessionsProvider).entries.first;
+      pair.taskSide.send(
+        SshStateEvent(
+          sessionId: entry.id,
+          state: SshSessionState.failed.name,
+          error: 'TCP connect failed: connection refused',
+          host: 'refused.example',
+          port: 22,
+          username: 'bob',
+        ).toJson(),
+      );
+      await _pumpFrames(tester, count: 20);
+
+      expect(find.byKey(const Key('connect-error-dialog')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('connect-error-back')));
+      await _pumpFrames(tester, count: 10);
+
+      expect(find.byKey(const Key('connect-error-dialog')), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
## Problem
Connecting to an unreachable host (down / bad host / wrong port) gave **no error and no feedback** on native — the user saw a silent spinner / no-op (owner report, device, build d6db187).

## Root cause
- The **controller** (`ssh_session.dart`) was already correct: an unreachable connect deterministically reaches `failed` with a meaningful error — either a TCP-connect throw ("TCP connect failed: …") or the half-open `readyTimeout` force-fail ("No SSH response in Ns…", #542/#563). Bounded, never an indefinite hang.
- The **UI** (`connect_form.dart`) was the bug. The chooser's `ref.listen(sshSessionDataProvider)` listened **only** for `pendingHostKey`. There was **no listener for `failed`**. The router (`main.dart` RootRouter) deliberately keeps the chooser mounted on a never-live `failed` so "the connect error renders there" — but nothing rendered it. Home route: silent. New-session route: `_popWhenConnected` saw `failed`, completed false, stayed put silently.

## Fix
- New `lib/ui/connect_error_dialog.dart` — `showConnectErrorDialog` (showDialog + AlertDialog, mirrors `showHostKeyDialog`) showing `host:port` + the reason with **Back** / **Retry**.
- `connect_form.dart` — extended the existing `ref.listen` to also fire on the **transition into `failed`** (`prev != failed`) → `_handleConnectFailure`, which surfaces the dialog. **Retry** re-dispatches the cached connect params through the active proxy; an `_errorDialogOpen` guard prevents stacking on a re-emit. Scoped to the always-mounted chooser, so it only fires for **never-live** connect failures (once connected, the router swaps to TerminalScreen and unmounts the chooser).

## Before → after
- Before: unreachable connect → `failed` (bounded) but UI showed nothing.
- After: same `failed` transition → a "Connection failed" dialog with the host:port + reason + Back/Retry. Deterministic, bounded, **visible**.

## Tests
- Unit (`handshake_timeout_test.dart`): unreachable host (TCP connect refused) → `failed` with "TCP connect failed", inside the readyTimeout bound.
- Widget (`connect_error_surfaced_test.dart`): a profile-tap connect that reaches `failed` surfaces the connect-error dialog with the reason; **Back** dismisses (no hang). RED (dialog missing) → GREEN.
- Full native unit suite: **444 passed, 5 skipped** (integration-tagged). `flutter analyze` clean.

## Validation note
Connect-state-machine / connect-flow change. The orchestrator should **device-validate** and run the **#589 integration suite** (connect smokes must stay green) on the emulator before merge — not claimed verified headless.

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)