### PR TITLE
feat(#649): per-row file icon on session menu rows

### DIFF
--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -220,7 +220,8 @@ class SessionMenu extends ConsumerWidget {
 /// One compact row replacing the old stack of secondary ListTiles (#567).
 ///
 /// Layout (left→right): theme cycle (icon + current label), font − [value] +,
-/// files, keybar toggle, disconnect. Monochrome Material icons only — no emoji
+/// keybar toggle, disconnect. (Files moved to a per-row icon, #649.)
+/// Monochrome Material icons only — no emoji
 /// (feedback_monochrome_icons_no_emoji). Controls disable themselves when there
 /// is no active session, mirroring the prior per-tile `enabled` gating.
 class _SessionControlsRow extends ConsumerWidget {
@@ -308,21 +309,11 @@ class _SessionControlsRow extends ConsumerWidget {
                 ? null
                 : () => _stepFont(ref, sessions, activeId!, kFontSizeStep),
           ),
-          // Browse / download remote files over SFTP (#559).
-          IconButton(
-            key: const Key('session-menu-files'),
-            tooltip: 'Files',
-            visualDensity: VisualDensity.compact,
-            icon: const Icon(Icons.folder_outlined),
-            onPressed: !hasActive
-                ? null
-                : () {
-                    final sessionId = activeId!;
-                    final navigator = Navigator.of(context);
-                    onClose();
-                    openFileBrowser(navigator.context, sessionId);
-                  },
-          ),
+          // Files moved to a PER-ROW affordance (#649): each session row now
+          // carries its own `session-menu-files-${id}` icon next to its X, so
+          // the browser opens for THAT row's session rather than only the
+          // active one. The active-only control here was removed to avoid a
+          // redundant second entry point.
           // Keybar visibility toggle. Filled icon = visible, outlined = hidden,
           // so the glyph itself communicates the toggle state (no SwitchListTile
           // row needed). Keybar visibility is global today; #573 moves it
@@ -390,13 +381,38 @@ class _SessionRow extends ConsumerWidget {
           fontWeight: isActive ? FontWeight.w600 : FontWeight.normal,
         ),
       ),
-      trailing: IconButton(
-        key: Key('session-menu-close-${entry.id}'),
-        tooltip: 'Close session',
-        icon: const Icon(Icons.close),
-        onPressed: () {
-          ref.read(sessionsProvider.notifier).close(entry.id);
-        },
+      // [file icon][X] — the file icon opens the browser for THIS row's
+      // session (#649); the X disconnects/closes THIS row's session. Both are
+      // per-row so a multi-session menu addresses each session independently.
+      // The file glyph is monochrome (Material `folder_outlined`, currentColor)
+      // — no emoji (feedback_monochrome_icons_no_emoji).
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            key: Key('session-menu-files-${entry.id}'),
+            tooltip: 'Files',
+            visualDensity: VisualDensity.compact,
+            icon: const Icon(Icons.folder_outlined),
+            // Open the file browser for THIS row's session id (its live SSH
+            // connection drives SFTP), not just the active session. Close the
+            // menu first so the browser route isn't covered by the overlay.
+            onPressed: () {
+              final sessionId = entry.id;
+              final navigator = Navigator.of(context);
+              onClose();
+              openFileBrowser(navigator.context, sessionId);
+            },
+          ),
+          IconButton(
+            key: Key('session-menu-close-${entry.id}'),
+            tooltip: 'Close session',
+            icon: const Icon(Icons.close),
+            onPressed: () {
+              ref.read(sessionsProvider.notifier).close(entry.id);
+            },
+          ),
+        ],
       ),
       onTap: () {
         ref.read(sessionsProvider.notifier).setActive(entry.id);

--- a/native/test/widget/session_menu_row_files_test.dart
+++ b/native/test/widget/session_menu_row_files_test.dart
@@ -1,0 +1,146 @@
+// Per-row file icon on the session menu (#649).
+//
+// Owner: "the file icon should be attached to the session line item next to the
+// x to disconnect." The slim session menu (#567) lists each active session as a
+// row `[color dot] label  [X]` where X disconnects THAT session. This adds a
+// FILE icon on EACH row, next to that row's X, opening the file browser for
+// THAT row's sessionId (reusing the existing openFileBrowser/FileBrowserScreen
+// route). The X (disconnect/close) must stay intact.
+//
+// These tests assert per-row behaviour (not active-only): with multiple
+// sessions, each row owns its own file icon, and tapping row A's icon opens the
+// browser for A — not the active session.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/session_menu.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+ProviderContainer _makeContainer() {
+  final pair = InMemoryGatewayPair();
+  final container = ProviderContainer(
+    overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+  );
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  addTearDown(container.dispose);
+  return container;
+}
+
+SessionEntry _add(ProviderContainer c, String host) {
+  return c
+      .read(sessionsProvider.notifier)
+      .addOrActivate(
+        SshConnectParams(
+          host: host,
+          port: 22,
+          username: 'u',
+          auth: const SshAuth.password('p'),
+        ),
+      );
+}
+
+Widget _host({required ProviderContainer container}) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(
+              key: const Key('open-menu'),
+              onPressed: () => showSessionMenu(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 8}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('Session menu per-row file icon (#649)', () {
+    testWidgets('each session row renders its own file icon next to the X', (
+      tester,
+    ) async {
+      final container = _makeContainer();
+      final a = _add(container, 'host-a');
+      final b = _add(container, 'host-b');
+
+      await tester.pumpWidget(_host(container: container));
+      await tester.tap(find.byKey(const Key('open-menu')));
+      await _pumpFrames(tester);
+
+      // One file icon per row, keyed by that row's session id.
+      expect(find.byKey(Key('session-menu-files-${a.id}')), findsOneWidget);
+      expect(find.byKey(Key('session-menu-files-${b.id}')), findsOneWidget);
+
+      // The X (close) icon per row remains intact.
+      expect(find.byKey(Key('session-menu-close-${a.id}')), findsOneWidget);
+      expect(find.byKey(Key('session-menu-close-${b.id}')), findsOneWidget);
+    });
+
+    testWidgets('tapping a row file icon opens the browser for THAT row', (
+      tester,
+    ) async {
+      final container = _makeContainer();
+      final a = _add(container, 'host-a');
+      _add(container, 'host-b'); // b is active
+
+      await tester.pumpWidget(_host(container: container));
+      await tester.tap(find.byKey(const Key('open-menu')));
+      await _pumpFrames(tester);
+
+      // Tap the file icon on the NON-active row (a). It must open the browser
+      // for a's session, not the active session (b).
+      await tester.tap(find.byKey(Key('session-menu-files-${a.id}')));
+      await _pumpFrames(tester);
+
+      final browser = tester.widget<FileBrowserScreen>(
+        find.byType(FileBrowserScreen),
+      );
+      expect(browser.sessionId, a.id);
+    });
+
+    testWidgets('the row X still disconnects/closes that session', (
+      tester,
+    ) async {
+      final container = _makeContainer();
+      final a = _add(container, 'host-a');
+      _add(container, 'host-b');
+
+      await tester.pumpWidget(_host(container: container));
+      await tester.tap(find.byKey(const Key('open-menu')));
+      await _pumpFrames(tester);
+
+      expect(container.read(sessionsProvider).entries.length, 2);
+
+      await tester.tap(find.byKey(Key('session-menu-close-${a.id}')));
+      await _pumpFrames(tester);
+
+      final entries = container.read(sessionsProvider).entries;
+      expect(entries.length, 1);
+      expect(entries.any((e) => e.id == a.id), isFalse);
+    });
+  });
+}

--- a/native/test/widget/session_menu_slim_test.dart
+++ b/native/test/widget/session_menu_slim_test.dart
@@ -88,7 +88,7 @@ void main() {
       tester,
     ) async {
       final container = _makeContainer();
-      _add(container, 'host-a');
+      final session = _add(container, 'host-a');
 
       await tester.pumpWidget(_host(container: container));
       await tester.tap(find.byKey(const Key('open-menu')));
@@ -106,7 +106,13 @@ void main() {
         find.byKey(const Key('session-menu-fontsize-inc')),
         findsOneWidget,
       );
-      expect(find.byKey(const Key('session-menu-files')), findsOneWidget);
+      // Files moved to a PER-ROW icon (#649): each session row carries its own
+      // `session-menu-files-${id}` next to its X, instead of one active-only
+      // control in the secondary row.
+      expect(
+        find.byKey(Key('session-menu-files-${session.id}')),
+        findsOneWidget,
+      );
       expect(
         find.byKey(const Key('session-menu-keybar-toggle')),
         findsOneWidget,


### PR DESCRIPTION
Bot fix for #649. Closes #649.