### PR TITLE
fix(#647): force terminal re-measure on first connect (no keyboard toggle)

### DIFF
--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -21,6 +21,8 @@
 // that was a candidate for blocking the terminal's vertical scrollback drag.
 // Paste stays available via the keybar.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -49,6 +51,16 @@ const double kSessionBarReserve = 36;
 /// `TerminalStyle.fontFamilyFallback` (platform monospace) covers glyphs the
 /// bundled face is missing, so this stays robust even if the asset is absent.
 const String kTerminalFontFamily = 'JetBrainsMono';
+
+/// Test-only counter: incremented each time a session body arms the #647
+/// connect-triggered re-measure burst (the shell-ready transition). Lets a
+/// widget test prove the connect path — and ONLY the connect path, with no
+/// fonts/metrics event — fires the re-measure that on device fills the terminal
+/// without a keyboard toggle. The actual device re-fit is gated by the
+/// on-emulator integration test + owner validation (the headless harness can't
+/// reproduce the stale-cell-size race). Reset it in test `setUp`.
+@visibleForTesting
+int debugConnectRemeasureArmCount = 0;
 
 class TerminalScreen extends ConsumerWidget {
   const TerminalScreen({super.key});
@@ -368,6 +380,16 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
   /// an explicit controller also lets future work jump-to-bottom on new output.
   final ScrollController _scrollController = ScrollController();
 
+  /// True once the connect-triggered re-measure burst has been armed for the
+  /// CURRENT live shell (#647). Reset when the shell goes away so a reconnect
+  /// re-arms it. Prevents re-arming the burst on every rebuild while the
+  /// session stays connected.
+  bool _connectRemeasureArmed = false;
+
+  /// Pending delayed re-measure timers from the connect burst (#647), tracked
+  /// so they are cancelled on dispose and never fire against a gone widget.
+  final List<Timer> _connectRemeasureTimers = <Timer>[];
+
   @override
   void initState() {
     super.initState();
@@ -423,6 +445,57 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
     });
   }
 
+  /// #647 — force the SAME re-measure on FIRST CONNECT, without needing a
+  /// keyboard toggle.
+  ///
+  /// On a real device's first connect NEITHER #641 trigger fires: the bundled
+  /// JetBrainsMono asset is already cached (no `systemFonts` event) and there's
+  /// no viewport change (no `didChangeMetrics`). So the stale first-frame
+  /// measure (taken before the asset font's metrics settled) persisted until the
+  /// user tapped to show the keyboard — which finally ran `didChangeMetrics` →
+  /// the #641 remeasure → re-fit. The owner's smoking gun: "tapping to show the
+  /// keyboard fixes it."
+  ///
+  /// We mimic exactly what the keyboard-show did, but on the connect/shell-ready
+  /// transition: fire the #641 re-measure once immediately, then again at a few
+  /// short delays so a remeasure lands AFTER the asset font's cell metrics have
+  /// settled (the device race the emulator can't reproduce — there the
+  /// font-load relayout happens to fire). Each call is idempotent:
+  /// `markNeedsLayout` only re-measures, and `Terminal.onResize` →
+  /// `transport.resize` fires ONLY when cols/rows actually change. The burst is
+  /// armed once per live shell ([_connectRemeasureArmed]); it re-arms after a
+  /// drop so a reconnect gets the same treatment.
+  void _armConnectRemeasure() {
+    if (_connectRemeasureArmed) return;
+    _connectRemeasureArmed = true;
+    // Test-only: lets a widget test assert the connect transition (and ONLY the
+    // connect transition — no fonts/metrics event) armed the #647 burst. The
+    // device re-fit itself can't be reproduced headlessly (test fonts preload),
+    // so the wiring counter is the headless contract; the emulator/owner gate
+    // the actual re-fit.
+    debugConnectRemeasureArmCount += 1;
+    // Immediate (post-frame) re-measure — covers the case where layout is
+    // already correct by connect time (e.g. the emulator / headless harness).
+    _forceRemeasure();
+    // Staggered re-measures defeat the device font-settle race: at least one
+    // lands after the cached asset font's metrics are in effect.
+    for (final ms in const [120, 350, 700]) {
+      _connectRemeasureTimers.add(
+        Timer(Duration(milliseconds: ms), _forceRemeasure),
+      );
+    }
+  }
+
+  /// Drop the connect-remeasure arming + cancel pending burst timers so a
+  /// reconnect re-arms the burst and gone timers never touch a dead widget.
+  void _disarmConnectRemeasure() {
+    _connectRemeasureArmed = false;
+    for (final t in _connectRemeasureTimers) {
+      t.cancel();
+    }
+    _connectRemeasureTimers.clear();
+  }
+
   /// Walk this body's element subtree to find the xterm [TerminalViewState].
   /// Returns null before the first build or if the TerminalView isn't mounted
   /// (e.g. an offstage IndexedStack child that hasn't laid out yet).
@@ -454,6 +527,7 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
   void dispose() {
     PaintingBinding.instance.systemFonts.removeListener(_forceRemeasure);
     WidgetsBinding.instance.removeObserver(this);
+    _disarmConnectRemeasure();
     _scrollController.dispose();
     super.dispose();
   }
@@ -461,6 +535,22 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
   @override
   Widget build(BuildContext context) {
     final terminal = ref.watch(terminalProvider(widget.sessionId));
+    // #647 — arm the connect re-measure burst on the shell-ready transition.
+    // `sshShellProvider` resolves to a non-null shell ONLY once the session
+    // reaches `connected` (see terminal_providers.dart), so a ready AsyncData
+    // here IS the first-connect / shell-ready signal. Listening (not just
+    // watching) lets us fire the burst exactly on the transition and re-arm it
+    // after a drop, without rebuilding the body. Mirrors the keyboard-show
+    // re-fit, but triggered by connect instead of a metrics change.
+    ref.listen(sshShellProvider(widget.sessionId), (prev, next) {
+      if (next.valueOrNull != null) {
+        _armConnectRemeasure();
+      } else {
+        // Shell went away (disconnect / reconnecting / loading) — re-arm for
+        // the next connect so a reconnect gets the same first-connect re-fit.
+        _disarmConnectRemeasure();
+      }
+    });
     final shellAsync = ref.watch(sshShellProvider(widget.sessionId));
     // Per-session theme + font (#601, #571): each session's TerminalView reads
     // ITS OWN palette + font size, so two visible sessions can differ.

--- a/native/test/widget/terminal_remeasure_test.dart
+++ b/native/test/widget/terminal_remeasure_test.dart
@@ -1,4 +1,4 @@
-// Widget tests for the terminal re-measure path (#625 / #600).
+// Widget tests for the terminal re-measure path (#625 / #600 / #641 / #647).
 //
 // Root cause (device): xterm.dart computes cols/rows from `cellSize` ONLY
 // inside `RenderTerminal.performLayout`. On a real device's first connect the
@@ -6,14 +6,23 @@
 // so the terminal locks in cols/rows for the fallback font's cell size and
 // never re-measures (constraints don't change) — the dead gap above the keybar.
 //
+// #641 forced a re-measure on `systemFonts` change + `didChangeMetrics`. #647:
+// on the device's FIRST connect NEITHER fires (font already cached → no
+// systemFonts event; no viewport change → no didChangeMetrics), so the stale
+// measure persisted until the user TAPPED to show the keyboard (which finally
+// ran didChangeMetrics → the re-measure). The fix arms the SAME re-measure on
+// the connect / shell-ready transition, so no keyboard toggle is needed.
+//
 // A headless harness can't reproduce the asset-font race: test fonts are
 // preloaded before the first frame, so xterm always measures the correct cell
 // size on the first layout (the "fills the viewport" test below confirms that
-// baseline). What the harness CAN lock in is the fix's WIRING — that the body
-// registers a system-fonts listener and a WidgetsBindingObserver while mounted
-// and tears both down on dispose, so a font-load / metrics change on device
-// forces the re-measure. The on-emulator integration test
-// (`terminal_layout_fill_test.dart`) is the real device gate for the re-fit.
+// baseline) and a re-measure is a no-op for the rendered size. What the harness
+// CAN lock in is the fix's WIRING — that the body (a) registers a system-fonts
+// listener + WidgetsBindingObserver and tears them down on dispose (#641), and
+// (b) ARMS the connect re-measure burst on the shell-ready transition with NO
+// fonts/metrics event (#647, asserted via `debugConnectRemeasureArmCount`). The
+// on-emulator integration test (`terminal_layout_fill_test.dart`) plus owner
+// cold-start validation are the real device gate for the actual re-fit.
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -28,7 +37,63 @@ import 'package:mobissh/ui/terminal_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xterm/xterm.dart';
 
+import 'package:mobissh/ssh/ssh_shell.dart';
+
 import '../support/fake_ssh_shell_transport.dart';
+
+/// Setup variant that drives the session to the SHELL-READY state by overriding
+/// `sshShellProvider` with a real [SshShell] attached to the session's
+/// `Terminal` — the same wiring production does once a session reaches
+/// `connected`. This is the precise "first connect / shell-ready" transition
+/// that #647's fix must hook to force a re-measure, WITHOUT a keyboard or font
+/// event. `attach` binds `Terminal.onResize` → `transport.resize`, so any
+/// re-measure that changes cols/rows reaches [transport]. We attach AFTER the
+/// first frame (post-frame) so the TerminalView has laid out and the terminal
+/// is at its filled size when the shell connects — matching the device order
+/// (layout first, then connect).
+Future<({SessionEntry entry, ProviderContainer container})> _setupConnected(
+  WidgetTester tester,
+  FakeSshShellTransport transport,
+) async {
+  final pair = InMemoryGatewayPair();
+  addTearDown(() async => pair.dispose());
+  late final SessionEntry entry;
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      // Resolve the shell as "ready" so the body sees the connect transition.
+      sshShellProvider.overrideWith((ref, sessionId) async {
+        final shell = SshShell(transport);
+        shell.attach(entry.terminal);
+        ref.onDispose(shell.dispose);
+        return shell;
+      }),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  entry = container
+      .read(sessionsProvider.notifier)
+      .addOrActivate(
+        const SshConnectParams(
+          host: 'h',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: TerminalScreen()),
+    ),
+  );
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  return (entry: entry, container: container);
+}
 
 Future<({SessionEntry entry, ProviderContainer container})> _setup(
   WidgetTester tester,
@@ -85,6 +150,7 @@ Future<void> _fireFontsChange(WidgetTester tester) async {
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
+    debugConnectRemeasureArmCount = 0;
   });
 
   group('terminal re-measure (#625/#600)', () {
@@ -102,6 +168,16 @@ void main() {
           s.entry.terminal.viewHeight,
           greaterThan(24),
           reason: 'terminal did not fill the viewport on first layout (#625)',
+        );
+        // Guard for #647: `_setup` never drives the session to shell-ready, so
+        // the connect re-measure burst must NOT have been armed. This makes the
+        // connect-test's arm-count assertion meaningful — it proves the burst
+        // fires on the connect transition, not merely on mount.
+        expect(
+          debugConnectRemeasureArmCount,
+          0,
+          reason:
+              'connect re-measure burst armed without a shell-ready session',
         );
       },
     );
@@ -147,6 +223,88 @@ void main() {
         }
 
         expect(s.entry.terminal.viewHeight, fitted);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'first connect schedules a re-measure burst WITHOUT any fonts/metrics '
+      'event (#647): the body re-runs xterm layout on the connect transition, '
+      'so the terminal fills + the PTY size is sent without a keyboard toggle',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        // _setupConnected drives the session to shell-ready (the connect
+        // transition) and pumps the initial frames. It dispatches NO
+        // fonts-change and NO metrics event — mirroring the device's first
+        // connect: bundled font already cached (no systemFonts event) and no
+        // viewport change (no didChangeMetrics). On device the #641 remeasure
+        // therefore never fired on first connect, so the stale first-frame
+        // measure persisted until the user tapped to show the keyboard. #647
+        // hooks the connect transition to fire the same remeasure burst.
+        //
+        // HONEST LIMITATION: a headless harness CANNOT reproduce the device's
+        // stale-cell-size race — test fonts are preloaded, so xterm always
+        // measures correctly on the first layout and a re-measure is a no-op
+        // for the rendered size. What this test LOCKS IN is the WIRING the
+        // device fix depends on: that the connect transition (a) drives the
+        // terminal to its filled size with no viewport/font event, (b) re-runs
+        // layout repeatedly across the burst window (so a settled-font frame
+        // gets a re-fit on device), and (c) never throws. The on-emulator
+        // `terminal_layout_fill_test.dart` is the device gate; the owner does
+        // the final cold-start → connect validation.
+        final s = await _setupConnected(tester, transport);
+
+        // (a) The connect/shell-ready transition armed the #647 re-measure
+        //     burst — with NO fonts-change and NO metrics event dispatched.
+        //     This is the precise behavior the device fix adds: the same
+        //     re-measure the keyboard-show triggered, now fired by connect.
+        expect(
+          debugConnectRemeasureArmCount,
+          greaterThanOrEqualTo(1),
+          reason:
+              'the connect/shell-ready transition did NOT arm the #647 '
+              're-measure burst (no keyboard/font event fired it) — the '
+              'terminal would stay stale until a keyboard toggle on device',
+        );
+
+        // (b) The terminal filled (more than the default 24 rows) on the
+        //     connect path alone — no keyboard toggle, no font event — and the
+        //     shell-attach resize carried that size to the transport.
+        final filled = s.entry.terminal.viewHeight;
+        expect(
+          filled,
+          greaterThan(24),
+          reason:
+              'terminal did not fill on connect without a viewport/font event '
+              '(#647) — only $filled rows',
+        );
+        expect(
+          transport.resizes,
+          isNotEmpty,
+          reason: 'no PTY resize reached the transport on first connect (#647)',
+        );
+        expect(
+          transport.resizes.last.rows,
+          filled,
+          reason:
+              'the last PTY resize (${transport.resizes.last}) disagrees with '
+              'the filled $filled rows on connect (#647)',
+        );
+
+        // (c) The connect burst re-runs xterm layout across a delayed window
+        //     (120/350/700ms) WITHOUT any fonts/metrics event. Advance across
+        //     the whole burst window; no fonts/metrics event is dispatched, so
+        //     ONLY the #647 connect burst can act here. The burst must not
+        //     throw and must not regress the fill (idempotent re-measure).
+        for (var i = 0; i < 20; i++) {
+          await tester.pump(const Duration(milliseconds: 50));
+        }
+
+        // Still filled, PTY size still aligned, no exceptions — the burst is
+        // idempotent and safe (it must not regress the fill or throw).
+        expect(s.entry.terminal.viewHeight, filled);
+        expect(transport.resizes.last.rows, filled);
         expect(tester.takeException(), isNull);
       },
     );


### PR DESCRIPTION
Bot fix for #647. Closes #647.