### PR TITLE
fix(#650): keybar Enter key uses Material icon, not tofu glyph

### DIFF
--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -1,7 +1,7 @@
 // Bottom keybar widget (#518).
 //
 // Mirrors the PWA's key bar (Esc / Tab / / / - / | / ^C / ^Z / ^D, plus
-// arrows / Home / End / ↵ / Paste). Pressing a key forwards the configured
+// arrows / Home / End / Enter / Paste). Pressing a key forwards the configured
 // byte sequence to the active session's terminal (xterm.dart) via
 // `Terminal.textInput`, which routes through the standard keystroke pipe
 // (see `keystroke_pipe_widget_test.dart`).
@@ -115,7 +115,16 @@ const List<KeybarKey> kDefaultKeybarKeys = [
   KeybarKey(id: 'keyEnd', label: 'End', sequence: '\x1b[F'),
   KeybarKey(id: 'keyPgUp', label: 'PgUp', sequence: '\x1b[5~'),
   KeybarKey(id: 'keyPgDn', label: 'PgDn', sequence: '\x1b[6~'),
-  KeybarKey(id: 'keyEnter', label: '↵', sequence: '\r'),
+  // #650: was `label: '↵'` (U+21B5), which renders as tofu in the bundled
+  // font — the SAME issue the arrows had. Use the monochrome Material icon
+  // path (Icons.keyboard_return) so it's clearly an Enter/Return key. The tap
+  // wiring still forwards `sequence` ('\r') regardless of the icon path.
+  KeybarKey(
+    id: 'keyEnter',
+    label: 'Enter',
+    sequence: '\r',
+    icon: Icons.keyboard_return,
+  ),
   KeybarKey(
     id: 'keyPaste',
     label: 'Paste',

--- a/native/test/widget/keybar_test.dart
+++ b/native/test/widget/keybar_test.dart
@@ -89,6 +89,39 @@ void main() {
       expect(ids, contains('keyEnd'));
     });
 
+    test(
+      'keyEnter uses the monochrome icon path, not a raw unicode glyph (#650)',
+      () {
+        // #650: the Enter key was `label: '↵'` (U+21B5), which renders as a
+        // tofu box in the bundled font — the SAME problem the arrows had. It
+        // must use the monochrome Material icon path like the arrows do.
+        final enter = kDefaultKeybarKeys.firstWhere((k) => k.id == 'keyEnter');
+        expect(
+          enter.icon,
+          isNotNull,
+          reason:
+              'keyEnter must render as a theme-tinted Material icon '
+              '(Icons.keyboard_return), not a unicode glyph that renders as '
+              'tofu in the bundled font',
+        );
+        // The raw glyph must not survive as a visible text label.
+        expect(
+          enter.label,
+          isNot(equals('↵')),
+          reason:
+              'keyEnter must not keep the unrecognized ↵ glyph as its label',
+        );
+      },
+    );
+
+    test('keyEnter still sends a carriage return (CR) (#650)', () {
+      // The glyph was the whole problem — the tap wiring forwards
+      // keyData.sequence regardless of the icon path, so Enter must still
+      // carry '\r'.
+      final enter = kDefaultKeybarKeys.firstWhere((k) => k.id == 'keyEnter');
+      expect(enter.sequence, equals('\r'));
+    });
+
     test('all four arrows use the monochrome icon path (icon != null)', () {
       final arrows = kDefaultKeybarKeys
           .where(


### PR DESCRIPTION
## Summary
The native keybar key after PgDn (`keyEnter`) used `label: '↵'` (U+21B5), which
renders as an unrecognized box in the bundled font — the same tofu problem the
arrow keys had (which is why the arrows use the Material icon path). The owner
reported it as unrecognizable and "doing nothing".

## Fix
- `native/lib/ui/keybar.dart`: `keyEnter` now uses the existing `KeybarKey.icon`
  path with `Icons.keyboard_return` (monochrome / theme-tinted), label `Enter`.
- The tap wiring (`_KeybarButton._onTap`) already forwards `keyData.sequence`
  for every non-paste key regardless of icon-vs-text path, so the icon-path
  button still sends `\r`. The glyph was the whole problem, not a wiring bug —
  "does nothing" was a misread of the tofu box.

## Tests (TDD)
- `native/test/widget/keybar_test.dart`:
  - `keyEnter uses the monochrome icon path, not a raw unicode glyph (#650)` —
    RED before fix (icon was null), GREEN after.
  - `keyEnter still sends a carriage return (CR) (#650)` — confirms the icon
    path keeps the `\r` sequence.
- Data-level assertions (the byte-to-terminal tap tests in this file are
  pre-existing `@skip` due to a Material-ripple pump hang).
- `flutter analyze`: clean. Full native unit suite (`--exclude-tags
  integration`): 443 pass, 5 skip.

## Scope
Touches only `native/lib/ui/keybar.dart` and its test. Visual change —
device validation by the orchestrator.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)