### PR TITLE
feat(#651,#653): center session title + per-session profile color swatch

### DIFF
--- a/native/lib/state/ui_prefs_providers.dart
+++ b/native/lib/state/ui_prefs_providers.dart
@@ -779,19 +779,35 @@ final activeTerminalThemeProvider = Provider<NamedTerminalTheme>((ref) {
 // global notifiers — that's the knob worth remembering across launches.
 
 /// Immutable per-session terminal appearance: which palette index + the font
-/// size in logical px. Both are clamped/validated by the notifier before they
-/// land here.
+/// size in logical px + the profile color (#653). Index/size are
+/// clamped/validated by the notifier; [color] is null when the session's
+/// profile carried no explicit color (the swatch then falls back to the theme
+/// accent — see `_SessionBar`).
 @immutable
 class SessionAppearance {
-  const SessionAppearance({required this.themeIndex, required this.fontSize});
+  const SessionAppearance({
+    required this.themeIndex,
+    required this.fontSize,
+    this.color,
+  });
 
   final int themeIndex;
   final double fontSize;
 
-  SessionAppearance copyWith({int? themeIndex, double? fontSize}) {
+  /// The session's profile color (#653), mirroring the PWA `session-dot`
+  /// identity color. Null when the profile has no explicit color; the swatch
+  /// then derives a fallback from the session's terminal theme accent.
+  final Color? color;
+
+  SessionAppearance copyWith({
+    int? themeIndex,
+    double? fontSize,
+    Color? color,
+  }) {
     return SessionAppearance(
       themeIndex: themeIndex ?? this.themeIndex,
       fontSize: fontSize ?? this.fontSize,
+      color: color ?? this.color,
     );
   }
 
@@ -799,10 +815,27 @@ class SessionAppearance {
   bool operator ==(Object other) =>
       other is SessionAppearance &&
       other.themeIndex == themeIndex &&
-      other.fontSize == fontSize;
+      other.fontSize == fontSize &&
+      other.color == color;
 
   @override
-  int get hashCode => Object.hash(themeIndex, fontSize);
+  int get hashCode => Object.hash(themeIndex, fontSize, color);
+}
+
+/// Parse a PWA-style profile color hex (#653) into a [Color]. Accepts
+/// `#RRGGBB`, `#AARRGGBB`, or those forms without a leading `#`. Returns null
+/// for empty/invalid input so the caller can fall back (PWA parity: the swatch
+/// must always render a sensible color, never blank).
+Color? colorFromHex(String? hex) {
+  if (hex == null) return null;
+  var s = hex.trim();
+  if (s.isEmpty) return null;
+  if (s.startsWith('#')) s = s.substring(1);
+  if (s.length != 6 && s.length != 8) return null;
+  final v = int.tryParse(s, radix: 16);
+  if (v == null) return null;
+  // 6 digits → assume fully opaque; 8 digits → caller-specified alpha.
+  return s.length == 6 ? Color(0xFF000000 | v) : Color(v);
 }
 
 /// Owns the per-session appearance map (sessionId → [SessionAppearance]).
@@ -863,6 +896,13 @@ class SessionAppearanceNotifier
   void adjustFontSize(String sessionId, double delta) {
     setFontSize(sessionId, appearanceOf(sessionId).fontSize + delta);
   }
+
+  /// Set [sessionId]'s profile color (#653). Affects only this session —
+  /// sibling sessions and the global default are untouched. Seeded on connect
+  /// from the profile's saved color (mirrors [setTheme]/[setFontSize]).
+  void setColor(String sessionId, Color color) {
+    _put(sessionId, appearanceOf(sessionId).copyWith(color: color));
+  }
 }
 
 final sessionAppearanceProvider =
@@ -902,6 +942,18 @@ final sessionFontSizeProvider = Provider.family<double, String>((
       .read(sessionAppearanceProvider.notifier)
       .appearanceOf(sessionId)
       .fontSize;
+});
+
+/// Per-session profile color (#653). The explicit color seeded from the
+/// profile on connect, or null when the profile had none — callers fall back
+/// to the session's terminal-theme accent so the swatch always renders a
+/// sensible color. Rebuilds when the session's appearance entry changes.
+final sessionColorProvider = Provider.family<Color?, String>((ref, sessionId) {
+  ref.watch(sessionAppearanceProvider);
+  return ref
+      .read(sessionAppearanceProvider.notifier)
+      .appearanceOf(sessionId)
+      .color;
 });
 
 /// The [NamedTerminalTheme] for a given session, guarding a stale index.

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -174,6 +174,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     required String initialCommand,
     String? themeName,
     double? fontSize,
+    String? colorHex,
   }) async {
     // Captured before the async gap so we can pop a pushed "New session" route
     // after dispatching connect without touching `context` post-await.
@@ -215,6 +216,18 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
           'ui.chooser',
           'applied profile fontSize $fontSize for ${entry.id}',
         );
+      }
+      // #653: seed THIS session's profile color from the profile's saved color
+      // (mirrors the theme/font seeds above). Per-session, keyed by the new
+      // session's id — NOT global. Only when the profile carries a valid color;
+      // otherwise the session bar's swatch falls back to the theme accent. The
+      // SAME color identifies the SAME profile everywhere (PWA `session-dot`).
+      final seededColor = colorFromHex(colorHex);
+      if (seededColor != null) {
+        ref
+            .read(sessionAppearanceProvider.notifier)
+            .setColor(entry.id, seededColor);
+        ctrace('ui.chooser', 'applied profile color $colorHex for ${entry.id}');
       }
       // Arm the run-on-connect command (#558) BEFORE dispatching connect, so
       // the one-shot listener is attached before the task side can emit
@@ -358,6 +371,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       initialCommand: profile.initialCommand ?? '',
       themeName: profile.theme,
       fontSize: profile.fontSize,
+      colorHex: profile.color,
     );
   }
 

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -100,6 +100,18 @@ class TerminalScreen extends ConsumerWidget {
     final activeEntry = sessions.active ?? entries.first;
     final activeIndex = entries.indexWhere((e) => e.id == activeEntry.id);
 
+    // #653: resolve the active session's swatch color. Prefer the profile's
+    // explicit color (seeded on connect); fall back to the session's terminal
+    // theme accent (the palette cursor — mirrors the PWA `profileColor()`
+    // theme-accent fallback). The cursor is always set, so the swatch is never
+    // blank.
+    final activePalette = ref.watch(
+      sessionTerminalThemeProvider(activeEntry.id),
+    );
+    final swatchColor =
+        ref.watch(sessionColorProvider(activeEntry.id)) ??
+        activePalette.theme.cursor;
+
     // No top AppBar (#566 follow-up): terminal real estate is at a premium and
     // the PWA is a full-screen terminal with bottom-only chrome. The session
     // label + menu + disconnect all live on the bottom session bar; the
@@ -139,6 +151,7 @@ class TerminalScreen extends ConsumerWidget {
                 _SessionBar(
                   label: activeEntry.label,
                   sessionCount: entries.length,
+                  swatchColor: swatchColor,
                   // Swipe left → next session, swipe right → previous, wrapping
                   // around the session ring (#568). No-op with a single session.
                   onSwipe: (delta) {
@@ -197,6 +210,7 @@ class _SessionBar extends StatefulWidget {
   const _SessionBar({
     required this.label,
     required this.sessionCount,
+    required this.swatchColor,
     required this.onSwipe,
     required this.composeOn,
     required this.onToggleCompose,
@@ -204,6 +218,12 @@ class _SessionBar extends StatefulWidget {
 
   final String label;
   final int sessionCount;
+
+  /// #653: the active session's profile color, shown as a small filled-circle
+  /// swatch tag immediately left of the (centered) title. Resolved by the
+  /// parent — the profile color when set, else the theme accent — so it is
+  /// always a sensible color (never blank). Mirrors the PWA `session-dot`.
+  final Color swatchColor;
 
   /// Called when a horizontal swipe crosses the threshold. `delta` is `+1` for
   /// a left swipe (next session) and `-1` for a right swipe (previous).
@@ -253,80 +273,130 @@ class _SessionBarState extends State<_SessionBar> {
     );
   }
 
+  /// Logical-px horizontal inset reserved on each side of the centered title
+  /// layer (#651) so the title — centered over the FULL bar width — clears the
+  /// left menu icon/count and the right compose toggle and never collides with
+  /// them. Symmetric so the title's center stays on the bar's center.
+  static const double _titleSideInset = 48;
+
   Widget _buildBar(BuildContext context, ThemeData theme) {
+    // #651/#653: the title (+ #653 swatch tag) is CENTERED across the full bar
+    // width via a Stack overlay rather than sitting flush-left after the menu
+    // icon (where it collided with the menu). The interactive controls — the
+    // menu/swipe InkWell (left, full-width tap target) and the compose toggle
+    // (right) — form the base layer; the centered title layer is wrapped in
+    // IgnorePointer so taps fall through to the InkWell beneath it.
     return Material(
       key: const Key('session-bar'),
       color: theme.colorScheme.surfaceContainerHighest,
-      child: Row(
+      child: Stack(
+        alignment: Alignment.center,
         children: [
-          Expanded(
-            child: InkWell(
-              // `session-menu-button` is retained as the stable terminal-screen-
-              // mounted marker that smoke/integration tests poll for; it moved
-              // from the AppBar to the bottom bar. `session-bar-open-menu` is the
-              // screenshot/test-addressable name for the menu affordance.
-              key: const Key('session-bar-open-menu'),
-              onTap: () {
-                // Suppress the tap that fires at the tail of a swipe so a
-                // swipe-to-switch doesn't also pop the session menu (#568).
-                if (_swipeOccurred) {
-                  _swipeOccurred = false;
-                  return;
-                }
-                // Pass the bar's own height so the menu panel floats ABOVE the
-                // bar (not over it) — the last menu row no longer lands on the
-                // trigger, and a second tap on the trigger dismisses via the
-                // overlay barrier (owner 2026-06-01). `context` here is the
-                // _SessionBar element, so `context.size` is the bar's height.
-                showSessionMenu(
-                  context,
-                  bottomReserve: context.size?.height ?? 0,
-                );
-              },
-              child: Padding(
-                // #615: vertical padding trimmed (was 8) to shrink the bar
-                // ~25%. Pairs with the smaller compose toggle icon below.
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 5,
-                ),
-                child: Row(
-                  key: const Key('session-menu-button'),
-                  children: [
-                    // #607: hamburger with the session-count badge folded onto
-                    // it (count moved LEFT). No expand_less up-arrow — session
-                    // switching is left/right SWIPE (#568), so an "expand"
-                    // affordance was misleading.
-                    _MenuIconWithCount(count: widget.sessionCount),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        widget.label,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodyMedium,
-                      ),
+          // Base layer: the menu/swipe tap target + the compose toggle.
+          Row(
+            children: [
+              Expanded(
+                child: InkWell(
+                  // `session-menu-button` is retained as the stable terminal-
+                  // screen-mounted marker smoke/integration tests poll for; it
+                  // moved from the AppBar to the bottom bar. `session-bar-open-
+                  // menu` is the screenshot/test-addressable name for the menu
+                  // affordance.
+                  key: const Key('session-bar-open-menu'),
+                  onTap: () {
+                    // Suppress the tap that fires at the tail of a swipe so a
+                    // swipe-to-switch doesn't also pop the session menu (#568).
+                    if (_swipeOccurred) {
+                      _swipeOccurred = false;
+                      return;
+                    }
+                    // Pass the bar's own height so the menu panel floats ABOVE
+                    // the bar (not over it) — the last menu row no longer lands
+                    // on the trigger, and a second tap on the trigger dismisses
+                    // via the overlay barrier (owner 2026-06-01). `context` here
+                    // is the _SessionBar element, so `context.size` is the bar's
+                    // height.
+                    showSessionMenu(
+                      context,
+                      bottomReserve: context.size?.height ?? 0,
+                    );
+                  },
+                  child: Padding(
+                    // #615: vertical padding trimmed (was 8) to shrink the bar
+                    // ~25%. Pairs with the smaller compose toggle icon below.
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 5,
                     ),
-                  ],
+                    child: Row(
+                      key: const Key('session-menu-button'),
+                      children: [
+                        // #607: hamburger with the session-count badge folded
+                        // onto it (count moved LEFT). No expand_less up-arrow —
+                        // session switching is left/right SWIPE (#568), so an
+                        // "expand" affordance was misleading. The title moved
+                        // OUT of this row into the centered overlay (#651).
+                        _MenuIconWithCount(count: widget.sessionCount),
+                      ],
+                    ),
+                  ),
                 ),
               ),
-            ),
+              // #607: compose-bar toggle replaces the disconnect button.
+              // Reflects on/off; disconnect now lives in the session menu.
+              IconButton(
+                key: const Key('session-bar-compose-toggle'),
+                tooltip: widget.composeOn
+                    ? 'Hide compose bar'
+                    : 'Compose (swipe / voice)',
+                isSelected: widget.composeOn,
+                color: widget.composeOn ? theme.colorScheme.primary : null,
+                // #615: tighter visual density so the IconButton's default 48px
+                // tap box doesn't set the bar height; row padding drives it.
+                visualDensity: VisualDensity.compact,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 28),
+                padding: EdgeInsets.zero,
+                icon: const Icon(Icons.edit_note_outlined, size: 18),
+                onPressed: widget.onToggleCompose,
+              ),
+            ],
           ),
-          // #607: compose-bar toggle replaces the disconnect button. Reflects
-          // on/off; disconnect now lives in the session menu.
-          IconButton(
-            key: const Key('session-bar-compose-toggle'),
-            tooltip: widget.composeOn
-                ? 'Hide compose bar'
-                : 'Compose (swipe / voice)',
-            isSelected: widget.composeOn,
-            color: widget.composeOn ? theme.colorScheme.primary : null,
-            // #615: tighter visual density so the IconButton's default 48px
-            // tap box doesn't set the bar height; the row padding now drives it.
-            visualDensity: VisualDensity.compact,
-            constraints: const BoxConstraints(minWidth: 36, minHeight: 28),
-            padding: EdgeInsets.zero,
-            icon: const Icon(Icons.edit_note_outlined, size: 18),
-            onPressed: widget.onToggleCompose,
+          // Centered title layer (#651) + profile color swatch tag (#653).
+          // IgnorePointer so the swipe/tap on the bar still reaches the base
+          // InkWell. Padded symmetrically so the title centers over the whole
+          // bar yet clears both controls.
+          IgnorePointer(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: _titleSideInset),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  // #653: profile color swatch — a small filled circle tag
+                  // immediately left of the title. Color resolved by the
+                  // parent (profile color, else theme accent). Mirrors the PWA
+                  // `session-dot`.
+                  Container(
+                    key: const Key('session-bar-swatch'),
+                    width: 10,
+                    height: 10,
+                    decoration: BoxDecoration(
+                      color: widget.swatchColor,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      widget.label,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
         ],
       ),

--- a/native/test/widget/session_bar_swatch_test.dart
+++ b/native/test/widget/session_bar_swatch_test.dart
@@ -1,0 +1,164 @@
+// Widget tests for the centered session title (#651) + per-session profile
+// color swatch tag (#653) on the bottom `_SessionBar`.
+//
+// Mirrors the PWA: the session bar shows a colored `session-dot` swatch next to
+// the (now centered) session label; the SAME color identifies the SAME profile
+// everywhere. The swatch color is the profile color when set, else the session's
+// terminal-theme accent — it must ALWAYS render a sensible color (never blank).
+//
+// Harness mirrors terminal_remeasure_test.dart: an InMemoryGatewayPair + a real
+// SshShell attached to the session terminal so TerminalScreen mounts the bar.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_shell.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_providers.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/ui/terminal_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../support/fake_ssh_shell_transport.dart';
+
+/// Mount TerminalScreen with one shell-ready session. Returns the container +
+/// the session entry so a test can seed per-session prefs (e.g. the color).
+Future<({SessionEntry entry, ProviderContainer container})> _mount(
+  WidgetTester tester,
+  FakeSshShellTransport transport,
+) async {
+  final pair = InMemoryGatewayPair();
+  addTearDown(() async => pair.dispose());
+  late final SessionEntry entry;
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      sshShellProvider.overrideWith((ref, sessionId) async {
+        final shell = SshShell(transport);
+        shell.attach(entry.terminal);
+        ref.onDispose(shell.dispose);
+        return shell;
+      }),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  entry = container
+      .read(sessionsProvider.notifier)
+      .addOrActivate(
+        const SshConnectParams(
+          host: 'h',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+        title: 'My Server',
+      );
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: TerminalScreen()),
+    ),
+  );
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  return (entry: entry, container: container);
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('session bar — centered title (#651) + color swatch (#653)', () {
+    testWidgets('the title is horizontally centered in the bar', (
+      tester,
+    ) async {
+      final transport = FakeSshShellTransport();
+      addTearDown(transport.close);
+      await _mount(tester, transport);
+
+      final barCenter = tester.getCenter(find.byKey(const Key('session-bar')));
+      // The label text sits in the centered overlay layer.
+      final titleCenter = tester.getCenter(find.text('My Server'));
+
+      // The title's center x must track the bar's center x within a small
+      // tolerance (the swatch sits just left of the text, so the swatch+title
+      // group is centered — the text itself is a hair right of dead-center).
+      expect(
+        (titleCenter.dx - barCenter.dx).abs(),
+        lessThan(24),
+        reason:
+            'session title is not centered over the bar — titleCenter.dx='
+            '${titleCenter.dx}, barCenter.dx=${barCenter.dx}',
+      );
+    });
+
+    testWidgets('a color swatch renders with the seeded profile color', (
+      tester,
+    ) async {
+      final transport = FakeSshShellTransport();
+      addTearDown(transport.close);
+      final s = await _mount(tester, transport);
+
+      // Seed an explicit per-session profile color (the connect path's
+      // setColor seed). #FF8800 → opaque orange.
+      const seeded = Color(0xFFFF8800);
+      s.container
+          .read(sessionAppearanceProvider.notifier)
+          .setColor(s.entry.id, seeded);
+      await tester.pump();
+
+      final swatch = tester.widget<Container>(
+        find.byKey(const Key('session-bar-swatch')),
+      );
+      final decoration = swatch.decoration as BoxDecoration;
+      expect(decoration.color, seeded);
+      expect(decoration.shape, BoxShape.circle);
+    });
+
+    testWidgets(
+      'the swatch falls back to the theme accent when no profile color is set',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final s = await _mount(tester, transport);
+
+        // No setColor call → sessionColorProvider yields null → the bar falls
+        // back to the session's terminal-theme cursor accent. The swatch must
+        // still render a non-null, sensible color (never blank).
+        final palette = s.container.read(
+          sessionTerminalThemeProvider(s.entry.id),
+        );
+        final swatch = tester.widget<Container>(
+          find.byKey(const Key('session-bar-swatch')),
+        );
+        final decoration = swatch.decoration as BoxDecoration;
+        expect(decoration.color, isNotNull);
+        expect(decoration.color, palette.theme.cursor);
+      },
+    );
+  });
+
+  group('colorFromHex (#653)', () {
+    test('parses #RRGGBB as opaque', () {
+      expect(colorFromHex('#00ff88'), const Color(0xFF00FF88));
+      expect(colorFromHex('00ff88'), const Color(0xFF00FF88));
+    });
+    test('parses #AARRGGBB verbatim', () {
+      expect(colorFromHex('#8000ff88'), const Color(0x8000FF88));
+    });
+    test('returns null for empty/invalid', () {
+      expect(colorFromHex(null), isNull);
+      expect(colorFromHex(''), isNull);
+      expect(colorFromHex('  '), isNull);
+      expect(colorFromHex('#zzz'), isNull);
+      expect(colorFromHex('#12345'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #651
Closes #653

Mirrors the PWA session bar in the native app's `_SessionBar` (terminal_screen.dart). The PWA is the spec — see `src/modules/profiles.ts` `profileColor()` + the `session-dot` swatch.

## #651 — center the session title
The title was flush-left after the menu icon (inside the menu Row), colliding with the menu. It now lives in an `IgnorePointer`'d centered overlay layer of a `Stack`:

- Base layer: the interactive controls — the menu/swipe `InkWell` (left, full-width tap target) and the compose toggle (right).
- Overlay layer: the swatch + title, centered over the FULL bar width with a symmetric side inset so the title's center stays on the bar's center while clearing both controls.

`TextOverflow.ellipsis` preserved. All existing keys (`session-bar`, `session-bar-open-menu`, `session-menu-button`, `session-bar-compose-toggle`, `_MenuIconWithCount`) and the #568 swipe / tap-to-open-menu behavior are intact (taps fall through the `IgnorePointer` to the base `InkWell`).

## #653 — per-profile color swatch
A 10px filled-circle swatch (`Key('session-bar-swatch')`) sits immediately left of the title — the PWA `session-dot` identity color. Color = the active session's profile color when set, else the session's terminal-theme cursor accent (never blank), mirroring `profileColor()`'s theme-accent fallback.

Per-session color follows the #571 theme / #640 fontSize precedent: `SessionAppearance` gains an optional `Color`, with `setColor` + `sessionColorProvider` (`Provider.family<Color?, String>`), seeded on connect in `connect_form.dart` from `profile.color` (parsed via `colorFromHex`).

## Scope
The #666 terminal-fill logic is untouched. Changes limited to `_SessionBar` + its parent construction (terminal_screen.dart), `ui_prefs_providers.dart`, `connect_form.dart`, plus a widget test.

## Tests
`native/test/widget/session_bar_swatch_test.dart`: title horizontally centered in the bar, swatch renders the seeded profile color, swatch falls back to the theme accent when the profile color is null, and `colorFromHex` parsing (RRGGBB / AARRGGBB / invalid). Native fast gate green (analyze clean, 472 + 6 new tests pass).

Device validation (visual centering / swatch on real hardware) is the owner's gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)