### PR TITLE
feat(#667): move all toasts to the top (shared top-toast helper)

### DIFF
--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -39,6 +39,7 @@ import 'host_key_dialog.dart';
 import 'import_profiles_dialog.dart';
 import 'profile_editor.dart';
 import 'profile_list.dart';
+import 'top_toast.dart';
 
 class ConnectForm extends ConsumerStatefulWidget {
   const ConnectForm({super.key});
@@ -334,11 +335,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
         'ui.chooser',
         'connectFromProfile ${profile.host}: no stored creds → editor',
       );
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('No saved credentials — enter them to connect.'),
-        ),
-      );
+      showTopToast(context, 'No saved credentials — enter them to connect.');
       await _editProfile(profile);
       return;
     }
@@ -403,7 +400,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     final msg = parts.isNotEmpty
         ? 'Imported ${parts.join(', ')}'
         : 'No profiles imported.';
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+    showTopToast(context, msg);
   }
 
   Future<void> _handleHostKeyPrompt(PendingHostKey pending) async {

--- a/native/lib/ui/diagnostics_section.dart
+++ b/native/lib/ui/diagnostics_section.dart
@@ -14,6 +14,7 @@ import '../diagnostics/connect_trace.dart';
 import '../diagnostics/crash_reporter.dart';
 import '../diagnostics/feedback_bundle.dart';
 import 'connection_audit.dart';
+import 'top_toast.dart';
 
 class DiagnosticsSection extends StatefulWidget {
   /// Allows tests to inject a fake share function so we don't open the real
@@ -66,9 +67,7 @@ class _DiagnosticsSectionState extends State<DiagnosticsSection> {
       );
     } catch (err) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Share failed: $err')));
+      showTopToast(context, 'Share failed: $err');
     }
   }
 
@@ -113,9 +112,7 @@ class _DiagnosticsSectionState extends State<DiagnosticsSection> {
       );
     } catch (err) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Share feedback failed: $err')));
+      showTopToast(context, 'Share feedback failed: $err');
     }
   }
 
@@ -126,15 +123,11 @@ class _DiagnosticsSectionState extends State<DiagnosticsSection> {
     } catch (err) {
       summary = const UploadSummary();
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Upload failed: $err')));
+        showTopToast(context, 'Upload failed: $err');
       }
     }
     if (mounted) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(summary.toString())));
+      showTopToast(context, summary.toString());
     }
     _refresh();
   }
@@ -271,11 +264,7 @@ class _ConnectLogTile extends StatelessWidget {
                                   ClipboardData(text: lines.join('\n')),
                                 );
                                 if (!context.mounted) return;
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text('Connect log copied.'),
-                                  ),
-                                );
+                                showTopToast(context, 'Connect log copied.');
                               },
                         icon: const Icon(Icons.copy),
                         label: const Text('Copy'),

--- a/native/lib/ui/feedback_overlay.dart
+++ b/native/lib/ui/feedback_overlay.dart
@@ -28,6 +28,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import 'package:mobissh/diagnostics/connect_trace.dart';
 import 'package:mobissh/diagnostics/feedback_bundle.dart' show scrubSecrets;
+import 'package:mobissh/ui/top_toast.dart';
 
 /// Prod endpoint that ingests bug reports (same one the web form posts to).
 /// The orchestrator's watcher polls the files this endpoint writes.
@@ -286,16 +287,17 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       connectLog: connectLog,
     );
     final ok = await widget.submitter.submit(payload);
-    // Confirmation via the app's ScaffoldMessenger key (the own context can't
-    // resolve a messenger either). This is the "OK response" the owner expects.
-    widget.messengerKey.currentState?.showSnackBar(
-      SnackBar(
-        content: Text(
-          ok ? 'Feedback sent — thanks!' : 'Send failed — try again.',
-        ),
-        duration: const Duration(seconds: 2),
-      ),
-    );
+    // Confirmation as a TOP toast (#667) so it doesn't occlude the bottom
+    // controls. This overlay sits ABOVE the Navigator (MaterialApp.builder, the
+    // #664 fix) and has no ScaffoldMessenger / ambient Overlay in its own
+    // context, so we hand showTopToast the navigator's OverlayState directly.
+    final overlay = widget.navigatorKey.currentState?.overlay;
+    if (overlay != null) {
+      showTopToastInOverlay(
+        overlay,
+        ok ? 'Feedback sent — thanks!' : 'Send failed — try again.',
+      );
+    }
   }
 
   @override

--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -23,6 +23,7 @@ import '../services/sftp_download.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../state/sessions.dart';
 import 'pdf_viewer_screen.dart';
+import 'top_toast.dart';
 
 /// Resolves the destination sink for downloads. Overridden in widget tests to
 /// avoid touching the real filesystem; production uses the app Downloads dir.
@@ -269,9 +270,7 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
 
   void _snack(String message) {
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    showTopToast(context, message);
   }
 
   void _onEntryTap(SftpEntry entry) {

--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -25,6 +25,7 @@ import '../diagnostics/connect_trace.dart';
 import '../state/profiles_providers.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
+import 'top_toast.dart';
 
 enum _AuthKind { password, key }
 
@@ -186,9 +187,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
     final username = _userCtrl.text.trim();
     final port = int.tryParse(_portCtrl.text.trim()) ?? 22;
     if (host.isEmpty || username.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Host and username are required')),
-      );
+      showTopToast(context, 'Host and username are required');
       return null;
     }
 

--- a/native/lib/ui/top_toast.dart
+++ b/native/lib/ui/top_toast.dart
@@ -1,0 +1,178 @@
+// Top-anchored transient toast (#667).
+//
+// All confirmations/errors previously used bottom-anchored Material SnackBars
+// (`ScaffoldMessenger.showSnackBar`), which cover the bottom controls — the
+// keybar / session bar (#653) / compose bar — on the terminal screen. That's
+// premium control real estate. [showTopToast] surfaces the same messages at the
+// TOP of the screen instead, below the status bar / notch (safe-area aware).
+//
+// Implemented as an [OverlayEntry] inserted into the ROOT overlay so it floats
+// above every route. It is theme-styled (surfaceContainerHighest / onSurface),
+// auto-dismisses after [duration], and is tap-to-dismiss. Only one toast lives
+// at a time — a new toast replaces the current one rather than stacking (so
+// nothing overflows off-screen).
+//
+// The feedback overlay (#661/#664) sits ABOVE the Navigator via
+// MaterialApp.builder and has no ScaffoldMessenger in its own context, so it
+// routes its confirmation through [showTopToastInOverlay] with the navigator's
+// own [OverlayState].
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// The single live toast, so a new toast can replace the old one (no stacking).
+OverlayEntry? _activeEntry;
+Timer? _activeTimer;
+
+/// Show a transient [message] anchored to the TOP of the screen.
+///
+/// Resolves the root [Overlay] from [context] and delegates to
+/// [showTopToastInOverlay]. Safe to call from any widget context that sits
+/// under an [Overlay] (the normal case).
+void showTopToast(
+  BuildContext context,
+  String message, {
+  Duration duration = const Duration(seconds: 2),
+}) {
+  final overlay = Overlay.maybeOf(context, rootOverlay: true);
+  if (overlay == null) return; // no overlay available — nothing to show
+  showTopToastInOverlay(overlay, message, duration: duration);
+}
+
+/// Show a transient [message] in an explicit [overlay].
+///
+/// Used by the feedback overlay (#664), which has no ScaffoldMessenger /
+/// ambient Overlay in its own builder context and must pass the navigator's
+/// [OverlayState] directly.
+void showTopToastInOverlay(
+  OverlayState overlay,
+  String message, {
+  Duration duration = const Duration(seconds: 2),
+}) {
+  // Replace any in-flight toast so we never stack off-screen.
+  _dismiss();
+
+  late final OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (context) => _TopToast(
+      message: message,
+      duration: duration,
+      onDismiss: () {
+        if (identical(_activeEntry, entry)) {
+          _dismiss();
+        }
+      },
+    ),
+  );
+  _activeEntry = entry;
+  overlay.insert(entry);
+}
+
+void _dismiss() {
+  _activeTimer?.cancel();
+  _activeTimer = null;
+  _activeEntry?.remove();
+  _activeEntry = null;
+}
+
+class _TopToast extends StatefulWidget {
+  const _TopToast({
+    required this.message,
+    required this.duration,
+    required this.onDismiss,
+  });
+
+  final String message;
+  final Duration duration;
+  final VoidCallback onDismiss;
+
+  @override
+  State<_TopToast> createState() => _TopToastState();
+}
+
+class _TopToastState extends State<_TopToast>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<double> _fade;
+  late final Animation<Offset> _slide;
+  Timer? _timer;
+  bool _leaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 220),
+    );
+    _fade = CurvedAnimation(parent: _ctrl, curve: Curves.easeOut);
+    _slide = Tween<Offset>(
+      begin: const Offset(0, -0.3),
+      end: Offset.zero,
+    ).animate(_fade);
+    _ctrl.forward();
+    _timer = Timer(widget.duration, _exit);
+  }
+
+  void _exit() {
+    if (_leaving || !mounted) return;
+    _leaving = true;
+    _timer?.cancel();
+    _ctrl.reverse().whenComplete(widget.onDismiss);
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final topInset = MediaQuery.of(context).padding.top;
+    return Positioned(
+      top: topInset + 12,
+      left: 16,
+      right: 16,
+      child: SafeArea(
+        bottom: false,
+        child: FadeTransition(
+          opacity: _fade,
+          child: SlideTransition(
+            position: _slide,
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: GestureDetector(
+                key: const Key('top-toast'),
+                onTap: _exit,
+                child: Material(
+                  color: theme.colorScheme.surfaceContainerHighest,
+                  elevation: 6,
+                  borderRadius: BorderRadius.circular(10),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 560),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                      child: Text(
+                        widget.message,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurface,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/native/test/widget/top_toast_test.dart
+++ b/native/test/widget/top_toast_test.dart
@@ -1,0 +1,88 @@
+// Top-toast helper (#667).
+//
+// All transient confirmations/errors used bottom-anchored Material SnackBars,
+// which occlude the bottom controls (keybar / session bar / compose bar) — the
+// premium control real estate on the terminal screen. [showTopToast] surfaces
+// the same messages at the TOP instead.
+//
+// Contract under test:
+//   - renders Key('top-toast') carrying the message text,
+//   - is positioned in the TOP half of the screen (center y above mid),
+//   - auto-dismisses after the given duration (pump past it → gone),
+//   - tap-to-dismiss.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/top_toast.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Pump a trivial app and fire the toast from a button so we have a real
+  // Overlay + MediaQuery in the tree.
+  Future<void> pumpAndFire(
+    WidgetTester tester,
+    String message, {
+    Duration duration = const Duration(seconds: 2),
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () =>
+                    showTopToast(context, message, duration: duration),
+                child: const Text('fire'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('fire'));
+    await tester.pump(); // insert overlay entry
+    await tester.pump(const Duration(milliseconds: 300)); // settle animation
+  }
+
+  testWidgets('renders Key(top-toast) with the message', (tester) async {
+    await pumpAndFire(tester, 'Hello toast');
+    expect(find.byKey(const Key('top-toast')), findsOneWidget);
+    expect(find.text('Hello toast'), findsOneWidget);
+  });
+
+  testWidgets('is positioned in the TOP half of the screen', (tester) async {
+    await pumpAndFire(tester, 'Top please');
+    final screenH =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    final toastCenter = tester.getCenter(find.byKey(const Key('top-toast')));
+    expect(
+      toastCenter.dy,
+      lessThan(screenH / 2),
+      reason:
+          'toast center y ${toastCenter.dy} must be above mid ${screenH / 2}',
+    );
+  });
+
+  testWidgets('auto-dismisses after the duration', (tester) async {
+    await pumpAndFire(
+      tester,
+      'Transient',
+      duration: const Duration(seconds: 1),
+    );
+    expect(find.byKey(const Key('top-toast')), findsOneWidget);
+    // Pump past duration + the exit animation.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.byKey(const Key('top-toast')), findsNothing);
+  });
+
+  testWidgets('tap dismisses early', (tester) async {
+    await pumpAndFire(tester, 'Tap me', duration: const Duration(seconds: 30));
+    expect(find.byKey(const Key('top-toast')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('top-toast')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.byKey(const Key('top-toast')), findsNothing);
+  });
+}


### PR DESCRIPTION
## #667 — move all toasts to the top

All native confirmations/errors used bottom-anchored Material `SnackBar`
(`ScaffoldMessenger.showSnackBar`). They occlude the bottom controls — keybar,
session bar (#653), compose bar — premium control real estate on the terminal
screen. This moves every transient toast to the TOP.

### Changes
- **New shared helper `native/lib/ui/top_toast.dart`:**
  - `showTopToast(context, msg, {duration})` — inserts a top-aligned
    `OverlayEntry` into the ROOT overlay
    (`Overlay.maybeOf(context, rootOverlay: true)`), safe-area aware
    (`MediaQuery.padding.top` + `SafeArea`, below the notch/status bar),
    theme-styled (`surfaceContainerHighest` / `onSurface`), slide+fade in/out,
    auto-dismiss after `duration`, tap-to-dismiss, `Key('top-toast')` for tests.
  - Single live toast (module-level guard): a new toast replaces the current one
    — never stacks off-screen.
  - `showTopToastInOverlay(OverlayState, ...)` variant for the feedback overlay
    (#664), which sits ABOVE the Navigator (`MaterialApp.builder`) and has no
    ambient `Overlay`/`ScaffoldMessenger` in its own context. It passes
    `navigatorKey.currentState?.overlay` directly.
- **Converted ALL call sites** (grep `showSnackBar` in `native/lib` → zero):
  - `file_browser_screen.dart` (`_snack`)
  - `connect_form.dart` (no-creds prompt, import summary)
  - `profile_editor.dart` (validation)
  - `diagnostics_section.dart` (share / share-feedback / upload-failed /
    upload-summary / connect-log-copied — 5)
  - `feedback_overlay.dart` (submit confirmation — routed via the overlay
    variant; the `navigatorKey`/`messengerKey` wiring from the #664 fix is left
    intact, only the confirmation routing changed)

### Tests (TDD red→green)
`native/test/widget/top_toast_test.dart`:
- renders `Key('top-toast')` with the message
- positioned in the TOP half of the screen (center y < mid)
- auto-dismisses after the duration
- tap dismisses early

### Gate
`scripts/native-fast-gate.sh`: analyze clean (No issues found), 482 tests pass.
`dart format` applied to all changed files.

Device validation (notch clearance / no keybar occlusion on real hardware) is
the owner's.

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)