### PR TITLE
feat(#573): per-session keybar visibility

### DIFF
--- a/native/integration_test/terminal_layout_fill_test.dart
+++ b/native/integration_test/terminal_layout_fill_test.dart
@@ -171,7 +171,10 @@ void main() {
       // grow (more rows) AND a fresh resize must reach the host. This is the
       // same lever every viewport change pulls (keyboard show/hide, rotation).
       spy.clear();
-      container.read(keybarVisibleProvider.notifier).toggle();
+      // #573: keybar visibility is PER-SESSION now — toggle THIS session's flag.
+      container
+          .read(sessionAppearanceProvider.notifier)
+          .toggleKeybarVisible(entry.id);
       for (var i = 0; i < 12; i++) {
         await tester.pump(const Duration(milliseconds: 250));
       }

--- a/native/lib/state/ui_prefs_providers.dart
+++ b/native/lib/state/ui_prefs_providers.dart
@@ -1,9 +1,12 @@
 // UI preference providers (#518, #552).
 //
-// `keybarVisibleProvider` controls whether the bottom keybar is rendered on
-// the terminal screen. Default: true (matches the PWA where the key bar is
-// visible whenever the keyboard is up). The toggle lives inside the session
-// menu; the setting persists across launches via SharedPreferences.
+// Keybar visibility is PER-SESSION (#573): it lives on [SessionAppearance]
+// (keyed by session id) alongside theme/font/color, NOT as a global flag.
+// Default: true ([keybarVisibleDefault]) — matches the PWA where the key bar
+// is visible. Toggling one session's keybar (session menu) leaves every other
+// session's keybar untouched. It is a pure runtime toggle (not persisted): a
+// session id is ephemeral by construction, so there is nothing to remember
+// across launches.
 //
 // #552 adds terminal-appearance preferences:
 //   - `fontSizeProvider` — terminal font size in logical px, persisted +
@@ -21,52 +24,10 @@ import 'package:xterm/xterm.dart';
 
 import 'sessions.dart';
 
-/// SharedPreferences key. Matches the keep-alive naming style.
-const String keybarVisiblePrefKey = 'mobissh.ui.keybarVisible';
-
-/// Default to visible — parity with the PWA default.
+/// Default keybar visibility — visible, for PWA parity. Used as the default
+/// for a session that hasn't toggled its keybar (#573); see [SessionAppearance]
+/// and [sessionKeybarVisibleProvider].
 const bool keybarVisibleDefault = true;
-
-/// User toggle for the bottom keybar. Synchronous value (defaulted to
-/// [keybarVisibleDefault] while we load preferences) so the UI doesn't need
-/// a loading state.
-class KeybarVisibleNotifier extends StateNotifier<bool> {
-  KeybarVisibleNotifier({Future<SharedPreferences>? prefs})
-    : _prefs = prefs ?? SharedPreferences.getInstance(),
-      super(keybarVisibleDefault) {
-    _hydrate();
-  }
-
-  final Future<SharedPreferences> _prefs;
-
-  Future<void> _hydrate() async {
-    try {
-      final prefs = await _prefs;
-      final stored = prefs.getBool(keybarVisiblePrefKey);
-      if (stored != null && stored != state) state = stored;
-    } catch (_) {
-      // SharedPreferences may be unavailable in tests without bindings; keep
-      // the default in that case.
-    }
-  }
-
-  Future<void> set(bool value) async {
-    state = value;
-    try {
-      final prefs = await _prefs;
-      await prefs.setBool(keybarVisiblePrefKey, value);
-    } catch (_) {
-      // best-effort persistence
-    }
-  }
-
-  void toggle() => set(!state);
-}
-
-final keybarVisibleProvider =
-    StateNotifierProvider<KeybarVisibleNotifier, bool>((ref) {
-      return KeybarVisibleNotifier();
-    });
 
 // ── Compose bar / IME editor (#599) ───────────────────────────────────────
 
@@ -79,7 +40,8 @@ const String composeBarVisiblePrefKey = 'mobissh.ui.composeBarVisible';
 /// own input disables composing, so swipe-typing + voice need this editable).
 const bool composeBarVisibleDefault = false;
 
-/// User toggle for the compose bar (IME editor). Mirrors [KeybarVisibleNotifier].
+/// User toggle for the compose bar (IME editor). A simple persisted global
+/// flag (the compose bar is NOT per-session — unlike the keybar, #573).
 class ComposeBarVisibleNotifier extends StateNotifier<bool> {
   ComposeBarVisibleNotifier({Future<SharedPreferences>? prefs})
     : _prefs = prefs ?? SharedPreferences.getInstance(),
@@ -789,6 +751,7 @@ class SessionAppearance {
     required this.themeIndex,
     required this.fontSize,
     this.color,
+    this.keybarVisible = keybarVisibleDefault,
   });
 
   final int themeIndex;
@@ -799,15 +762,23 @@ class SessionAppearance {
   /// then derives a fallback from the session's terminal theme accent.
   final Color? color;
 
+  /// Whether THIS session's bottom keybar is visible (#573). PER-SESSION, not
+  /// global: hiding it on one session leaves every sibling session's keybar
+  /// untouched. Defaults to [keybarVisibleDefault] (true) so a fresh session
+  /// shows the keybar (PWA parity — no behavior change for a new session).
+  final bool keybarVisible;
+
   SessionAppearance copyWith({
     int? themeIndex,
     double? fontSize,
     Color? color,
+    bool? keybarVisible,
   }) {
     return SessionAppearance(
       themeIndex: themeIndex ?? this.themeIndex,
       fontSize: fontSize ?? this.fontSize,
       color: color ?? this.color,
+      keybarVisible: keybarVisible ?? this.keybarVisible,
     );
   }
 
@@ -816,10 +787,11 @@ class SessionAppearance {
       other is SessionAppearance &&
       other.themeIndex == themeIndex &&
       other.fontSize == fontSize &&
-      other.color == color;
+      other.color == color &&
+      other.keybarVisible == keybarVisible;
 
   @override
-  int get hashCode => Object.hash(themeIndex, fontSize, color);
+  int get hashCode => Object.hash(themeIndex, fontSize, color, keybarVisible);
 }
 
 /// Parse a PWA-style profile color hex (#653) into a [Color]. Accepts
@@ -903,6 +875,19 @@ class SessionAppearanceNotifier
   void setColor(String sessionId, Color color) {
     _put(sessionId, appearanceOf(sessionId).copyWith(color: color));
   }
+
+  /// Set [sessionId]'s keybar visibility (#573). Affects only this session —
+  /// sibling sessions never change (the per-session isolation the issue is
+  /// about). Mirrors [setTheme]/[setFontSize].
+  void setKeybarVisible(String sessionId, bool visible) {
+    _put(sessionId, appearanceOf(sessionId).copyWith(keybarVisible: visible));
+  }
+
+  /// Flip [sessionId]'s keybar visibility (#573). Reads the session's CURRENT
+  /// (possibly defaulted) value and inverts it — touching only this session.
+  void toggleKeybarVisible(String sessionId) {
+    setKeybarVisible(sessionId, !appearanceOf(sessionId).keybarVisible);
+  }
 }
 
 final sessionAppearanceProvider =
@@ -956,6 +941,24 @@ final sessionColorProvider = Provider.family<Color?, String>((ref, sessionId) {
       .color;
 });
 
+/// Per-session keybar visibility (#573). Falls back to [keybarVisibleDefault]
+/// (true) for an un-customized session, so a fresh session shows the keybar.
+/// Rebuilds when the session's appearance entry changes — toggling one session
+/// rebuilds ONLY that session's value, leaving siblings untouched (the
+/// per-session isolation the issue requires). No global notifier to watch:
+/// keybar visibility is a pure per-session runtime toggle, not a persisted
+/// global default (unlike theme/font, which DO track a global default).
+final sessionKeybarVisibleProvider = Provider.family<bool, String>((
+  ref,
+  sessionId,
+) {
+  ref.watch(sessionAppearanceProvider);
+  return ref
+      .read(sessionAppearanceProvider.notifier)
+      .appearanceOf(sessionId)
+      .keybarVisible;
+});
+
 /// The [NamedTerminalTheme] for a given session, guarding a stale index.
 final sessionTerminalThemeProvider =
     Provider.family<NamedTerminalTheme, String>((ref, sessionId) {
@@ -981,4 +984,13 @@ final activeSessionFontSizeProvider = Provider<double>((ref) {
   final activeId = ref.watch(activeSessionIdProvider);
   if (activeId == null) return ref.watch(fontSizeProvider);
   return ref.watch(sessionFontSizeProvider(activeId));
+});
+
+/// The ACTIVE session's keybar visibility (#573) — what the session menu's
+/// keybar toggle reflects/flips. Falls back to [keybarVisibleDefault] when no
+/// session is active so the toggle still renders sensibly.
+final activeSessionKeybarVisibleProvider = Provider<bool>((ref) {
+  final activeId = ref.watch(activeSessionIdProvider);
+  if (activeId == null) return keybarVisibleDefault;
+  return ref.watch(sessionKeybarVisibleProvider(activeId));
 });

--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -12,8 +12,9 @@
 // theme — never colorful emoji (the Paste key was a 📋 emoji; now a
 // theme-tinted Icons.content_paste). See memory feedback_monochrome_icons_no_emoji.
 //
-// Visibility is controlled by `keybarVisibleProvider` (SharedPreferences).
-// The toggle lives in the session menu; this widget is just the renderer.
+// Visibility is PER-SESSION (#573): the terminal screen renders this widget
+// only when the ACTIVE session's `sessionKeybarVisibleProvider` is true. The
+// toggle lives in the session menu; this widget is just the renderer.
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -140,10 +140,11 @@ class SessionMenu extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sessions = ref.watch(sessionsProvider);
-    final keybarVisible = ref.watch(keybarVisibleProvider);
-    // Theme + font are PER-SESSION (#601, #571): the menu rows read and mutate
-    // the ACTIVE session only. With no active session (empty list) these resolve
-    // to the global default so the rows still render sensibly.
+    // Theme + font + keybar are all PER-SESSION (#601, #571, #573): the menu
+    // rows read and mutate the ACTIVE session only. With no active session
+    // (empty list) these resolve to the default so the rows still render
+    // sensibly.
+    final keybarVisible = ref.watch(activeSessionKeybarVisibleProvider);
     final activeId = sessions.activeId;
     final palette = ref.watch(activeSessionThemeProvider);
     final fontSize = ref.watch(activeSessionFontSizeProvider);
@@ -316,8 +317,9 @@ class _SessionControlsRow extends ConsumerWidget {
           // redundant second entry point.
           // Keybar visibility toggle. Filled icon = visible, outlined = hidden,
           // so the glyph itself communicates the toggle state (no SwitchListTile
-          // row needed). Keybar visibility is global today; #573 moves it
-          // per-session as a separate change — keep the wiring intact here.
+          // row needed). PER-SESSION (#573): flips THIS (active) session's flag
+          // only — sibling sessions keep their own keybar state. Disabled with
+          // no active session, mirroring the other controls.
           IconButton(
             key: const Key('session-menu-keybar-toggle'),
             tooltip: keybarVisible ? 'Hide keybar' : 'Show keybar',
@@ -325,8 +327,11 @@ class _SessionControlsRow extends ConsumerWidget {
             isSelected: keybarVisible,
             icon: const Icon(Icons.keyboard_outlined),
             selectedIcon: const Icon(Icons.keyboard),
-            onPressed: () =>
-                ref.read(keybarVisibleProvider.notifier).set(!keybarVisible),
+            onPressed: !hasActive
+                ? null
+                : () => ref
+                      .read(sessionAppearanceProvider.notifier)
+                      .toggleKeybarVisible(activeId!),
           ),
           // Disconnect the ACTIVE session (#607). Fully closes (disconnect +
           // dispose + REMOVE the entry) so a re-connect restarts the service

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -87,7 +87,6 @@ class TerminalScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sessions = ref.watch(sessionsProvider);
-    final keybarVisible = ref.watch(keybarVisibleProvider);
     final composeBarVisible = ref.watch(composeBarVisibleProvider);
     final entries = sessions.entries;
 
@@ -99,6 +98,14 @@ class TerminalScreen extends ConsumerWidget {
 
     final activeEntry = sessions.active ?? entries.first;
     final activeIndex = entries.indexWhere((e) => e.id == activeEntry.id);
+
+    // #573: keybar visibility is PER-SESSION — read the ACTIVE session's flag.
+    // Switching sessions re-watches the new active id, so each session shows
+    // its own keybar state; toggling one never affects another. The compose
+    // bar's bottomReserve (below) consumes the same active-session value.
+    final keybarVisible = ref.watch(
+      sessionKeybarVisibleProvider(activeEntry.id),
+    );
 
     // #653: resolve the active session's swatch color. Prefer the profile's
     // explicit color (seeded on connect); fall back to the session's terminal

--- a/native/test/widget/keybar_per_session_test.dart
+++ b/native/test/widget/keybar_per_session_test.dart
@@ -1,0 +1,283 @@
+// Widget tests for PER-SESSION keybar visibility (#573).
+//
+// Keybar visibility used to be a single GLOBAL flag, so toggling it changed the
+// keybar for EVERY session. #573 makes it per-session (keyed by session id) on
+// `SessionAppearance`, defaulting to visible. The whole point of the issue is
+// ISOLATION: hiding the keybar on session A must leave session B's keybar
+// visible, and switching the active session must surface each session's own
+// state. These tests assert exactly that — both at the state layer
+// (`sessionKeybarVisibleProvider`) and at the render layer (the `Keybar` widget
+// mounting on TerminalScreen for the ACTIVE session only).
+//
+// Harness mirrors terminal_remeasure_test.dart / session_bar_swatch_test.dart:
+// an InMemoryGatewayPair + a real SshShell per session attached to that
+// session's terminal so TerminalScreen mounts the chrome (keybar + session bar).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_shell.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_providers.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/ui/keybar.dart';
+import 'package:mobissh/ui/terminal_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../support/fake_ssh_shell_transport.dart';
+
+/// Mount TerminalScreen with TWO shell-ready sessions (a, b). Returns the two
+/// entries + the container so a test can read/mutate per-session keybar state
+/// and switch the active session. b is active on mount (last added).
+Future<({SessionEntry a, SessionEntry b, ProviderContainer container})>
+_mountTwo(WidgetTester tester) async {
+  final pair = InMemoryGatewayPair();
+  addTearDown(() async => pair.dispose());
+
+  // One transport per session so each shell drives its own terminal.
+  final transports = <String, FakeSshShellTransport>{};
+
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      // Attach a real shell to THIS session's terminal so the body reaches the
+      // connected/shell-ready state and TerminalScreen renders its chrome.
+      sshShellProvider.overrideWith((ref, sessionId) async {
+        final entry = ref
+            .read(sessionsProvider)
+            .entries
+            .firstWhere((e) => e.id == sessionId);
+        final transport = transports.putIfAbsent(
+          sessionId,
+          FakeSshShellTransport.new,
+        );
+        final shell = SshShell(transport);
+        shell.attach(entry.terminal);
+        ref.onDispose(shell.dispose);
+        return shell;
+      }),
+    ],
+  );
+  addTearDown(() {
+    for (final t in transports.values) {
+      t.close();
+    }
+    container.dispose();
+  });
+
+  final notifier = container.read(sessionsProvider.notifier);
+  final a = notifier.addOrActivate(
+    const SshConnectParams(
+      host: 'host-a',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    ),
+    title: 'Session A',
+  );
+  final b = notifier.addOrActivate(
+    const SshConnectParams(
+      host: 'host-b',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    ),
+    title: 'Session B',
+  );
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: TerminalScreen()),
+    ),
+  );
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  return (a: a, b: b, container: container);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('per-session keybar visibility (#573) — state', () {
+    test('a fresh session defaults to keybar visible', () {
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async => pair.dispose());
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+      );
+      addTearDown(container.dispose);
+
+      final entry = container
+          .read(sessionsProvider.notifier)
+          .addOrActivate(
+            const SshConnectParams(
+              host: 'h',
+              port: 22,
+              username: 'u',
+              auth: SshAuth.password('p'),
+            ),
+          );
+
+      expect(container.read(sessionKeybarVisibleProvider(entry.id)), isTrue);
+    });
+
+    test('toggling one session does NOT change another (isolation)', () {
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async => pair.dispose());
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(sessionsProvider.notifier);
+      final a = notifier.addOrActivate(
+        const SshConnectParams(
+          host: 'a',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+      final b = notifier.addOrActivate(
+        const SshConnectParams(
+          host: 'b',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+
+      final appearance = container.read(sessionAppearanceProvider.notifier);
+
+      // Hide a's keybar — b must stay visible.
+      appearance.toggleKeybarVisible(a.id);
+      expect(container.read(sessionKeybarVisibleProvider(a.id)), isFalse);
+      expect(
+        container.read(sessionKeybarVisibleProvider(b.id)),
+        isTrue,
+        reason: 'b keybar must not change when a is toggled (#573)',
+      );
+
+      // Hide b too — a must remain hidden (independent state).
+      appearance.toggleKeybarVisible(b.id);
+      expect(container.read(sessionKeybarVisibleProvider(a.id)), isFalse);
+      expect(container.read(sessionKeybarVisibleProvider(b.id)), isFalse);
+
+      // Show a again — b stays hidden.
+      appearance.toggleKeybarVisible(a.id);
+      expect(container.read(sessionKeybarVisibleProvider(a.id)), isTrue);
+      expect(container.read(sessionKeybarVisibleProvider(b.id)), isFalse);
+    });
+
+    test('setKeybarVisible affects only the named session', () {
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async => pair.dispose());
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(sessionsProvider.notifier);
+      final a = notifier.addOrActivate(
+        const SshConnectParams(
+          host: 'a',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+      final b = notifier.addOrActivate(
+        const SshConnectParams(
+          host: 'b',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+
+      container
+          .read(sessionAppearanceProvider.notifier)
+          .setKeybarVisible(a.id, false);
+      expect(container.read(sessionKeybarVisibleProvider(a.id)), isFalse);
+      expect(container.read(sessionKeybarVisibleProvider(b.id)), isTrue);
+    });
+  });
+
+  group('per-session keybar visibility (#573) — render', () {
+    testWidgets(
+      'hiding the active session keybar leaves the other visible on switch',
+      (tester) async {
+        final m = await _mountTwo(tester);
+
+        // Both default visible; the keybar renders for the active session (b).
+        expect(find.byType(Keybar), findsOneWidget);
+
+        // Hide the ACTIVE session (b) keybar.
+        m.container
+            .read(sessionAppearanceProvider.notifier)
+            .setKeybarVisible(m.b.id, false);
+        await tester.pump();
+
+        // b is active and hidden → no keybar rendered.
+        expect(
+          find.byType(Keybar),
+          findsNothing,
+          reason: 'active session (b) keybar hidden → not rendered',
+        );
+
+        // Switch to a — a still defaults to visible, so the keybar reappears.
+        m.container.read(sessionsProvider.notifier).setActive(m.a.id);
+        await tester.pump();
+
+        expect(
+          find.byType(Keybar),
+          findsOneWidget,
+          reason:
+              'sibling session (a) keybar stayed visible — no leakage (#573)',
+        );
+
+        // Switch back to b — still hidden (b kept its own state).
+        m.container.read(sessionsProvider.notifier).setActive(m.b.id);
+        await tester.pump();
+        expect(
+          find.byType(Keybar),
+          findsNothing,
+          reason: 'b kept its own hidden state across the switch',
+        );
+      },
+    );
+
+    testWidgets(
+      'the session-menu keybar toggle hides only the active session',
+      (tester) async {
+        final m = await _mountTwo(tester);
+
+        // Open the session menu from the bottom session bar.
+        await tester.tap(find.byKey(const Key('session-bar-open-menu')));
+        for (var i = 0; i < 6; i++) {
+          await tester.pump(const Duration(milliseconds: 50));
+        }
+
+        // Toggle the keybar — active session is b.
+        await tester.tap(find.byKey(const Key('session-menu-keybar-toggle')));
+        await tester.pump();
+
+        expect(m.container.read(sessionKeybarVisibleProvider(m.b.id)), isFalse);
+        expect(
+          m.container.read(sessionKeybarVisibleProvider(m.a.id)),
+          isTrue,
+          reason: 'toggling b via the menu must not change a (#573)',
+        );
+      },
+    );
+  });
+}

--- a/native/test/widget/session_menu_test.dart
+++ b/native/test/widget/session_menu_test.dart
@@ -3,7 +3,7 @@
 // Covers the contract the PWA's session menu exposes:
 //   - tap-to-switch sets activeSessionId and dismisses the menu
 //   - long-press opens the contextual actions sheet
-//   - the keybar toggle flips the global preference
+//   - the keybar toggle flips ONLY the active session's keybar (#573)
 //   - the close affordance on each row removes the entry
 //
 // Tests pump bounded frames rather than `pumpAndSettle` — the modal bottom
@@ -140,33 +140,70 @@ void main() {
       );
     });
 
-    testWidgets('keybar toggle flips keybarVisibleProvider', (tester) async {
-      final container = _makeContainer();
-      addTearDown(container.dispose);
+    testWidgets(
+      'keybar toggle flips ONLY the active session, not siblings (#573)',
+      (tester) async {
+        final container = _makeContainer();
+        addTearDown(container.dispose);
 
-      container
-          .read(sessionsProvider.notifier)
-          .addOrActivate(
-            const SshConnectParams(
-              host: 'host-a',
-              port: 22,
-              username: 'u',
-              auth: SshAuth.password('p'),
-            ),
-          );
+        final notifier = container.read(sessionsProvider.notifier);
+        final a = notifier.addOrActivate(
+          const SshConnectParams(
+            host: 'host-a',
+            port: 22,
+            username: 'u',
+            auth: SshAuth.password('p'),
+          ),
+        );
+        final b = notifier.addOrActivate(
+          const SshConnectParams(
+            host: 'host-b',
+            port: 22,
+            username: 'u',
+            auth: SshAuth.password('p'),
+          ),
+        );
+        // b is the active session.
+        expect(container.read(sessionsProvider).activeId, b.id);
 
-      // Default is visible.
-      expect(container.read(keybarVisibleProvider), isTrue);
+        // Both sessions default to visible (PWA parity).
+        expect(container.read(sessionKeybarVisibleProvider(a.id)), isTrue);
+        expect(container.read(sessionKeybarVisibleProvider(b.id)), isTrue);
 
-      await tester.pumpWidget(_host(container: container));
-      await tester.tap(find.byKey(const Key('open-menu')));
-      await _pumpFrames(tester);
+        await tester.pumpWidget(_host(container: container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
 
-      await tester.tap(find.byKey(const Key('session-menu-keybar-toggle')));
-      await _pumpFrames(tester);
+        // Toggle hides the keybar — for the ACTIVE session (b) only.
+        await tester.tap(find.byKey(const Key('session-menu-keybar-toggle')));
+        await _pumpFrames(tester);
 
-      expect(container.read(keybarVisibleProvider), isFalse);
-    });
+        expect(
+          container.read(sessionKeybarVisibleProvider(b.id)),
+          isFalse,
+          reason: 'active session keybar should be hidden after toggle',
+        );
+        expect(
+          container.read(sessionKeybarVisibleProvider(a.id)),
+          isTrue,
+          reason: 'sibling session keybar must NOT change (no leakage, #573)',
+        );
+
+        // Switch active to a and toggle: a flips, b stays hidden — each session
+        // carries its own keybar state.
+        notifier.setActive(a.id);
+        await _pumpFrames(tester);
+        await tester.tap(find.byKey(const Key('session-menu-keybar-toggle')));
+        await _pumpFrames(tester);
+
+        expect(container.read(sessionKeybarVisibleProvider(a.id)), isFalse);
+        expect(
+          container.read(sessionKeybarVisibleProvider(b.id)),
+          isFalse,
+          reason: 'toggling a must not re-show b',
+        );
+      },
+    );
 
     testWidgets('tapping the close button removes the entry', (tester) async {
       final container = _makeContainer();


### PR DESCRIPTION
## Per-session keybar visibility (#573)

Keybar visibility was a single **global** `StateNotifierProvider<_, bool>`, so toggling it changed the keybar for **every** session. This makes it **per-session**, keyed by session id, defaulting to visible (PWA parity — no behavior change for a fresh session).

### Approach
Mirrors the existing per-session `SessionAppearance` pattern (#571 theme / #640 fontSize / #653 color) in `ui_prefs_providers.dart`:

- `SessionAppearance` gains a `bool keybarVisible` field (default `keybarVisibleDefault` = true) + `copyWith`/`==`/`hashCode`.
- `SessionAppearanceNotifier` gains `setKeybarVisible(sessionId, bool)` + `toggleKeybarVisible(sessionId)` — each mutates only the named session's entry, never siblings or the default.
- New `sessionKeybarVisibleProvider` family + `activeSessionKeybarVisibleProvider` (mirrors `sessionFontSizeProvider` / `activeSessionFontSizeProvider`).
- The now-dead global `KeybarVisibleNotifier` / `keybarVisibleProvider` / `keybarVisiblePrefKey` were removed (kept `keybarVisibleDefault`). Keybar visibility is a pure runtime per-session toggle — not persisted, since session ids are ephemeral.

### Call sites
- `session_menu.dart`: the keybar toggle flips the **active** session's flag (disabled with no active session, like the other per-session controls).
- `terminal_screen.dart`: the `if (keybarVisible) Keybar(...)` decision reads the **active** session's per-session flag.
- `integration_test/terminal_layout_fill_test.dart`: the keybar-toggle reflow step now toggles the active session's flag.

### Isolation (the point of the issue)
`test/widget/keybar_per_session_test.dart` asserts per-session isolation at **both** layers:
- **State**: 2 sessions, default visible; toggling one leaves the other untouched; each keeps independent state across multiple toggles.
- **Render**: TerminalScreen with 2 connected sessions — hiding the active session's keybar removes the `Keybar` widget; switching to the sibling re-shows it (it never changed); switching back preserves each session's own state. Also exercised through the actual session-menu toggle button.

`session_menu_test.dart`'s keybar test was rewritten for the per-session contract (toggle the active session only; sibling unchanged; switch + toggle the other).

Untouched per scope: #666 terminal-fill logic and #653 `_SessionBar` swatch/title code.

### Gate
`scripts/native-fast-gate.sh` passes (analyze clean, all unit/widget tests pass). Device validation is the owner's.

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)