### PR TITLE
ux(#672): Import label + New/Import on one row

### DIFF
--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -97,10 +97,10 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
 
     // #643: the chooser FILLS the screen. The saved-profile list goes in an
     // `Expanded` so it takes all the vertical room above the actions (it
-    // scrolls within that full height); "New connection" + "Import from PWA"
-    // pin directly below the full-height list. Previously the list was capped
-    // at 220px and the whole Column was wrapped in a SingleChildScrollView at
-    // both call sites, so it collapsed to the top ~40% with a blank band below.
+    // scrolls within that full height); the "New" + "Import" action row pins
+    // directly below the full-height list. Previously the list was capped at
+    // 220px and the whole Column was wrapped in a SingleChildScrollView at both
+    // call sites, so it collapsed to the top ~40% with a blank band below.
     // This widget now needs a BOUNDED height (it no longer lives inside a
     // SingleChildScrollView) — its hosts (ConnectHomePage / NewSessionPage)
     // give it the full screen height.
@@ -119,31 +119,35 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
             ),
           ),
           const SizedBox(height: 4),
-          // The single "New" affordance: opens the editor in create mode. The
-          // editor is the ad-hoc / new-connection entry now that the inline
-          // form is gone (#583).
-          FilledButton.icon(
-            key: const Key('new-connection'),
-            onPressed: _busy ? null : _newConnection,
-            icon: const Icon(Icons.add),
-            label: Text(_busy ? 'Connecting…' : 'New connection'),
+          // #672: "New" + "Import" share ONE horizontal row (two Expanded
+          // buttons side by side) instead of being stacked on separate lines,
+          // reclaiming vertical space for the profile list. "New" opens the
+          // editor in create mode (the ad-hoc / new-connection entry now that
+          // the inline form is gone, #583). "Import" pulls profiles from the
+          // PWA — the "from PWA" suffix is an implementation detail, dropped
+          // from the label. Settings + Diagnostics live on the home bottom nav
+          // (#611 Part A), not here.
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.icon(
+                  key: const Key('new-connection'),
+                  onPressed: _busy ? null : _newConnection,
+                  icon: const Icon(Icons.add),
+                  label: Text(_busy ? 'Connecting…' : 'New connection'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: OutlinedButton.icon(
+                  key: const Key('open-import-profiles-dialog'),
+                  onPressed: _openImportDialog,
+                  icon: const Icon(Icons.download_outlined),
+                  label: const Text('Import'),
+                ),
+              ),
+            ],
           ),
-          const SizedBox(height: 4),
-          // Slim secondary access: Import-from-PWA. Settings + Diagnostics live
-          // on the home bottom nav (#611 Part A), not here.
-          Align(
-            alignment: Alignment.centerRight,
-            child: TextButton.icon(
-              key: const Key('open-import-profiles-dialog'),
-              onPressed: _openImportDialog,
-              icon: const Icon(Icons.download_outlined),
-              label: const Text('Import from PWA'),
-            ),
-          ),
-          // #611 Part A: Settings + Diagnostics moved OUT of the chooser into
-          // their own bottom-nav destinations (SettingsScreen / DiagnosticsScreen
-          // on ConnectHomePage). The home view is now JUST the profile chooser,
-          // and so is the pushed "New session" route (NewSessionPage).
         ],
       ),
     );

--- a/native/test/widget/profile_chooser_fill_test.dart
+++ b/native/test/widget/profile_chooser_fill_test.dart
@@ -251,6 +251,56 @@ void main() {
     );
   });
 
+  testWidgets('#672: Import button reads "Import" (not "Import from PWA") and '
+      'New + Import share one row', (tester) async {
+    tester.view.physicalSize = const Size(1000, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store = ProfilesStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    final pair = InMemoryGatewayPair();
+    addTearDown(() async => pair.dispose());
+    final container = _container(store: store, secrets: secrets, pair: pair);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: ConnectHomePage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Label dropped "from PWA" — just "Import".
+    expect(find.text('Import'), findsOneWidget);
+    expect(find.text('Import from PWA'), findsNothing);
+
+    // Both affordances still present (keys preserved).
+    final newBtn = find.byKey(const Key('new-connection'));
+    final importBtn = find.byKey(const Key('open-import-profiles-dialog'));
+    expect(newBtn, findsOneWidget);
+    expect(importBtn, findsOneWidget);
+
+    // They share ONE horizontal row: same vertical center, side by side.
+    final newCenter = tester.getCenter(newBtn);
+    final importCenter = tester.getCenter(importBtn);
+    expect(
+      (newCenter.dy - importCenter.dy).abs(),
+      lessThan(1.0),
+      reason:
+          'New + Import should be on one row (same vertical position), '
+          'newDy=${newCenter.dy} importDy=${importCenter.dy}',
+    );
+    // Side by side: New on the left, Import on the right.
+    expect(
+      newCenter.dx,
+      lessThan(importCenter.dx),
+      reason: 'New should be left of Import on the shared row',
+    );
+  });
+
   testWidgets('#611-A bottom nav still exposes Settings + Diagnostics', (
     tester,
   ) async {


### PR DESCRIPTION
## #672 — Profile chooser: "Import" label + New/Import on one row

Owner report (build 0.1.0+2):
> import from pwa should just be import. new and import can share one line of buttons.

### What changed
On the Profiles chooser (`native/lib/ui/connect_form.dart`):
- Relabeled **"Import from PWA"** → **"Import"** (dropped the implementation detail).
- Placed **"New connection"** + **"Import"** side by side in a single `Row` of two
  `Expanded` buttons, instead of a full-width FilledButton stacked above a
  right-aligned TextButton. Reclaims a row of vertical space for the profile list.
- New = `FilledButton.icon` (primary), Import = `OutlinedButton.icon` (secondary).
  Both test keys (`new-connection`, `open-import-profiles-dialog`) preserved.
- Connect + import **flows unchanged**; import success still surfaces via the existing
  `showTopToast` (no SnackBar reintroduced).

### Test
Extended `native/test/widget/profile_chooser_fill_test.dart` with a #672 widget test:
asserts `find.text('Import')` present, `'Import from PWA'` absent, both buttons present,
and New + Import share one row (same vertical center, New left of Import).

### Gate
`scripts/native-fast-gate.sh`: analyze pass, test pass (All tests passed, +487 incl. the
new #672 test). `dart format` applied to both changed files.

Device validation is the owner's.

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)