### PR TITLE
ux(#673): label Diagnostics Share-feedback as offline backup

### DIFF
--- a/native/lib/ui/diagnostics_section.dart
+++ b/native/lib/ui/diagnostics_section.dart
@@ -74,9 +74,12 @@ class _DiagnosticsSectionState extends State<DiagnosticsSection> {
   /// Assemble the full feedback bundle (connect log + last crash + env +
   /// version/git-hash + device/OS) and share it off the device (#553).
   ///
-  /// Defensive: any failure surfaces a snackbar instead of crashing the form.
-  /// Network is never blocking — the share sheet is the primary path; an
-  /// optional upload is fire-and-forget elsewhere.
+  /// This is the OFFLINE BACKUP path (#673): the integrated in-app Feedback
+  /// overlay (#664) is the primary route but needs prod/Tailscale reachable.
+  /// This share-sheet path is the only way to get a feedback bundle off the
+  /// device (email/files) when the network is unavailable.
+  ///
+  /// Defensive: any failure surfaces a toast instead of crashing the form.
   Future<void> _shareFeedback() async {
     try {
       final info = await CrashReporter.environmentSnapshot();
@@ -155,11 +158,23 @@ class _DiagnosticsSectionState extends State<DiagnosticsSection> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  FilledButton.icon(
+                  OutlinedButton.icon(
                     key: const ValueKey('share-feedback-button'),
                     onPressed: _shareFeedback,
                     icon: const Icon(Icons.ios_share),
-                    label: const Text('Share feedback'),
+                    label: const Text('Share feedback (offline backup)'),
+                  ),
+                  const Padding(
+                    key: ValueKey('share-feedback-caption'),
+                    padding: EdgeInsets.only(top: 4, bottom: 4),
+                    child: Text(
+                      'Offline backup — the in-app Feedback button is the '
+                      'primary path.',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
                   ),
                   const SizedBox(height: 8),
                   if (latest != null)

--- a/native/test/widget/diagnostics_section_widget_test.dart
+++ b/native/test/widget/diagnostics_section_widget_test.dart
@@ -22,8 +22,9 @@ void main() {
 
   setUp(() async {
     tempRoot = await Directory.systemTemp.createTemp('mobissh_dx_widget_');
-    env = FakeCrashEnvironment(dir: Directory('${tempRoot.path}/crashes')
-      ..createSync(recursive: true));
+    env = FakeCrashEnvironment(
+      dir: Directory('${tempRoot.path}/crashes')..createSync(recursive: true),
+    );
     CrashReporter.reset();
   });
 
@@ -61,7 +62,9 @@ void main() {
     for (var i = 0; i < count; i++) {
       final stamp = '20260522T1000${i.toString().padLeft(2, '0')}';
       final file = File('${env.dir.path}/$stamp-dart.json');
-      file.writeAsStringSync('{"schema":1,"kind":"dart","seq":$i,"error":"seed-$i"}');
+      file.writeAsStringSync(
+        '{"schema":1,"kind":"dart","seq":$i,"error":"seed-$i"}',
+      );
       files.add(file);
     }
     return files;
@@ -71,15 +74,12 @@ void main() {
     CrashReporter.configure(env: env);
     seedCrashes(count);
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(body: DiagnosticsSection()),
-      ),
+      const MaterialApp(home: Scaffold(body: DiagnosticsSection())),
     );
     await pumpBounded(tester);
   }
 
-  testWidgets('share button hidden when no crashes exist',
-      (tester) async {
+  testWidgets('share button hidden when no crashes exist', (tester) async {
     await pumpWithCrashes(tester, 0);
 
     await tester.tap(find.byKey(const ValueKey('diagnostics-section')));
@@ -89,78 +89,160 @@ void main() {
     expect(find.text('No crash report on disk.'), findsOneWidget);
   });
 
-  testWidgets('share button visible when one crash exists',
-      (tester) async {
-    await pumpWithCrashes(tester, 1);
+  testWidgets(
+    'share button visible when one crash exists',
+    (tester) async {
+      await pumpWithCrashes(tester, 1);
 
+      await tester.tap(find.byKey(const ValueKey('diagnostics-section')));
+      await pumpBounded(tester);
+
+      expect(
+        find.byKey(const ValueKey('share-last-crash-button')),
+        findsOneWidget,
+      );
+    },
+    // TODO(#501): flutter_test's fake-async clock doesn't reliably drive
+    // Directory.list() to completion within bounded pumps. The unit-test
+    // suite (test/diagnostics/crash_reporter_test.dart) covers the same
+    // logic against real I/O. Re-enable once we have a `runAsync`-friendly
+    // wrapper around the FutureBuilder, or switch the widget to a
+    // Listenable model that updates synchronously.
+    skip: true,
+  );
+
+  testWidgets(
+    'force upload button triggers uploadPending and shows snackbar',
+    (tester) async {
+      var calls = 0;
+      CrashReporter.configure(
+        env: env,
+        httpClient: MockClient((req) async {
+          calls++;
+          return http.Response('ok', 200);
+        }),
+        endpoint: 'http://fake/endpoint',
+      );
+      seedCrashes(1);
+
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: DiagnosticsSection())),
+      );
+      // Bounded pumps only — pumpAndSettle waits for the snackbar's 4s
+      // dismiss animation and we don't need it.
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+
+      await tester.tap(find.byKey(const ValueKey('diagnostics-section')));
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      await tester.tap(find.byKey(const ValueKey('force-upload-button')));
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      expect(calls, 1);
+      expect(
+        find.textContaining('Uploaded'),
+        findsOneWidget,
+        reason: 'snackbar should report upload result',
+      );
+    },
+    // TODO(#501): see skip note on "share button visible when one crash"
+    // — same fake-async + file-system interaction issue. Force-upload
+    // logic is covered by crash_reporter_test.dart's uploadPending tests.
+    skip: true,
+  );
+
+  testWidgets(
+    'share button invokes injected handler with latest file',
+    (tester) async {
+      CrashReporter.configure(env: env);
+      seedCrashes(2); // last file's stamp sorts highest lexicographically
+
+      File? sharedFile;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DiagnosticsSection(
+              onShare: (file) async {
+                sharedFile = file;
+              },
+            ),
+          ),
+        ),
+      );
+      await pumpBounded(tester);
+      await tester.tap(find.byKey(const ValueKey('diagnostics-section')));
+      await pumpBounded(tester);
+      await tester.tap(find.byKey(const ValueKey('share-last-crash-button')));
+      await pumpBounded(tester);
+
+      expect(sharedFile, isNotNull);
+      final body = await sharedFile!.readAsString();
+      // seedCrashes(2) writes seed-0 then seed-1; lexicographic sort places
+      // seed-1's file last so it should be selected as the latest.
+      expect(
+        body,
+        contains('seed-1'),
+        reason: 'share button should fire with the most recent crash',
+      );
+    },
+    // TODO(#501): see skip note on "share button visible when one crash".
+    // Share-handler invocation is exercised via the injected `onShare`
+    // hook in DiagnosticsSection — once we move to a Listenable model the
+    // assertion is one extra line.
+    skip: true,
+  );
+
+  // #673: the "Share feedback" button is KEPT but reframed as the OFFLINE
+  // BACKUP path (the in-app Feedback overlay is primary). These assertions
+  // don't depend on crash files, so they don't hit the FutureBuilder skip
+  // issue above — the share-feedback button always renders.
+  testWidgets('share-feedback button is labeled as an offline backup', (
+    tester,
+  ) async {
+    CrashReporter.configure(env: env);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: DiagnosticsSection(onShareFeedback: (_) async {})),
+      ),
+    );
+    await pumpBounded(tester);
     await tester.tap(find.byKey(const ValueKey('diagnostics-section')));
     await pumpBounded(tester);
 
+    // New backup label on the button itself.
     expect(
-        find.byKey(const ValueKey('share-last-crash-button')), findsOneWidget);
-  },
-      // TODO(#501): flutter_test's fake-async clock doesn't reliably drive
-      // Directory.list() to completion within bounded pumps. The unit-test
-      // suite (test/diagnostics/crash_reporter_test.dart) covers the same
-      // logic against real I/O. Re-enable once we have a `runAsync`-friendly
-      // wrapper around the FutureBuilder, or switch the widget to a
-      // Listenable model that updates synchronously.
-      skip: true);
-
-  testWidgets('force upload button triggers uploadPending and shows snackbar',
-      (tester) async {
-    var calls = 0;
-    CrashReporter.configure(
-      env: env,
-      httpClient: MockClient((req) async {
-        calls++;
-        return http.Response('ok', 200);
-      }),
-      endpoint: 'http://fake/endpoint',
+      find.text('Share feedback (offline backup)'),
+      findsOneWidget,
+      reason: '#673: button must read as the offline backup',
     );
-    seedCrashes(1);
-
-    await tester.pumpWidget(
-      const MaterialApp(home: Scaffold(body: DiagnosticsSection())),
-    );
-    // Bounded pumps only — pumpAndSettle waits for the snackbar's 4s
-    // dismiss animation and we don't need it.
-    for (var i = 0; i < 5; i++) {
-      await tester.pump(const Duration(milliseconds: 50));
-    }
-
-    await tester.tap(find.byKey(const ValueKey('diagnostics-section')));
-    for (var i = 0; i < 5; i++) {
-      await tester.pump(const Duration(milliseconds: 100));
-    }
-    await tester.tap(find.byKey(const ValueKey('force-upload-button')));
-    for (var i = 0; i < 10; i++) {
-      await tester.pump(const Duration(milliseconds: 100));
-    }
-
-    expect(calls, 1);
+    // Caption clarifying the in-app Feedback button is primary.
     expect(
-        find.textContaining('Uploaded'), findsOneWidget,
-        reason: 'snackbar should report upload result');
-  },
-      // TODO(#501): see skip note on "share button visible when one crash"
-      // — same fake-async + file-system interaction issue. Force-upload
-      // logic is covered by crash_reporter_test.dart's uploadPending tests.
-      skip: true);
+      find.byKey(const ValueKey('share-feedback-caption')),
+      findsOneWidget,
+      reason: '#673: caption must point at the primary in-app path',
+    );
+    expect(find.textContaining('primary path'), findsOneWidget);
+  });
 
-  testWidgets('share button invokes injected handler with latest file',
-      (tester) async {
+  testWidgets('share-feedback button still fires the share path', (
+    tester,
+  ) async {
     CrashReporter.configure(env: env);
-    seedCrashes(2); // last file's stamp sorts highest lexicographically
 
-    File? sharedFile;
-
+    String? bundle;
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: DiagnosticsSection(
-            onShare: (file) async {
-              sharedFile = file;
+            onShareFeedback: (b) async {
+              bundle = b;
             },
           ),
         ),
@@ -169,19 +251,13 @@ void main() {
     await pumpBounded(tester);
     await tester.tap(find.byKey(const ValueKey('diagnostics-section')));
     await pumpBounded(tester);
-    await tester.tap(find.byKey(const ValueKey('share-last-crash-button')));
+    await tester.tap(find.byKey(const ValueKey('share-feedback-button')));
     await pumpBounded(tester);
 
-    expect(sharedFile, isNotNull);
-    final body = await sharedFile!.readAsString();
-    // seedCrashes(2) writes seed-0 then seed-1; lexicographic sort places
-    // seed-1's file last so it should be selected as the latest.
-    expect(body, contains('seed-1'),
-        reason: 'share button should fire with the most recent crash');
-  },
-      // TODO(#501): see skip note on "share button visible when one crash".
-      // Share-handler invocation is exercised via the injected `onShare`
-      // hook in DiagnosticsSection — once we move to a Listenable model the
-      // assertion is one extra line.
-      skip: true);
+    expect(
+      bundle,
+      isNotNull,
+      reason: '#673: relabel must not change the share_plus behavior',
+    );
+  });
 }


### PR DESCRIPTION
## #673 — Reframe Diagnostics "Share feedback" as a labeled offline backup

The integrated in-app Feedback overlay (#664) is now the PRIMARY feedback path,
but it requires prod/Tailscale to be reachable. The Diagnostics **Share feedback**
button (share_plus, #553) is the only OFFLINE route — it shares the feedback bundle
(connect log + last crash + crash environment + device info) to email/files via the
OS share sheet.

Owner decision: **keep it, but make it read as the fallback.**

### Changes (label/framing only — `native/lib/ui/diagnostics_section.dart`)
- Relabel button: `Share feedback` → **`Share feedback (offline backup)`**.
- Add a muted caption beneath it: *"Offline backup — the in-app Feedback button is the
  primary path."* (key `share-feedback-caption`).
- De-emphasize visually: `FilledButton` → `OutlinedButton`, matching the other
  secondary diagnostics actions (it's no longer the prominent filled CTA).
- `share_plus` behavior, button key (`share-feedback-button`), and the `onShareFeedback`
  test hook are **unchanged**.
- Connection Audit / Connect log / Force-upload-pending-crashes / Share-last-crash:
  untouched.

### Tests
Extended `native/test/widget/diagnostics_section_widget_test.dart` with two tests:
1. Button presents the new backup label + caption ("primary path").
2. Tapping still fires the share path via the injected handler.

### Gate
- `dart format` clean on both changed files.
- `scripts/native-fast-gate.sh` PASSED (analyze: no issues; test: all pass).

Device validation is the owner's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)