### PR TITLE
feat(#570): copy & navigate URLs — Slice 1 (detect + long-press Copy/Open + highlight)

### DIFF
--- a/native/android/app/src/main/AndroidManifest.xml
+++ b/native/android/app/src/main/AndroidManifest.xml
@@ -66,5 +66,17 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- url_launcher (#570 "copy & navigate URLs"): Android 11+ package
+             visibility requires declaring the browse intent so launchUrl can
+             resolve a browser for a detected terminal URL. Without this,
+             canLaunchUrl/launchUrl fail to find a handler on API 30+. -->
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="http"/>
+        </intent>
     </queries>
 </manifest>

--- a/native/integration_test/url_copy_navigate_test.dart
+++ b/native/integration_test/url_copy_navigate_test.dart
@@ -1,0 +1,238 @@
+// On-emulator acceptance (#570 "copy & navigate URLs" — Slice 1): terminal URL
+// long-press → identify the URL → Copy/Open action menu, on a REAL rendered
+// terminal (real cell metrics, real scroll offset), not a synthetic widget-test
+// surface.
+//
+// Flow:
+//   1. Connect to test-sshd (reusing the connect harness).
+//   2. `echo URLSPIKE https://example.com/path` so a known URL lands on a known
+//      row.
+//   3. Find that URL's on-screen pixel rect from xterm's PUBLIC
+//      RenderTerminal.getOffset(CellOffset) + cellSize, convert to global,
+//      long-press its center.
+//   4. Assert `debugLastHitUrl == 'https://example.com/path'` (the cell→URL
+//      hit-test fired) AND the Copy/Open action menu appeared.
+//   5. Tap Copy → assert the system clipboard holds the URL.
+//   6. NEGATIVE: long-press an EMPTY cell → the hit clears to null (URL vs
+//      non-URL discrimination, no menu).
+//
+// Open is NOT exercised against a real browser here — the launcher is overridden
+// (debugUrlOpenerOverride) so the emulator gate never leaves the app.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/url_copy_navigate_test.dart
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:xterm/xterm.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/terminal_screen.dart' as term_screen;
+import 'package:mobissh/ui/url_action_overlay.dart' as url_overlay;
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('long-press a printed URL → identify + Copy/Open menu', (
+    tester,
+  ) async {
+    FlutterForegroundTask.initCommunicationPort();
+    term_screen.debugLastHitUrl = null;
+    // Open must not leave the app on the emulator gate — capture instead.
+    url_overlay.debugUrlOpenerOverride = (u) async => true;
+    addTearDown(() => url_overlay.debugUrlOpenerOverride = null);
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
+
+    // Reach the terminal screen (accept the host-key prompt on first use).
+    var connected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        connected = true;
+        break;
+      }
+    }
+    expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after connect');
+    final terminal = entry!.terminal;
+
+    // Wait for the shell prompt so the PTY is live.
+    final out = <int>[];
+    final sub = entry.proxy.output.listen(out.addAll);
+    addTearDown(sub.cancel);
+    for (var i = 0; i < 40 && out.isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+    expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+    // Print a line carrying a KNOWN URL behind a marker token.
+    const url = 'https://example.com/path';
+    const marker = 'URLSPIKE';
+    entry.proxy.sendInput(
+      Uint8List.fromList(utf8.encode('echo $marker $url\n')),
+    );
+
+    // Wait until the PRINTED line (not the typed echo of the command) is in the
+    // buffer: a row containing BOTH marker and URL that is NOT the command line.
+    int? urlRow;
+    int? urlCol;
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final b = terminal.buffer;
+      for (var y = b.height - 1; y >= 0; y--) {
+        final text = b.lines[y].toString();
+        if (text.contains(marker) &&
+            text.contains(url) &&
+            !text.contains('echo ')) {
+          urlRow = y;
+          urlCol = text.indexOf(url);
+          break;
+        }
+      }
+      if (urlRow != null) break;
+    }
+    expect(
+      urlRow,
+      isNotNull,
+      reason: 'printed URL line never appeared in the terminal buffer',
+    );
+
+    // Locate the live RenderTerminal to convert (row,col) → screen pixels — the
+    // INVERSE of the production hit-test (pixels → cell), so a round-trip
+    // through both proves the mapping is consistent.
+    final termFinder = find.byKey(Key('terminal-view-${entry.id}'));
+    expect(termFinder, findsOneWidget);
+    final box = _findRenderTerminal(tester, termFinder);
+    expect(box, isNotNull, reason: 'could not locate RenderTerminal');
+
+    final cell = CellOffset(urlCol! + 3, urlRow!);
+    final localTopLeft = (box! as dynamic).getOffset(cell) as Offset;
+    final cellSize = (box as dynamic).cellSize as Size;
+    final localCenter =
+        localTopLeft + Offset(cellSize.width / 2, cellSize.height / 2);
+    final global = box.localToGlobal(localCenter);
+
+    // Long-press the URL cell.
+    term_screen.debugLastHitUrl = null;
+    await tester.longPressAt(global);
+    for (var i = 0; i < 8; i++) {
+      await tester.pump(const Duration(milliseconds: 150));
+    }
+
+    // (a) the cell→URL hit-test resolved the URL,
+    expect(
+      term_screen.debugLastHitUrl,
+      url,
+      reason:
+          'long-press on the printed URL cell did NOT resolve the URL — '
+          'cell hit-test failed (row=$urlRow col=$urlCol)',
+    );
+    // (b) the Copy/Open action menu appeared.
+    expect(
+      find.byKey(const Key('url-action-menu')),
+      findsOneWidget,
+      reason: 'no action menu after long-press on a URL',
+    );
+    expect(find.byKey(const Key('url-action-copy')), findsOneWidget);
+    expect(find.byKey(const Key('url-action-open')), findsOneWidget);
+
+    // (c) Copy writes the URL to the system clipboard.
+    await tester.tap(find.byKey(const Key('url-action-copy')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    final clip = await Clipboard.getData(Clipboard.kTextPlain);
+    expect(
+      clip?.text,
+      url,
+      reason: 'Copy did not put the URL on the system clipboard',
+    );
+
+    // NEGATIVE CHECK: long-press an empty cell far to the right of any text —
+    // the hit-test clears to null and no menu appears (URL discrimination).
+    final emptyCell = CellOffset(terminal.viewWidth - 1, urlRow);
+    final emptyLocal =
+        ((box as dynamic).getOffset(emptyCell) as Offset) +
+        Offset(cellSize.width / 2, cellSize.height / 2);
+    term_screen.debugLastHitUrl = url; // seed non-null to prove it clears
+    await tester.longPressAt(box.localToGlobal(emptyLocal));
+    for (var i = 0; i < 8; i++) {
+      await tester.pump(const Duration(milliseconds: 150));
+    }
+    expect(
+      term_screen.debugLastHitUrl,
+      isNull,
+      reason: 'long-press on an empty cell wrongly reported a URL',
+    );
+    expect(
+      find.byKey(const Key('url-action-menu')),
+      findsNothing,
+      reason: 'action menu wrongly appeared on a non-URL long-press',
+    );
+  });
+}
+
+/// Locate the live `RenderTerminal` render object under [finder]. The type is
+/// not exported from package:xterm, so we walk the render subtree and match by
+/// the presence of the public `getOffset`/`cellSize` API via duck typing.
+RenderBox? _findRenderTerminal(WidgetTester tester, Finder finder) {
+  final element = finder.evaluate().first;
+  RenderBox? result;
+  void visit(RenderObject node) {
+    if (result != null) return;
+    if (node is RenderBox) {
+      try {
+        final dynamic d = node;
+        final probe = d.cellSize;
+        if (probe is Size) {
+          result = node;
+          return;
+        }
+      } catch (_) {
+        // not RenderTerminal — keep descending
+      }
+    }
+    node.visitChildren(visit);
+  }
+
+  element.renderObject?.let(visit);
+  return result;
+}
+
+extension _Let<T extends Object> on T {
+  void let(void Function(T) fn) => fn(this);
+}

--- a/native/lib/terminal/session_stream_parser.dart
+++ b/native/lib/terminal/session_stream_parser.dart
@@ -101,6 +101,33 @@ final RegExp _defaultUrlPattern = RegExp(
   caseSensitive: false,
 );
 
+/// The default URL matcher pattern, exposed for the hit-test layer (#570) so the
+/// tap→URL mapping uses the EXACT same detection as the stream parser — one
+/// source of truth for "what is a URL". Used by [urlMatchAt].
+RegExp get defaultUrlPattern => _defaultUrlPattern;
+
+/// Pure hit-test: given a [line] of LOGICAL text (a full, soft-wrap-coalesced
+/// terminal line reconstructed by the UI from the xterm buffer) and a 0-based
+/// character [col] within it, return the URL substring that [col] lands inside,
+/// or null if the column is not on a URL.
+///
+/// This is the #570 hit-test CORE, kept PURE (no Flutter, no buffer types) so it
+/// is unit-testable and shared between the gesture handler and tests. It
+/// deliberately does NOT use the stream parser's session-absolute offsets: those
+/// index the logical stream, while a tap yields a (row,col) in the reflowed
+/// circular buffer. Reconstructing the logical line from the buffer at tap time
+/// and matching it here sidesteps the (fragile) reconciliation of those two
+/// coordinate spaces — and is robust to scrollback trimming + reflow.
+String? urlMatchAt(String line, int col) {
+  if (col < 0 || col >= line.length) return null;
+  for (final m in _defaultUrlPattern.allMatches(line)) {
+    if (col >= m.start && col < m.end) {
+      return m.group(0);
+    }
+  }
+  return null;
+}
+
 /// Consumes a session's logical text stream and emits [StreamMatch]es.
 ///
 /// One instance per session by construction. Not thread-safe; feed from a single

--- a/native/lib/terminal/url_hit_test.dart
+++ b/native/lib/terminal/url_hit_test.dart
@@ -1,0 +1,152 @@
+// Terminal URL hit-testing (#570): map a long-press to a buffer cell and, if
+// the cell lands on a detected URL, return that URL plus the buffer-cell range
+// it occupies (for the transient highlight overlay).
+//
+// THE TWO COORDINATE SYSTEMS (the core difficulty):
+//   * SessionStreamParser tracks session-ABSOLUTE offsets in the decoded LOGICAL
+//     stream.
+//   * A tap yields a (row, col) in xterm's 2D buffer — a circular scrollback
+//     that TRIMS old lines and REFLOWS on resize. Those drift relative to the
+//     parser's absolute offsets, so reconciling them is fragile.
+//
+// The answer: don't reconcile. At tap time, reconstruct the full
+// soft-wrap-coalesced LOGICAL line straight from the live buffer at the tapped
+// row, then run the SAME URL regex (urlMatchAt, from session_stream_parser) over
+// that line and test column containment. Robust to trimming + reflow because it
+// reads the buffer as it is right now.
+//
+// Cell mapping itself is NOT reimplemented: xterm's RenderTerminal exposes a
+// PUBLIC `getCellOffset(Offset) -> CellOffset(x: col, y: absoluteBufferRow)`
+// that already accounts for scroll offset + padding. The UI feeds it the
+// gesture's local offset and uses the returned cell directly.
+
+import 'package:xterm/xterm.dart';
+
+import 'session_stream_parser.dart';
+
+/// Result of a successful URL hit-test: the matched URL plus where in the
+/// reconstructed logical line it sits. The buffer row the tap landed on and the
+/// logical-line column range let the UI translate the match back into per-row
+/// buffer cells for the highlight overlay (a soft-wrapped URL spans rows).
+class UrlHit {
+  const UrlHit({
+    required this.url,
+    required this.row,
+    required this.col,
+    required this.logicalStart,
+    required this.logicalEnd,
+    required this.logicalLineStartRow,
+    required this.lineWidth,
+  });
+
+  /// The matched URL substring (same detection as the stream parser).
+  final String url;
+
+  /// Absolute buffer row the tap landed on.
+  final int row;
+
+  /// Column within the LOGICAL (soft-wrap-coalesced) line the tap landed on.
+  final int col;
+
+  /// Start column (inclusive) of the URL within the logical line.
+  final int logicalStart;
+
+  /// End column (exclusive) of the URL within the logical line.
+  final int logicalEnd;
+
+  /// The absolute buffer row at which the logical line begins (its first,
+  /// non-wrapped row). Combined with [lineWidth] this maps a logical-line column
+  /// back to a (row, col) buffer cell: row = startRow + col ~/ width, etc.
+  final int logicalLineStartRow;
+
+  /// The terminal's view width (columns per rendered row) at hit time, used to
+  /// translate a logical-line column into a (row, col) buffer cell.
+  final int lineWidth;
+
+  @override
+  String toString() =>
+      'UrlHit($url @ row=$row col=$col [$logicalStart,$logicalEnd))';
+}
+
+/// Reconstruct the full LOGICAL line that buffer row [row] belongs to, by
+/// walking back over `isWrapped` continuations to the logical start and forward
+/// while subsequent rows are wrapped continuations. Returns the concatenated
+/// text, the column OFFSET that [row]'s start sits at within that logical line,
+/// and the absolute buffer row the logical line begins at.
+///
+/// xterm marks a row `isWrapped == true` when it is the CONTINUATION of the row
+/// ABOVE it (a soft wrap). So the logical line is: the first ancestor row that
+/// is NOT wrapped, then every following row while it IS wrapped.
+({String line, int rowStartCol, int startRow}) reconstructLogicalLine(
+  Buffer buffer,
+  int row,
+) {
+  final lines = buffer.lines;
+  final total = lines.length;
+  if (row < 0 || row >= total) {
+    return (line: '', rowStartCol: 0, startRow: row);
+  }
+
+  // Walk back to the logical start: the first row at-or-above [row] whose
+  // `isWrapped` is false. Row 0 is always a logical start.
+  var start = row;
+  while (start > 0 && lines[start].isWrapped) {
+    start--;
+  }
+
+  // Walk forward to the logical end: include rows while the NEXT row is a
+  // wrapped continuation.
+  var end = start;
+  while (end + 1 < total && lines[end + 1].isWrapped) {
+    end++;
+  }
+
+  // Concatenate. Track where [row]'s text begins within the logical line so the
+  // caller can offset a per-row column into a logical-line column.
+  final builder = StringBuffer();
+  var rowStartCol = 0;
+  for (var i = start; i <= end; i++) {
+    if (i == row) {
+      rowStartCol = builder.length;
+    }
+    builder.write(lines[i].getText());
+  }
+  return (line: builder.toString(), rowStartCol: rowStartCol, startRow: start);
+}
+
+/// Hit-test entry point. Given the [terminal] and a [cell] returned by
+/// `RenderTerminal.getCellOffset`, reconstruct the logical line at the cell's
+/// row and return the URL the cell lands on (or null).
+///
+/// [perRowCol] is the column WITHIN the tapped buffer row (xterm's
+/// `CellOffset.x`). We add the row's start offset within the reconstructed
+/// logical line so the column indexes the coalesced string correctly.
+UrlHit? hitTestUrl(Terminal terminal, CellOffset cell) {
+  final recon = reconstructLogicalLine(terminal.buffer, cell.y);
+  if (recon.line.isEmpty) return null;
+  final logicalCol = recon.rowStartCol + cell.x;
+  final url = urlMatchAt(recon.line, logicalCol);
+  if (url == null) return null;
+
+  // Recover the URL's [start, end) within the logical line so the overlay can
+  // highlight the exact run (urlMatchAt only returns the matched text).
+  var start = 0;
+  var endEx = recon.line.length;
+  for (final m in defaultUrlPattern.allMatches(recon.line)) {
+    if (logicalCol >= m.start && logicalCol < m.end) {
+      start = m.start;
+      endEx = m.end;
+      break;
+    }
+  }
+
+  return UrlHit(
+    url: url,
+    row: cell.y,
+    col: logicalCol,
+    logicalStart: start,
+    logicalEnd: endEx,
+    logicalLineStartRow: recon.startRow,
+    lineWidth: terminal.viewWidth,
+  );
+}

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -33,9 +33,11 @@ import '../ssh/ssh_session.dart';
 import '../state/sessions.dart';
 import '../state/terminal_providers.dart';
 import '../state/ui_prefs_providers.dart';
+import '../terminal/url_hit_test.dart';
 import 'compose_bar.dart';
 import 'keybar.dart';
 import 'session_menu.dart';
+import 'url_action_overlay.dart';
 
 /// Minimum horizontal travel (logical px) before a drag on the session bar is
 /// treated as a swipe-to-switch. Matches the ~50px threshold in the design so
@@ -80,6 +82,12 @@ int debugExplicitFitAppliedCount = 0;
 /// dedupes `terminal.resize` when unchanged). Reset it in test `setUp`.
 @visibleForTesting
 int debugForcedPtyResyncCount = 0;
+
+/// #570 — test hook. Set to the URL a long-press hit-test resolved (or null when
+/// a long-press landed on no URL). Lets the on-emulator integration test assert
+/// the tap→cell→URL path end to end without UI scraping. Reset in test `setUp`.
+@visibleForTesting
+String? debugLastHitUrl;
 
 class TerminalScreen extends ConsumerWidget {
   const TerminalScreen({super.key});
@@ -727,6 +735,98 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
     _connectRemeasureTimers.clear();
   }
 
+  /// #570: map a long-press to a buffer cell and, if it lands on a detected
+  /// URL, show the Copy/Open action menu + a transient highlight over the URL's
+  /// on-screen cell rects. [localPosition] is in the wrapping GestureDetector's
+  /// coordinate space; we convert through GLOBAL coordinates into the
+  /// RenderTerminal's own space so cell mapping is correct regardless of any
+  /// padding/offset between the two render boxes.
+  ///
+  /// Cell mapping reuses xterm's PUBLIC `RenderTerminal.getCellOffset` (which
+  /// already accounts for scroll offset + padding), so we never reimplement the
+  /// layout math. The URL test reconstructs the logical line from the live
+  /// buffer (url_hit_test.dart) and matches with the parser's regex.
+  void _onTerminalLongPress(Terminal terminal, Offset localPosition) {
+    // Mouse-reporting apps (vim/tmux/less with mouse ON) own the pointer; a tap
+    // there is a click the app expects, not a URL probe. Skip so we never steal
+    // the gesture from an interactive full-screen program (#570 conflict gate).
+    if (terminal.mouseMode != MouseMode.none) {
+      ctrace('ui.url570', 'skip — mouseMode=${terminal.mouseMode}');
+      return;
+    }
+    final state = _findTerminalViewState();
+    if (state == null) return;
+
+    final CellOffset cell;
+    final dynamic box;
+    final Offset global;
+    try {
+      box = state.renderTerminal;
+      if (!(box.attached as bool)) return;
+      // GestureDetector localPosition → global → RenderTerminal-local.
+      final renderObj = context.findRenderObject();
+      global = renderObj is RenderBox
+          ? renderObj.localToGlobal(localPosition)
+          : localPosition;
+      final local = box.globalToLocal(global) as Offset;
+      cell = box.getCellOffset(local) as CellOffset;
+    } catch (_) {
+      return;
+    }
+
+    final hit = hitTestUrl(terminal, cell);
+    debugLastHitUrl = hit?.url;
+    ctrace(
+      'ui.url570',
+      'cell=(${cell.x},${cell.y}) hit=${hit?.url ?? "<none>"}',
+    );
+    if (hit == null || !mounted) return;
+
+    // Compute the URL's on-screen cell rect(s). A soft-wrapped URL spans
+    // multiple rendered rows, so we walk the logical-column range and emit one
+    // GLOBAL rect per row segment via xterm's PUBLIC getOffset + cellSize.
+    final rects = _urlHighlightRects(box, hit);
+
+    showUrlActions(context, hit.url, highlightRects: rects, anchor: global);
+  }
+
+  /// Translate a [hit]'s logical-column range into GLOBAL on-screen rects, one
+  /// per rendered buffer row the URL occupies. Uses xterm's PUBLIC
+  /// `RenderTerminal.getOffset(CellOffset)` (cell top-left, RenderTerminal-local)
+  /// + `cellSize`. Best-effort: wraps in try/catch so a layout race never throws.
+  List<Rect> _urlHighlightRects(dynamic box, UrlHit hit) {
+    final rects = <Rect>[];
+    try {
+      final cellSize = box.cellSize as Size;
+      final width = hit.lineWidth > 0 ? hit.lineWidth : 1;
+      for (var c = hit.logicalStart; c < hit.logicalEnd;) {
+        final rowOffset = c ~/ width;
+        final colInRow = c % width;
+        final row = hit.logicalLineStartRow + rowOffset;
+        // How many columns of this URL remain on this rendered row.
+        final colsLeftOnRow = width - colInRow;
+        final remaining = hit.logicalEnd - c;
+        final span = remaining < colsLeftOnRow ? remaining : colsLeftOnRow;
+
+        final topLeftLocal = box.getOffset(CellOffset(colInRow, row)) as Offset;
+        final localRect = Rect.fromLTWH(
+          topLeftLocal.dx,
+          topLeftLocal.dy,
+          cellSize.width * span,
+          cellSize.height,
+        );
+        final globalTopLeft = (box as RenderBox).localToGlobal(
+          localRect.topLeft,
+        );
+        rects.add(globalTopLeft & localRect.size);
+        c += span;
+      }
+    } catch (_) {
+      return rects;
+    }
+    return rects;
+  }
+
   /// Walk this body's element subtree to find the xterm [TerminalViewState].
   /// Returns null before the first build or if the TerminalView isn't mounted
   /// (e.g. an offstage IndexedStack child that hasn't laid out yet).
@@ -824,20 +924,31 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
             ),
           ),
         Expanded(
-          // #617: no wrapping Listener/GestureDetector. The terminal's own
-          // vertical-scroll gesture (xterm's alt-buffer scroll handler →
-          // corrected wheel SGR via WheelFixMouseHandler) drives tmux
-          // scrollback unobstructed. The long-press selection menu was removed.
-          child: TerminalView(
-            terminal,
-            key: Key('terminal-view-${widget.sessionId}'),
-            scrollController: _scrollController,
-            autofocus: false,
-            padding: const EdgeInsets.all(4),
-            theme: palette.theme,
-            textStyle: TerminalStyle(
-              fontSize: fontSize,
-              fontFamily: kTerminalFontFamily,
+          // #570: a LONG-PRESS GestureDetector wraps the TerminalView to probe
+          // URL hit-testing → Copy/Open menu + highlight. Long-press is
+          // deliberately the gesture: it does NOT compete with xterm's
+          // vertical-drag scrollback (a pan, via the corrected wheel SGR — #617)
+          // nor with tap/click mouse reporting, so the existing scroll path
+          // stays unobstructed. `behavior: deferToChild` keeps the
+          // TerminalView's own recognizers first in the arena — the long-press
+          // only claims the pointer once the press-and-hold threshold passes,
+          // after a drag would already have won. (NO wrapping Listener — that
+          // was the #617 wheel-SGR regression source.)
+          child: GestureDetector(
+            behavior: HitTestBehavior.deferToChild,
+            onLongPressStart: (details) =>
+                _onTerminalLongPress(terminal, details.localPosition),
+            child: TerminalView(
+              terminal,
+              key: Key('terminal-view-${widget.sessionId}'),
+              scrollController: _scrollController,
+              autofocus: false,
+              padding: const EdgeInsets.all(4),
+              theme: palette.theme,
+              textStyle: TerminalStyle(
+                fontSize: fontSize,
+                fontFamily: kTerminalFontFamily,
+              ),
             ),
           ),
         ),

--- a/native/lib/ui/url_action_overlay.dart
+++ b/native/lib/ui/url_action_overlay.dart
@@ -1,0 +1,285 @@
+// URL action overlay (#570 "copy & navigate URLs" — Slice 1).
+//
+// On a long-press that lands on a detected terminal URL, show:
+//   * a transient HIGHLIGHT over the URL's on-screen cell rect(s) (a
+//     soft-wrapped URL spans multiple rendered rows → multiple rects), and
+//   * a small popup menu with COPY and OPEN actions.
+//
+// Copy → Clipboard.setData + a top toast confirmation (NOT a bottom SnackBar —
+// that covers the keybar/compose bar, see top_toast.dart). Open → url_launcher
+// in externalApplication mode (the real browser); injectable for tests so the
+// widget test never hits a real browser.
+//
+// The overlay dismisses on: an action tap, a tap outside the menu, or a short
+// timeout. Implemented as a single root-overlay OverlayEntry so it floats above
+// the route and any keyboard; only one is live at a time.
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'top_toast.dart';
+
+/// Pluggable URL opener so the widget test can assert "Open was invoked with
+/// this URL" without launching a real browser. Returns true on success.
+typedef UrlOpener = Future<bool> Function(String url);
+
+/// Default opener: the system browser via url_launcher, external application.
+Future<bool> _defaultOpen(String url) async {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return false;
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+/// Test seam: overrides the opener used by [showUrlActions] when non-null.
+@visibleForTesting
+UrlOpener? debugUrlOpenerOverride;
+
+/// The single live overlay entry, so a new long-press replaces the old one.
+OverlayEntry? _activeEntry;
+Timer? _activeTimer;
+
+void _dismiss() {
+  _activeTimer?.cancel();
+  _activeTimer = null;
+  _activeEntry?.remove();
+  _activeEntry = null;
+}
+
+/// Test seam: tear down any live overlay + its auto-dismiss timer so a widget
+/// test that leaves the menu open doesn't trip the "Timer still pending" check.
+@visibleForTesting
+void debugDismissUrlActions() => _dismiss();
+
+/// Show the Copy/Open action menu + transient highlight for [url].
+///
+/// [highlightRects] are the URL's on-screen cell rectangles in GLOBAL
+/// coordinates (one per rendered row the URL spans). [anchor] is the global
+/// point the menu is positioned near (typically the long-press location).
+///
+/// Safe to call from any context under an [Overlay]. No-op if no overlay.
+void showUrlActions(
+  BuildContext context,
+  String url, {
+  required List<Rect> highlightRects,
+  required Offset anchor,
+  Duration timeout = const Duration(seconds: 6),
+}) {
+  final overlay = Overlay.maybeOf(context, rootOverlay: true);
+  if (overlay == null) return;
+
+  _dismiss();
+
+  final opener = debugUrlOpenerOverride ?? _defaultOpen;
+
+  late final OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (ctx) => _UrlActionLayer(
+      url: url,
+      highlightRects: highlightRects,
+      anchor: anchor,
+      onCopy: () {
+        Clipboard.setData(ClipboardData(text: url));
+        if (identical(_activeEntry, entry)) _dismiss();
+        showTopToastInOverlay(overlay, 'Copied: $url');
+      },
+      onOpen: () async {
+        if (identical(_activeEntry, entry)) _dismiss();
+        final ok = await opener(url);
+        if (!ok) {
+          showTopToastInOverlay(overlay, 'Could not open: $url');
+        }
+      },
+      onDismiss: () {
+        if (identical(_activeEntry, entry)) _dismiss();
+      },
+    ),
+  );
+  _activeEntry = entry;
+  overlay.insert(entry);
+
+  _activeTimer = Timer(timeout, () {
+    if (identical(_activeEntry, entry)) _dismiss();
+  });
+}
+
+/// Full-screen layer: tap-outside scrim + highlight painter + action menu card.
+class _UrlActionLayer extends StatelessWidget {
+  const _UrlActionLayer({
+    required this.url,
+    required this.highlightRects,
+    required this.anchor,
+    required this.onCopy,
+    required this.onOpen,
+    required this.onDismiss,
+  });
+
+  final String url;
+  final List<Rect> highlightRects;
+  final Offset anchor;
+  final VoidCallback onCopy;
+  final Future<void> Function() onOpen;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final media = MediaQuery.of(context);
+    final accent = theme.colorScheme.primary;
+
+    // Position the menu just below the lowest highlight rect (or the anchor),
+    // clamped within the screen so it never runs off the bottom/edges.
+    final below = highlightRects.isEmpty
+        ? anchor.dy + 24
+        : highlightRects.map((r) => r.bottom).reduce((a, b) => a > b ? a : b) +
+              8;
+    // The card sizes to its content (intrinsic); these are the layout estimates
+    // used only to anchor + clamp the position so it never runs off-screen.
+    const estMenuWidth = 220.0;
+    const menuHeight = 56.0;
+    var left = anchor.dx - estMenuWidth / 2;
+    left = left.clamp(8.0, math.max(8.0, media.size.width - estMenuWidth - 8));
+    var top = below;
+    if (top + menuHeight > media.size.height - 8) {
+      // No room below — place above the highlight.
+      final aboveTop = highlightRects.isEmpty
+          ? anchor.dy - menuHeight - 24
+          : highlightRects.map((r) => r.top).reduce((a, b) => a < b ? a : b) -
+                menuHeight -
+                8;
+      top = aboveTop.clamp(8.0, media.size.height - menuHeight - 8);
+    }
+
+    return Stack(
+      children: [
+        // Tap-outside scrim (transparent) — dismiss without consuming nothing
+        // else. Behaves as a full-screen catcher behind the menu.
+        Positioned.fill(
+          child: GestureDetector(
+            key: const Key('url-action-scrim'),
+            behavior: HitTestBehavior.translucent,
+            onTap: onDismiss,
+          ),
+        ),
+        // Transient highlight over the URL's cell rects.
+        Positioned.fill(
+          child: IgnorePointer(
+            child: CustomPaint(
+              painter: _UrlHighlightPainter(
+                rects: highlightRects,
+                color: accent,
+              ),
+            ),
+          ),
+        ),
+        // The action menu card.
+        Positioned(
+          left: left,
+          top: top,
+          child: Material(
+            key: const Key('url-action-menu'),
+            color: theme.colorScheme.surfaceContainerHighest,
+            elevation: 8,
+            borderRadius: BorderRadius.circular(10),
+            // Intrinsic width: the Row sizes to its two buttons (a fixed width
+            // overflowed by a few px depending on text metrics). Clamp the max
+            // so a future longer label can't run off-screen.
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: math.min(media.size.width - 16, 320),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _ActionButton(
+                      key: const Key('url-action-copy'),
+                      icon: Icons.content_copy,
+                      label: 'Copy',
+                      onTap: onCopy,
+                    ),
+                    const SizedBox(width: 8),
+                    _ActionButton(
+                      key: const Key('url-action-open'),
+                      icon: Icons.open_in_new,
+                      label: 'Open',
+                      onTap: () {
+                        onOpen();
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurface;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 18, color: color),
+            const SizedBox(width: 6),
+            Text(label, style: TextStyle(color: color, fontSize: 14)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Paints a translucent rounded highlight over each URL cell rect.
+class _UrlHighlightPainter extends CustomPainter {
+  _UrlHighlightPainter({required this.rects, required this.color});
+
+  final List<Rect> rects;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final fill = Paint()..color = color.withValues(alpha: 0.28);
+    final stroke = Paint()
+      ..color = color.withValues(alpha: 0.9)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.2;
+    for (final r in rects) {
+      final rr = RRect.fromRectAndRadius(
+        r.inflate(1),
+        const Radius.circular(3),
+      );
+      canvas.drawRRect(rr, fill);
+      canvas.drawRRect(rr, stroke);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_UrlHighlightPainter old) =>
+      old.rects != rects || old.color != color;
+}

--- a/native/pubspec.lock
+++ b/native/pubspec.lock
@@ -1053,7 +1053,7 @@ packages:
     source: hosted
     version: "1.4.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -64,6 +64,11 @@ dependencies:
   # SFTP-fetched temp PDF in the file explorer's preview route.
   pdfrx: ^1.0.0
 
+  # Open detected terminal URLs in the system browser (#570 "copy & navigate
+  # URLs"). launchUrl(..., LaunchMode.externalApplication). Needs the Android
+  # <queries> https intent in AndroidManifest to resolve a browser (added).
+  url_launcher: ^6.3.0
+
   # Crash telemetry pipeline (#501 crash-on-launch).
   # http: bridge upload. path_provider: app-docs dir shared with the Kotlin
   # crash writer. device_info_plus + package_info_plus: enrich crash JSON.

--- a/native/test/terminal/url_hit_test_test.dart
+++ b/native/test/terminal/url_hit_test_test.dart
@@ -1,0 +1,126 @@
+// Unit tests for the URL hit-test core (#570).
+//
+// Covers the two pure pieces the feature depends on:
+//   1. `urlMatchAt(line, col)` — column containment against the parser's URL
+//      regex (the SAME detection as SessionStreamParser).
+//   2. `reconstructLogicalLine(buffer, row)` — coalescing soft-wrapped buffer
+//      rows back into one logical line, with the per-row column offset so a
+//      tapped (row,col) maps into the logical-line column space.
+//   3. `hitTestUrl` — resolving a URL (and its logical-column range + start row)
+//      from a buffer cell, including a soft-wrapped URL.
+//
+// These are the device-independent halves of the proof; the on-emulator
+// integration test (url_copy_navigate_test.dart) covers the live cell mapping.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/terminal/session_stream_parser.dart';
+import 'package:mobissh/terminal/url_hit_test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  group('urlMatchAt', () {
+    const line = 'see https://example.com/path for more';
+    final urlStart = line.indexOf('https');
+    const url = 'https://example.com/path';
+    final urlEnd = urlStart + url.length;
+
+    test('a column inside the URL returns the full URL', () {
+      expect(urlMatchAt(line, urlStart), url);
+      expect(urlMatchAt(line, urlStart + 5), url);
+      expect(urlMatchAt(line, urlEnd - 1), url);
+    });
+
+    test('a column before the URL returns null', () {
+      expect(urlMatchAt(line, 0), isNull);
+      expect(urlMatchAt(line, urlStart - 1), isNull);
+    });
+
+    test('the column one past the URL end returns null', () {
+      expect(urlMatchAt(line, urlEnd), isNull);
+    });
+
+    test('out-of-range columns return null', () {
+      expect(urlMatchAt(line, -1), isNull);
+      expect(urlMatchAt(line, line.length), isNull);
+      expect(urlMatchAt('', 0), isNull);
+    });
+
+    test('matches the parser regex exactly (single source of truth)', () {
+      final parsed = <StreamMatch>[];
+      SessionStreamParser(onMatch: parsed.add).feed('$line\n');
+      expect(parsed.single.text, url);
+      expect(urlMatchAt(line, urlStart), parsed.single.text);
+    });
+  });
+
+  group('reconstructLogicalLine', () {
+    Terminal makeTerminal(int cols) {
+      final t = Terminal(maxLines: 200);
+      t.resize(cols, 24);
+      return t;
+    }
+
+    test('a non-wrapped single line reconstructs verbatim', () {
+      final t = makeTerminal(80);
+      t.write('hello world\r\n');
+      final recon = reconstructLogicalLine(t.buffer, 0);
+      expect(recon.line.trimRight(), 'hello world');
+      expect(recon.rowStartCol, 0);
+      expect(recon.startRow, 0);
+    });
+
+    test('a soft-wrapped URL coalesces across rows into one logical line', () {
+      final t = makeTerminal(20); // force wrap
+      const text = 'x https://example.com/very/long/path/segment/here y';
+      t.write(text);
+      var wrappedRow = -1;
+      for (var i = 0; i < t.buffer.lines.length; i++) {
+        if (t.buffer.lines[i].isWrapped) {
+          wrappedRow = i;
+          break;
+        }
+      }
+      expect(
+        wrappedRow,
+        greaterThan(0),
+        reason: 'expected the long URL to soft-wrap (isWrapped continuation)',
+      );
+      final recon = reconstructLogicalLine(t.buffer, wrappedRow);
+      expect(
+        recon.line.contains('https://example.com/very/long/path/segment/here'),
+        isTrue,
+        reason: 'soft-wrapped URL was not coalesced: "${recon.line}"',
+      );
+      // The reconstructed line starts at the first, non-wrapped row.
+      expect(recon.startRow, lessThan(wrappedRow));
+      expect(t.buffer.lines[recon.startRow].isWrapped, isFalse);
+    });
+
+    test('hitTestUrl resolves a URL on a soft-wrapped row', () {
+      final t = makeTerminal(20);
+      const url = 'https://example.com/very/long/path/segment/here';
+      t.write('x $url y');
+      var wrappedRow = -1;
+      for (var i = 0; i < t.buffer.lines.length; i++) {
+        if (t.buffer.lines[i].isWrapped) {
+          wrappedRow = i;
+          break;
+        }
+      }
+      expect(wrappedRow, greaterThan(0));
+      final hit = hitTestUrl(t, CellOffset(0, wrappedRow));
+      expect(hit, isNotNull);
+      expect(hit!.url, url);
+      // The logical-column range bounds the URL within the coalesced line.
+      expect(hit.logicalEnd - hit.logicalStart, url.length);
+      expect(hit.lineWidth, 20);
+    });
+
+    test('hitTestUrl returns null on a non-URL cell', () {
+      final t = makeTerminal(80);
+      t.write('just some plain text here\r\n');
+      final hit = hitTestUrl(t, const CellOffset(2, 0));
+      expect(hit, isNull);
+    });
+  });
+}

--- a/native/test/widget/url_action_overlay_test.dart
+++ b/native/test/widget/url_action_overlay_test.dart
@@ -1,0 +1,164 @@
+// URL action overlay (#570 "copy & navigate URLs" — Slice 1).
+//
+// Contract under test:
+//   - long-press on a detected URL surfaces a Copy/Open menu,
+//   - Copy puts the URL on the system clipboard + shows a top-toast confirmation,
+//   - Open invokes the (injected, fake) launcher with the URL — NOT a real
+//     browser,
+//   - tap-outside dismisses the menu,
+//   - a transient highlight is painted over the URL's cell rect(s).
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/url_action_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const url = 'https://example.com/path';
+
+  // Capture clipboard writes via the platform channel mock.
+  String? lastClipboard;
+
+  setUp(() {
+    lastClipboard = null;
+    debugUrlOpenerOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            lastClipboard = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+    debugUrlOpenerOverride = null;
+  });
+
+  // Drain any live overlay + toast timers at the END of a test body (before the
+  // framework's "Timer still pending" invariant runs, which `addTearDown` is too
+  // late for). Dismiss the menu, then pump past the top-toast's auto-dismiss.
+  Future<void> settle(WidgetTester tester) async {
+    debugDismissUrlActions();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  Future<void> pumpAndShow(
+    WidgetTester tester, {
+    List<Rect> rects = const [Rect.fromLTWH(40, 40, 120, 18)],
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => showUrlActions(
+                  context,
+                  url,
+                  highlightRects: rects,
+                  anchor: const Offset(100, 50),
+                ),
+                child: const Text('fire'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('fire'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+
+  testWidgets('shows the Copy/Open menu', (tester) async {
+    await pumpAndShow(tester);
+    expect(find.byKey(const Key('url-action-menu')), findsOneWidget);
+    expect(find.byKey(const Key('url-action-copy')), findsOneWidget);
+    expect(find.byKey(const Key('url-action-open')), findsOneWidget);
+    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Open'), findsOneWidget);
+    await settle(tester);
+  });
+
+  testWidgets('Copy puts the URL on the clipboard + confirms via top-toast', (
+    tester,
+  ) async {
+    await pumpAndShow(tester);
+    await tester.tap(find.byKey(const Key('url-action-copy')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(lastClipboard, url);
+    // Confirmation surfaces as a top-toast (not a bottom SnackBar).
+    expect(find.byKey(const Key('top-toast')), findsOneWidget);
+    // Menu is dismissed after the action.
+    expect(find.byKey(const Key('url-action-menu')), findsNothing);
+    await settle(tester);
+  });
+
+  testWidgets('Open invokes the injected launcher with the URL', (
+    tester,
+  ) async {
+    String? opened;
+    debugUrlOpenerOverride = (u) async {
+      opened = u;
+      return true;
+    };
+    await pumpAndShow(tester);
+    await tester.tap(find.byKey(const Key('url-action-open')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(opened, url, reason: 'Open should call the launcher with the URL');
+    expect(find.byKey(const Key('url-action-menu')), findsNothing);
+    await settle(tester);
+  });
+
+  testWidgets('Open failure shows an error top-toast', (tester) async {
+    debugUrlOpenerOverride = (u) async => false;
+    await pumpAndShow(tester);
+    await tester.tap(find.byKey(const Key('url-action-open')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byKey(const Key('top-toast')), findsOneWidget);
+    expect(find.textContaining('Could not open'), findsOneWidget);
+    await settle(tester);
+  });
+
+  testWidgets('tap-outside dismisses the menu', (tester) async {
+    await pumpAndShow(tester);
+    expect(find.byKey(const Key('url-action-menu')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('url-action-scrim')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.byKey(const Key('url-action-menu')), findsNothing);
+    await settle(tester);
+  });
+
+  testWidgets('paints a highlight (CustomPaint present)', (tester) async {
+    await pumpAndShow(
+      tester,
+      rects: const [
+        Rect.fromLTWH(40, 40, 120, 18),
+        Rect.fromLTWH(40, 58, 80, 18),
+      ],
+    );
+    // The overlay includes a CustomPaint for the highlight rects.
+    expect(
+      find.descendant(
+        of: find.byType(IgnorePointer),
+        matching: find.byType(CustomPaint),
+      ),
+      findsWidgets,
+    );
+    await settle(tester);
+  });
+}


### PR DESCRIPTION
## Slice 1 of #570 — copy & navigate URLs (native)

Built on the **proven spike** (PR #676, branch `spike/570-url-hittest`). Scope: **URLs only**. OSC 8 (#631) and configurable patterns (#478) are **later slices**.

### What this does
Long-press a detected URL in the terminal → a **Copy / Open** popup menu + a transient highlight over the URL's cell rect(s).

- **Detection / hit-test** (`native/lib/terminal/url_hit_test.dart`, promoted from the spike): xterm 4.0.0's public `RenderTerminal.getCellOffset(Offset)→CellOffset` maps the press to a buffer cell; the soft-wrap-coalesced **logical line** is reconstructed from the live buffer at tap time and matched against the URL regex (`urlMatchAt`, same detection as the stream parser — single source of truth). Robust to scrollback trim + reflow. `UrlHit` now also carries the logical `[start,end)` range + start row + line width so the overlay can compute per-row highlight rects for a **wrapped** URL.
- **Action menu + highlight** (`native/lib/ui/url_action_overlay.dart`): root-overlay popup; **Copy** → `Clipboard.setData` + `showTopToast` confirmation (not a bottom SnackBar, which would cover the keybar/compose bar); **Open** → `url_launcher` `launchUrl(..., LaunchMode.externalApplication)`, behind an injectable `UrlOpener` test seam. Theme-styled `CustomPaint` highlight; dismiss on action / tap-outside / timeout.
- **Long-press wiring** (`terminal_screen.dart`): reuses the spike's gating — `mouseMode==none`, `GestureDetector` `deferToChild`, **no `Listener` wrapper** (that was the #617 wheel-SGR regression source). Works alongside #666 / #653 / #573.
- **Dependency**: `url_launcher: ^6.3.0` + Android `<queries>` `https`/`http` VIEW intents so `launchUrl` resolves a browser on API 30+.

### Tests
- **Unit** `test/terminal/url_hit_test_test.dart` — `urlMatchAt` containment, logical-line reconstruction (incl. a soft-wrapped URL), `hitTestUrl` range/startRow.
- **Widget** `test/widget/url_action_overlay_test.dart` — menu appears; Copy → clipboard + top-toast; Open → injected fake launcher; failure toast; tap-outside dismiss; highlight painted.
- **Integration (device gate)** `integration_test/url_copy_navigate_test.dart` — long-press a printed URL on the live terminal → `debugLastHitUrl` resolves + menu appears + Copy writes the clipboard; negative check on an empty cell.

Run the device gate:

```
scripts/native-connect-test.sh integration_test/url_copy_navigate_test.dart
```

`scripts/native-fast-gate.sh` passes (analyze clean + all headless tests green).

### Caveat
Wide CJK/emoji cells (display column vs String index in the logical-line reconstruction) are **best-effort, unverified on device** — URLs are overwhelmingly ASCII. Noted in TRACE.

### Follow-on
- #631 — OSC 8 hyperlinks
- #478 — configurable detection patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)