### PR TITLE
spike(#570 Slice 2): stream-based wrapped-URL detection + offset→cell mapping [DO-NOT-MERGE]

### DIFF
--- a/native/integration_test/url_copy_navigate_test.dart
+++ b/native/integration_test/url_copy_navigate_test.dart
@@ -204,6 +204,141 @@ void main() {
       reason: 'action menu wrongly appeared on a non-URL long-press',
     );
   });
+
+  // SPIKE (#570 Slice 2) — wrapped-URL case on REAL hardware.
+  //
+  // Echoes a URL LONGER than the terminal width so the terminal SOFT-wraps it
+  // across rendered rows (no \n in the byte stream), then long-presses a cell on
+  // the WRAPPED TAIL row. Asserts the hit-test resolves the FULL URL. This is
+  // the on-device confirmation of the spike's STEP 1 finding: Slice 1's buffer
+  // reconstruction already handles SOFT wrap. (The HARD-wrap case — a literal
+  // \n mid-URL from the source/TUI — is the documented remaining gap; it needs
+  // the continuation-join heuristic proven in test/terminal/wrapped_url_join_
+  // test.dart and is NOT asserted here.)
+  testWidgets('long-press the WRAPPED TAIL of a soft-wrapped URL → full URL', (
+    tester,
+  ) async {
+    FlutterForegroundTask.initCommunicationPort();
+    term_screen.debugLastHitUrl = null;
+    url_overlay.debugUrlOpenerOverride = (u) async => true;
+    addTearDown(() => url_overlay.debugUrlOpenerOverride = null);
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
+
+    var connected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        connected = true;
+        break;
+      }
+    }
+    expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after connect');
+    final terminal = entry!.terminal;
+
+    final out = <int>[];
+    final sub = entry.proxy.output.listen(out.addAll);
+    addTearDown(sub.cancel);
+    for (var i = 0; i < 40 && out.isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+    expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+    // A URL guaranteed LONGER than any phone-width terminal so it must wrap.
+    final width = terminal.viewWidth;
+    final longUrl = 'https://example.com/${'segment/' * ((width ~/ 8) + 4)}end';
+    expect(
+      longUrl.length > width,
+      isTrue,
+      reason: 'URL must exceed view width to force a soft wrap',
+    );
+    entry.proxy.sendInput(Uint8List.fromList(utf8.encode('echo $longUrl\n')));
+
+    // Wait for the printed URL and find its FIRST (scheme) row in the buffer.
+    int? schemeRow;
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final b = terminal.buffer;
+      for (var y = b.height - 1; y >= 0; y--) {
+        final text = b.lines[y].toString();
+        if (text.contains('https://example.com/') && !text.contains('echo ')) {
+          schemeRow = y;
+          break;
+        }
+      }
+      if (schemeRow != null) break;
+    }
+    expect(
+      schemeRow,
+      isNotNull,
+      reason: 'printed wrapped URL never appeared in the buffer',
+    );
+
+    // The row AFTER the scheme row is the wrapped continuation (the tail).
+    final b = terminal.buffer;
+    expect(
+      b.lines[schemeRow! + 1].isWrapped,
+      isTrue,
+      reason:
+          'continuation row not marked isWrapped — not a soft wrap on device',
+    );
+    final tailRow = schemeRow + 1;
+
+    final termFinder = find.byKey(Key('terminal-view-${entry.id}'));
+    expect(termFinder, findsOneWidget);
+    final box = _findRenderTerminal(tester, termFinder);
+    expect(box, isNotNull, reason: 'could not locate RenderTerminal');
+
+    // Long-press a cell INSIDE the wrapped tail (a few cols in from the left).
+    final cell = CellOffset(2, tailRow);
+    final localTopLeft = (box! as dynamic).getOffset(cell) as Offset;
+    final cellSize = (box as dynamic).cellSize as Size;
+    final localCenter =
+        localTopLeft + Offset(cellSize.width / 2, cellSize.height / 2);
+    final global = box.localToGlobal(localCenter);
+
+    term_screen.debugLastHitUrl = null;
+    await tester.longPressAt(global);
+    for (var i = 0; i < 8; i++) {
+      await tester.pump(const Duration(milliseconds: 150));
+    }
+
+    // The crux: a tap on the WRAPPED TAIL resolves the FULL URL (Slice 1's
+    // buffer reconstruction coalesces the isWrapped rows).
+    expect(
+      term_screen.debugLastHitUrl,
+      longUrl,
+      reason:
+          'long-press on the WRAPPED TAIL of a soft-wrapped URL did not resolve '
+          'the full URL (tailRow=$tailRow) — soft-wrap reconstruction broken',
+    );
+    expect(find.byKey(const Key('url-action-menu')), findsOneWidget);
+  });
 }
 
 /// Locate the live `RenderTerminal` render object under [finder]. The type is

--- a/native/lib/terminal/wrapped_url_join.dart
+++ b/native/lib/terminal/wrapped_url_join.dart
@@ -1,0 +1,73 @@
+// SPIKE (#570 Slice 2) — continuation-join heuristic for HARD-wrapped URLs.
+//
+// The spike's STEP 1 finding inverted the premise: a SOFT-wrapped URL (terminal
+// display-wrapped, no \n in the byte stream) is ALREADY resolved by Slice 1's
+// buffer reconstruction (url_hit_test.dart walks isWrapped rows) AND seen as one
+// contiguous run by SessionStreamParser. The owner's real bug is the HARD case —
+// the source/TUI emitted a LITERAL \n mid-URL — and there BOTH the buffer walk
+// and the stream parser break at the newline.
+//
+// This module is the de-risk for the ONLY thing that actually moves the needle:
+// rejoining a URL across a hard newline. It is a HEURISTIC, deliberately
+// conservative, and PURE (no Flutter, no buffer). It is NOT wired into the
+// production path — it exists to prove tractability and bound the effort.
+//
+// Heuristic: a hard wrap that splits a URL leaves a line ending in a URL-legal
+// run with NO trailing whitespace, whose tail starts with a scheme OR is the
+// continuation of a scheme on a prior line; the NEXT line begins (column 0) with
+// a URL-legal, non-space character. Joining the two with no separator and
+// re-running the URL matcher recovers the full URL. We only join when:
+//   1. the left line's last char is URL-legal and not whitespace, AND
+//   2. the left line contains a scheme `http(s)://` that has no whitespace after
+//      it (the wrap fell inside the URL), AND
+//   3. the right line's first char is URL-legal and not whitespace.
+// Otherwise we do NOT join (a normal paragraph wrap must not glue two words).
+
+import 'session_stream_parser.dart';
+
+final RegExp _scheme = RegExp(r'https?://', caseSensitive: false);
+
+bool _isUrlLegal(int c) {
+  // Anything that is not whitespace and not an angle/quote delimiter — matches
+  // the spirit of the default URL matcher's character class.
+  if (c == 0x20 || c == 0x09 || c == 0x0a || c == 0x0d) return false;
+  if (c == 0x3c || c == 0x3e) return false; // < >
+  if (c == 0x22 || c == 0x27) return false; // " '
+  return true;
+}
+
+/// Returns true when [left] and [right] look like the two halves of a single
+/// URL that a HARD newline split, so they should be joined with no separator
+/// before URL matching. Conservative — see file header.
+bool shouldJoinHardWrap(String left, String right) {
+  if (left.isEmpty || right.isEmpty) return false;
+  if (!_isUrlLegal(left.codeUnitAt(left.length - 1))) return false;
+  if (!_isUrlLegal(right.codeUnitAt(0))) return false;
+  final m = _scheme.firstMatch(left);
+  if (m == null) return false;
+  // No whitespace AFTER the scheme on the left line → the wrap fell inside the
+  // URL (the URL ran to the end of the line).
+  final afterScheme = left.substring(m.end);
+  if (afterScheme.contains(RegExp(r'\s'))) return false;
+  return true;
+}
+
+/// Given a list of physical [lines] (as the source emitted them, split on hard
+/// \n) reconstruct the logical text by gluing lines that pass
+/// [shouldJoinHardWrap], then return every URL the default matcher finds in the
+/// reconstructed logical text. Proves the heuristic recovers a hard-wrapped URL.
+List<String> recoverHardWrappedUrls(List<String> lines) {
+  if (lines.isEmpty) return const [];
+  final buf = StringBuffer(lines.first);
+  for (var i = 1; i < lines.length; i++) {
+    final prevTail = buf.toString();
+    if (shouldJoinHardWrap(prevTail, lines[i])) {
+      buf.write(lines[i]); // glue, no separator
+    } else {
+      buf.write('\n');
+      buf.write(lines[i]);
+    }
+  }
+  final logical = buf.toString();
+  return defaultUrlPattern.allMatches(logical).map((m) => m.group(0)!).toList();
+}

--- a/native/test/terminal/stream_parser_hardwrap_test.dart
+++ b/native/test/terminal/stream_parser_hardwrap_test.dart
@@ -1,0 +1,46 @@
+// SPIKE diagnostic (#570 Slice 2) — what SessionStreamParser does with a HARD
+// (literal-\n) wrapped URL, and whether a continuation-join heuristic recovers
+// it. This is the actual bug shape (owner build 0.1.2+4): the source/TUI
+// inserted a newline mid-URL before the terminal saw it.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/terminal/session_stream_parser.dart';
+
+void main() {
+  test('SOFT wrap (no \\n): parser sees ONE contiguous URL', () {
+    final matches = <StreamMatch>[];
+    final p = SessionStreamParser(onMatch: matches.add);
+    // The decoded stream of a soft-wrapped URL has NO newline mid-URL — the
+    // terminal does the wrapping at render time, not the byte stream.
+    p.feed(
+      'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2\n',
+    );
+    expect(matches, hasLength(1));
+    expect(
+      matches.single.text,
+      'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2',
+    );
+  });
+
+  test('HARD wrap (literal \\n mid-URL): parser sees TWO broken fragments', () {
+    final matches = <StreamMatch>[];
+    final p = SessionStreamParser(onMatch: matches.add);
+    // Source/TUI hard-wrapped the URL with a real newline.
+    p.feed('https://github.com/flavordrake/mobissh/releas\n');
+    p.feed('es/tag/native-v0.1.2 done\n');
+    // The first fragment is a valid URL on its own (scheme + chars), the second
+    // is not a URL at all → the FULL URL is NOT recovered. This is why even a
+    // stream parser misses the owner's case without a join heuristic.
+    final urls = matches.map((m) => m.text).toList();
+    expect(
+      urls.contains(
+        'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2',
+      ),
+      isFalse,
+      reason:
+          'EVIDENCE: the stream parser ALSO fails the hard-wrap case — the \\n '
+          'is a token boundary. Stream detection does not solve the bug; a '
+          'continuation-join heuristic does. Got: $urls',
+    );
+  });
+}

--- a/native/test/terminal/wrapped_url_diagnostic_test.dart
+++ b/native/test/terminal/wrapped_url_diagnostic_test.dart
@@ -1,0 +1,133 @@
+// SPIKE diagnostic (#570 Slice 2) — STEP 1 load-bearing question.
+//
+// Drives a REAL xterm `Terminal` (not a synthetic surface) to settle whether a
+// long URL that the terminal SOFT-WRAPS across display rows is:
+//   (a) stored as `isWrapped` continuation rows that Slice 1's
+//       `reconstructLogicalLine` already coalesces, OR
+//   (b) something the buffer walk misses.
+//
+// And whether Slice 1's `hitTestUrl` already resolves a tap on a soft-wrapped
+// URL. The answer decides fork-vs-index. These tests are diagnostic — they
+// ASSERT the behaviour we observe so a regression is visible, and the prose at
+// the end of each is the spike's STEP 1 evidence.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+import 'package:mobissh/terminal/url_hit_test.dart';
+
+void main() {
+  group('STEP 1: how does xterm store a soft-wrapped URL', () {
+    test(
+      'a contiguous long URL (no \\n) wraps into isWrapped continuation rows',
+      () {
+        // 40-col terminal, a URL longer than 40 chars, written contiguously —
+        // exactly the "source has the URL whole, terminal display-wraps it"
+        // SOFT case.
+        final term = Terminal(maxLines: 200);
+        term.resize(40, 24);
+        const url =
+            'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2';
+        expect(url.length > 40, isTrue, reason: 'URL must exceed view width');
+        term.write('see $url done\r\n');
+
+        final b = term.buffer;
+        // Find the first row that contains the scheme.
+        var schemeRow = -1;
+        for (var y = 0; y < b.height; y++) {
+          if (b.lines[y].toString().contains('https://')) {
+            schemeRow = y;
+            break;
+          }
+        }
+        expect(schemeRow, isNot(-1), reason: 'scheme row not found');
+
+        // The row AFTER the scheme row should be a wrapped continuation (soft
+        // wrap), proving xterm stores the contiguous write as isWrapped rows.
+        expect(
+          b.lines[schemeRow + 1].isWrapped,
+          isTrue,
+          reason:
+              'continuation row is NOT marked isWrapped — buffer walk would '
+              'treat the URL tail as a separate logical line',
+        );
+      },
+    );
+  });
+
+  group('STEP 1+3: does Slice 1 hitTestUrl resolve a soft-wrapped URL', () {
+    test('tap on the WRAPPED TAIL of a soft-wrapped URL resolves full URL', () {
+      final term = Terminal(maxLines: 200);
+      term.resize(40, 24);
+      const url =
+          'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2';
+      term.write('see $url done\r\n');
+
+      final b = term.buffer;
+      // Locate the continuation row (the wrapped tail) and a column inside the
+      // URL tail on that row.
+      var schemeRow = -1;
+      for (var y = 0; y < b.height; y++) {
+        if (b.lines[y].toString().contains('https://')) {
+          schemeRow = y;
+          break;
+        }
+      }
+      final tailRow = schemeRow + 1;
+      // The tail row begins with the continuation of the URL ("...releas" |
+      // "es/tag/..."). col 0 of the tail row is mid-URL.
+      final cell = CellOffset(0, tailRow);
+
+      final hit = hitTestUrl(term, cell);
+      // This is the crux: if Slice 1 ALREADY resolves a soft-wrapped tail tap,
+      // then the production bug is NOT soft wrap — it is the HARD case
+      // (source/TUI inserted a real \n). If it returns null, Slice 1's buffer
+      // walk is broken for soft wraps and the index approach is warranted.
+      expect(
+        hit?.url,
+        url,
+        reason:
+            'EVIDENCE: hitTestUrl on a soft-wrapped URL tail returned '
+            '${hit?.url}. If null, Slice 1 buffer-walk fails on soft wrap.',
+      );
+    });
+
+    test('a HARD-wrapped URL (real \\n mid-URL) is BROKEN into two lines', () {
+      // The HARD case: the source/TUI itself emitted a newline mid-URL. The
+      // terminal stores two SEPARATE logical lines (continuation row is NOT
+      // isWrapped). Slice 1's buffer walk cannot rejoin them, and neither can a
+      // stream parser without a continuation-join heuristic.
+      final term = Terminal(maxLines: 200);
+      term.resize(80, 24);
+      const head = 'https://github.com/flavordrake/mobissh/releas';
+      const tail = 'es/tag/native-v0.1.2';
+      term.write('$head\r\n$tail done\r\n');
+
+      final b = term.buffer;
+      var headRow = -1;
+      for (var y = 0; y < b.height; y++) {
+        if (b.lines[y].toString().contains('https://')) {
+          headRow = y;
+          break;
+        }
+      }
+      // The row after a HARD newline is NOT a wrapped continuation.
+      expect(
+        b.lines[headRow + 1].isWrapped,
+        isFalse,
+        reason: 'a real \\n must NOT produce an isWrapped row',
+      );
+      // And the head row alone does not contain a tappable full URL tail.
+      final hit = hitTestUrl(term, CellOffset(0, headRow + 1));
+      expect(
+        hit?.url,
+        isNot(
+          'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2',
+        ),
+        reason:
+            'EVIDENCE: hard-wrapped URL tail cannot resolve the full URL from '
+            'the buffer — needs a continuation-join heuristic (out of scope).',
+      );
+    });
+  });
+}

--- a/native/test/terminal/wrapped_url_edgecases_test.dart
+++ b/native/test/terminal/wrapped_url_edgecases_test.dart
@@ -1,0 +1,78 @@
+// SPIKE diagnostic (#570 Slice 2) — edge cases that could make a soft-wrapped
+// URL long-press "do nothing" even though Slice 1 nominally handles soft wrap.
+//
+// Probes the two most likely real-world failure shapes:
+//   1. getText() trailing-space padding bleeding a space INTO the reconstructed
+//      logical line at the wrap seam (would split the URL regex match).
+//   2. A URL that wraps across THREE rows (long GitHub release URL on a narrow
+//      phone terminal) — tap on the MIDDLE wrapped row.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+import 'package:mobissh/terminal/url_hit_test.dart';
+
+void main() {
+  test('reconstructed logical line has NO space injected at the wrap seam', () {
+    final term = Terminal(maxLines: 200);
+    term.resize(40, 24);
+    const url =
+        'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2';
+    term.write('$url\r\n');
+    final b = term.buffer;
+    var row = -1;
+    for (var y = 0; y < b.height; y++) {
+      if (b.lines[y].toString().contains('https://')) {
+        row = y;
+        break;
+      }
+    }
+    final recon = reconstructLogicalLine(b, row);
+    // The URL must appear CONTIGUOUSLY in the reconstructed line — if getText()
+    // padded the first wrapped row with trailing spaces to view width, the
+    // logical line would be "...releas  es/tag..." and the regex would stop.
+    expect(
+      recon.line.contains(url),
+      isTrue,
+      reason:
+          'reconstructed logical line does not contain the contiguous URL — '
+          'wrap seam likely padded with spaces. recon="${recon.line}"',
+    );
+  });
+
+  test('URL wrapping across 3 rows — tap on the MIDDLE row resolves it', () {
+    final term = Terminal(maxLines: 200);
+    term.resize(24, 24); // very narrow → 3 wrapped rows for a 65-char URL
+    const url =
+        'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2';
+    term.write('$url\r\n');
+    final b = term.buffer;
+    var first = -1;
+    for (var y = 0; y < b.height; y++) {
+      if (b.lines[y].toString().contains('https://')) {
+        first = y;
+        break;
+      }
+    }
+    // Count wrapped continuation rows.
+    var wraps = 0;
+    while (first + 1 + wraps < b.height &&
+        b.lines[first + 1 + wraps].isWrapped) {
+      wraps++;
+    }
+    expect(
+      wraps >= 2,
+      isTrue,
+      reason: 'expected >=3 total rows, got ${wraps + 1}',
+    );
+
+    // Tap the middle wrapped row.
+    final midRow = first + 1;
+    final hit = hitTestUrl(term, CellOffset(0, midRow));
+    expect(
+      hit?.url,
+      url,
+      reason: 'tap on a middle wrapped row did not resolve the full URL',
+    );
+  });
+}

--- a/native/test/terminal/wrapped_url_join_test.dart
+++ b/native/test/terminal/wrapped_url_join_test.dart
@@ -1,0 +1,57 @@
+// SPIKE (#570 Slice 2) — proves the continuation-join heuristic recovers a
+// HARD-wrapped URL (the owner's actual bug) while NOT gluing ordinary wrapped
+// paragraph text.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/terminal/wrapped_url_join.dart';
+
+void main() {
+  test('recovers the owner-reported hard-wrapped GitHub release URL', () {
+    final urls = recoverHardWrappedUrls([
+      'https://github.com/flavordrake/mobissh/releas',
+      'es/tag/native-v0.1.2 done',
+    ]);
+    expect(
+      urls,
+      contains(
+        'https://github.com/flavordrake/mobissh/releases/tag/native-v0.1.2',
+      ),
+    );
+  });
+
+  test('recovers a URL hard-wrapped across THREE physical lines', () {
+    final urls = recoverHardWrappedUrls([
+      'https://example.com/very/long/',
+      'path/segment/that/keeps/',
+      'going?q=1#frag rest',
+    ]);
+    expect(
+      urls,
+      contains(
+        'https://example.com/very/long/path/segment/that/keeps/going?q=1#frag',
+      ),
+    );
+  });
+
+  test('does NOT glue ordinary wrapped paragraph words', () {
+    // A normal hard-wrapped sentence: no scheme on the left line → no join.
+    final urls = recoverHardWrappedUrls(['the quick brown', 'fox jumps over']);
+    expect(urls, isEmpty);
+  });
+
+  test('does NOT join when the left line has whitespace after the scheme', () {
+    // The URL ended on the left line (followed by a word); the next line is a
+    // new word, not a continuation. Must not glue.
+    final urls = recoverHardWrappedUrls([
+      'see https://example.com/path and',
+      'then continue reading',
+    ]);
+    // The complete URL on line 1 is still recovered, but NOT glued to "and...".
+    expect(urls, contains('https://example.com/path'));
+    expect(
+      urls.any((u) => u.contains('andthen')),
+      isFalse,
+      reason: 'must not glue across a real word boundary',
+    );
+  });
+}


### PR DESCRIPTION
## DO-NOT-MERGE — spike / de-risk for #570 Slice 2

Spike to prove the STREAM-based wrapped-URL approach + offset→cell mapping and recommend fork-vs-index. Builds on Slice 1 (merged). All artifacts are spike-only and unwired into production.

### STEP 1 — the load-bearing question (SOFT vs HARD), answered

The premise is **inverted** by the evidence. There are two wrap kinds:

- **SOFT wrap** (terminal display-wraps a contiguous write; **no `\n` in the byte stream**): xterm marks continuation rows `isWrapped`. Slice 1's `reconstructLogicalLine` already coalesces them and `hitTestUrl` already resolves a tap on the wrapped tail — **proven on a real `Terminal`** across 2-row and 3-row wraps, tail and middle-row taps, with no seam-padding corruption. The stream parser also sees the URL contiguously. **Stream detection adds nothing here.**
- **HARD wrap** (source/TUI emitted a **literal `\n` mid-URL** — e.g. a width-limited TUI box, `gh`/`git`/`fold` output): xterm stores two separate logical lines (continuation **not** `isWrapped`). The buffer walk can't rejoin them — **and neither can the stream parser**: the `\n` is a token boundary, so it emits two broken fragments, never the full URL.

Since Slice 1 demonstrably handles soft wrap, the owner's "long-press does nothing" bug (`…mobissh/releas` → `tes/tag/native-v0.1.2`) is the **HARD case**. The stream-offset↔cell index does **not** solve it (no contiguous full-URL match to map).

> Byte-level emulator confirmation of which wrap the owner hit is pending (no AVD booted this run). The conclusion holds regardless: a real "does nothing" bug ⟹ hard wrap, because soft wrap is proven already-handled.

### STEP 2 — what actually moves the needle

Built and proved a conservative **continuation-join heuristic** (`lib/terminal/wrapped_url_join.dart`) instead of a fragile offset→cell index that wouldn't fix the real bug. It recovers the owner's exact hard-wrapped GitHub release URL and 3-line wraps, and refuses to glue ordinary paragraph wraps / cross word boundaries (`shouldJoinHardWrap`). Wiring the parser to the session output is trivial (one `feed()` in the existing `outputSub` listener) but is **not** the bottleneck, so it's left unwired.

### STEP 3 — recommendation: NEITHER fork NOR index

- **Index**: doesn't address the real (hard-wrap) bug + fragile against the circular/reflow buffer → high cost, no payoff.
- **Fork**: unjustified — Slice 1's public-API reconstruction already handles every soft wrap.
- **Slice 2 = continuation-join at the hit-test layer.** Extend `reconstructLogicalLine` to optionally bridge a hard-newline seam when both sides look like a split URL (proven `shouldJoinHardWrap` predicate), and extend the highlight-rect math for the bridged seam. **~0.5–1 day.** The stream parser stays for #575 / token matchers; it is not needed to fix this bug.

### Tests (native fast gate green — analyze + 522 unit tests)

- `test/terminal/wrapped_url_diagnostic_test.dart` — soft-wrap is `isWrapped` + Slice 1 resolves it
- `test/terminal/wrapped_url_edgecases_test.dart` — no seam padding, 3-row wrap, middle-row tap
- `test/terminal/stream_parser_hardwrap_test.dart` — parser breaks on a literal `\n`
- `test/terminal/wrapped_url_join_test.dart` — join recovers the hard wrap (4/4)
- `integration_test/url_copy_navigate_test.dart` — added an on-device soft-wrap-tail long-press case

Orchestrator runs the emulator case:
`scripts/native-connect-test.sh integration_test/url_copy_navigate_test.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)