### PR TITLE
spike(#582): flterm/ghostty feasibility — build + render + drag-select

### DIFF
--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -20,6 +20,8 @@ import 'state/terminal_providers.dart';
 import 'ui/connect_form.dart';
 import 'ui/diagnostics_screen.dart';
 import 'ui/feedback_overlay.dart';
+// SPIKE (#582, DO-NOT-MERGE): temporary debug entry to the flterm/ghostty probe.
+import 'ui/ghostty_spike_screen.dart';
 import 'ui/settings_screen.dart';
 import 'ui/terminal_screen.dart';
 
@@ -247,6 +249,16 @@ class _ConnectHomePageState extends State<ConnectHomePage> {
     // rather than rebuilding from scratch on every tap.
     return Scaffold(
       appBar: AppBar(title: Text(_titles[_index])),
+      // SPIKE (#582, DO-NOT-MERGE): temporary debug FAB → standalone flterm /
+      // ghostty probe screen. Remove with the spike (this and the import).
+      floatingActionButton: FloatingActionButton.extended(
+        key: const Key('ghostty-spike-fab'),
+        icon: const Icon(Icons.terminal),
+        label: const Text('ghostty spike'),
+        onPressed: () => Navigator.of(context).push(
+          MaterialPageRoute<void>(builder: (_) => const GhosttySpikeScreen()),
+        ),
+      ),
       body: SafeArea(
         child: IndexedStack(
           index: _index,

--- a/native/lib/ui/ghostty_spike_screen.dart
+++ b/native/lib/ui/ghostty_spike_screen.dart
@@ -1,0 +1,156 @@
+// SPIKE (#582, DO-NOT-MERGE): flterm / libghostty feasibility probe.
+//
+// Standalone debug screen that mounts the flterm TerminalView (powered by
+// Ghostty's libghostty-vt native engine) WITHOUT touching the real session
+// stack (terminal_screen.dart / sessions.dart are owned by Phase 2). It feeds
+// static multi-line text — including a long URL and a wrapping paragraph — into
+// the terminal and lets a human confirm three things on a real device:
+//
+//   1. RENDER       — the libghostty native .so loaded and the grid paints.
+//   2. KEYBOARD      — tapping focuses the grid, the soft keyboard appears, and
+//                      typed characters echo (we loop onOutput back into write).
+//   3. DRAG-SELECT   — long-press + drag highlights cells; "Copy selection"
+//                      pulls TerminalController.selectedText() to the clipboard.
+//                      This is the WHOLE reason for the spike: xterm.dart v4 has
+//                      no selection-extend API.
+//
+// Reachable only via the temporary debug FAB on the connect home page. Delete
+// this file + the FAB when the spike concludes (GO → Phase 2 abstraction; or
+// NO-GO → fork xterm.dart).
+
+import 'dart:convert';
+
+// flterm re-exports libghostty's `Key` input enum, which collides with
+// Flutter's widget `Key`. We only use Flutter's, so hide flterm's.
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Sample content exercising wide layout, a long URL (OSC-8-free plain), and a
+/// wrapping paragraph so we can verify soft-wrap selection on a narrow phone.
+const _sampleText =
+    'MobiSSH flterm/ghostty spike (#582)\r\n'
+    '\r\n'
+    'Long URL (try long-press + drag to select, then Copy selection):\r\n'
+    'https://github.com/elias8/libghostty/releases/tag/libghostty-v0.0.9\r\n'
+    '\r\n'
+    'Paragraph (soft-wrap selection check): The quick brown fox jumps over '
+    'the lazy dog while a second clause keeps going well past the right edge '
+    'of a typical phone screen so the line must wrap and selection must follow '
+    'the wrap boundary cleanly without dropping characters.\r\n'
+    '\r\n'
+    r'$ ls -la /usr/local/bin'
+    '\r\n'
+    'total 0  drwxr-xr-x  2 root root  4096 Jun  2 19:50 .\r\n'
+    '\r\n'
+    'Type below — characters echo locally (onOutput looped into write):\r\n'
+    r'$ ';
+
+class GhosttySpikeScreen extends StatefulWidget {
+  const GhosttySpikeScreen({super.key});
+
+  @override
+  State<GhosttySpikeScreen> createState() => _GhosttySpikeScreenState();
+}
+
+class _GhosttySpikeScreenState extends State<GhosttySpikeScreen> {
+  late final TerminalController _controller;
+  String _status = 'initializing libghostty…';
+
+  @override
+  void initState() {
+    super.initState();
+    try {
+      _controller = TerminalController();
+      // Local echo: there's no PTY in the spike, so loop the terminal's own
+      // output (keystrokes encoded by sendKey/sendText) straight back into the
+      // grid. This proves the keyboard → libghostty → render path end to end.
+      _controller.onOutput = (Uint8List bytes) {
+        _controller.write(bytes);
+      };
+      _controller.write(Uint8List.fromList(utf8.encode(_sampleText)));
+      _status = 'libghostty loaded — grid below should be painted';
+    } catch (e, st) {
+      // If the native .so failed to load (the make-or-break), surface it on
+      // screen instead of a blank crash so the device tester can report it.
+      _status = 'FAILED to init libghostty: $e\n$st';
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _copySelection() async {
+    final text = _controller.selectedText();
+    if (text.isEmpty) {
+      _toast('No selection — long-press + drag the grid first.');
+      return;
+    }
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+    _toast('Copied ${text.length} chars to clipboard.');
+  }
+
+  void _selectAll() {
+    _controller.selectAll();
+    _toast('selectAll() invoked — Copy selection to verify.');
+  }
+
+  void _toast(String msg) {
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('flterm/ghostty spike (#582)'),
+        actions: [
+          IconButton(
+            key: const Key('spike-select-all'),
+            tooltip: 'Select all',
+            icon: const Icon(Icons.select_all),
+            onPressed: _selectAll,
+          ),
+          IconButton(
+            key: const Key('spike-copy-selection'),
+            tooltip: 'Copy selection',
+            icon: const Icon(Icons.copy),
+            onPressed: _copySelection,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Text(
+              _status,
+              key: const Key('spike-status'),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          Expanded(
+            child: TerminalView(
+              key: const Key('spike-terminal-view'),
+              controller: _controller,
+              autofocus: true,
+              theme: TerminalTheme.dark(),
+              // Defaults already enable longPress + word + line + drag +
+              // selectAll, but we name them explicitly so the spike intent is
+              // legible: native touch drag-select is what we're proving.
+              gestureSettings: const TerminalGestureSettings(
+                enabledSelections: SelectionGesture.all,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/native/pubspec.lock
+++ b/native/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "67cf6d84013f9c601e42a6f8a6b74c4c0d9dc1a1619d775f2b28b732d3551b85"
+      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.0.0"
   collection:
     dependency: transitive
     description:
@@ -241,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  flterm:
+    dependency: "direct main"
+    description:
+      name: flterm
+      sha256: "36c31553b3bc188b2a1abe3c8935a2108759e0b44586fcf37d72d1dd9306ede3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -374,10 +382,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: a41af4e8fc687cd6d33de9751eb936c8c0204ebe2bcb6c15ecf707504bf47f31
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.3"
   html:
     dependency: transitive
     description:
@@ -495,6 +503,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  libghostty:
+    dependency: transitive
+    description:
+      name: libghostty
+      sha256: b7f79f84060c6e0475be4bcb2eadc0525e354452d32c2defa46a3ddf599b8e5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.9"
   lints:
     dependency: transitive
     description:
@@ -591,6 +607,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.6"
   node_preamble:
     dependency: transitive
     description:
@@ -603,10 +627,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.1"
+    version: "9.3.0"
   package_config:
     dependency: transitive
     description:
@@ -1246,4 +1270,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.44.0"

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -42,6 +42,11 @@ dependencies:
   # Terminal widget (terminal.studio, same publisher as dartssh2)
   xterm: ^4.0.0
 
+  # SPIKE (#582, DO-NOT-MERGE): flterm = Flutter terminal widget on libghostty-vt.
+  # Evaluating as an ALTERNATE backend for native drag-select (xterm.dart v4 has
+  # no selection-extend API). Pulls libghostty (native FFI via Dart build hooks).
+  flterm: ^0.0.3
+
   # OS-backed credential vault — replaces PWA's PBKDF2+WebAuthn dance
   flutter_secure_storage: ^9.2.2
 


### PR DESCRIPTION
## SPIKE (#582) — DO NOT MERGE

Feasibility probe for adopting **flterm / libghostty** (Ghostty's libghostty-vt
engine, as a Flutter widget) as an ALTERNATE terminal backend for the native app
(#501, #582). The make-or-break: does it **build for Android** and **render +
support native drag-select**? xterm.dart v4 has no selection-extend API, which is
the entire motivation.

This branch is a throwaway reference, not for merge. It adds a dependency, a
standalone debug screen, and a temporary debug FAB — nothing wired to real
sessions (Phase 2, separate).

### What's here
- `flterm: ^0.0.3` added to `native/pubspec.yaml` (pulls `libghostty 0.0.9`).
- `native/lib/ui/ghostty_spike_screen.dart` — standalone screen mounting
  `TerminalView`, feeding static multi-line text (long URL + wrapping paragraph),
  local-echo keyboard, and Select-all / Copy-selection buttons.
- `native/lib/main.dart` — temporary "ghostty spike" debug FAB on the connect
  home page that pushes the spike screen. Marked DO-NOT-MERGE.

### Findings (see TRACE in PR discussion / agent report)
- **Package + version:** `flterm 0.0.3` (MIT), `libghostty 0.0.9` (Dart FFI
  bindings to libghostty-vt via Dart build hooks / code assets).
- **Android build:** the build hook's default `DownloadPrebuilt` provider pulls a
  prebuilt `.so` per Zig target triple from the libghostty GitHub release.
  `asset_hashes.dart` ships hashes for `aarch64-linux-android`,
  `arm-linux-androideabi`, and `x86_64-linux-android` — i.e. arm64-v8a,
  armeabi-v7a, and x86_64 (emulator). **No Zig / NDK needed** (this env has
  neither). Compile-from-source is opt-in (`-Dsource=compile`, needs Zig).
- **Drag-select:** `TerminalGestureSettings` defaults enable `longPress`, `word`,
  `line`, `drag`, `selectAll`. `selectedText()` returns the highlighted text.
  Touch long-press drag-select is first-class.
- **PTY wiring API (for Phase 2):** `controller.onOutput = (bytes) => pty.write`,
  `ptyOutputStream.listen(controller.write)`, `controller.onResize = (size) =>
  pty.resize(size.cols, size.rows)`, `onBell`, `onTitleChanged`. Mirrors the
  xterm.dart `Terminal` model closely.

### Device verification needed (owner)
Build the debug APK from this branch, install, tap the "ghostty spike" FAB, and
confirm: grid renders, soft keyboard echoes, long-press + drag highlights, and
Copy-selection lands text on the clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)