### PR TITLE
fix(#690): Ghostty touch-swipe scrolls (no remote mouse-drag → no tmux selection)

### DIFF
--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -41,12 +41,28 @@
 // "select mode" toggle — see [kGhosttyScrollSettings] / [kGhosttySelectSettings]
 // and `_selectMode`.
 //
+// #690 fix (SWIPE forwarded to the REMOTE as a mouse-button DRAG): distinct
+// from #688's LOCAL selection. When the remote enables mouse mode (DECSET
+// 1000/1002/1003/1006, e.g. tmux), flterm's `TerminalGestureDetector` forwards a
+// finger swipe to the PTY as a button1 press+motion+release — a DRAG — which tmux
+// reads as a mouse SELECTION (its own selection styling appears). flterm 0.0.3
+// exposes NO interception hook analogous to xterm's `Terminal.mouseHandler` (the
+// #617 fix): the report path is fully internal to its gesture detector,
+// `TerminalGestureSettings` explicitly CANNOT disable mouse tracking, and the
+// only built-in bypass (virtual Shift) leaks into key/scroll encoding and clears
+// on the next keystroke. So we intercept ONE layer up — see
+// [_ScrollInsteadOfMouseDrag] / [ghosttySwipeShouldScrollLocally]. The wheel
+// reports flterm emits for an actual scroll ARE correct (libghostty's own SGR
+// wheel encoding, not xterm-4.0.0's buggy 68/69 — so no #617-style fix is needed
+// for the wheel path here).
+//
 // flterm re-exports libghostty's `Key` input enum, which collides with
 // Flutter's widget `Key`. We only use Flutter's, so hide flterm's.
 
 import 'dart:async';
 
 import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -126,6 +142,114 @@ const TerminalGestureSettings kGhosttySelectSettings = TerminalGestureSettings(
   lineSelectMode: LineSelectMode.full,
 );
 
+/// Whether a touch SWIPE should be intercepted and turned into a local scroll
+/// instead of being forwarded to the remote PTY as a mouse-button DRAG (#690).
+///
+/// flterm forwards swipes as button1 press+motion+release ONLY when the remote
+/// has mouse tracking on (`mouseTracking != MouseTracking.none`). When the user
+/// has DELIBERATELY entered select mode we leave flterm's native gestures alone
+/// (so a long-press-drag still works, mirroring #688). So the swipe-scroll
+/// interception is active exactly when mouse tracking is on AND select mode is
+/// off. Pure (no FFI), so it's unit-testable headless.
+bool ghosttySwipeShouldScrollLocally({
+  required MouseTracking mouseTracking,
+  required bool selectMode,
+}) {
+  return mouseTracking != MouseTracking.none && !selectMode;
+}
+
+/// Map a vertical swipe DELTA (logical px the finger moved this update) to a
+/// scrollback pixel delta to apply to the [TerminalScrollController] (#690).
+///
+/// A finger dragging DOWN (positive dy) reveals OLDER content, i.e. scrolls the
+/// viewport UP toward smaller pixel offsets — so the scroll delta is the
+/// negation of the finger delta, matching a natural touch-scroll. Pure.
+double ghosttyScrollDeltaForSwipe(double fingerDy) => -fingerDy;
+
+/// A gesture layer that absorbs touch swipes and drives a
+/// [TerminalScrollController] directly, so the swipe SCROLLS the scrollback
+/// instead of flterm forwarding it to the remote PTY as a button1 DRAG (#690).
+///
+/// Active only while [active] is true (see [ghosttySwipeShouldScrollLocally]).
+///
+/// Why OPAQUE, not translucent: flterm reports tracked mouse via a raw
+/// `Listener` (onPointerDown/Move/Up), which is NOT a gesture-arena participant
+/// — so merely WINNING the arena for the drag would not stop flterm from also
+/// emitting button press/motion on the same pointer. The only way to keep the
+/// swipe off flterm's `Listener` is to be the opaque hit-test target so the
+/// pointer never reaches the terminal below. Because that also swallows taps, we
+/// add a tap recognizer that forwards focus via [onTap] (so tapping still raises
+/// the keyboard) while the vertical-drag recognizer (touch-only) does the scroll.
+///
+/// When [active] is false (mouse mode off, or deliberate select mode on) it is
+/// inert (`IgnorePointer`), so flterm's native scroll/selection is untouched.
+class _ScrollInsteadOfMouseDrag extends StatefulWidget {
+  const _ScrollInsteadOfMouseDrag({
+    required this.active,
+    required this.scrollController,
+    required this.onTap,
+  });
+
+  /// Whether to intercept swipes (mouse tracking on AND select mode off).
+  final bool active;
+
+  /// The SAME controller handed to the flterm [TerminalView] — moving it routes
+  /// through flterm's `_onScrollChanged` → wheel reports / local scroll.
+  final TerminalScrollController scrollController;
+
+  /// Forwarded on a tap so focus/keyboard still work while the overlay is the
+  /// opaque hit-test target (typically `controller.requestFocus`).
+  final VoidCallback onTap;
+
+  @override
+  State<_ScrollInsteadOfMouseDrag> createState() =>
+      _ScrollInsteadOfMouseDragState();
+}
+
+class _ScrollInsteadOfMouseDragState extends State<_ScrollInsteadOfMouseDrag> {
+  void _onUpdate(DragUpdateDetails details) {
+    final controller = widget.scrollController;
+    if (!controller.hasClients) return;
+    final position = controller.position;
+    final target =
+        (position.pixels + ghosttyScrollDeltaForSwipe(details.delta.dy)).clamp(
+          position.minScrollExtent,
+          position.maxScrollExtent,
+        );
+    if (target == position.pixels) return;
+    controller.jumpTo(target);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.active) {
+      // Inert: flterm's own gesture detector / Scrollable handles everything.
+      return const IgnorePointer(child: SizedBox.expand());
+    }
+    return RawGestureDetector(
+      behavior: HitTestBehavior.opaque,
+      gestures: <Type, GestureRecognizerFactory>{
+        VerticalDragGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
+              () => VerticalDragGestureRecognizer(
+                // Restrict to touch: a real mouse drag should still reach the
+                // remote (mouse mode wants mouse drags); only FINGER swipes are
+                // re-routed to scroll.
+                supportedDevices: const {PointerDeviceKind.touch},
+              ),
+              (recognizer) => recognizer.onUpdate = _onUpdate,
+            ),
+        TapGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+              () => TapGestureRecognizer(),
+              (recognizer) => recognizer.onTap = widget.onTap,
+            ),
+      },
+      child: const SizedBox.expand(),
+    );
+  }
+}
+
 /// A session terminal rendered with flterm (libghostty). Wires the active
 /// session's proxy I/O to an flterm [TerminalController], applies the
 /// per-session font/size (#686), and exposes copy + select-all affordances that
@@ -143,8 +267,18 @@ class GhosttyTerminalView extends ConsumerStatefulWidget {
 class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   TerminalController? _controller;
 
+  /// Scrollback controller shared with the flterm [TerminalView] so the #690
+  /// swipe-scroll overlay can drive scrollback (→ flterm wheel reports) instead
+  /// of letting flterm forward a swipe as a remote button drag.
+  final TerminalScrollController _scrollController = TerminalScrollController();
+
   /// PTY output (bytes) -> controller.write subscription. Cancelled on dispose.
   StreamSubscription<Uint8List>? _outputSub;
+
+  /// Live remote mouse-tracking mode, mirrored from the controller (#690). The
+  /// controller is a `ChangeNotifier` that fires when the remote toggles mouse
+  /// mode; we rebuild so the swipe-scroll overlay activates/deactivates.
+  MouseTracking _mouseTracking = MouseTracking.none;
 
   String? _initError;
 
@@ -206,12 +340,27 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
           // Defensive — a single PTY byte must never crash the session.
         }
       });
+      // Track remote mouse-mode changes so the #690 swipe-scroll overlay turns
+      // on/off as the remote toggles mouse reporting (e.g. tmux mouse on/off).
+      controller.addListener(_syncMouseTracking);
+      _mouseTracking = controller.mouseTracking;
       _controller = controller;
     } catch (e) {
       // If libghostty's native .so failed to load, surface it instead of a
       // blank crash so the device tester can report it (mirrors the spike).
       _initError = 'flterm init failed: $e';
     }
+  }
+
+  /// Mirror the controller's live mouse-tracking mode into [_mouseTracking],
+  /// rebuilding only when it actually changes (the controller notifies on many
+  /// unrelated events too) so the swipe-scroll overlay (#690) follows the remote.
+  void _syncMouseTracking() {
+    final controller = _controller;
+    if (controller == null) return;
+    final next = controller.mouseTracking;
+    if (next == _mouseTracking) return;
+    if (mounted) setState(() => _mouseTracking = next);
   }
 
   SshSessionProxy? _resolveProxy() {
@@ -254,9 +403,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   @override
   void dispose() {
     _outputSub?.cancel();
+    _controller?.removeListener(_syncMouseTracking);
     _controller?.onOutput = null;
     _controller?.onResize = null;
     _controller?.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -290,6 +441,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             autofocus: false,
             theme: buildGhosttyTheme(family: fontFamily, fontSize: fontSize),
             padding: const EdgeInsets.all(4),
+            // #690: share the scroll controller so the overlay below can drive
+            // scrollback (→ flterm wheel reports) under remote mouse mode.
+            scrollController: _scrollController,
             // #688: swipe = scroll-ONLY by default; deliberate long-press-drag
             // selection only while select mode is ON. See the two settings
             // objects' docs for the flterm root cause (touch long-press, not
@@ -297,6 +451,23 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             gestureSettings: _selectMode
                 ? kGhosttySelectSettings
                 : kGhosttyScrollSettings,
+          ),
+        ),
+        // #690: when the remote has mouse mode on (tmux etc.), a finger swipe
+        // would otherwise be forwarded as a button1 DRAG → tmux selection. This
+        // overlay claims the touch vertical-drag and scrolls the scrollback
+        // (flterm then emits canonical wheel reports), so a swipe SCROLLS and
+        // never drags. Inert when mouse mode is off or select mode is on, so
+        // #688's gestures are untouched. Sits below the affordance buttons so
+        // they stay tappable.
+        Positioned.fill(
+          child: _ScrollInsteadOfMouseDrag(
+            active: ghosttySwipeShouldScrollLocally(
+              mouseTracking: _mouseTracking,
+              selectMode: _selectMode,
+            ),
+            scrollController: _scrollController,
+            onTap: controller.requestFocus,
           ),
         ),
         // Selection affordances (bottom-right). flterm's long-press select

--- a/native/test/ui/ghostty_swipe_mousereport_test.dart
+++ b/native/test/ui/ghostty_swipe_mousereport_test.dart
@@ -1,0 +1,104 @@
+// #690 — Ghostty: a touch swipe must SCROLL the scrollback, not be forwarded to
+// the remote as a mouse-button DRAG (which tmux reads as a selection).
+//
+// flterm 0.0.3 exposes NO interception hook analogous to xterm's
+// `Terminal.mouseHandler` (the #617 fix): its mouse-report path is internal to
+// `TerminalGestureDetector` (a raw `Listener`, not an arena participant), and
+// `TerminalGestureSettings` explicitly cannot disable mouse tracking. So the fix
+// lives ABOVE the flterm widget — a pointer-absorbing overlay that, when the
+// remote has mouse mode on and select mode is off, claims the touch swipe and
+// scrolls the scroll controller (flterm then emits canonical wheel reports).
+//
+// flterm/libghostty can't render headless (native .so), so these gate the PURE
+// decision + math the overlay uses. The two predicates fully determine when the
+// drag is intercepted and which way the scrollback moves; the real tmux-mouse
+// behaviour is OWNER-validated on device.
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+void main() {
+  group('ghosttySwipeShouldScrollLocally — when to intercept (#690)', () {
+    test('intercepts when mouse mode is ON and select mode is OFF', () {
+      // The bug case: tmux has mouse on; a swipe would be a remote drag.
+      for (final mode in const [
+        MouseTracking.any,
+        MouseTracking.button,
+        MouseTracking.normal,
+        MouseTracking.x10,
+      ]) {
+        expect(
+          ghosttySwipeShouldScrollLocally(
+            mouseTracking: mode,
+            selectMode: false,
+          ),
+          isTrue,
+          reason: 'mouse mode $mode + no select mode → swipe must scroll',
+        );
+      }
+    });
+
+    test('does NOT intercept when the remote has no mouse tracking', () {
+      // No mouse mode → flterm never forwards a drag; its own Scrollable scrolls.
+      expect(
+        ghosttySwipeShouldScrollLocally(
+          mouseTracking: MouseTracking.none,
+          selectMode: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does NOT intercept while DELIBERATE select mode is on', () {
+      // #688's select mode must keep working: long-press-drag selection stays
+      // flterm-native, so the overlay steps aside even under mouse tracking.
+      for (final mode in const [
+        MouseTracking.any,
+        MouseTracking.button,
+        MouseTracking.normal,
+        MouseTracking.x10,
+      ]) {
+        expect(
+          ghosttySwipeShouldScrollLocally(
+            mouseTracking: mode,
+            selectMode: true,
+          ),
+          isFalse,
+          reason: 'select mode is deliberate → do not steal the gesture',
+        );
+      }
+    });
+
+    test('select mode off + no mouse tracking is also not intercepted', () {
+      expect(
+        ghosttySwipeShouldScrollLocally(
+          mouseTracking: MouseTracking.none,
+          selectMode: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('ghosttyScrollDeltaForSwipe — natural-direction scroll (#690)', () {
+    test('dragging the finger DOWN scrolls toward older content (up)', () {
+      // Finger down (+dy) reveals older lines = smaller pixel offset = negative.
+      expect(ghosttyScrollDeltaForSwipe(24), -24);
+    });
+
+    test('dragging the finger UP scrolls toward newer content (down)', () {
+      expect(ghosttyScrollDeltaForSwipe(-24), 24);
+    });
+
+    test('a still finger produces no scroll', () {
+      expect(ghosttyScrollDeltaForSwipe(0), 0);
+    });
+
+    test('is exactly the negation of the finger delta', () {
+      for (final dy in const [1.0, -1.0, 5.5, -120.0, 0.0]) {
+        expect(ghosttyScrollDeltaForSwipe(dy), -dy);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## #690 — Ghostty touch-swipe forwarded to the remote as a mouse-button DRAG

When the remote enables mouse mode (DECSET 1000/1002/1003/1006, e.g. **tmux**), a finger
**swipe** was forwarded to the PTY as a button1 press+motion+release — a **DRAG** — which
tmux interprets as a mouse **selection** (its own selection styling appears). This is
**distinct from #688** (which stopped flterm's *local* selection); this is the **remote
mouse-report** path. Same class as the xterm fix **#617**.

### flterm 0.0.3 mouse-reporting model (the adopt-flterm data point)
- Reporting is owned by flterm's internal `TerminalGestureDetector`: when
  `controller.mouseTracking != none`, a raw `Listener` turns swipe pointers into
  `handleMouseEvent(press/motion/release)` → libghostty `MouseEncoder` → PTY.
- **Interceptable like xterm's `Terminal.mouseHandler` (#617)? No.** flterm exposes no
  mouse-handler override and no config to disable touch reporting:
  - `TerminalGestureSettings` docstring: *"mouse tracking ... work regardless of these
    settings"* — #688's `enabledSelections` only affect local selection.
  - The report path is a raw `Listener` (not a gesture-arena participant), so winning the
    arena does not stop it.
  - The only built-in bypass is Shift (`virtualMods.hasShift`), but a persistent virtual
    Shift leaks into every wheel/scroll/key report and auto-clears on focus loss / next
    keystroke. Fragile — rejected.
- **What IS clean:** flterm's `TerminalScrollController` is a real `ScrollController`;
  moving it fires `_onScrollChanged` → `handleScroll`, which under mouse tracking emits
  **canonical SGR wheel reports** (libghostty's own encoding — not xterm-4.0.0's buggy
  68/69, so no #617-style rewrite needed). Driving the scroll controller gives the remote
  clean wheel events for tmux scrollback, never a drag.

### The fix (no flterm fork)
Intercept one layer up: a pointer-absorbing overlay (`_ScrollInsteadOfMouseDrag`) in
`GhosttyTerminalView`'s existing `Stack`, active **only** when
`mouseTracking != none && !selectMode`. It is the **opaque** hit-test target (must be
opaque, not translucent, because flterm's `Listener` is non-arena and would still fire on a
translucent overlay), claims the **touch** vertical-drag and scrolls the **shared**
`TerminalScrollController` (→ flterm wheel reports). Taps forward to
`controller.requestFocus` so the keyboard still works; **real mouse drags pass through**
(recognizer is touch-only). **Inert** (`IgnorePointer`) when mouse mode is off or
deliberate select mode is on — **#688 untouched**.

### Scope
- Only `native/lib/ui/ghostty_terminal_view.dart` (+ a new unit-test file). xterm path,
  #685 switch, #686 font, #688 scroll/select-mode all untouched.

### Tests
- `native/test/ui/ghostty_swipe_mousereport_test.dart` — pure-logic gates for the
  activation predicate (`ghosttySwipeShouldScrollLocally`) and the scroll-direction math
  (`ghosttyScrollDeltaForSwipe`). flterm can't render headless, so the real tmux-mouse
  behaviour is **owner-validated on device**.
- `scripts/native-fast-gate.sh`: `flutter analyze` clean, all 564 tests pass.

### Owner validates on device
1. tmux with `set -g mouse on`: a finger swipe **scrolls scrollback** and tmux shows **no
   selection** (no drag styling).
2. Deliberate **select mode** (touch_app toggle) still selects via long-press-drag (#688).
3. tmux mouse **off**: scrollback still scrolls normally (unchanged).

Refs #690, #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)