### PR TITLE
feat(#694): keybar sticky Ctrl modifier (PWA ctrlActive parity)

### DIFF
--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -55,6 +55,7 @@ class KeybarKey {
     required this.label,
     required this.sequence,
     this.icon,
+    this.isModifier = false,
   });
 
   final String id;
@@ -64,6 +65,59 @@ class KeybarKey {
   /// When non-null, the button shows this monochrome icon instead of [label]
   /// text (e.g. Paste). [label] is still used as the accessibility tooltip.
   final IconData? icon;
+
+  /// A sticky modifier key (the Ctrl key, #694) — tapping it ARMS the modifier
+  /// rather than emitting [sequence]. Modifier keys carry no literal byte; the
+  /// transform is applied to the NEXT key. See [CtrlModifier] / [ctrlTransform].
+  final bool isModifier;
+}
+
+/// Transform a keybar [sequence] as if Ctrl were held (#694), mirroring the
+/// PWA's `ctrlActive` mapping (`e.key.toLowerCase().charCodeAt(0) - 96`).
+///
+/// A single ASCII letter a–z / A–Z becomes its control byte via `& 0x1f`
+/// (Ctrl+A = \x01 … Ctrl+Z = \x1a). Anything else — a multi-byte CSI escape
+/// (arrows), an already-control byte (^C), an empty sequence (Paste), or a
+/// symbol with no letter control meaning — passes through UNCHANGED. The caller
+/// still clears the armed modifier afterward (one-shot sticky).
+String ctrlTransform(String sequence) {
+  if (sequence.length != 1) return sequence;
+  final code = sequence.codeUnitAt(0);
+  final isLetter =
+      (code >= 0x41 && code <= 0x5a) || (code >= 0x61 && code <= 0x7a);
+  if (!isLetter) return sequence;
+  return String.fromCharCode(code & 0x1f);
+}
+
+/// Sticky one-shot Ctrl modifier state (#694), mirroring the PWA's
+/// `ctrlActive`. [arm] toggles the armed flag (a second tap CANCELS). [apply]
+/// transforms the next key's sequence when armed and AUTO-CLEARS (one-shot).
+///
+/// Kept as a plain state holder (no widget dependency) so the arm/transform/
+/// clear lifecycle is unit-testable — the keybar widget tap path hangs the
+/// headless harness on Material ripple (see keybar_test.dart).
+class CtrlModifier {
+  bool _armed = false;
+
+  bool get armed => _armed;
+
+  /// Tap the Ctrl key: arm if disarmed, cancel if already armed.
+  void arm() {
+    _armed = !_armed;
+  }
+
+  /// Force the modifier off (e.g. when switching sessions).
+  void clear() {
+    _armed = false;
+  }
+
+  /// Apply Ctrl to [sequence] if armed, then auto-clear. Returns the bytes to
+  /// actually send. When disarmed, returns [sequence] verbatim.
+  String apply(String sequence) {
+    if (!_armed) return sequence;
+    _armed = false;
+    return ctrlTransform(sequence);
+  }
 }
 
 /// Default key layout — one flat line (scrolls horizontally), mirroring the
@@ -132,20 +186,69 @@ const List<KeybarKey> kDefaultKeybarKeys = [
     sequence: '', // handled out-of-band
     icon: Icons.content_paste,
   ),
-  // --- control sequences grouped LAST (owner-mandated, do not intersperse) ---
+  // --- control group LAST (owner-mandated, do not intersperse) ---
+  // #694: the sticky Ctrl MODIFIER leads the control group. Tapping it arms
+  // Ctrl for the next keybar key (Ctrl+A..Z etc.), then auto-clears. It carries
+  // no literal byte (isModifier). The fixed ^C/^Z/^B/^D quick-access combos
+  // stay after it for one-tap common interrupts.
+  KeybarKey(id: 'keyCtrl', label: 'Ctrl', sequence: '', isModifier: true),
   KeybarKey(id: 'keyCtrlC', label: '^C', sequence: '\x03'),
   KeybarKey(id: 'keyCtrlZ', label: '^Z', sequence: '\x1a'),
   KeybarKey(id: 'keyCtrlB', label: '^B', sequence: '\x02'),
   KeybarKey(id: 'keyCtrlD', label: '^D', sequence: '\x04'),
 ];
 
-class Keybar extends ConsumerWidget {
+class Keybar extends ConsumerStatefulWidget {
   const Keybar({super.key, required this.activeEntry});
 
   final SessionEntry activeEntry;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<Keybar> createState() => _KeybarState();
+}
+
+class _KeybarState extends ConsumerState<Keybar> {
+  // #694: sticky one-shot Ctrl modifier, mirroring the PWA's `ctrlActive`.
+  // Tapping the Ctrl key arms it; the next keybar key transforms to its control
+  // byte, then it auto-clears.
+  final CtrlModifier _ctrl = CtrlModifier();
+
+  void _onKeyTap(KeybarKey k) {
+    final terminal = widget.activeEntry.terminal;
+
+    // The Ctrl modifier key itself: arm/cancel, no byte emitted.
+    if (k.isModifier) {
+      setState(_ctrl.arm);
+      return;
+    }
+
+    // Paste pulls from the clipboard out-of-band. If Ctrl was armed, it has no
+    // single-letter control meaning, so clear the modifier and paste literally.
+    if (k.id == 'keyPaste') {
+      final wasArmed = _ctrl.armed;
+      if (wasArmed) setState(_ctrl.clear);
+      _paste(terminal);
+      return;
+    }
+
+    // Apply the (possibly armed) Ctrl transform and send. `apply` auto-clears
+    // the one-shot modifier; rebuild so the armed highlight clears.
+    final wasArmed = _ctrl.armed;
+    final bytes = _ctrl.apply(k.sequence);
+    if (bytes.isNotEmpty) terminal.textInput(bytes);
+    if (wasArmed) setState(() {});
+  }
+
+  Future<void> _paste(Terminal terminal) async {
+    final data = await Clipboard.getData('text/plain');
+    final text = data?.text;
+    if (text != null && text.isNotEmpty) {
+      terminal.textInput(text);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Material(
       key: const Key('keybar'),
@@ -168,7 +271,9 @@ class Keybar extends ConsumerWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 2),
                   child: _KeybarButton(
                     keyData: k,
-                    terminal: activeEntry.terminal,
+                    // The Ctrl key shows an accented/armed state while sticky.
+                    armed: k.isModifier && _ctrl.armed,
+                    onTap: () => _onKeyTap(k),
                   ),
                 ),
             ],
@@ -180,22 +285,18 @@ class Keybar extends ConsumerWidget {
 }
 
 class _KeybarButton extends StatelessWidget {
-  const _KeybarButton({required this.keyData, required this.terminal});
+  const _KeybarButton({
+    required this.keyData,
+    required this.onTap,
+    this.armed = false,
+  });
 
   final KeybarKey keyData;
-  final Terminal terminal;
+  final VoidCallback onTap;
 
-  Future<void> _onTap(BuildContext context) async {
-    if (keyData.id == 'keyPaste') {
-      final data = await Clipboard.getData('text/plain');
-      final text = data?.text;
-      if (text != null && text.isNotEmpty) {
-        terminal.textInput(text);
-      }
-      return;
-    }
-    terminal.textInput(keyData.sequence);
-  }
+  /// #694: when true (the armed Ctrl modifier), the button paints an accented
+  /// highlight so it's clear Ctrl is sticky for the next key.
+  final bool armed;
 
   @override
   Widget build(BuildContext context) {
@@ -206,11 +307,16 @@ class _KeybarButton extends StatelessWidget {
     final bool isEsc = keyData.id == 'keyEsc';
     // Monochrome icon (theme-tinted) when set, else the label glyph/text.
     // Never an emoji — see memory feedback_monochrome_icons_no_emoji.
+    // #694: the armed Ctrl modifier paints accent-tinted text so the sticky
+    // state reads clearly. Other keys use the normal onSurface tint.
+    final Color fg = armed
+        ? theme.colorScheme.onPrimary
+        : theme.colorScheme.onSurface;
     final Widget child = keyData.icon != null
         ? Icon(
             keyData.icon,
             size: kKeybarIconSize,
-            color: theme.colorScheme.onSurface,
+            color: fg,
             semanticLabel: keyData.label,
           )
         : Text(
@@ -218,13 +324,17 @@ class _KeybarButton extends StatelessWidget {
             style: TextStyle(
               fontSize: isEsc ? kKeybarEscFontSize : kKeybarLabelFontSize,
               fontFamily: 'monospace',
+              color: armed ? fg : null,
             ),
             overflow: TextOverflow.ellipsis,
           );
     return OutlinedButton(
       key: Key('keybar-btn-${keyData.id}'),
-      onPressed: () => _onTap(context),
+      onPressed: onTap,
       style: OutlinedButton.styleFrom(
+        // #694: armed Ctrl fills with the accent color so the sticky state is
+        // unmistakable (mirrors the PWA's `.active` keybar styling).
+        backgroundColor: armed ? theme.colorScheme.primary : null,
         // #615: tighter padding for the ~25% shrink. Still a touch-friendly
         // tap target via minimumSize below.
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -233,10 +343,13 @@ class _KeybarButton extends StatelessWidget {
         minimumSize: const Size(kKeybarButtonMinWidth, kKeybarButtonMinHeight),
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         // #615: lighter outline — thinner, lower-opacity border so the bar
-        // reads as a quiet strip rather than a grid of boxes.
+        // reads as a quiet strip rather than a grid of boxes. Armed Ctrl uses a
+        // solid accent border to match its filled state.
         side: BorderSide(
-          color: theme.colorScheme.outline.withValues(alpha: 0.4),
-          width: 0.5,
+          color: armed
+              ? theme.colorScheme.primary
+              : theme.colorScheme.outline.withValues(alpha: 0.4),
+          width: armed ? 1.0 : 0.5,
         ),
         // Squarer look matching the PWA keybar — subtle rounding, not pill.
         shape: const RoundedRectangleBorder(

--- a/native/test/widget/keybar_ctrl_modifier_test.dart
+++ b/native/test/widget/keybar_ctrl_modifier_test.dart
@@ -1,0 +1,186 @@
+// Tests for the sticky Ctrl modifier on the keybar (#694).
+//
+// PWA `ctrlActive` parity: tap Ctrl to ARM, the next keybar key transforms to
+// its control byte, then Ctrl AUTO-CLEARS (one-shot sticky). Tapping Ctrl while
+// armed toggles it OFF (cancel). A non-letter key while armed sends unmodified
+// and still clears Ctrl.
+//
+// The byte-transform is a PURE helper (`ctrlTransform`) so it's unit-testable
+// without pumping widgets — the keybar widget tap path hangs the headless
+// harness on Material ripple animations (see keybar_test.dart). The arm/clear
+// lifecycle is exercised through `CtrlModifier`, a plain state holder the
+// widget delegates to, so the state machine is covered without a live tap.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/keybar.dart';
+
+void main() {
+  group('ctrlTransform — letter → control byte (#694)', () {
+    test('lowercase a → \\x01 (Ctrl+A)', () {
+      expect(ctrlTransform('a'), equals('\x01'));
+    });
+
+    test('uppercase A → \\x01 (case-insensitive, matches PWA)', () {
+      expect(ctrlTransform('A'), equals('\x01'));
+    });
+
+    test('l/L → \\x0c (Ctrl+L, clear screen)', () {
+      expect(ctrlTransform('l'), equals('\x0c'));
+      expect(ctrlTransform('L'), equals('\x0c'));
+    });
+
+    test('z → \\x1a (Ctrl+Z, the high end of the letter range)', () {
+      expect(ctrlTransform('z'), equals('\x1a'));
+    });
+
+    test('every a–z maps to byte 1..26 via & 0x1f', () {
+      for (var c = 'a'.codeUnitAt(0); c <= 'z'.codeUnitAt(0); c++) {
+        final letter = String.fromCharCode(c);
+        final expected = c & 0x1f; // 1..26
+        expect(
+          ctrlTransform(letter).codeUnitAt(0),
+          equals(expected),
+          reason: 'Ctrl+$letter should be byte $expected',
+        );
+      }
+    });
+  });
+
+  group('ctrlTransform — non-letter keys pass through unmodified (#694)', () {
+    test('a multi-byte CSI arrow sequence is left unchanged', () {
+      expect(ctrlTransform('\x1b[D'), equals('\x1b[D'));
+    });
+
+    test('a slash has no letter control meaning → unmodified', () {
+      expect(ctrlTransform('/'), equals('/'));
+    });
+
+    test('an already-control byte (^C = \\x03) is unmodified', () {
+      expect(ctrlTransform('\x03'), equals('\x03'));
+    });
+
+    test('an empty sequence (e.g. Paste) is unmodified', () {
+      expect(ctrlTransform(''), equals(''));
+    });
+
+    test('Enter CR is left unchanged', () {
+      expect(ctrlTransform('\r'), equals('\r'));
+    });
+  });
+
+  group('CtrlModifier — arm / one-shot / toggle (#694)', () {
+    test('starts disarmed', () {
+      final m = CtrlModifier();
+      expect(m.armed, isFalse);
+    });
+
+    test('arm() toggles ON from disarmed', () {
+      final m = CtrlModifier();
+      m.arm();
+      expect(m.armed, isTrue);
+    });
+
+    test('arm() while armed toggles OFF (cancel) — Ctrl pressed twice', () {
+      final m = CtrlModifier();
+      m.arm();
+      m.arm();
+      expect(m.armed, isFalse, reason: 'second Ctrl tap cancels the modifier');
+    });
+
+    test('apply() while armed transforms a letter and auto-clears', () {
+      final m = CtrlModifier();
+      m.arm();
+      final out = m.apply('a');
+      expect(out, equals('\x01'), reason: 'armed Ctrl+a → \\x01');
+      expect(m.armed, isFalse, reason: 'one-shot: Ctrl clears after one key');
+    });
+
+    test('apply() while disarmed returns the sequence verbatim', () {
+      final m = CtrlModifier();
+      final out = m.apply('a');
+      expect(out, equals('a'));
+      expect(m.armed, isFalse);
+    });
+
+    test(
+      'apply() while armed on a non-letter sends unmodified, still clears',
+      () {
+        final m = CtrlModifier();
+        m.arm();
+        final out = m.apply('/');
+        expect(
+          out,
+          equals('/'),
+          reason: 'no letter control meaning → unmodified',
+        );
+        expect(
+          m.armed,
+          isFalse,
+          reason: 'Ctrl still auto-clears after one key',
+        );
+      },
+    );
+
+    test(
+      'armed → letter → armed-again requires a fresh tap (sticky one-shot)',
+      () {
+        final m = CtrlModifier();
+        m.arm();
+        expect(m.apply('a'), equals('\x01'));
+        // Without re-arming, the next key is literal.
+        expect(m.apply('b'), equals('b'));
+        // Re-arm for the next control byte.
+        m.arm();
+        expect(m.apply('c'), equals('\x03'));
+      },
+    );
+  });
+
+  group('Ctrl key in the default layout (#694)', () {
+    test('a Ctrl modifier key exists in the default keybar', () {
+      final ids = kDefaultKeybarKeys.map((k) => k.id).toList();
+      expect(
+        ids,
+        contains('keyCtrl'),
+        reason: 'the sticky Ctrl modifier key must be on the default bar',
+      );
+    });
+
+    test('Ctrl is grouped with the control keys at the END of the bar', () {
+      final ids = kDefaultKeybarKeys.map((k) => k.id).toList();
+      final ctrlGroup = {
+        'keyCtrl',
+        'keyCtrlC',
+        'keyCtrlZ',
+        'keyCtrlB',
+        'keyCtrlD',
+      };
+      final lastNonCtrlIndex = ids.lastIndexWhere(
+        (id) => !ctrlGroup.contains(id),
+      );
+      final firstCtrlIndex = ids.indexWhere((id) => ctrlGroup.contains(id));
+      expect(
+        firstCtrlIndex,
+        greaterThan(lastNonCtrlIndex),
+        reason:
+            'control group (incl. the new Ctrl modifier) must be at the END, '
+            'not interspersed among nav/symbol keys. Order: $ids',
+      );
+    });
+
+    test('the Ctrl key is a modifier, not a fixed control byte', () {
+      final ctrl = kDefaultKeybarKeys.firstWhere((k) => k.id == 'keyCtrl');
+      // It carries no literal sequence — tapping it arms the modifier, it does
+      // NOT emit a byte like ^C/^Z do.
+      expect(ctrl.isModifier, isTrue);
+      expect(ctrl.sequence, isEmpty);
+    });
+
+    test('the fixed ^C/^Z/^B/^D quick keys are retained (#694)', () {
+      final ids = kDefaultKeybarKeys.map((k) => k.id).toSet();
+      for (final id in ['keyCtrlC', 'keyCtrlZ', 'keyCtrlB', 'keyCtrlD']) {
+        expect(ids, contains(id), reason: '$id must remain on the bar');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #694.

## What

Adds a sticky one-shot **Ctrl** modifier to the native Flutter keybar, mirroring the PWA's `ctrlActive`. The keybar previously shipped only four fixed control combos (`^C`/`^Z`/`^B`/`^D`), so any other control byte (`^A` `^R` `^L` `^W` `^U` `^K` `^E` …) was impossible. The Ctrl modifier makes all of them reachable.

## State model (arm / transform / auto-clear)

- **`ctrlTransform(seq)`** — pure helper. A single ASCII letter a–z/A–Z → `byte & 0x1f` (Ctrl+A=`\x01` … Ctrl+Z=`\x1a`, matching the PWA's `charCodeAt(0)-96`). Anything else — multi-byte CSI arrows, already-control bytes (`^C`), empty Paste, symbols with no letter control meaning — passes through unchanged.
- **`CtrlModifier`** — tiny one-shot state holder. `arm()` toggles armed (a second Ctrl tap **cancels**); `apply(seq)` transforms when armed then **auto-clears**; `clear()` forces off.
- **`Keybar`** is now a `ConsumerStatefulWidget` holding one `CtrlModifier`. Tap flow:
  - Ctrl key (`isModifier`) → arm, no byte emitted; armed paints an accent-filled button (primary background + onPrimary fg/border), mirroring the PWA's `.active` styling.
  - any other key while armed → `apply(sequence)` → send → auto-clear → rebuild.
  - Paste while armed → clears Ctrl, pastes literally.
  - fixed `^C`/`^Z`/`^B`/`^D` retained; `ctrlTransform` is a no-op on those bytes.

`keyCtrl` leads the control group at the **END** of the bar, keeping the control group contiguous and last (owner-mandated order contract).

## Scope: keybar keys only (not IME chars)

Ctrl applies to the **next keybar key**, not soft-keyboard / IME characters. Those flow through xterm.dart's own `CustomTextEdit` platform-channel input straight into `Terminal` — the keybar widget has no clean interception seam, and the compose bar is a separate widget. Bolting global key interception onto xterm is out of scope per the issue. IME-char arming is deferred until a clean seam exists.

Backend-agnostic: the keybar sends via `terminal.textInput`, so this works for both xterm and Ghostty with no backend special-casing.

## Tests

21 new tests in `native/test/widget/keybar_ctrl_modifier_test.dart`: letter→control mapping (every a–z), non-letter pass-through, arm/one-shot/toggle-off lifecycle, Ctrl key presence + control-group ordering, fixed combos retained. Native fast gate green (585 tests, `flutter analyze` clean).

## Owner device-validates

- Ctrl key shows the armed (accent-filled) visual when tapped.
- Armed Ctrl + a letter sends the right control byte on a real terminal (e.g. Ctrl+L clears, Ctrl+R reverse-search, Ctrl+A start-of-line).
- Second Ctrl tap cancels without sending anything.
- Both xterm and Ghostty backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)