### PR TITLE
feat(#709): FGS notification shows live session count (slice 1)

### DIFF
--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -121,6 +121,16 @@ abstract class KeepaliveGateway {
     required String notificationText,
   });
 
+  /// Update the ongoing notification's title/text WITHOUT re-starting the
+  /// foreground service (#709 slice 1). Used to reflect the live session count
+  /// as sessions connect/disconnect. The keep-alive channel is configured with
+  /// `onlyAlertOnce: true`, so repeated updates are silent — no sound/vibration
+  /// re-alert per change. No-op when the service is not running.
+  Future<bool> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  });
+
   Future<bool> stopService();
 }
 
@@ -140,6 +150,27 @@ ForegroundTaskOptions buildKeepaliveTaskOptions() {
     allowWakeLock: true,
     allowWifiLock: false,
   );
+}
+
+/// Pure mapping from the live connected-session count to the FGS notification
+/// text (#709 slice 1). Kept top-level + side-effect-free so the mapping is
+/// unit-testable without binding to the foreground-task plugin.
+///
+///   - 0 connected → the minimal handshake text ("Connecting…"). This is only
+///     shown transiently while the service is started on connect-initiation
+///     (#539) before any session reaches `connected`; the service stops once
+///     no sessions remain.
+///   - 1 connected → "Connected — `hostLabel`" when a label is available
+///     (e.g. `user@host`), else the count form "1 session connected".
+///   - N greater than 1 → "N sessions connected".
+String keepaliveNotificationText(int count, {String? hostLabel}) {
+  if (count <= 0) return 'Connecting…';
+  if (count == 1) {
+    final label = hostLabel?.trim();
+    if (label != null && label.isNotEmpty) return 'Connected — $label';
+    return '1 session connected';
+  }
+  return '$count sessions connected';
 }
 
 /// No-op keep-alive gateway for desktop (macOS / Linux / Windows, #577).
@@ -165,6 +196,12 @@ class NoopKeepaliveGateway implements KeepaliveGateway {
 
   @override
   Future<bool> startService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async => true;
+
+  @override
+  Future<bool> updateService({
     required String notificationTitle,
     required String notificationText,
   }) async => true;
@@ -238,6 +275,23 @@ class FlutterForegroundTaskGateway implements KeepaliveGateway {
   }
 
   @override
+  Future<bool> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    // Silent update: the channel is `onlyAlertOnce: true` (importance/priority
+    // LOW), so changing the ongoing notification's text as sessions come and go
+    // does NOT re-alert (no sound/vibration). `updateService` throws if the
+    // service isn't running — that's surfaced as a failure (caught by the
+    // caller's tolerant wrapper), not an exception that breaks the FGS.
+    final result = await FlutterForegroundTask.updateService(
+      notificationTitle: notificationTitle,
+      notificationText: notificationText,
+    );
+    return result is ServiceRequestSuccess;
+  }
+
+  @override
   Future<bool> stopService() async {
     final result = await FlutterForegroundTask.stopService();
     return result is ServiceRequestSuccess;
@@ -258,9 +312,12 @@ class KeepaliveController {
     KeepaliveGateway? gateway,
     bool enabled = true,
     void Function()? onServiceStopped,
+    String? Function()? notificationLabelResolver,
   }) : _gateway = gateway ?? FlutterForegroundTaskGateway(),
        // ignore: prefer_initializing_formals
-       _onServiceStopped = onServiceStopped {
+       _onServiceStopped = onServiceStopped,
+       // ignore: prefer_initializing_formals
+       _notificationLabelResolver = notificationLabelResolver {
     _enabled = enabled;
   }
 
@@ -270,6 +327,14 @@ class KeepaliveController {
   /// UI↔task gateway can reset to not-ready and re-buffer commands until the
   /// next isolate generation re-handshakes (#564 reconnect fix).
   final void Function()? _onServiceStopped;
+
+  /// Optional resolver for the single-session notification label (#709 slice
+  /// 1). Consulted only when exactly one session is connected, to render
+  /// "Connected — `user@host`" instead of the bare "1 session connected".
+  /// Returns null when no label is readily available (the count form is used).
+  /// Lives UI-side (the count-owning controller reads `sessionsProvider`); the
+  /// start-only starter controller leaves it null.
+  final String? Function()? _notificationLabelResolver;
   bool _enabled = true;
   int _connectedCount = 0;
   final Map<Object, StreamSubscription<SshSessionData>> _subscriptions = {};
@@ -347,16 +412,31 @@ class KeepaliveController {
     var wasConnected = _holdsService(snapshot().state);
     if (wasConnected) {
       _connectedCount += 1;
-      unawaited(_startIfStopped());
+      if (_connectedCount == 1) {
+        unawaited(_startIfStopped());
+      } else {
+        unawaited(_refreshNotification());
+      }
     }
     _subscriptions[session] = stream.listen((data) {
       final isConnected = _holdsService(data.state);
       if (isConnected && !wasConnected) {
         _connectedCount += 1;
-        unawaited(_startIfStopped());
+        // 0→1 starts the service (text set at start). 1→N+1 keeps it running,
+        // so push the new count into the ongoing notification (#709 slice 1).
+        if (_connectedCount == 1) {
+          unawaited(_startIfStopped());
+        } else {
+          unawaited(_refreshNotification());
+        }
       } else if (!isConnected && wasConnected) {
         _connectedCount = (_connectedCount - 1).clamp(0, 1 << 30);
-        if (_connectedCount == 0) unawaited(_stopIfRunning());
+        if (_connectedCount == 0) {
+          unawaited(_stopIfRunning());
+        } else {
+          // N→M (still >0): service stays up, update the count text (#709).
+          unawaited(_refreshNotification());
+        }
       } else if (!isConnected &&
           _connectedCount == 0 &&
           _isTerminal(data.state)) {
@@ -387,7 +467,12 @@ class KeepaliveController {
     final (_, SshSessionData Function() snapshot) = _viewOf(session);
     if (_holdsService(snapshot().state)) {
       _connectedCount = (_connectedCount - 1).clamp(0, 1 << 30);
-      if (_connectedCount == 0) await _stopIfRunning();
+      if (_connectedCount == 0) {
+        await _stopIfRunning();
+      } else {
+        // Still >0 connected: keep the service, update the count text (#709).
+        await _refreshNotification();
+      }
     }
   }
 
@@ -439,13 +524,39 @@ class KeepaliveController {
     ctrace('ui.keepalive', '_startIfStopped: calling startService...');
     final ok = await _gateway.startService(
       notificationTitle: 'MobiSSH',
-      notificationText: _connectedCount == 0
-          ? 'Connecting…'
-          : _connectedCount == 1
-          ? '1 session connected'
-          : '$_connectedCount sessions connected',
+      notificationText: _notificationText(),
     );
     ctrace('ui.keepalive', '_startIfStopped: startService → $ok');
+  }
+
+  /// Compute the current notification text from the live connected count,
+  /// consulting [_notificationLabelResolver] for the single-session host label
+  /// (#709 slice 1). Delegates to the pure [keepaliveNotificationText] mapping.
+  String _notificationText() {
+    final label = _connectedCount == 1
+        ? _notificationLabelResolver?.call()
+        : null;
+    return keepaliveNotificationText(_connectedCount, hostLabel: label);
+  }
+
+  /// Push the current notification text into the ongoing FGS notification
+  /// without restarting the service (#709 slice 1). No-op when the service is
+  /// not running or the gateway is uninitialized — the text is set at start in
+  /// those cases. Silent: the channel is `onlyAlertOnce: true`, so this never
+  /// re-alerts. Tolerant of a missing platform plugin (same policy as
+  /// [ensureStarted]) — a notification refresh must never break keep-alive.
+  Future<void> _refreshNotification() async {
+    if (!_enabled) return;
+    if (!_gateway.isInitialized) return;
+    try {
+      if (!await _gateway.isRunningService) return;
+      await _gateway.updateService(
+        notificationTitle: 'MobiSSH',
+        notificationText: _notificationText(),
+      );
+    } catch (e) {
+      ctrace('ui.keepalive', '_refreshNotification: EXCEPTION — $e');
+    }
   }
 
   Future<void> _stopIfRunning({bool notifyGateway = true}) async {

--- a/native/lib/state/keepalive_providers.dart
+++ b/native/lib/state/keepalive_providers.dart
@@ -11,8 +11,28 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../platform/desktop.dart';
 import '../services/keepalive_task.dart';
+import '../ssh/ssh_session.dart';
 import 'session_host_providers.dart';
 import 'sessions.dart';
+
+/// Label of the single session currently holding the keep-alive service open
+/// (#709 slice 1). Returns the entry's `label` (`user@host:port` or the saved
+/// profile title) when EXACTLY one session is in a service-holding state
+/// (`connected`/`reconnecting`), else null so the controller falls back to the
+/// count form. Mirrors `KeepaliveController._holdsService`: a session counts as
+/// "connected" for notification purposes in both states.
+String? _soleConnectedSessionLabel(SessionsState sessions) {
+  SessionEntry? sole;
+  for (final e in sessions.entries) {
+    final state = e.proxy.data.state;
+    if (state == SshSessionState.connected ||
+        state == SshSessionState.reconnecting) {
+      if (sole != null) return null; // more than one — use the count form
+      sole = e;
+    }
+  }
+  return sole?.label;
+}
 
 /// Selects the keep-alive gateway for the current platform (#577). Desktop has
 /// no foreground service (the process persists), so it uses a no-op gateway;
@@ -89,6 +109,13 @@ final keepaliveControllerProvider = Provider<KeepaliveController>((ref) {
     enabled: ref.read(keepaliveEnabledProvider),
     onServiceStopped: () =>
         ref.read(taskSshGatewayProvider).markServiceStopped(),
+    // #709 slice 1: when exactly one session is connected, label the ongoing
+    // notification with that session's `user@host` (or saved title). The
+    // controller only consults this on a single-session count, so we return the
+    // label of the sole connected entry. ref.read (not watch) keeps this
+    // provider from rebuilding — the resolver is pulled on demand at update time.
+    notificationLabelResolver: () =>
+        _soleConnectedSessionLabel(ref.read(sessionsProvider)),
   );
   // Initial attach for whatever sessions already exist when this controller
   // is first read (typically zero on cold start, but the proxy/session

--- a/native/test/services/keepalive_task_test.dart
+++ b/native/test/services/keepalive_task_test.dart
@@ -47,6 +47,15 @@ class FakeKeepaliveGateway implements KeepaliveGateway {
   }
 
   @override
+  Future<bool> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    calls.add('update:$notificationText');
+    return true;
+  }
+
+  @override
   Future<bool> stopService() async {
     calls.add('stop');
     _running = false;
@@ -94,6 +103,164 @@ Future<void> _drain() async {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // #709 slice 1: pure count → notification-text mapping.
+  group('keepaliveNotificationText', () {
+    test('0 connected → minimal handshake text', () {
+      expect(keepaliveNotificationText(0), 'Connecting…');
+    });
+
+    test('1 connected, no label → singular count form', () {
+      expect(keepaliveNotificationText(1), '1 session connected');
+    });
+
+    test('1 connected, empty/whitespace label → singular count form', () {
+      expect(
+        keepaliveNotificationText(1, hostLabel: ''),
+        '1 session connected',
+      );
+      expect(
+        keepaliveNotificationText(1, hostLabel: '   '),
+        '1 session connected',
+      );
+    });
+
+    test('1 connected, with label → "Connected — <label>"', () {
+      expect(
+        keepaliveNotificationText(1, hostLabel: 'me@example.com'),
+        'Connected — me@example.com',
+      );
+    });
+
+    test('1 connected trims surrounding whitespace on the label', () {
+      expect(
+        keepaliveNotificationText(1, hostLabel: '  me@host  '),
+        'Connected — me@host',
+      );
+    });
+
+    test('N>1 connected → plural count form (label ignored)', () {
+      expect(keepaliveNotificationText(2), '2 sessions connected');
+      expect(
+        keepaliveNotificationText(3, hostLabel: 'me@host'),
+        '3 sessions connected',
+      );
+    });
+  });
+
+  // #709 slice 1: the controller drives updateService on count changes while
+  // the service stays running, and renders the single-session host label.
+  group('KeepaliveController notification updates (#709)', () {
+    test(
+      'start shows the single-session label when a resolver is set',
+      () async {
+        final gateway = FakeKeepaliveGateway();
+        final controller = KeepaliveController(
+          gateway: gateway,
+          notificationLabelResolver: () => 'me@host:22',
+        );
+        final session = StubSession();
+        controller.attach(session);
+
+        session.emit(SshSessionState.connected);
+        await _drain();
+        expect(gateway.calls, contains('start:Connected — me@host:22'));
+
+        await controller.dispose();
+        await session.dispose();
+      },
+    );
+
+    test('second session updates notification to plural count', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(
+        gateway: gateway,
+        notificationLabelResolver: () => 'me@host:22',
+      );
+      final s1 = StubSession();
+      final s2 = StubSession();
+      controller.attach(s1);
+      controller.attach(s2);
+
+      s1.emit(SshSessionState.connected);
+      await _drain();
+      expect(controller.connectedCount, 1);
+      expect(gateway.calls, contains('start:Connected — me@host:22'));
+
+      s2.emit(SshSessionState.connected);
+      await _drain();
+      expect(controller.connectedCount, 2);
+      // Service stays running (no second start); count text pushed via update.
+      expect(gateway.calls, contains('update:2 sessions connected'));
+      expect(
+        gateway.calls.where((c) => c.startsWith('start:')).length,
+        1,
+        reason: 'second session must not re-start the service',
+      );
+
+      await controller.dispose();
+      await s1.dispose();
+      await s2.dispose();
+    });
+
+    test('disconnecting one of two pushes a single-session update', () async {
+      final gateway = FakeKeepaliveGateway();
+      // The UI resolver returns the sole connected session's label; emulate it
+      // here with a flag the test flips as it drives the stub session counts.
+      var oneConnected = false;
+      final controller = KeepaliveController(
+        gateway: gateway,
+        notificationLabelResolver: () => oneConnected ? 'me@host:22' : null,
+      );
+      final s1 = StubSession();
+      final s2 = StubSession();
+      controller.attach(s1);
+      controller.attach(s2);
+
+      s1.emit(SshSessionState.connected);
+      s2.emit(SshSessionState.connected);
+      await _drain();
+      expect(controller.connectedCount, 2);
+
+      // One drops → back to a single connected session; the resolver now yields
+      // the surviving label, and the controller pushes a silent update.
+      oneConnected = true;
+      s2.emit(SshSessionState.disconnected);
+      await _drain();
+      expect(controller.connectedCount, 1);
+      expect(gateway.calls, contains('update:Connected — me@host:22'));
+      expect(
+        await gateway.isRunningService,
+        isTrue,
+        reason: 'service must stay running while one session remains',
+      );
+
+      await controller.dispose();
+      await s1.dispose();
+      await s2.dispose();
+    });
+
+    test('no label resolver → count form on start and update', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final s1 = StubSession();
+      final s2 = StubSession();
+      controller.attach(s1);
+      controller.attach(s2);
+
+      s1.emit(SshSessionState.connected);
+      await _drain();
+      expect(gateway.calls, contains('start:1 session connected'));
+
+      s2.emit(SshSessionState.connected);
+      await _drain();
+      expect(gateway.calls, contains('update:2 sessions connected'));
+
+      await controller.dispose();
+      await s1.dispose();
+      await s2.dispose();
+    });
+  });
+
   group('KeepaliveController', () {
     test('starts service when session enters connected', () async {
       final gateway = FakeKeepaliveGateway();
@@ -103,8 +270,11 @@ void main() {
 
       session.emit(SshSessionState.connecting);
       await _drain();
-      expect(gateway.calls, isEmpty,
-          reason: 'no service start while still connecting');
+      expect(
+        gateway.calls,
+        isEmpty,
+        reason: 'no service start while still connecting',
+      );
 
       session.emit(SshSessionState.connected);
       await _drain();
@@ -157,10 +327,7 @@ void main() {
 
     test('does not start service when disabled', () async {
       final gateway = FakeKeepaliveGateway();
-      final controller = KeepaliveController(
-        gateway: gateway,
-        enabled: false,
-      );
+      final controller = KeepaliveController(gateway: gateway, enabled: false);
       final session = StubSession();
       controller.attach(session);
 
@@ -191,25 +358,29 @@ void main() {
       await session.dispose();
     });
 
-    test('toggle back on starts service if a session is still connected',
-        () async {
-      final gateway = FakeKeepaliveGateway();
-      final controller =
-          KeepaliveController(gateway: gateway, enabled: false);
-      final session = StubSession();
-      controller.attach(session);
+    test(
+      'toggle back on starts service if a session is still connected',
+      () async {
+        final gateway = FakeKeepaliveGateway();
+        final controller = KeepaliveController(
+          gateway: gateway,
+          enabled: false,
+        );
+        final session = StubSession();
+        controller.attach(session);
 
-      session.emit(SshSessionState.connected);
-      await _drain();
-      expect(await gateway.isRunningService, isFalse);
+        session.emit(SshSessionState.connected);
+        await _drain();
+        expect(await gateway.isRunningService, isFalse);
 
-      controller.enabled = true;
-      await _drain();
-      expect(await gateway.isRunningService, isTrue);
+        controller.enabled = true;
+        await _drain();
+        expect(await gateway.isRunningService, isTrue);
 
-      await controller.dispose();
-      await session.dispose();
-    });
+        await controller.dispose();
+        await session.dispose();
+      },
+    );
 
     test('detach decrements connected count and stops if zero', () async {
       final gateway = FakeKeepaliveGateway();
@@ -244,15 +415,21 @@ void main() {
 
       session.emit(SshSessionState.reconnecting);
       await _drain();
-      expect(await gateway.isRunningService, isTrue,
-          reason: 'service must stay running across transient reconnects');
+      expect(
+        await gateway.isRunningService,
+        isTrue,
+        reason: 'service must stay running across transient reconnects',
+      );
       expect(controller.connectedCount, 1);
 
       session.emit(SshSessionState.connected);
       await _drain();
       expect(await gateway.isRunningService, isTrue);
-      expect(controller.connectedCount, 1,
-          reason: 'no double-count when transitioning back to connected');
+      expect(
+        controller.connectedCount,
+        1,
+        reason: 'no double-count when transitioning back to connected',
+      );
 
       await controller.dispose();
       await session.dispose();
@@ -304,16 +481,17 @@ void main() {
       addTearDown(pair.dispose);
       final controller = KeepaliveController(gateway: fakeGateway);
 
-      final proxy =
-          SshSessionProxy(sessionId: 'sid', gateway: pair.uiSide);
+      final proxy = SshSessionProxy(sessionId: 'sid', gateway: pair.uiSide);
       addTearDown(proxy.dispose);
       controller.attach(proxy);
 
       // Push a `connected` state event from the task side.
-      pair.taskSide.send(SshStateEvent(
-        sessionId: 'sid',
-        state: SshSessionState.connected.name,
-      ).toJson());
+      pair.taskSide.send(
+        SshStateEvent(
+          sessionId: 'sid',
+          state: SshSessionState.connected.name,
+        ).toJson(),
+      );
       await _drain();
 
       expect(fakeGateway.calls.first, 'init');
@@ -330,15 +508,16 @@ void main() {
       addTearDown(pair.dispose);
       final controller = KeepaliveController(gateway: fakeGateway);
 
-      final proxy =
-          SshSessionProxy(sessionId: 'sid', gateway: pair.uiSide);
+      final proxy = SshSessionProxy(sessionId: 'sid', gateway: pair.uiSide);
       addTearDown(proxy.dispose);
       controller.attach(proxy);
 
-      pair.taskSide.send(SshStateEvent(
-        sessionId: 'sid',
-        state: SshSessionState.connected.name,
-      ).toJson());
+      pair.taskSide.send(
+        SshStateEvent(
+          sessionId: 'sid',
+          state: SshSessionState.connected.name,
+        ).toJson(),
+      );
       await _drain();
       expect(await fakeGateway.isRunningService, isTrue);
 
@@ -356,25 +535,31 @@ void main() {
       addTearDown(pair.dispose);
       final controller = KeepaliveController(gateway: fakeGateway);
 
-      final proxy =
-          SshSessionProxy(sessionId: 'sid', gateway: pair.uiSide);
+      final proxy = SshSessionProxy(sessionId: 'sid', gateway: pair.uiSide);
       addTearDown(proxy.dispose);
       controller.attach(proxy);
 
-      pair.taskSide.send(SshStateEvent(
-        sessionId: 'sid',
-        state: SshSessionState.connected.name,
-      ).toJson());
+      pair.taskSide.send(
+        SshStateEvent(
+          sessionId: 'sid',
+          state: SshSessionState.connected.name,
+        ).toJson(),
+      );
       await _drain();
       expect(await fakeGateway.isRunningService, isTrue);
 
-      pair.taskSide.send(SshStateEvent(
-        sessionId: 'sid',
-        state: SshSessionState.reconnecting.name,
-      ).toJson());
+      pair.taskSide.send(
+        SshStateEvent(
+          sessionId: 'sid',
+          state: SshSessionState.reconnecting.name,
+        ).toJson(),
+      );
       await _drain();
-      expect(await fakeGateway.isRunningService, isTrue,
-          reason: 'service must stay running across transient reconnects');
+      expect(
+        await fakeGateway.isRunningService,
+        isTrue,
+        reason: 'service must stay running across transient reconnects',
+      );
       expect(controller.connectedCount, 1);
 
       await controller.dispose();

--- a/native/test/services/task_bootstrap_test.dart
+++ b/native/test/services/task_bootstrap_test.dart
@@ -53,6 +53,15 @@ class FakeKeepaliveGateway implements KeepaliveGateway {
   }
 
   @override
+  Future<bool> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    calls.add('update');
+    return true;
+  }
+
+  @override
   Future<bool> stopService() async {
     calls.add('stop');
     _running = false;
@@ -69,54 +78,71 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('FlutterForegroundSshGateway buffering (#539)', () {
-    test('buffers commands sent before ready, flushes in order after ready',
-        () async {
-      final pair = StubFftTransportPair();
-      addTearDown(pair.dispose);
+    test(
+      'buffers commands sent before ready, flushes in order after ready',
+      () async {
+        final pair = StubFftTransportPair();
+        addTearDown(pair.dispose);
 
-      // Capture what the UI side actually pushes toward the task.
-      final received = <Map<String, dynamic>>[];
-      pair.taskSide.registerReceiver((data) {
-        received.add(Map<String, dynamic>.from(data as Map));
-      });
+        // Capture what the UI side actually pushes toward the task.
+        final received = <Map<String, dynamic>>[];
+        pair.taskSide.registerReceiver((data) {
+          received.add(Map<String, dynamic>.from(data as Map));
+        });
 
-      final ui = FlutterForegroundSshGateway(transport: pair.uiSide);
-      addTearDown(ui.dispose);
+        final ui = FlutterForegroundSshGateway(transport: pair.uiSide);
+        addTearDown(ui.dispose);
 
-      // The task isolate hasn't signalled ready yet. Send three commands in a
-      // specific order: connect, input, resize.
-      ui.send(SshConnectCommand(
-        sessionId: 'sid',
-        host: 'h',
-        port: 22,
-        username: 'u',
-        authJson: const {'type': 'password', 'password': 'p'},
-      ).toJson());
-      ui.send(SshResizeCommand(sessionId: 'sid', cols: 80, rows: 24).toJson());
-      await _drain();
+        // The task isolate hasn't signalled ready yet. Send three commands in a
+        // specific order: connect, input, resize.
+        ui.send(
+          SshConnectCommand(
+            sessionId: 'sid',
+            host: 'h',
+            port: 22,
+            username: 'u',
+            authJson: const {'type': 'password', 'password': 'p'},
+          ).toJson(),
+        );
+        ui.send(
+          SshResizeCommand(sessionId: 'sid', cols: 80, rows: 24).toJson(),
+        );
+        await _drain();
 
-      expect(received, isEmpty,
-          reason: 'commands must be buffered until the task is ready');
+        expect(
+          received,
+          isEmpty,
+          reason: 'commands must be buffered until the task is ready',
+        );
 
-      // Task signals ready (the first inbound payload the UI ever sees).
-      pair.taskSide.send(const SshTaskReadyEvent().toJson());
-      await _drain();
+        // Task signals ready (the first inbound payload the UI ever sees).
+        pair.taskSide.send(const SshTaskReadyEvent().toJson());
+        await _drain();
 
-      expect(received.length, 2,
-          reason: 'buffered commands flush once ready arrives');
-      expect(received[0]['kind'], SshTaskCommandKind.connect.name);
-      expect(received[1]['kind'], SshTaskCommandKind.resize.name,
-          reason: 'order must be preserved: connect before resize');
+        expect(
+          received.length,
+          2,
+          reason: 'buffered commands flush once ready arrives',
+        );
+        expect(received[0]['kind'], SshTaskCommandKind.connect.name);
+        expect(
+          received[1]['kind'],
+          SshTaskCommandKind.resize.name,
+          reason: 'order must be preserved: connect before resize',
+        );
 
-      // After ready, sends pass through immediately.
-      ui.send(SshInputCommand(
-        sessionId: 'sid',
-        bytes: Uint8List.fromList('x'.codeUnits),
-      ).toJson());
-      await _drain();
-      expect(received.length, 3);
-      expect(received[2]['kind'], SshTaskCommandKind.input.name);
-    });
+        // After ready, sends pass through immediately.
+        ui.send(
+          SshInputCommand(
+            sessionId: 'sid',
+            bytes: Uint8List.fromList('x'.codeUnits),
+          ).toJson(),
+        );
+        await _drain();
+        expect(received.length, 3);
+        expect(received[2]['kind'], SshTaskCommandKind.input.name);
+      },
+    );
 
     test('any inbound payload (not only ready) flushes the buffer', () async {
       // Defensive: even if the first task→UI payload is a state event rather
@@ -131,13 +157,15 @@ void main() {
       final ui = FlutterForegroundSshGateway(transport: pair.uiSide);
       addTearDown(ui.dispose);
 
-      ui.send(SshConnectCommand(
-        sessionId: 'sid',
-        host: 'h',
-        port: 22,
-        username: 'u',
-        authJson: const {'type': 'password', 'password': 'p'},
-      ).toJson());
+      ui.send(
+        SshConnectCommand(
+          sessionId: 'sid',
+          host: 'h',
+          port: 22,
+          username: 'u',
+          authJson: const {'type': 'password', 'password': 'p'},
+        ).toJson(),
+      );
       await _drain();
       expect(received, isEmpty);
 
@@ -156,33 +184,42 @@ void main() {
       final pair = InMemoryGatewayPair();
       addTearDown(pair.dispose);
 
-      final container = ProviderContainer(overrides: [
-        // UI talks to the in-memory pair so no platform channels are touched.
-        taskSshGatewayProvider.overrideWithValue(pair.uiSide),
-        // The keepalive controller used by the starter seam uses the fake
-        // foreground-task gateway so we can observe startService.
-        keepaliveServiceStarterProvider.overrideWith((ref) {
-          final controller = KeepaliveController(gateway: fakeGateway);
-          ref.onDispose(controller.dispose);
-          return controller.ensureStarted;
-        }),
-      ]);
+      final container = ProviderContainer(
+        overrides: [
+          // UI talks to the in-memory pair so no platform channels are touched.
+          taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+          // The keepalive controller used by the starter seam uses the fake
+          // foreground-task gateway so we can observe startService.
+          keepaliveServiceStarterProvider.overrideWith((ref) {
+            final controller = KeepaliveController(gateway: fakeGateway);
+            ref.onDispose(controller.dispose);
+            return controller.ensureStarted;
+          }),
+        ],
+      );
       addTearDown(container.dispose);
 
       final notifier = container.read(sessionsProvider.notifier);
-      notifier.addOrActivate(const SshConnectParams(
-        host: 'h',
-        port: 22,
-        username: 'u',
-        auth: SshAuth.password('p'),
-      ));
+      notifier.addOrActivate(
+        const SshConnectParams(
+          host: 'h',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
       await _drain();
 
-      expect(fakeGateway.calls, contains('start'),
-          reason: 'addOrActivate must start the foreground service');
+      expect(
+        fakeGateway.calls,
+        contains('start'),
+        reason: 'addOrActivate must start the foreground service',
+      );
       // start happens via ensureStarted → init then start.
-      expect(fakeGateway.calls.indexOf('init'),
-          lessThan(fakeGateway.calls.indexOf('start')));
+      expect(
+        fakeGateway.calls.indexOf('init'),
+        lessThan(fakeGateway.calls.indexOf('start')),
+      );
     });
 
     test('ensureStarted is idempotent — no double start', () async {
@@ -194,8 +231,11 @@ void main() {
       await controller.ensureStarted();
       await _drain();
 
-      expect(fakeGateway.calls.where((c) => c == 'start').length, 1,
-          reason: 'second ensureStarted must not start a second service');
+      expect(
+        fakeGateway.calls.where((c) => c == 'start').length,
+        1,
+        reason: 'second ensureStarted must not start a second service',
+      );
     });
   });
 }


### PR DESCRIPTION
## Slice 1 of #709 — FGS notification shows live session count

The Android foreground-service keep-alive notification was static
("Connecting…"): set once at `startService` time and never refreshed. It now
reflects the **live active-session count**, updated as sessions connect/disconnect.

### Count -> text mapping
| Connected count | Notification text |
|---|---|
| 0 | `Connecting…` (transient handshake text only; service stops once no sessions remain) |
| 1 (label known) | `Connected — user@host:port` (or saved profile title) |
| 1 (no label) | `1 session connected` |
| N > 1 | `N sessions connected` |

### Update wiring
- **`keepaliveNotificationText(count, {hostLabel})`** — pure, unit-tested mapping fn.
- **`KeepaliveGateway.updateService({title, text})`** — new interface method. The
  Flutter impl calls `FlutterForegroundTask.updateService`; the desktop Noop is a no-op.
- **`KeepaliveController._refreshNotification()`** fires on count changes that keep the
  service running: `1->N`, `N->M(>0)`, and the down-to-1 case all call `updateService`.
  `0->1` still sets the text via `startService`. Wrapped in try/catch (tolerant of
  `MissingPluginException`) so a notification refresh never breaks keep-alive.
- **`keepaliveControllerProvider`** (the count-owning controller) injects a
  `notificationLabelResolver` that reads the **sole** connected session's `label` from
  `sessionsProvider` (`_soleConnectedSessionLabel`). Returns null when 0 or >1 connected
  -> count form. The start-only starter controller leaves the resolver null.

### Minimal / silent
The keep-alive channel keeps `channelImportance`/`priority` **LOW** + `onlyAlertOnce: true`.
On an only-alert-once channel, `updateService` does **not** re-alert (no sound/vibration)
per change — that is the silent-update mechanism. **No FGS lifecycle or
connect/reconnect state-machine changes** — only notification text/options.

### Out of scope (Slice 2 / follow-up #710)
Terminal-bell -> notification, URL-in-output -> clickable notification (launchUrl on tap),
a separate higher-importance event channel, and notification action buttons. NOT in this PR.

### Tests
- New `keepaliveNotificationText` group: 0/1-host/1-fallback/whitespace-trim/N-plural.
- New `KeepaliveController notification updates (#709)` group: asserts `updateService`
  is called with the right text on session-count changes (label form, plural, no-label),
  and that a second session does not re-start the service.
- All existing keepalive + bootstrap tests stay green. `dart format` applied.
- `scripts/native-fast-gate.sh` (analyze + test, 574 passing) — **green**.

### #589-sensitive — device validation required at merge
`keepalive_task.dart` / the FGS service is a #589 integration-required path. Headless
gate is green, but emulator/device validation of **keep-alive surviving backgrounding**
and the **notification text updating live** (connect 1 -> 2 -> disconnect -> 1) is
**required before merge** — the FGS notification is mandatory for the service on Android
API 33+, and only on-device confirms importance/silent-update behavior.

Closes #709 (slice 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)