### PR TITLE
chore(#713): install-page markdown via marked (sub-bullets/bold/code)

### DIFF
--- a/scripts/gen-apk-install-page.sh
+++ b/scripts/gen-apk-install-page.sh
@@ -90,73 +90,48 @@ check_notes_freshness() {
 }
 check_notes_freshness
 
-# Minimal HTML escape (& < >).
-esc() {
-  sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
-}
-
-# The "What to verify" bullets come from the FIRST `## ` section of
-# native-release-notes.md — its `- ` lines, in order, until the next `## `.
-# This is the curated user-facing list; raw git log is not used.
-notes_bullets() {
-  [ -f "$NOTES_FILE" ] || return 0
-  awk '
-    /^## / { if (seen) exit; seen=1; next }
-    seen && /^- / { sub(/^- /, ""); print }
-  ' "$NOTES_FILE"
-}
-
-# Heading shown for the curated section (the first `## ` title, sans marker), so
-# the page reads e.g. "Build 2026-06-01 — reliability sweep (verify on device)".
-notes_heading() {
-  [ -f "$NOTES_FILE" ] || { echo "What to verify"; return 0; }
-  local h
-  h="$(awk '/^## /{sub(/^## /,""); print; exit}' "$NOTES_FILE")"
-  [ -n "$h" ] && echo "$h" || echo "What to verify"
-}
-
-NOTES_HEADING="$(notes_heading | esc)"
-NOTES_HTML=""
-while IFS= read -r line; do
-  [ -z "$line" ] && continue
-  safe="$(printf '%s' "$line" | esc)"
-  NOTES_HTML="${NOTES_HTML}    <li>${safe}</li>"$'\n'
-done < <(notes_bullets)
-if [ -z "$NOTES_HTML" ]; then
-  NOTES_HTML="    <li>(curate user-facing notes in native-release-notes.md)</li>"$'\n'
+# Render the curated release notes to HTML via the `marked` markdown library
+# (scripts/render-release-notes.mjs). This replaced a hand-rolled awk/sed pass
+# that DROPPED indented sub-bullets and rendered **bold** / `code` literally
+# (#713). The renderer splits native-release-notes.md on `## ` headings:
+#   - the FIRST section is the curated "What to verify" list (verifyHtml)
+#   - every SUBSEQUENT section becomes a collapsible <details> (changelogHtml)
+# It emits one JSON object: { heading, verifyHtml, changelogHtml }. marked emits
+# its OWN <ul>, so the template injects verifyHtml directly (no outer <ul>).
+#
+# marked lives in server/node_modules (zero-dep); the renderer resolves it from
+# there. If it fails (marked missing, file unreadable), the renderer exits
+# non-zero and we abort LOUDLY rather than ship a broken page.
+RENDERER="${REPO_ROOT}/scripts/render-release-notes.mjs"
+NOTES_JSON=""
+if [ -f "$NOTES_FILE" ] && [ -f "$RENDERER" ]; then
+  if ! NOTES_JSON="$(node "$RENDERER" "$NOTES_FILE")"; then
+    echo "! render-release-notes.mjs failed — cannot generate install page" >&2
+    echo "!   (is marked installed? run: npm install --prefix server)" >&2
+    exit 1
+  fi
 fi
 
-# Changelog: render EVERY `## ` section AFTER the first as collapsible history,
-# so the page shows build-to-build deltas (the owner couldn't tell the notes had
-# gone stale because only the latest section was shown). Each older section is a
-# <details> (no JS needed). Skips the file's intro prose before the first `## `.
-CHANGELOG_HTML=""
-section=0
-cur_title=""
-cur_items=""
-flush_section() {
-  [ -z "$cur_title" ] && return
-  CHANGELOG_HTML="${CHANGELOG_HTML}  <details class=\"clog\"><summary>${cur_title}</summary><ul>"$'\n'"${cur_items}  </ul></details>"$'\n'
-  cur_title=""
-  cur_items=""
+# Pull the three fields out of the JSON with node (robust against embedded
+# quotes/newlines in the HTML). Defaults cover a missing/empty notes file.
+extract_field() {
+  # $1 = JSON, $2 = field name. Empty JSON → empty output.
+  [ -z "$1" ] && return 0
+  printf '%s' "$1" | node -e '
+    let s = "";
+    process.stdin.on("data", d => s += d);
+    process.stdin.on("end", () => {
+      const o = JSON.parse(s);
+      process.stdout.write(String(o[process.argv[1]] ?? ""));
+    });
+  ' "$2"
 }
-while IFS= read -r line; do
-  case "$line" in
-    '## '*)
-      flush_section
-      section=$((section + 1))
-      if [ "$section" -ge 2 ]; then
-        cur_title="$(printf '%s' "${line#'## '}" | esc)"
-      fi
-      ;;
-    '- '*)
-      if [ "$section" -ge 2 ]; then
-        cur_items="${cur_items}    <li>$(printf '%s' "${line#'- '}" | esc)</li>"$'\n'
-      fi
-      ;;
-  esac
-done < "$NOTES_FILE"
-flush_section
+
+NOTES_HEADING="$(extract_field "$NOTES_JSON" heading)"
+[ -n "$NOTES_HEADING" ] || NOTES_HEADING="What to verify"
+NOTES_HTML="$(extract_field "$NOTES_JSON" verifyHtml)"
+[ -n "$NOTES_HTML" ] || NOTES_HTML='<ul><li>(curate user-facing notes in native-release-notes.md)</li></ul>'
+CHANGELOG_HTML="$(extract_field "$NOTES_JSON" changelogHtml)"
 
 cat > "$OUT" <<HTMLEOF
 <!DOCTYPE html>
@@ -242,8 +217,7 @@ cat > "$OUT" <<HTMLEOF
   </dl>
 
   <h2>What to verify — ${NOTES_HEADING}</h2>
-  <ul>
-${NOTES_HTML}  </ul>
+${NOTES_HTML}
 
   <h2>Changelog</h2>
 ${CHANGELOG_HTML}

--- a/scripts/render-release-notes.mjs
+++ b/scripts/render-release-notes.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// scripts/render-release-notes.mjs — Render native-release-notes.md sections to HTML.
+//
+// Replaces the hand-rolled awk/sed markdown in gen-apk-install-page.sh, which
+// dropped indented sub-bullets and rendered **bold** / `code` literally (#713).
+//
+// The notes file is split on lines starting with "## " into sections. The FIRST
+// section is the curated "What to verify" list; each SUBSEQUENT section becomes a
+// collapsible <details class="clog"> changelog entry. Intro prose before the
+// first "## " is ignored (matches the prior behavior).
+//
+// Markdown is rendered by `marked` (zero-dep, resolved from server/node_modules).
+// Input is our own trusted notes, so no HTML sanitizer is needed.
+//
+// Usage:   node scripts/render-release-notes.mjs <notes-file>
+// Output:  JSON on stdout: { heading, verifyHtml, changelogHtml }
+//   heading        first section title (sans "## "), or "What to verify"
+//   verifyHtml      marked() of the first section body (emits its own <ul>)
+//   changelogHtml   joined <details> blocks for sections[1..]
+//
+// Fails LOUDLY (non-zero exit, message on stderr) if marked can't be imported or
+// the notes file can't be read — the caller must not emit broken HTML silently.
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const notesPath = process.argv[2];
+if (!notesPath) {
+  console.error('render-release-notes: missing notes file path argument');
+  process.exit(2);
+}
+
+// marked lives in server/node_modules (zero-dep). This script sits in scripts/,
+// so a bare `import 'marked'` won't resolve. Resolve it explicitly relative to
+// server/package.json via createRequire, then import the resolved file URL.
+let marked;
+try {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const serverRequire = createRequire(
+    pathToFileURL(join(here, '..', 'server', 'package.json'))
+  );
+  const markedPath = serverRequire.resolve('marked');
+  ({ marked } = await import(pathToFileURL(markedPath).href));
+} catch (err) {
+  console.error('render-release-notes: cannot import "marked" — run `npm install` in server/');
+  console.error(String(err && err.message ? err.message : err));
+  process.exit(3);
+}
+
+let raw;
+try {
+  raw = readFileSync(notesPath, 'utf8');
+} catch (err) {
+  console.error(`render-release-notes: cannot read notes file: ${notesPath}`);
+  console.error(String(err && err.message ? err.message : err));
+  process.exit(4);
+}
+
+// Split into sections on lines that start with "## ". Each section keeps its
+// title (the text after "## ") and its body (everything up to the next "## ").
+const lines = raw.split('\n');
+const sections = [];
+let cur = null;
+for (const line of lines) {
+  const m = /^## (.*)$/.exec(line);
+  if (m) {
+    if (cur) sections.push(cur);
+    cur = { title: m[1].trim(), body: [] };
+  } else if (cur) {
+    cur.body.push(line);
+  }
+  // lines before the first "## " (intro prose) are dropped
+}
+if (cur) sections.push(cur);
+
+// marked configuration: GitHub-flavored defaults are fine. Input is trusted
+// (our own release notes), so the default HTML passthrough is acceptable.
+marked.setOptions({ gfm: true, breaks: false });
+
+const renderBody = (bodyLines) => marked.parse(bodyLines.join('\n').trim());
+
+// Defensive escape for the <summary> title text (our own trusted text, but keep
+// the markup valid if a title ever contains angle brackets/ampersands).
+const escTitle = (t) =>
+  t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+let heading = 'What to verify';
+let verifyHtml = '<ul>\n<li>(curate user-facing notes in native-release-notes.md)</li>\n</ul>';
+let changelogHtml = '';
+
+if (sections.length > 0) {
+  heading = sections[0].title || 'What to verify';
+  const firstHtml = renderBody(sections[0].body);
+  if (firstHtml.trim()) verifyHtml = firstHtml;
+
+  const blocks = [];
+  for (const s of sections.slice(1)) {
+    const inner = renderBody(s.body);
+    blocks.push(
+      `  <details class="clog"><summary>${escTitle(s.title)}</summary>${inner}</details>`
+    );
+  }
+  changelogHtml = blocks.join('\n');
+}
+
+process.stdout.write(JSON.stringify({ heading, verifyHtml, changelogHtml }));

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "mobissh-server",
-  "version": "0.9.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobissh-server",
-      "version": "0.9.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
+        "marked": "^18.0.4",
         "ssh2": "^1.15.0",
         "ws": "^8.16.0"
       },
@@ -2062,6 +2063,18 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/minimatch": {
       "version": "10.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "test": "node --test test.js"
   },
   "dependencies": {
+    "marked": "^18.0.4",
     "ssh2": "^1.15.0",
     "ws": "^8.16.0"
   },


### PR DESCRIPTION
## #713 — install-page markdown via marked

Replaces the hand-rolled awk/sed markdown→HTML in `scripts/gen-apk-install-page.sh` with the [`marked`](https://www.npmjs.com/package/marked) library, so the APK install page (`public/native.html`) renders sub-bullets, **bold**, and `code` correctly. Previously sub-bullets were dropped and `**`/backticks rendered literally.

### Changes
- **`server/package.json` + lock**: add `marked` (^18, zero-dep) dependency.
- **`scripts/render-release-notes.mjs`** (new, Node ESM): splits `native-release-notes.md` on `## ` headings into sections. First section → "What to verify" list HTML; subsequent sections → collapsible `<details class="clog">` changelog entries. Renders each body with `marked`. Emits `{ heading, verifyHtml, changelogHtml }` JSON on stdout. Fails loudly (non-zero exit) if `marked` can't import or the notes file can't be read.
- **`gen-apk-install-page.sh`**: calls the renderer, aborts if it fails, injects the rendered HTML. Drops the outer `<ul>` wrapper (marked emits its own `<ul>`), so the markup stays valid. Removes the dead `esc()` / `notes_bullets` / `notes_heading` / changelog while-loops.

### How marked is wired
`marked` lives in `server/node_modules`. The renderer is in `scripts/`, so a bare `import 'marked'` won't resolve (NODE_PATH does not work for ESM bare specifiers). It resolves marked via `createRequire(server/package.json).resolve('marked')` then `import(fileURL)`, pinning resolution to server's deps regardless of CWD.

### Verification (no flutter gate applies — page generator + node script)
- Ran the generator against the real `native-release-notes.md`: verify list renders with `<strong>`, a single `<ul>` (no duplicate wrapper), and 25 collapsible `<details class="clog">` changelog entries.
- Synthetic notes with sub-bullets + bold + code proved: nested `<ul>` inside `<li>`, `**`→`<strong>`, `` `code` ``→`<code>`, intro prose ignored.
- Renderer exits non-zero on a missing file / missing marked → generator aborts loudly (no broken HTML).

Touches only the install-page generator + server deps — disjoint from the in-flight app PRs.

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)