### PR TITLE
chore(#725): Ghostty is the default engine (v0.1.8.1) + xterm-path test pins

### DIFF
--- a/native-release-notes.md
+++ b/native-release-notes.md
@@ -7,6 +7,9 @@ internal/test/CI/refactor work OUT. **Update this every release** (the gate
 refuses to ship if the top section's commit is older than the build — see
 gen-apk-install-page.sh staleness check).
 
+## v0.1.8.1 (2026-06-03) — Ghostty is the default
+- **Ghostty (flterm) is now the default terminal engine** — xterm is still selectable in **Settings → Terminal engine**.
+
 ## v0.1.8 (2026-06-03) — Ghostty terminal, hardened
 - **Ghostty (flterm) is the recommended engine** — native touch drag-select + copy, precise tmux selection, faster scrolling. Turn it on in **Settings → Terminal engine** (it becomes the default in the next build).
 - Ghostty terminal:

--- a/native/lib/state/terminal_backend.dart
+++ b/native/lib/state/terminal_backend.dart
@@ -1,10 +1,10 @@
 // Switchable terminal backend (#684, #582).
 //
 // MobiSSH renders session terminals with one of two widgets:
-//   - `xterm` (xterm.dart) — the DEFAULT and the only production-proven path.
-//   - `ghostty` (flterm, powered by libghostty-vt) — opt-in. flterm has native
-//     touch drag-select + copy, which xterm.dart v4 lacks (#582). It's offered
-//     so the owner can device-test drag-select on real sessions.
+//   - `ghostty` (flterm, powered by libghostty-vt) — the DEFAULT (#725). flterm
+//     has native touch drag-select + copy, which xterm.dart v4 lacks (#582).
+//   - `xterm` (xterm.dart) — selectable fallback for anyone who prefers it or
+//     hits a flterm device issue. The original production-proven path.
 //
 // The choice is a persisted GLOBAL preference (NOT per-session): it picks the
 // rendering engine for every new session terminal. It is read at terminal-view
@@ -22,19 +22,21 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 /// The terminal rendering engine for session terminals (#684).
 enum TerminalBackend {
-  /// xterm.dart `TerminalView` — the default, production-proven path.
+  /// xterm.dart `TerminalView` — selectable fallback, production-proven path.
   xterm,
 
-  /// flterm `TerminalView` (libghostty-vt) — opt-in, native drag-select (#582).
+  /// flterm `TerminalView` (libghostty-vt) — the default, native drag-select (#582, #725).
   ghostty,
 }
 
 /// SharedPreferences key for the selected terminal backend.
 const String terminalBackendPrefKey = 'mobissh.ui.terminalBackend';
 
-/// Default backend — `xterm`. The switch must ship safely even if flterm has
-/// device issues: the owner simply won't flip it.
-const TerminalBackend terminalBackendDefault = TerminalBackend.xterm;
+/// Default backend — `ghostty` (flterm, #725). flterm's native touch
+/// drag-select + copy is the headline terminal UX, so it ships as the default.
+/// `xterm` stays selectable in Settings → Terminal engine as the fallback for
+/// anyone who prefers it or hits a flterm device issue.
+const TerminalBackend terminalBackendDefault = TerminalBackend.ghostty;
 
 /// Resolve a stored backend id (the enum `name`) to a [TerminalBackend],
 /// falling back to [terminalBackendDefault] for null/unknown values so a stale

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.8+10
+version: 0.1.8.1+11
 
 environment:
   sdk: ^3.12.0

--- a/native/test/state/terminal_backend_test.dart
+++ b/native/test/state/terminal_backend_test.dart
@@ -1,8 +1,8 @@
 // Unit tests for the #684 switchable terminal backend preference.
 //
-// Locks the persisted-enum contract: default xterm, hydrate a stored value,
-// set+persist, and a corrupt/unknown stored id falling back to the default
-// (a stale pref must never crash the terminal).
+// Locks the persisted-enum contract: default ghostty (#725), hydrate a stored
+// value, set+persist, and a corrupt/unknown stored id falling back to the
+// default (a stale pref must never crash the terminal).
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/state/terminal_backend.dart';
@@ -21,9 +21,9 @@ void main() {
   });
 
   group('terminalBackendFromId', () {
-    test('null falls back to the default (xterm)', () {
+    test('null falls back to the default (ghostty)', () {
       expect(terminalBackendFromId(null), terminalBackendDefault);
-      expect(terminalBackendDefault, TerminalBackend.xterm);
+      expect(terminalBackendDefault, TerminalBackend.ghostty);
     });
 
     test('known ids parse to the matching enum', () {
@@ -39,10 +39,10 @@ void main() {
   });
 
   group('TerminalBackendNotifier', () {
-    test('defaults to xterm with no stored value', () async {
+    test('defaults to ghostty with no stored value', () async {
       final n = TerminalBackendNotifier(prefs: SharedPreferences.getInstance());
       await _settle();
-      expect(n.state, TerminalBackend.xterm);
+      expect(n.state, TerminalBackend.ghostty);
     });
 
     test('hydrates a stored ghostty value', () async {
@@ -60,7 +60,7 @@ void main() {
       });
       final n = TerminalBackendNotifier(prefs: SharedPreferences.getInstance());
       await _settle();
-      expect(n.state, TerminalBackend.xterm);
+      expect(n.state, TerminalBackend.ghostty);
     });
 
     test('set updates state and persists the enum name', () async {

--- a/native/test/widget/terminal_backend_selection_test.dart
+++ b/native/test/widget/terminal_backend_selection_test.dart
@@ -3,7 +3,9 @@
 // These gate the SWITCH (which widget mounts), NOT flterm's rendering — the
 // libghostty-backed flterm view can't paint headless, so the ghostty branch is
 // device-validated by the owner. We assert:
-//   1. Default (xterm): the xterm `TerminalView` mounts; no GhosttyTerminalView.
+//   1. backend=xterm (explicit override): the xterm `TerminalView` mounts; no
+//      GhosttyTerminalView. (Ghostty is the default since #725, so the xterm
+//      path is pinned via an override to keep its coverage.)
 //   2. backend=ghostty: a GhosttyTerminalView mounts; no xterm `TerminalView`.
 //
 // `GhosttyTerminalView` defends against a failed libghostty load by catching
@@ -76,15 +78,23 @@ void main() {
   });
 
   group('TerminalScreen backend switch (#684)', () {
-    testWidgets('default backend mounts the xterm TerminalView, not ghostty', (
+    testWidgets('backend=xterm mounts the xterm TerminalView, not ghostty', (
       tester,
     ) async {
       final transport = FakeSshShellTransport();
       addTearDown(transport.close);
-      final container = await _mountWithBackend(tester, transport);
+      final container = await _mountWithBackend(
+        tester,
+        transport,
+        overrides: [
+          terminalBackendProvider.overrideWith(
+            (ref) => TerminalBackendNotifier()..set(TerminalBackend.xterm),
+          ),
+        ],
+      );
       addTearDown(container.dispose);
 
-      // Sanity: the default really is xterm.
+      // Pinned to xterm via override (ghostty is the default since #725).
       expect(container.read(terminalBackendProvider), TerminalBackend.xterm);
       expect(find.byType(TerminalView), findsWidgets);
       expect(find.byType(GhosttyTerminalView), findsNothing);

--- a/native/test/widget/terminal_font_apply_test.dart
+++ b/native/test/widget/terminal_font_apply_test.dart
@@ -18,6 +18,7 @@ import 'package:mobissh/services/task_ssh_gateway.dart';
 import 'package:mobissh/ssh/ssh_connect_params.dart';
 import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_backend.dart';
 import 'package:mobissh/state/terminal_providers.dart';
 import 'package:mobissh/state/ui_prefs_providers.dart';
 import 'package:mobissh/ui/terminal_screen.dart';
@@ -33,6 +34,11 @@ ProviderContainer _makeContainer(FakeSshShellTransport transport) {
       taskSshGatewayProvider.overrideWithValue(pair.uiSide),
       sshShellOpenerProvider.overrideWithValue(
         (ref, sessionId, terminal) async => transport,
+      ),
+      // Ghostty is the default since #725; these are xterm-render assertions
+      // (flterm can't paint headless), so pin the xterm backend.
+      terminalBackendProvider.overrideWith(
+        (ref) => TerminalBackendNotifier()..set(TerminalBackend.xterm),
       ),
     ],
   );

--- a/native/test/widget/terminal_remeasure_test.dart
+++ b/native/test/widget/terminal_remeasure_test.dart
@@ -46,6 +46,7 @@ import 'package:mobissh/services/task_ssh_gateway.dart';
 import 'package:mobissh/ssh/ssh_connect_params.dart';
 import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_backend.dart';
 import 'package:mobissh/state/terminal_providers.dart';
 import 'package:mobissh/ui/terminal_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -82,6 +83,11 @@ Future<({SessionEntry entry, ProviderContainer container})> _setupConnected(
         ref.onDispose(shell.dispose);
         return shell;
       }),
+      // Ghostty is the default since #725; these are xterm-render assertions
+      // (flterm can't paint headless), so pin the xterm backend.
+      terminalBackendProvider.overrideWith(
+        (ref) => TerminalBackendNotifier()..set(TerminalBackend.xterm),
+      ),
     ],
   );
   addTearDown(container.dispose);
@@ -120,6 +126,11 @@ Future<({SessionEntry entry, ProviderContainer container})> _setup(
       taskSshGatewayProvider.overrideWithValue(pair.uiSide),
       sshShellOpenerProvider.overrideWithValue(
         (ref, sessionId, terminal) async => transport,
+      ),
+      // Ghostty is the default since #725; these are xterm-render assertions
+      // (flterm can't paint headless), so pin the xterm backend.
+      terminalBackendProvider.overrideWith(
+        (ref) => TerminalBackendNotifier()..set(TerminalBackend.xterm),
       ),
     ],
   );

--- a/native/test/widget/terminal_screen_widget_test.dart
+++ b/native/test/widget/terminal_screen_widget_test.dart
@@ -16,6 +16,7 @@ import 'package:mobissh/services/task_ssh_gateway.dart';
 import 'package:mobissh/ssh/ssh_connect_params.dart';
 import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_backend.dart';
 import 'package:mobissh/state/terminal_providers.dart';
 import 'package:mobissh/ui/terminal_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -39,6 +40,11 @@ Future<({SessionEntry entry, ProviderContainer container})> _setupSingleSession(
       taskSshGatewayProvider.overrideWithValue(pair.uiSide),
       sshShellOpenerProvider.overrideWithValue(
         (ref, sessionId, terminal) async => transport,
+      ),
+      // Ghostty is the default since #725; this file asserts the xterm
+      // TerminalView mounts (flterm can't paint headless), so pin xterm.
+      terminalBackendProvider.overrideWith(
+        (ref) => TerminalBackendNotifier()..set(TerminalBackend.xterm),
       ),
     ],
   );


### PR DESCRIPTION
Closes #725.

Flip the default terminal backend to Ghostty (flterm) for the native Flutter app (v0.1.8.1).

## Change
- `native/lib/state/terminal_backend.dart`: `terminalBackendDefault` `TerminalBackend.xterm` → `TerminalBackend.ghostty`; doc comments updated to reflect ghostty-as-default / xterm-as-fallback. xterm stays selectable in **Settings → Terminal engine**.
- No other feature code touched (`ghostty_terminal_view.dart` untouched, per scope).

## Tests fixed (the flip makes the default mount the Ghostty view)
xterm-render tests are pinned to xterm via `terminalBackendProvider.overrideWith((ref) => TerminalBackendNotifier()..set(TerminalBackend.xterm))` (flterm can't paint headless):
- `native/test/state/terminal_backend_test.dart` — default-case assertions (null / no-stored / corrupt) flipped to ghostty; explicit `set(xterm)`/`set(ghostty)` + known-id tests kept.
- `native/test/widget/terminal_backend_selection_test.dart` — "default mounts xterm" → "backend=xterm mounts ..." with an explicit xterm override (preserves the xterm-switch coverage).
- `native/test/widget/terminal_font_apply_test.dart`
- `native/test/widget/terminal_screen_widget_test.dart`
- `native/test/widget/terminal_remeasure_test.dart` (both setup helpers)

No other `TerminalScreen`-mounting test broke — the gate confirmed only these 5 files needed pins.

## Version + notes
- `native/pubspec.yaml`: `0.1.8+10` → `0.1.8.1+11`.
- `native-release-notes.md`: prepended `## v0.1.8.1 (2026-06-03) — Ghostty is the default`.

## Gate
`scripts/native-fast-gate.sh` (in-worktree, relative): analyze + test **PASS**, green on the first cycle (+719 ~5 skipped, 0 failed).

## Owner device-validates
- Fresh install / cleared `mobissh.ui.terminalBackend` pref → terminal renders the Ghostty (flterm) view by default.
- Settings → Terminal engine can switch to xterm and back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)