### PR TITLE
feat(#726): Ghostty URL detect + highlight + tap-to-copy (Slice 1)

### DIFF
--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -177,6 +177,7 @@ import '../ssh/ssh_session_proxy.dart';
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
+import 'ghostty_url_detector.dart';
 import 'top_toast.dart';
 
 /// Build the flterm [ColorPalette] for the per-session theme [palette] (#716).
@@ -1022,6 +1023,8 @@ class GhosttyPointerGestureRouter extends StatefulWidget {
     required this.onSelectionExtend,
     required this.hasSelection,
     required this.onSelectionClear,
+    required this.urlAtCell,
+    required this.onUrlTap,
   });
 
   /// Whether to intercept touch (the remote has mouse tracking on).
@@ -1095,6 +1098,17 @@ class GhosttyPointerGestureRouter extends StatefulWidget {
   /// invoked when a TAP lands while a selection is active (#706, issue 2). The
   /// tap is then SWALLOWED — no SGR click / type is forwarded.
   final VoidCallback onSelectionClear;
+
+  /// #726: resolve a 0-based viewport ([col], [row]) cell to the URL it lands
+  /// in, or null. The parent owns the detected [GhosttyUrlMatch] list, so it
+  /// answers this live at tap time via [ghosttyUrlAtCell].
+  final GhosttyUrlMatch? Function(int col, int row) urlAtCell;
+
+  /// #726: copy the tapped URL (a single-tap on a highlighted URL copies it +
+  /// shows a top-toast). When a tap lands on a URL the gesture is SWALLOWED —
+  /// no #693 SGR click / focus / type is forwarded — exactly like the #706
+  /// selection-dismiss path.
+  final void Function(GhosttyUrlMatch match) onUrlTap;
 
   @override
   State<GhosttyPointerGestureRouter> createState() =>
@@ -1337,6 +1351,17 @@ class _GhosttyPointerGestureRouterState
       _trace('tap-dismiss-selection', local.dx, local.dy, null, null, null);
       return;
     }
+    // #726: if the tap landed on a detected URL, COPY it and SWALLOW the tap —
+    // no #693 SGR click, no focus/keyboard, no type. Checked after the #706
+    // selection-dismiss (a selection still clears first) but before the normal
+    // tap behaviour. The cell map uses the SAME #723-correct grid as the click.
+    final (urlCol, urlRow) = _cellAt(local);
+    final url = widget.urlAtCell(urlCol - 1, urlRow - 1);
+    if (url != null) {
+      _trace('tap-url-copy', local.dx, local.dy, urlCol, urlRow, null);
+      widget.onUrlTap(url);
+      return;
+    }
     // Order: focus + raise the keyboard FIRST so the IME comes up regardless of
     // whether the click forwards (the keyboard is the always-on behaviour).
     widget.onTap();
@@ -1381,6 +1406,16 @@ class _GhosttyPointerGestureRouterState
               null,
               null,
             );
+            return;
+          }
+          // #726: a single tap on a detected URL copies it + swallows the tap,
+          // even in a plain shell (no mouse mode). Same 1-based→0-based cell
+          // convention as the active branch.
+          final (urlCol, urlRow) = _cellAt(local);
+          final url = widget.urlAtCell(urlCol - 1, urlRow - 1);
+          if (url != null) {
+            _trace('tap-url-copy', local.dx, local.dy, urlCol, urlRow, null);
+            widget.onUrlTap(url);
             return;
           }
           widget.onTap();
@@ -1436,6 +1471,92 @@ class _GhosttyPointerGestureRouterState
       },
       child: const SizedBox.expand(),
     );
+  }
+}
+
+/// Paints the URL HIGHLIGHT overlay above the flterm [TerminalView] (#726).
+///
+/// flterm 0.0.3 has exactly ONE selection and no multi-range highlight API, so
+/// detected URLs can't be marked via the controller. Instead this CustomPainter
+/// draws a subtle UNDERLINE under each URL's cell range, using the SAME
+/// #723-correct cell metrics ([cellWidth]/[cellHeight]) and the
+/// [kGhosttyTerminalPadding] the grid is offset by — so the underline lands
+/// exactly under the on-screen text. It repaints when the [matches] list, the
+/// cell metrics, or the [color] change (the parent re-runs detection on a
+/// debounced controller notify + on scroll, and rebuilds this painter), so the
+/// highlights follow scroll + resize.
+///
+/// Each [GhosttyUrlMatch] is in 0-based VIEWPORT cells ([endCol] exclusive). A
+/// single-row URL underlines `[startCol, endCol)` on its row; a soft-wrapped URL
+/// underlines the start row's tail, every interior row full-width, and the end
+/// row's head — matching [ghosttyCellInUrl]'s hit-test geometry so what's
+/// underlined is exactly what a tap copies. Pure paint (no FFI) — the geometry
+/// is exercised by the matcher tests via the shared cell model.
+class GhosttyUrlHighlightPainter extends CustomPainter {
+  GhosttyUrlHighlightPainter({
+    required this.matches,
+    required this.cellWidth,
+    required this.cellHeight,
+    required this.cols,
+    required this.color,
+    this.padding = kGhosttyTerminalPadding,
+  });
+
+  /// The detected URL ranges to underline (0-based viewport cells).
+  final List<GhosttyUrlMatch> matches;
+
+  /// The REAL flterm cell size (see [ghosttyMeasureCellSize]) — the underline
+  /// geometry MUST use this, not `size/rows`, to land under the rendered text.
+  final double cellWidth;
+  final double cellHeight;
+
+  /// The grid width, used to extend an interior/start row's underline to the
+  /// full row when a URL wraps.
+  final int cols;
+
+  /// The underline colour (the theme's accent / selection colour) so the
+  /// highlight is theme-consistent (#716).
+  final Color color;
+
+  /// The flterm [TerminalView] padding the grid is offset by ([kGhosttyTerminalPadding]).
+  final double padding;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (cellWidth <= 0 || cellHeight <= 0 || matches.isEmpty) return;
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke;
+    for (final m in matches) {
+      for (var row = m.startRow; row <= m.endRow; row++) {
+        final startCol = row == m.startRow ? m.startCol : 0;
+        final endCol = row == m.endRow ? m.endCol : cols;
+        if (endCol <= startCol) continue;
+        final x0 = padding + startCol * cellWidth;
+        final x1 = padding + endCol * cellWidth;
+        // Underline sits ~1px above the cell's bottom edge.
+        final y = padding + (row + 1) * cellHeight - 1.5;
+        canvas.drawLine(Offset(x0, y), Offset(x1, y), paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(GhosttyUrlHighlightPainter old) =>
+      old.color != color ||
+      old.cellWidth != cellWidth ||
+      old.cellHeight != cellHeight ||
+      old.cols != cols ||
+      old.padding != padding ||
+      !_sameMatches(old.matches, matches);
+
+  static bool _sameMatches(List<GhosttyUrlMatch> a, List<GhosttyUrlMatch> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 }
 
@@ -1511,6 +1632,16 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// listener drives the rebuild — no second listener.
   bool _hasSelection = false;
 
+  /// #726: the URLs currently detected in the VISIBLE viewport, highlighted by
+  /// [GhosttyUrlHighlightPainter] and hit-tested by a tap (single-tap copies the
+  /// URL). Re-detected on a DEBOUNCED controller notify (output/scroll) via
+  /// [_scheduleUrlDetect] so streaming output doesn't re-scan every byte.
+  List<GhosttyUrlMatch> _urlMatches = const [];
+
+  /// #726: debounce timer for URL re-detection. The controller notifies on every
+  /// output write; coalesce a burst into a single scan after a short idle.
+  Timer? _urlDebounce;
+
   /// #702: the session proxy, resolved once in [initState] so the shellReady
   /// subscription + forced resize re-sync don't re-walk the sessions list.
   SshSessionProxy? _proxy;
@@ -1573,6 +1704,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         _cols = cols;
         _rows = rows;
         _sendResize(cols, rows);
+        // #726: a resize changes the cell ranges (and the cols the matcher joins
+        // wrapped rows by), so re-detect URLs against the new grid (debounced).
+        _scheduleUrlDetect();
       };
       // PTY output bytes -> terminal. The subscription lives on this state so
       // dispose() cancels it.
@@ -1620,6 +1754,56 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     _reanchorSelectionOnGrowth();
     _syncMouseTracking();
     _syncHasSelection();
+    // #726: the visible buffer may have changed (output/scroll) — re-detect URLs
+    // on a debounce so a streaming burst doesn't re-scan every byte.
+    _scheduleUrlDetect();
+  }
+
+  /// #726: debounce a URL re-detection. The controller fires on every output
+  /// write; coalesce a burst into one scan ~120ms after the last notify so
+  /// streaming output stays cheap. A short delay also lets flterm settle the
+  /// grid before we read it. Cancelled/replaced on each notify; cleared on
+  /// dispose.
+  void _scheduleUrlDetect() {
+    _urlDebounce?.cancel();
+    _urlDebounce = Timer(const Duration(milliseconds: 120), _detectUrls);
+  }
+
+  /// #726: read the VISIBLE viewport text from flterm and re-detect URLs.
+  ///
+  /// The buffer READ uses flterm's public
+  /// `controller.createFormatter(format: plain, unwrap: false).format()`, which
+  /// returns the ACTIVE SCREEN (visible viewport, NOT scrollback) as plain text,
+  /// one VISIBLE ROW per `\n`. We split on `\n` to get the per-row strings and
+  /// hand them to the PURE [detectGhosttyUrls] matcher with the live grid width
+  /// ([_cols]) — which re-joins soft-wrapped rows and maps each URL to a viewport
+  /// cell range. Only rebuilds when the match list actually changes (the painter
+  /// + tap hit-test read [_urlMatches]). Defensive: a formatter/FFI error must
+  /// never crash the session, so it falls back to no highlights.
+  void _detectUrls() {
+    if (!mounted) return;
+    final controller = _controller;
+    if (controller == null) return;
+    List<GhosttyUrlMatch> next;
+    try {
+      final formatter = controller.createFormatter(
+        format: FormatterFormat.plain,
+        unwrap: false,
+      );
+      final String text;
+      try {
+        text = formatter.format();
+      } finally {
+        formatter.dispose();
+      }
+      final rows = text.split('\n');
+      next = detectGhosttyUrls(rows, cols: _cols);
+    } catch (_) {
+      // A formatter/FFI hiccup must not crash the session — drop highlights.
+      next = const [];
+    }
+    if (GhosttyUrlHighlightPainter._sameMatches(_urlMatches, next)) return;
+    if (mounted) setState(() => _urlMatches = next);
   }
 
   /// #712: mirror whether a selection is active into [_hasSelection], rebuilding
@@ -2000,6 +2184,13 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     controller.selection = reanchored;
   }
 
+  /// #726: copy a tapped URL to the clipboard + confirm via a top-toast. Invoked
+  /// when a single tap lands on a highlighted URL (the tap is swallowed).
+  Future<void> _copyUrl(GhosttyUrlMatch match) async {
+    await Clipboard.setData(ClipboardData(text: match.url));
+    if (mounted) showTopToast(context, 'Copied URL');
+  }
+
   Future<void> _copySelection() async {
     final controller = _controller;
     if (controller == null) return;
@@ -2041,6 +2232,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       t.cancel();
     }
     _resyncTimers.clear();
+    _urlDebounce?.cancel();
     _outputSub?.cancel();
     _controller?.removeListener(_onControllerChanged);
     _controller?.onOutput = null;
@@ -2130,6 +2322,26 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             gestureSettings: kGhosttyScrollSettings,
           ),
         ),
+        // #726: URL highlight overlay — a subtle underline under each detected
+        // URL's cell range, drawn with the SAME #723-correct cell metrics + the
+        // flterm padding so it lands under the on-screen text. IgnorePointer so
+        // it never steals the tap (the gesture router below handles tap-to-copy).
+        // Repaints when _urlMatches / metrics change (debounced re-detection on
+        // controller notify), so it follows scroll + resize. Uses the theme's
+        // selection colour for theme consistency (#716).
+        Positioned.fill(
+          child: IgnorePointer(
+            child: CustomPaint(
+              painter: GhosttyUrlHighlightPainter(
+                matches: _urlMatches,
+                cellWidth: cellSize.width,
+                cellHeight: cellSize.height,
+                cols: _cols,
+                color: palette.theme.selection,
+              ),
+            ),
+          ),
+        ),
         // #690/#692/#693: routes touch so the remote (tmux) behaves. When mouse
         // mode is ON the overlay is OPAQUE and routes the gesture: a finger SWIPE
         // scrolls the scrollback (flterm emits canonical wheel reports — never a
@@ -2214,6 +2426,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             // selection active?" live and clears it on demand.
             hasSelection: () => controller.selection != null,
             onSelectionClear: _clearSelection,
+            // #726: resolve a tapped cell to a detected URL (0-based viewport
+            // cells) and copy it on tap. The parent owns _urlMatches.
+            urlAtCell: (col, row) =>
+                ghosttyUrlAtCell(_urlMatches, col: col, row: row),
+            onUrlTap: _copyUrl,
           ),
         ),
         // Selection affordances (bottom-right). #712: shown ONLY while a

--- a/native/lib/ui/ghostty_url_detector.dart
+++ b/native/lib/ui/ghostty_url_detector.dart
@@ -1,0 +1,263 @@
+// Ghostty URL smart-select — Slice 1 PURE matcher (#726).
+//
+// Detects http/https/www URLs in the VISIBLE terminal viewport and maps each
+// to a viewport cell RANGE so the [GhosttyTerminalView] can:
+//   - HIGHLIGHT each URL (an overlay drawn over the cell range), and
+//   - resolve a TAP cell to a URL (single-tap copies it).
+//
+// This file is PURE Dart (no FFI / no flterm widget) so it is unit-testable
+// headless — the flterm buffer-READ that feeds it is the only native part, and
+// the view passes that text + grid metrics in.
+//
+// How the view reads the visible buffer text (the flterm API found, #726):
+// flterm 0.0.3's public `TerminalController` exposes `createFormatter(format:
+// plain, unwrap: false).format()`, which returns the ACTIVE SCREEN (the visible
+// viewport — NOT scrollback) as plain text, one VISIBLE ROW per `\n`-separated
+// line. (The internal `terminal`/`GridRef`/`lineBoundaryAt` row API and the
+// libghostty `Selection`/`PointTag` types are NOT exported, so per-row grid
+// reads aren't available publicly — the row-joined formatter output is.) The
+// view splits that on `\n` to get the per-row strings this matcher consumes.
+//
+// SOFT-WRAP joining (like the PWA #570): a terminal soft-wraps a long logical
+// line across several viewport rows with NO break character. `unwrap: false`
+// keeps those as separate rows, so this matcher RE-JOINS them: a row whose
+// trimmed-right content fills the FULL grid width ([cols]) is treated as
+// soft-wrapped into the next row, and a URL spanning the wrap is detected on the
+// joined logical line, then mapped back to a multi-row cell range. This is the
+// standard width heuristic (flterm's own `rowWrap` flag is internal/unexported).
+//
+// OUT OF SCOPE for Slice 1 (do NOT add here): long-press options menu / Open
+// (Slice 2), file paths (Slice 3), scrollback URLs. Visible buffer + URLs only.
+
+/// A detected URL and the VIEWPORT cell range it occupies (#726).
+///
+/// Coordinates are 0-based viewport cells: [startRow]/[endRow] are visible-row
+/// indices (0 == top visible row), [startCol] is the first cell of the URL and
+/// [endCol] is EXCLUSIVE (one past the last cell) on [endRow]. A URL that fits
+/// on one row has `startRow == endRow`; a URL across a soft-wrap spans rows.
+class GhosttyUrlMatch {
+  const GhosttyUrlMatch({
+    required this.url,
+    required this.startCol,
+    required this.startRow,
+    required this.endCol,
+    required this.endRow,
+  });
+
+  /// The matched URL text (already normalised — a bare `www.` match is prefixed
+  /// with `https://`).
+  final String url;
+
+  /// First cell column (0-based, inclusive) on [startRow].
+  final int startCol;
+
+  /// First visible row (0-based).
+  final int startRow;
+
+  /// One-past-the-last cell column (0-based, EXCLUSIVE) on [endRow].
+  final int endCol;
+
+  /// Last visible row (0-based).
+  final int endRow;
+
+  @override
+  bool operator ==(Object other) =>
+      other is GhosttyUrlMatch &&
+      other.url == url &&
+      other.startCol == startCol &&
+      other.startRow == startRow &&
+      other.endCol == endCol &&
+      other.endRow == endRow;
+
+  @override
+  int get hashCode => Object.hash(url, startCol, startRow, endCol, endRow);
+
+  @override
+  String toString() =>
+      'GhosttyUrlMatch($url @ ($startCol,$startRow)->($endCol,$endRow))';
+}
+
+/// The URL pattern (#726). Matches `http://` / `https://` absolute URLs and
+/// bare `www.` hosts. Trailing sentence punctuation (`.,;:!?` and a closing
+/// bracket/quote) is excluded from the match so a URL at the end of a sentence
+/// doesn't swallow the period — mirroring the PWA detector.
+///
+/// Deliberately conservative for Slice 1: no `ftp:`/`mailto:`/file paths
+/// (Slice 3), no IDN/unicode hosts. The character class stops at whitespace and
+/// the few characters terminals/shells never put MID-url.
+final RegExp _kUrlPattern = RegExp(
+  r'(?:https?://|www\.)[^\s<>"'
+  "'"
+  r'`]+',
+  caseSensitive: false,
+);
+
+/// Trailing characters trimmed off the END of a raw match (sentence
+/// punctuation / unbalanced closers) so `(see https://x.com).` → `https://x.com`.
+const String _kTrailingTrim = '.,;:!?)]}>\'"';
+
+/// A logical line assembled from one or more soft-wrapped viewport rows, with
+/// enough geometry to map a character offset in the joined text back to a
+/// (col, row) viewport cell. Internal to [detectGhosttyUrls].
+class _LogicalLine {
+  _LogicalLine(this.text, this.rows, this.cols);
+
+  /// The joined text of all rows in this logical line (rows concatenated with
+  /// NO separator, exactly as a soft-wrap reads).
+  final String text;
+
+  /// The 0-based viewport row indices this logical line spans, in order.
+  final List<int> rows;
+
+  /// The grid width (cells per row) used to map a flat offset to (col, row).
+  final int cols;
+
+  /// Map a 0-based character [offset] in [text] to a (col, row) viewport cell.
+  ///
+  /// Each row holds up to [cols] characters; offsets past the assembled text
+  /// clamp to the last row's end. Used to resolve a URL's start/end offset to
+  /// the cell where the highlight begins/ends.
+  (int col, int row) cellAt(int offset) {
+    if (cols <= 0 || rows.isEmpty) return (0, rows.isEmpty ? 0 : rows.first);
+    final clamped = offset < 0 ? 0 : offset;
+    final rowIndex = clamped ~/ cols;
+    final col = clamped % cols;
+    if (rowIndex >= rows.length) {
+      // Past the last assembled row — clamp to the end of the final row.
+      return (cols, rows.last);
+    }
+    return (col, rows[rowIndex]);
+  }
+}
+
+/// Whether viewport [row] (its right-trimmed text [content]) soft-wraps into the
+/// next row — i.e. its content fills the FULL grid width [cols] with no trailing
+/// blank (the standard width heuristic, since flterm's `rowWrap` flag isn't
+/// exported). A row shorter than [cols] ended naturally (a real line break).
+bool _rowSoftWraps(String content, int cols) =>
+    cols > 0 && content.length >= cols;
+
+/// Assemble visible [rows] (one string per viewport row, top-first) into
+/// logical lines, joining soft-wrapped rows by the [cols]-width heuristic.
+///
+/// Each row is right-padded to [cols] when joined so a character offset in the
+/// joined text maps cleanly to (offset % cols, rows[offset ~/ cols]) — a URL
+/// that wraps mid-row then continues on the next row keeps contiguous cells.
+List<_LogicalLine> _logicalLines(List<String> rows, int cols) {
+  final lines = <_LogicalLine>[];
+  var i = 0;
+  while (i < rows.length) {
+    final memberRows = <int>[i];
+    final buffer = StringBuffer();
+    // A soft-wrapped row contributes its FULL [cols] cells (right-padded) so the
+    // next row's text continues at a clean row boundary in the flat offset map.
+    var current = rows[i];
+    while (_rowSoftWraps(_trimRight(current), cols) && i + 1 < rows.length) {
+      buffer.write(_padRight(current, cols));
+      i++;
+      current = rows[i];
+      memberRows.add(i);
+    }
+    buffer.write(current);
+    lines.add(_LogicalLine(buffer.toString(), memberRows, cols));
+    i++;
+  }
+  return lines;
+}
+
+String _trimRight(String s) {
+  var end = s.length;
+  while (end > 0 && (s.codeUnitAt(end - 1) == 0x20)) {
+    end--;
+  }
+  return s.substring(0, end);
+}
+
+String _padRight(String s, int width) {
+  if (s.length >= width) return s.substring(0, width);
+  return s + (' ' * (width - s.length));
+}
+
+/// Normalise a raw match: prefix a bare `www.` host with `https://`.
+String _normalizeUrl(String raw) {
+  final lower = raw.toLowerCase();
+  if (lower.startsWith('http://') || lower.startsWith('https://')) return raw;
+  return 'https://$raw';
+}
+
+/// Detect http/https/www URLs in the VISIBLE viewport [rows] (#726).
+///
+/// [rows] is one string per visible viewport row (top-first), as read from
+/// `controller.createFormatter(format: plain, unwrap: false).format()` split on
+/// `\n`. [cols] is the grid width, used to (a) re-join soft-wrapped rows into a
+/// logical line and (b) map a URL's character offset back to viewport cells.
+///
+/// Returns one [GhosttyUrlMatch] per URL with its 0-based viewport cell range
+/// ([endCol] exclusive). A URL spanning a soft-wrap yields a multi-row range.
+/// Pure (no FFI / no widget) → unit-testable headless.
+List<GhosttyUrlMatch> detectGhosttyUrls(
+  List<String> rows, {
+  required int cols,
+}) {
+  if (cols <= 0 || rows.isEmpty) return const [];
+  final matches = <GhosttyUrlMatch>[];
+  for (final line in _logicalLines(rows, cols)) {
+    for (final m in _kUrlPattern.allMatches(line.text)) {
+      var raw = m.group(0)!;
+      // Trim trailing sentence punctuation / unbalanced closers from the END.
+      while (raw.isNotEmpty && _kTrailingTrim.contains(raw[raw.length - 1])) {
+        raw = raw.substring(0, raw.length - 1);
+      }
+      if (raw.isEmpty) continue;
+      final startOffset = m.start;
+      final endOffset = m.start + raw.length; // exclusive in joined text
+      final (startCol, startRow) = line.cellAt(startOffset);
+      final (endCol, endRow) = line.cellAt(endOffset);
+      matches.add(
+        GhosttyUrlMatch(
+          url: _normalizeUrl(raw),
+          startCol: startCol,
+          startRow: startRow,
+          endCol: endCol,
+          endRow: endRow,
+        ),
+      );
+    }
+  }
+  return matches;
+}
+
+/// Whether the 0-based viewport cell ([col], [row]) falls inside [match]'s
+/// range (#726). Used by the tap handler to resolve a tap to a URL.
+///
+/// The range reads left-to-right, top-to-bottom: a cell is inside iff it is at
+/// or after the start cell AND strictly before the (exclusive) end cell, walking
+/// rows in order. A single-row match is a simple `[startCol, endCol)` test; a
+/// multi-row match includes the start row's tail, every full interior row, and
+/// the end row's head.
+bool ghosttyCellInUrl(
+  GhosttyUrlMatch match, {
+  required int col,
+  required int row,
+}) {
+  if (row < match.startRow || row > match.endRow) return false;
+  if (match.startRow == match.endRow) {
+    return col >= match.startCol && col < match.endCol;
+  }
+  if (row == match.startRow) return col >= match.startCol;
+  if (row == match.endRow) return col < match.endCol;
+  return true; // an interior fully-covered row
+}
+
+/// Find the URL the 0-based viewport cell ([col], [row]) lands in, or null
+/// (#726). The first match containing the cell wins (URLs never overlap).
+GhosttyUrlMatch? ghosttyUrlAtCell(
+  List<GhosttyUrlMatch> matches, {
+  required int col,
+  required int row,
+}) {
+  for (final m in matches) {
+    if (ghosttyCellInUrl(m, col: col, row: row)) return m;
+  }
+  return null;
+}

--- a/native/test/ui/ghostty_resize_source_of_truth_test.dart
+++ b/native/test/ui/ghostty_resize_source_of_truth_test.dart
@@ -70,6 +70,8 @@ void main() {
             onSelectionExtend: (_, _) {},
             hasSelection: hasSelection ?? () => false,
             onSelectionClear: () {},
+            urlAtCell: (_, _) => null,
+            onUrlTap: (_) {},
           ),
         ),
       ),

--- a/native/test/ui/ghostty_swipe_windowswitch_smoke_test.dart
+++ b/native/test/ui/ghostty_swipe_windowswitch_smoke_test.dart
@@ -75,6 +75,8 @@ void main() {
             onSelectionExtend: (_, _) {},
             hasSelection: () => false,
             onSelectionClear: () {},
+            urlAtCell: (_, _) => null,
+            onUrlTap: (_) {},
           ),
         ),
       ),
@@ -88,15 +90,17 @@ void main() {
     ) async {
       // rows=24, in sync with tmux → status row is 24 (bottom).
       final reports = await pumpRouter(tester, rows: 24);
-      final center = tester.getCenter(
-        find.byType(GhosttyPointerGestureRouter),
-      );
+      final center = tester.getCenter(find.byType(GhosttyPointerGestureRouter));
       // A clear horizontal drag well past the 32px window-switch threshold, with
       // ~zero vertical so axis-lock commits horizontal.
       await tester.dragFrom(center, const Offset(120, 0));
       await tester.pumpAndSettle();
 
-      expect(reports, hasLength(1), reason: 'ONE discrete window step per swipe');
+      expect(
+        reports,
+        hasLength(1),
+        reason: 'ONE discrete window step per swipe',
+      );
       expect(
         wheelButton(reports.single),
         65,
@@ -113,9 +117,7 @@ void main() {
       tester,
     ) async {
       final reports = await pumpRouter(tester, rows: 30);
-      final center = tester.getCenter(
-        find.byType(GhosttyPointerGestureRouter),
-      );
+      final center = tester.getCenter(find.byType(GhosttyPointerGestureRouter));
       await tester.dragFrom(center, const Offset(-120, 0));
       await tester.pumpAndSettle();
 
@@ -132,9 +134,7 @@ void main() {
       tester,
     ) async {
       final reports = await pumpRouter(tester);
-      final center = tester.getCenter(
-        find.byType(GhosttyPointerGestureRouter),
-      );
+      final center = tester.getCenter(find.byType(GhosttyPointerGestureRouter));
       // Past the axis-lock slop (12) so it commits horizontal, but under the
       // 32px window-switch threshold → committed-horizontal but no step.
       await tester.dragFrom(center, const Offset(20, 0));
@@ -150,27 +150,30 @@ void main() {
       // window-switch wheel is forwarded to the remote. This is the axis-lock
       // guarantee: a scroll must never step a tmux window (#708/#719).
       final reports = await pumpRouter(tester);
-      final center = tester.getCenter(
-        find.byType(GhosttyPointerGestureRouter),
-      );
+      final center = tester.getCenter(find.byType(GhosttyPointerGestureRouter));
       await tester.dragFrom(center, const Offset(0, -120));
       await tester.pumpAndSettle();
-      expect(reports, isEmpty, reason: 'vertical = scroll, never a wheel report');
+      expect(
+        reports,
+        isEmpty,
+        reason: 'vertical = scroll, never a wheel report',
+      );
     });
 
-    testWidgets('a vertical drag with horizontal jitter still does not switch', (
-      tester,
-    ) async {
-      // The #708 regression half: a scroll with a few px of horizontal drift
-      // must NOT trip a window-switch. dy dominates → locks vertical.
-      final reports = await pumpRouter(tester);
-      final center = tester.getCenter(
-        find.byType(GhosttyPointerGestureRouter),
-      );
-      await tester.dragFrom(center, const Offset(20, -120));
-      await tester.pumpAndSettle();
-      expect(reports, isEmpty);
-    });
+    testWidgets(
+      'a vertical drag with horizontal jitter still does not switch',
+      (tester) async {
+        // The #708 regression half: a scroll with a few px of horizontal drift
+        // must NOT trip a window-switch. dy dominates → locks vertical.
+        final reports = await pumpRouter(tester);
+        final center = tester.getCenter(
+          find.byType(GhosttyPointerGestureRouter),
+        );
+        await tester.dragFrom(center, const Offset(20, -120));
+        await tester.pumpAndSettle();
+        expect(reports, isEmpty);
+      },
+    );
   });
 
   group('#719 inactive overlay (no mouse mode) forwards no wheel', () {
@@ -180,9 +183,7 @@ void main() {
       // active=false → translucent tap layer, no pan router; flterm handles its
       // own scroll. A swipe must NOT synthesise a window-switch wheel.
       final reports = await pumpRouter(tester, active: false);
-      final center = tester.getCenter(
-        find.byType(GhosttyPointerGestureRouter),
-      );
+      final center = tester.getCenter(find.byType(GhosttyPointerGestureRouter));
       await tester.dragFrom(center, const Offset(120, 0));
       await tester.pumpAndSettle();
       expect(reports, isEmpty);

--- a/native/test/ui/ghostty_url_detector_test.dart
+++ b/native/test/ui/ghostty_url_detector_test.dart
@@ -1,0 +1,176 @@
+// #726 — Ghostty URL smart-select Slice 1: PURE matcher + cell-range mapping.
+//
+// The view reads the VISIBLE viewport text via flterm's
+// `controller.createFormatter(format: plain, unwrap: false).format()` (the
+// per-row, viewport-only buffer read) and splits it on `\n` into rows; this
+// matcher then finds http/https/www URLs over each logical line (soft-wrapped
+// rows re-joined by the cols-width heuristic) and maps each to a 0-based
+// viewport cell range. flterm can't render headless (native .so), so the buffer
+// READ is owner-validated on device; the detection + mapping math is gated here.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_url_detector.dart';
+
+void main() {
+  group('detectGhosttyUrls — single-line detection (#726)', () {
+    test('a line with one URL → correct range', () {
+      // "see https://example.com now" — URL starts at col 4, ends before col 23.
+      const row = 'see https://example.com now';
+      final matches = detectGhosttyUrls([row], cols: 80);
+      expect(matches, hasLength(1));
+      final m = matches.single;
+      expect(m.url, 'https://example.com');
+      expect(m.startRow, 0);
+      expect(m.endRow, 0);
+      expect(m.startCol, 4);
+      expect(m.endCol, 4 + 'https://example.com'.length);
+    });
+
+    test('no URL → empty', () {
+      final matches = detectGhosttyUrls([
+        'just some shell output, nothing here',
+        r'$ ls -la /home/user',
+      ], cols: 80);
+      expect(matches, isEmpty);
+    });
+
+    test('multiple URLs on separate rows → one match each', () {
+      final matches = detectGhosttyUrls([
+        'first http://a.test/path',
+        'second https://b.test',
+      ], cols: 80);
+      expect(matches, hasLength(2));
+      expect(matches[0].url, 'http://a.test/path');
+      expect(matches[0].startRow, 0);
+      expect(matches[1].url, 'https://b.test');
+      expect(matches[1].startRow, 1);
+    });
+
+    test('bare www. host is normalised to https://', () {
+      final matches = detectGhosttyUrls([
+        'visit www.example.org today',
+      ], cols: 80);
+      expect(matches, hasLength(1));
+      expect(matches.single.url, 'https://www.example.org');
+      // The cell range still maps to the raw "www.example.org" text on screen.
+      expect(matches.single.startCol, 'visit '.length);
+      expect(matches.single.endCol, 'visit '.length + 'www.example.org'.length);
+    });
+
+    test('trailing sentence punctuation is excluded from the URL', () {
+      final matches = detectGhosttyUrls([
+        '(see https://example.com/path).',
+      ], cols: 80);
+      expect(matches, hasLength(1));
+      expect(matches.single.url, 'https://example.com/path');
+      // endCol must stop before the trailing ")." — exclusive end.
+      final start = '(see '.length;
+      expect(matches.single.startCol, start);
+      expect(matches.single.endCol, start + 'https://example.com/path'.length);
+    });
+  });
+
+  group('detectGhosttyUrls — soft-wrap join (#726, #570 parity)', () {
+    test('a URL across a soft-wrap → joined into one multi-row range', () {
+      // cols=10: row 0 is FULL (10 chars, soft-wraps) and the URL continues on
+      // row 1. The matcher joins them and detects the whole URL across the wrap.
+      // row0: "x http://e"  (10 chars, fills the grid → soft-wrapped)
+      // row1: "x.co/p end"  (continues the URL: ".co/p" then " end")
+      const row0 = 'x http://e';
+      const row1 = 'x.co/p end';
+      final matches = detectGhosttyUrls([row0, row1], cols: 10);
+      expect(matches, hasLength(1));
+      final m = matches.single;
+      expect(m.url, 'http://ex.co/p');
+      // Starts on row 0 at col 2 ("http://e" begins after "x ").
+      expect(m.startRow, 0);
+      expect(m.startCol, 2);
+      // Ends on row 1: joined offset of URL end = 2 + len("http://ex.co/p") = 16
+      // → row 16~/10 = 1, col 16%10 = 6 (exclusive, before " end").
+      expect(m.endRow, 1);
+      expect(m.endCol, 6);
+    });
+
+    test('a full row that ends a natural line is NOT joined to the next', () {
+      // row0 is full width BUT row1 starts a brand-new logical line; the width
+      // heuristic still joins (no rowWrap flag available) — documented limit.
+      // Here we assert the URL on row1 alone is detected with the joined offset.
+      const row0 = '0123456789'; // 10 chars, full → treated as wrapped
+      const row1 = 'go https://z.io';
+      final matches = detectGhosttyUrls([row0, row1], cols: 10);
+      expect(matches, hasLength(1));
+      final m = matches.single;
+      expect(m.url, 'https://z.io');
+      // Joined text = row0(10) + row1; "https://z.io" starts at joined offset
+      // 10 + 3 = 13 → row 1, col 3.
+      expect(m.startRow, 1);
+      expect(m.startCol, 3);
+    });
+  });
+
+  group('ghosttyCellInUrl / ghosttyUrlAtCell — hit-test (#726)', () {
+    const match = GhosttyUrlMatch(
+      url: 'https://example.com',
+      startCol: 4,
+      startRow: 0,
+      endCol: 23,
+      endRow: 0,
+    );
+
+    test('tap cell INSIDE the range → true', () {
+      expect(ghosttyCellInUrl(match, col: 4, row: 0), isTrue); // start
+      expect(ghosttyCellInUrl(match, col: 10, row: 0), isTrue); // middle
+      expect(ghosttyCellInUrl(match, col: 22, row: 0), isTrue); // last cell
+    });
+
+    test('tap cell OUTSIDE the range → false', () {
+      expect(ghosttyCellInUrl(match, col: 3, row: 0), isFalse); // before start
+      expect(
+        ghosttyCellInUrl(match, col: 23, row: 0),
+        isFalse,
+      ); // exclusive end
+      expect(ghosttyCellInUrl(match, col: 10, row: 1), isFalse); // wrong row
+    });
+
+    test('multi-row range: tail of start row, interior, head of end row', () {
+      const wrapped = GhosttyUrlMatch(
+        url: 'http://ex.co/p',
+        startCol: 2,
+        startRow: 0,
+        endCol: 6,
+        endRow: 1,
+      );
+      expect(ghosttyCellInUrl(wrapped, col: 9, row: 0), isTrue); // start tail
+      expect(
+        ghosttyCellInUrl(wrapped, col: 1, row: 0),
+        isFalse,
+      ); // before start
+      expect(ghosttyCellInUrl(wrapped, col: 5, row: 1), isTrue); // end head
+      expect(
+        ghosttyCellInUrl(wrapped, col: 6, row: 1),
+        isFalse,
+      ); // exclusive end
+    });
+
+    test('ghosttyUrlAtCell returns the containing match or null', () {
+      final matches = detectGhosttyUrls([
+        'a https://one.test b https://two.test',
+      ], cols: 80);
+      expect(matches, hasLength(2));
+      final hit = ghosttyUrlAtCell(matches, col: matches[1].startCol, row: 0);
+      expect(hit?.url, 'https://two.test');
+      final miss = ghosttyUrlAtCell(matches, col: 0, row: 0);
+      expect(miss, isNull);
+    });
+  });
+
+  group('detectGhosttyUrls — degenerate input (#726)', () {
+    test('empty rows → empty', () {
+      expect(detectGhosttyUrls(const [], cols: 80), isEmpty);
+    });
+
+    test('cols <= 0 → empty (no grid to map onto)', () {
+      expect(detectGhosttyUrls(['https://x.com'], cols: 0), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## #726 — Ghostty URL smart-select, Slice 1 (MVP)

Detect URLs in the **visible** ghostty terminal viewport, **highlight** them, and **single-tap to copy**. Native Flutter app (#501), file `native/lib/ui/ghostty_terminal_view.dart` + a new pure detector. xterm path untouched.

### What this slice does
- Detects `http://` / `https://` URLs and bare `www.` hosts in the visible buffer.
- Underlines each URL (theme selection colour) following scroll + resize.
- Single-tap on a URL copies it (`Copied URL` toast) and swallows the tap.

### Out of scope (deferred)
- Long-press options menu / Open in browser → **Slice 2**
- File-path detection → **Slice 3**
- Scrollback URLs (visible viewport only)

### Buffer read — flterm API found
flterm 0.0.3's public `TerminalController.createFormatter(format: plain, unwrap: false).format()` returns the **active screen** (visible viewport, not scrollback) as plain text, one row per `\n`. The internal `terminal` / `GridRef` / `lineBoundaryAt` row API and the libghostty `Selection` / `PointTag` types are **unexported**, so soft-wrap joining uses the pure cols-width heuristic (PWA #570 parity), not flterm's native `rowWrap` flag. The formatter read is the only FFI part; everything downstream is pure.

### Implementation
- **`ghostty_url_detector.dart`** (new, pure): `detectGhosttyUrls(rows, cols)` → `{url, startCol/Row, endCol(exclusive)/Row}`; `www.`→`https://` normalise, trailing-punctuation trim, soft-wrap → multi-row range; `ghosttyCellInUrl` / `ghosttyUrlAtCell` hit-test. **13 unit tests.**
- **`GhosttyUrlHighlightPainter`**: `IgnorePointer` `CustomPaint` above `TerminalView`, underlines each range with the #723-correct cell metrics + 4px grid padding.
- **Debounced re-detection** (120ms) on controller notify (output/scroll) + `onResize`; defensive try/catch around the FFI read.
- **Gesture router**: new `urlAtCell` + `onUrlTap` params; both tap branches (active opaque + inactive translucent) copy a tapped URL and swallow the tap, after the #706 selection-dismiss check; non-URL taps fall through to the exact prior #693 path.

### No regression
#705/#706 selection + buttons + tap-dismiss, #693 tap-keyboard/click, #708 axis-lock, #719/#723 resize/grid, #716 theme, #712 buttons — all behaviour unchanged. Two router-test files updated for the 2 new required params.

### Tests
`scripts/native-fast-gate.sh` green — analyze + format + **732 tests** (incl. 13 new). flterm can't render headless, so this is the standard ghostty constraint: the matcher + mapping are gated headless; the on-device behaviour is owner-validated.

### Owner device-validates
- URLs underlined in the visible terminal.
- Single-tap on a URL copies it (`Copied URL` toast).
- Non-URL taps behave exactly as before (keyboard / click / selection).

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)