### PR TITLE
fix(#728): apply keybar Ctrl to soft-keyboard keys (Ghostty)

### DIFF
--- a/native/lib/state/ctrl_modifier_provider.dart
+++ b/native/lib/state/ctrl_modifier_provider.dart
@@ -1,0 +1,66 @@
+// Shared sticky one-shot Ctrl-modifier state (#728).
+//
+// #694 gave the keybar a sticky Ctrl modifier (`CtrlModifier` in ui/keybar.dart):
+// tap Ctrl to ARM, the next KEYBAR key transforms to its control byte, then Ctrl
+// auto-clears (one-shot). But that armed flag lived INSIDE the keybar widget, so
+// the terminal soft-keyboard input path could never read it. There are no letter
+// keys on the keybar, so to send Ctrl+R the user types R on the SOFT KEYBOARD —
+// which flows through flterm's `controller.onOutput(bytes) → proxy.sendInput`
+// (ui/ghostty_terminal_view.dart) and never reached the keybar's `CtrlModifier`.
+// Armed Ctrl + a keyboard letter did nothing and Ctrl stayed stuck armed.
+//
+// #728 lifts the armed flag into THIS shared Riverpod provider so BOTH the keybar
+// (which drives arm/disarm as the user taps the Ctrl key) AND the terminal input
+// path (which reads + one-shot-clears it before forwarding a keystroke) see the
+// same state. The keybar keeps its own `CtrlModifier` for its existing #694 key
+// path AND mirrors the armed state into this provider so the two stay in sync.
+//
+// This is a NEW file in state/ — deliberately separate from the #589-sensitive
+// session/connection providers, which must not be touched.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The sticky one-shot Ctrl modifier, as a shared `bool` (true == armed).
+///
+/// Mirrors the keybar's `CtrlModifier` lifecycle but lives outside any widget so
+/// the terminal input path can read + clear it. The terminal soft-keyboard path
+/// calls [CtrlModifierNotifier.consume] to apply Ctrl to exactly the next typed
+/// character (one-shot), then clears.
+class CtrlModifierNotifier extends StateNotifier<bool> {
+  CtrlModifierNotifier() : super(false);
+
+  /// Arm the modifier (idempotent — arming twice stays armed; this is NOT a
+  /// toggle, so the terminal path / explicit callers can force it on without
+  /// accidentally cancelling). For the keybar's tap-to-cancel behaviour use
+  /// [toggle].
+  void arm() {
+    if (!state) state = true;
+  }
+
+  /// Force the modifier off (e.g. when switching sessions, or after a keystroke
+  /// consumed it through a path that doesn't call [consume]).
+  void disarm() {
+    if (state) state = false;
+  }
+
+  /// Flip the armed flag — mirrors the keybar's Ctrl key tap (arm if disarmed,
+  /// CANCEL if already armed), matching #694's `CtrlModifier.arm`.
+  void toggle() {
+    state = !state;
+  }
+
+  /// One-shot read-and-clear: returns whether the modifier WAS armed, and clears
+  /// it. The terminal input path calls this for each typed keystroke — when it
+  /// returns true the caller applies the Ctrl transform to that one character.
+  bool consume() {
+    final wasArmed = state;
+    if (wasArmed) state = false;
+    return wasArmed;
+  }
+}
+
+/// Shared armed-Ctrl flag (#728). Read by the terminal soft-keyboard input path;
+/// driven by the keybar's Ctrl key.
+final ctrlModifierProvider = StateNotifierProvider<CtrlModifierNotifier, bool>(
+  (ref) => CtrlModifierNotifier(),
+);

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -174,11 +174,48 @@ import 'package:xterm/xterm.dart' as xterm;
 import '../diagnostics/gesture_trace.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
+import '../state/ctrl_modifier_provider.dart';
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import 'ghostty_url_detector.dart';
+import 'keybar.dart';
 import 'top_toast.dart';
+
+/// Apply the shared armed keybar Ctrl modifier (#728) to a SOFT-KEYBOARD
+/// keystroke flowing through flterm's `controller.onOutput`.
+///
+/// #694's keybar Ctrl modifier only transformed KEYBAR key presses. There are no
+/// letter keys on the keybar, so to send Ctrl+R the user types R on the soft
+/// keyboard — input that flows through `controller.onOutput(bytes) →
+/// proxy.sendInput` and never reached the keybar's `CtrlModifier`. This is the
+/// PURE decision the terminal input path makes once it has read the shared
+/// [ctrlModifierProvider] armed flag: given [armed] and the typed [bytes], it
+/// returns the bytes to actually send plus whether the one-shot Ctrl should now
+/// be cleared.
+///
+/// Rules (mirroring the keybar's [ctrlTransform] for parity):
+///   - NOT [armed]            → passthrough, `shouldClear == false` (nothing to clear);
+///   - armed + single ASCII letter (a–z/A–Z) → `& 0x1f` control byte, cleared;
+///   - armed + single non-letter (digit, symbol, CR, …) → [ctrlTransform]
+///     (which passes non-letters through unchanged), still cleared (one-shot);
+///   - armed + multi-byte (len > 1: IME / paste / a CSI escape) → passthrough
+///     UNCHANGED so multi-char input is never corrupted, still cleared so the
+///     sticky Ctrl can't get stuck.
+///
+/// Pure (no FFI / no widget / no provider) → unit-testable headless.
+({String bytes, bool shouldClear}) ghosttyApplyArmedCtrl({
+  required bool armed,
+  required String bytes,
+}) {
+  if (!armed) return (bytes: bytes, shouldClear: false);
+  // Multi-byte IME / paste / escape sequences pass through untouched — only a
+  // single typed character carries a Ctrl meaning. The one-shot still clears.
+  if (bytes.length != 1) return (bytes: bytes, shouldClear: true);
+  // Single char: the keybar's transform maps a letter → its control byte and
+  // leaves a non-letter unchanged, so keybar-key and keyboard-key Ctrl match.
+  return (bytes: ctrlTransform(bytes), shouldClear: true);
+}
 
 /// Build the flterm [ColorPalette] for the per-session theme [palette] (#716).
 ///
@@ -1692,7 +1729,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // shell.
       controller.onOutput = (bytes) {
         if (proxy.data.state != SshSessionState.connected) return;
-        proxy.sendInput(bytes);
+        proxy.sendInput(_applyArmedCtrlToKeystroke(bytes));
       };
       // Grid resize -> PTY resize. flterm reports (cols, rows); the proxy's
       // pixel sizes default to 0 (the task isolate only needs cols/rows). Also
@@ -1835,6 +1872,36 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       if (e.id == widget.sessionId) return e.proxy;
     }
     return null;
+  }
+
+  /// Apply the shared armed keybar Ctrl modifier (#728) to a soft-keyboard
+  /// keystroke before it is forwarded to the PTY.
+  ///
+  /// The keybar's Ctrl key arms [ctrlModifierProvider] (in addition to its own
+  /// #694 `CtrlModifier`); there are no letter keys on the keybar, so to send
+  /// Ctrl+R the user types R on the soft keyboard — which flterm delivers here as
+  /// `controller.onOutput` bytes. When Ctrl is armed we transform the next typed
+  /// character to its control byte and CLEAR the one-shot.
+  ///
+  /// Byte-level care (mirrors [ghosttyApplyArmedCtrl] but stays on bytes so
+  /// multi-byte UTF-8 is never round-tripped): only a SINGLE ASCII byte (< 0x80)
+  /// can carry a Ctrl-letter meaning, so we decode just that one byte, run the
+  /// pure helper, and re-encode the single transformed char. Any multi-byte input
+  /// (IME / paste / a CSI escape) passes through UNCHANGED — but the one-shot Ctrl
+  /// still clears so it can't get stuck. When Ctrl is NOT armed this is a no-op
+  /// fast path returning the original bytes untouched.
+  Uint8List _applyArmedCtrlToKeystroke(Uint8List bytes) {
+    final notifier = ref.read(ctrlModifierProvider.notifier);
+    // One-shot: read+clear. If it wasn't armed, forward the bytes verbatim.
+    if (!notifier.consume()) return bytes;
+    // Only a single ASCII byte can be a Ctrl-letter; anything else (multi-byte
+    // UTF-8 / IME / paste / escape) passes through unchanged.
+    if (bytes.length != 1 || bytes[0] >= 0x80) return bytes;
+    final result = ghosttyApplyArmedCtrl(
+      armed: true,
+      bytes: String.fromCharCode(bytes[0]),
+    );
+    return Uint8List.fromList(result.bytes.codeUnits);
   }
 
   /// #702: on `shellReady`, force a resize re-sync now, then a short burst of

--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -21,6 +21,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
 
+import '../state/ctrl_modifier_provider.dart';
 import '../state/sessions.dart';
 
 /// Bottom-chrome sizing. These are the single source of truth for the button
@@ -248,35 +249,41 @@ class Keybar extends ConsumerStatefulWidget {
 }
 
 class _KeybarState extends ConsumerState<Keybar> {
-  // #694: sticky one-shot Ctrl modifier, mirroring the PWA's `ctrlActive`.
-  // Tapping the Ctrl key arms it; the next keybar key transforms to its control
-  // byte, then it auto-clears.
-  final CtrlModifier _ctrl = CtrlModifier();
+  // #694 + #728: the sticky one-shot Ctrl modifier now lives in the SHARED
+  // [ctrlModifierProvider] (state/ctrl_modifier_provider.dart) rather than a
+  // widget-local `CtrlModifier`, so the terminal soft-keyboard input path
+  // (flterm `controller.onOutput`) can read + clear the SAME armed state. There
+  // are no letter keys on the bar, so Ctrl+R is typed on the keyboard — #728
+  // makes that path see this arm. The keybar drives the provider (toggle on the
+  // Ctrl key, consume on the next keybar key) and reads it for the armed
+  // highlight; the per-key byte transform still uses the pure [ctrlTransform],
+  // exactly as #694's `CtrlModifier.apply` did.
 
   void _onKeyTap(KeybarKey k) {
     final terminal = widget.activeEntry.terminal;
+    final ctrl = ref.read(ctrlModifierProvider.notifier);
 
-    // The Ctrl modifier key itself: arm/cancel, no byte emitted.
+    // The Ctrl modifier key itself: arm/cancel, no byte emitted. `toggle` mirrors
+    // #694 (a second Ctrl tap cancels). Reading the provider drives the rebuild.
     if (k.isModifier) {
-      setState(_ctrl.arm);
+      ctrl.toggle();
       return;
     }
 
     // Paste pulls from the clipboard out-of-band. If Ctrl was armed, it has no
     // single-letter control meaning, so clear the modifier and paste literally.
     if (k.id == 'keyPaste') {
-      final wasArmed = _ctrl.armed;
-      if (wasArmed) setState(_ctrl.clear);
+      ctrl.disarm();
       _paste(terminal);
       return;
     }
 
-    // Apply the (possibly armed) Ctrl transform and send. `apply` auto-clears
-    // the one-shot modifier; rebuild so the armed highlight clears.
-    final wasArmed = _ctrl.armed;
-    final bytes = _ctrl.apply(k.sequence);
+    // Apply the (possibly armed) one-shot Ctrl transform and send. `consume`
+    // reads + clears the shared modifier (so the keybar highlight clears and the
+    // terminal path won't also see it); the byte transform mirrors #694.
+    final wasArmed = ctrl.consume();
+    final bytes = wasArmed ? ctrlTransform(k.sequence) : k.sequence;
     if (bytes.isNotEmpty) terminal.textInput(bytes);
-    if (wasArmed) setState(() {});
   }
 
   Future<void> _paste(Terminal terminal) async {
@@ -289,6 +296,10 @@ class _KeybarState extends ConsumerState<Keybar> {
 
   @override
   Widget build(BuildContext context) {
+    // #728: the armed-Ctrl highlight reads the SHARED provider so it stays in
+    // sync whether the modifier was consumed by a keybar key OR by a keyboard
+    // keystroke through the terminal input path.
+    final ctrlArmed = ref.watch(ctrlModifierProvider);
     return Material(
       key: const Key('keybar'),
       // #696: high-contrast strip. The bar backs the keys with near-black so the
@@ -314,7 +325,7 @@ class _KeybarState extends ConsumerState<Keybar> {
                   child: _KeybarButton(
                     keyData: k,
                     // The Ctrl key shows an accented/armed state while sticky.
-                    armed: k.isModifier && _ctrl.armed,
+                    armed: k.isModifier && ctrlArmed,
                     onTap: () => _onKeyTap(k),
                   ),
                 ),

--- a/native/test/state/ctrl_modifier_provider_test.dart
+++ b/native/test/state/ctrl_modifier_provider_test.dart
@@ -1,0 +1,89 @@
+// Tests for the shared Ctrl-modifier provider (#728).
+//
+// #694 gave the KEYBAR a sticky one-shot Ctrl modifier, but its armed state
+// lived in the keybar widget (`CtrlModifier`), so the terminal soft-keyboard
+// input path (flterm `controller.onOutput`) could never see it — armed Ctrl + a
+// keyboard letter (e.g. R) did nothing and Ctrl stayed armed. #728 lifts the
+// armed flag into this shared Riverpod provider so BOTH the keybar and the
+// terminal input path can read + clear it.
+//
+// The notifier is a plain `bool` state with arm()/disarm()/toggle()/consume().
+// `consume()` is the one-shot clear the terminal path calls after applying Ctrl
+// to a keystroke; it returns whether it WAS armed so the caller knows whether to
+// transform.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/ctrl_modifier_provider.dart';
+
+void main() {
+  group('CtrlModifierNotifier — arm/disarm/toggle/consume (#728)', () {
+    test('starts disarmed', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(ctrlModifierProvider), isFalse);
+    });
+
+    test('arm() sets armed true', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(ctrlModifierProvider.notifier).arm();
+      expect(container.read(ctrlModifierProvider), isTrue);
+    });
+
+    test('disarm() clears armed', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final n = container.read(ctrlModifierProvider.notifier);
+      n.arm();
+      n.disarm();
+      expect(container.read(ctrlModifierProvider), isFalse);
+    });
+
+    test('toggle() flips armed each call (matches keybar Ctrl tap)', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final n = container.read(ctrlModifierProvider.notifier);
+      n.toggle();
+      expect(container.read(ctrlModifierProvider), isTrue);
+      n.toggle();
+      expect(
+        container.read(ctrlModifierProvider),
+        isFalse,
+        reason: 'a second Ctrl tap cancels the modifier',
+      );
+    });
+
+    test('consume() returns true and clears when armed (one-shot)', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final n = container.read(ctrlModifierProvider.notifier);
+      n.arm();
+      final wasArmed = n.consume();
+      expect(wasArmed, isTrue);
+      expect(
+        container.read(ctrlModifierProvider),
+        isFalse,
+        reason: 'consume clears the one-shot modifier',
+      );
+    });
+
+    test('consume() returns false and stays clear when disarmed', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final n = container.read(ctrlModifierProvider.notifier);
+      final wasArmed = n.consume();
+      expect(wasArmed, isFalse);
+      expect(container.read(ctrlModifierProvider), isFalse);
+    });
+
+    test('arm() while armed stays armed (idempotent, not a toggle)', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final n = container.read(ctrlModifierProvider.notifier);
+      n.arm();
+      n.arm();
+      expect(container.read(ctrlModifierProvider), isTrue);
+    });
+  });
+}

--- a/native/test/ui/ghostty_keyboard_ctrl_test.dart
+++ b/native/test/ui/ghostty_keyboard_ctrl_test.dart
@@ -1,0 +1,127 @@
+// Tests for applying the armed keybar Ctrl modifier to SOFT-KEYBOARD input on
+// the Ghostty backend (#728).
+//
+// The keybar Ctrl modifier (#694) only transformed KEYBAR key presses. There are
+// no letter keys on the keybar, so to send Ctrl+R the user types R on the soft
+// keyboard — which flows through flterm's `controller.onOutput(bytes) →
+// proxy.sendInput` and never reached the keybar's `CtrlModifier`. #728 reads the
+// shared armed flag in that input path and transforms the next typed character.
+//
+// `ghosttyApplyArmedCtrl(armed, bytes)` is the PURE decision: given the armed
+// flag and the typed bytes, it returns the bytes to actually send plus whether
+// the one-shot Ctrl should now be cleared. It mirrors the keybar's `ctrlTransform`
+// so keybar-key and keyboard-key Ctrl behave identically.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+void main() {
+  group('ghosttyApplyArmedCtrl — armed + single letter (#728)', () {
+    test("armed + 'R' (0x52) → 0x12 (Ctrl+R), cleared", () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: 'R');
+      expect(r.bytes, equals('\x12'));
+      expect(r.bytes.codeUnitAt(0), equals(0x12));
+      expect(r.shouldClear, isTrue);
+    });
+
+    test("armed + 'r' (0x72) → 0x12 (case-insensitive), cleared", () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: 'r');
+      expect(r.bytes, equals('\x12'));
+      expect(r.bytes.codeUnitAt(0), equals(0x12));
+      expect(r.shouldClear, isTrue);
+    });
+
+    test("armed + 'c' → 0x03 (Ctrl+C), cleared", () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: 'c');
+      expect(r.bytes, equals('\x03'));
+      expect(r.shouldClear, isTrue);
+    });
+
+    test('every a–z maps to byte 1..26 via & 0x1f when armed', () {
+      for (var c = 'a'.codeUnitAt(0); c <= 'z'.codeUnitAt(0); c++) {
+        final letter = String.fromCharCode(c);
+        final r = ghosttyApplyArmedCtrl(armed: true, bytes: letter);
+        expect(
+          r.bytes.codeUnitAt(0),
+          equals(c & 0x1f),
+          reason: 'armed Ctrl+$letter should be byte ${c & 0x1f}',
+        );
+        expect(r.shouldClear, isTrue);
+      }
+    });
+  });
+
+  group('ghosttyApplyArmedCtrl — armed + non-letter single char (#728)', () {
+    test("armed + '5' → passthrough '5', still cleared (one-shot)", () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: '5');
+      expect(
+        r.bytes,
+        equals('5'),
+        reason: 'a digit has no letter control meaning → unmodified',
+      );
+      expect(
+        r.shouldClear,
+        isTrue,
+        reason: 'Ctrl auto-clears after one key even on a non-letter',
+      );
+    });
+
+    test("armed + '/' → passthrough '/', cleared", () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: '/');
+      expect(r.bytes, equals('/'));
+      expect(r.shouldClear, isTrue);
+    });
+
+    test("armed + a CR ('\\r') → passthrough, cleared", () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: '\r');
+      expect(r.bytes, equals('\r'));
+      expect(r.shouldClear, isTrue);
+    });
+  });
+
+  group('ghosttyApplyArmedCtrl — armed + multi-char (IME/paste) (#728)', () {
+    test('armed + multi-char string → passthrough UNCHANGED, cleared', () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: 'hello world');
+      expect(
+        r.bytes,
+        equals('hello world'),
+        reason: 'never corrupt multi-byte IME/paste — pass through unchanged',
+      );
+      expect(
+        r.shouldClear,
+        isTrue,
+        reason: 'the one-shot Ctrl still clears so it does not get stuck',
+      );
+    });
+
+    test('armed + a CSI escape (multi-byte) → passthrough, cleared', () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: '\x1b[A');
+      expect(r.bytes, equals('\x1b[A'));
+      expect(r.shouldClear, isTrue);
+    });
+
+    test('armed + empty string → passthrough empty, cleared', () {
+      final r = ghosttyApplyArmedCtrl(armed: true, bytes: '');
+      expect(r.bytes, equals(''));
+      expect(r.shouldClear, isTrue);
+    });
+  });
+
+  group('ghosttyApplyArmedCtrl — NOT armed (#728)', () {
+    test("not armed + 'R' → passthrough, NOT cleared", () {
+      final r = ghosttyApplyArmedCtrl(armed: false, bytes: 'R');
+      expect(r.bytes, equals('R'));
+      expect(
+        r.shouldClear,
+        isFalse,
+        reason: 'nothing to clear when Ctrl was not armed',
+      );
+    });
+
+    test('not armed + multi-char → passthrough unchanged, NOT cleared', () {
+      final r = ghosttyApplyArmedCtrl(armed: false, bytes: 'ls -la');
+      expect(r.bytes, equals('ls -la'));
+      expect(r.shouldClear, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #728. Armed keybar Ctrl now applies to the next soft-keyboard character on the Ghostty backend (R → 0x12), one-shot clear. Shared ctrl_modifier_provider as single source of truth; pure ghosttyApplyArmedCtrl helper (byte-safe: multi-byte/IME/paste pass through unchanged but still clear). 19 new tests; 751 pass. xterm path deferred (its input lives in #589-forbidden sessions.dart). Based on current main.