### PR TITLE
feat(#732): keybar arrow/navigation keys auto-repeat on press-and-hold (haptic per tick)

### DIFF
--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -16,6 +16,8 @@
 // only when the ACTIVE session's `sessionKeybarVisibleProvider` is true. The
 // toggle lives in the session menu; this widget is just the renderer.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -239,6 +241,89 @@ const List<KeybarKey> kDefaultKeybarKeys = [
   KeybarKey(id: 'keyCtrlD', label: '^D', sequence: '\x04'),
 ];
 
+/// Keys that AUTO-REPEAT on press-and-hold (#732). Cursor / navigation keys
+/// only — holding one repeats the SAME keystroke until release, so arrowing
+/// through shell history / moving the cursor / scrolling a TUI doesn't need
+/// many taps. Keyed on the key id so the set is EXPLICIT and trivial to extend.
+///
+/// Deliberately EXCLUDED: modifier / one-shot keys (Esc, the sticky Ctrl,
+/// Tab), symbol keys (/ - |), the fixed control combos (^C/^Z/^B/^D), Enter
+/// (one line at a time), and Paste (out-of-band). A hold on those does nothing
+/// extra — a single tap still sends exactly once.
+const Set<String> kRepeatEligibleKeyIds = {
+  'keyLeft',
+  'keyUp',
+  'keyDown',
+  'keyRight',
+  'keyHome',
+  'keyEnd',
+  'keyPgUp',
+  'keyPgDn',
+};
+
+/// Whether the keybar key with [id] auto-repeats on press-and-hold (#732).
+bool isRepeatEligibleKeyId(String id) => kRepeatEligibleKeyIds.contains(id);
+
+/// Default press-and-hold timing (#732), matching the standard terminal
+/// key-repeat feel: a brief initial delay before repeating kicks in (so a quick
+/// tap never repeats), then a steady, fast cadence until the finger lifts.
+const Duration kKeyRepeatInitialDelay = Duration(milliseconds: 400);
+const Duration kKeyRepeatInterval = Duration(milliseconds: 60);
+
+/// Drives the press-and-hold auto-repeat for a single keybar key (#732).
+///
+/// Kept as a plain, widget-free state holder (like [CtrlModifier]) so the timer
+/// lifecycle is unit-testable with `fakeAsync` — the keybar widget tap path
+/// hangs the headless harness on Material ripple animations (see
+/// keybar_test.dart).
+///
+/// Lifecycle: [start] schedules an initial-delay [Timer]; when it fires, the
+/// first [onTick] runs and a [Timer.periodic] takes over at [interval], firing
+/// [onTick] each tick. [stop] cancels BOTH timers (idempotent) — call it on
+/// pointer up / cancel / dispose. Because the first tick only fires AFTER
+/// [initialDelay], a quick tap (released before the delay) produces ZERO ticks,
+/// so the tap's single send is never doubled.
+///
+/// The controller is intentionally haptic-agnostic: it fires only [onTick]; the
+/// widget's tick callback does the byte-send AND the per-tick haptic. That
+/// keeps the timer logic cleanly unit-testable (the haptic is device-validated).
+class KeyRepeatController {
+  KeyRepeatController({
+    this.initialDelay = kKeyRepeatInitialDelay,
+    this.interval = kKeyRepeatInterval,
+  });
+
+  final Duration initialDelay;
+  final Duration interval;
+
+  Timer? _initialTimer;
+  Timer? _repeatTimer;
+
+  /// True once the hold has begun (initial-delay or repeat timer is live).
+  bool get isRunning => _initialTimer != null || _repeatTimer != null;
+
+  /// Begin the hold: after [initialDelay], fire [onTick] once and start the
+  /// periodic repeat. Restarting while already running cancels the prior
+  /// schedule first (no overlapping cadence, no leaked timer).
+  void start(void Function() onTick) {
+    stop();
+    _initialTimer = Timer(initialDelay, () {
+      _initialTimer = null;
+      onTick();
+      _repeatTimer = Timer.periodic(interval, (_) => onTick());
+    });
+  }
+
+  /// Cancel the hold immediately. Safe to call when nothing is running and safe
+  /// to call repeatedly (idempotent).
+  void stop() {
+    _initialTimer?.cancel();
+    _initialTimer = null;
+    _repeatTimer?.cancel();
+    _repeatTimer = null;
+  }
+}
+
 class Keybar extends ConsumerStatefulWidget {
   const Keybar({super.key, required this.activeEntry});
 
@@ -286,6 +371,23 @@ class _KeybarState extends ConsumerState<Keybar> {
     if (bytes.isNotEmpty) terminal.textInput(bytes);
   }
 
+  /// One auto-repeat tick for a held nav key (#732). Reuses the SAME byte-send
+  /// the tap path uses ([_onKeyTap] for a non-modifier, non-paste key): apply
+  /// the one-shot Ctrl transform if armed, then forward the bytes. The first
+  /// tick consumes any armed Ctrl exactly as a tap would (one-shot, mirrors
+  /// #694); subsequent ticks send the plain CSI sequence — Ctrl never re-arms
+  /// itself, so a held arrow keeps sending the arrow. A minuscule
+  /// `HapticFeedback.selectionClick()` accompanies each tick (owner: the
+  /// lightest, device-validated). Only eligible keys ever reach here.
+  void _onRepeatTick(KeybarKey k) {
+    final terminal = widget.activeEntry.terminal;
+    final ctrl = ref.read(ctrlModifierProvider.notifier);
+    final wasArmed = ctrl.consume();
+    final bytes = wasArmed ? ctrlTransform(k.sequence) : k.sequence;
+    if (bytes.isNotEmpty) terminal.textInput(bytes);
+    HapticFeedback.selectionClick();
+  }
+
   Future<void> _paste(Terminal terminal) async {
     final data = await Clipboard.getData('text/plain');
     final text = data?.text;
@@ -327,6 +429,12 @@ class _KeybarState extends ConsumerState<Keybar> {
                     // The Ctrl key shows an accented/armed state while sticky.
                     armed: k.isModifier && ctrlArmed,
                     onTap: () => _onKeyTap(k),
+                    // #732: press-and-hold auto-repeat for cursor/nav keys only.
+                    // null for non-eligible keys → no repeat wiring at all (a
+                    // hold does nothing extra, a tap still sends once).
+                    onRepeat: isRepeatEligibleKeyId(k.id)
+                        ? () => _onRepeatTick(k)
+                        : null,
                   ),
                 ),
             ],
@@ -337,11 +445,12 @@ class _KeybarState extends ConsumerState<Keybar> {
   }
 }
 
-class _KeybarButton extends StatelessWidget {
+class _KeybarButton extends StatefulWidget {
   const _KeybarButton({
     required this.keyData,
     required this.onTap,
     this.armed = false,
+    this.onRepeat,
   });
 
   final KeybarKey keyData;
@@ -351,8 +460,40 @@ class _KeybarButton extends StatelessWidget {
   /// highlight so it's clear Ctrl is sticky for the next key.
   final bool armed;
 
+  /// #732: press-and-hold auto-repeat handler. Non-null ONLY for repeat-eligible
+  /// (cursor/nav) keys — a hold then fires this once per repeat tick after the
+  /// initial delay. Null for every other key, which therefore never repeats.
+  final VoidCallback? onRepeat;
+
+  @override
+  State<_KeybarButton> createState() => _KeybarButtonState();
+}
+
+class _KeybarButtonState extends State<_KeybarButton> {
+  // #732: each eligible button owns its own auto-repeat controller so a held
+  // pointer repeats the keystroke. Cancelled on pointer up / cancel / dispose
+  // so a lifted finger stops immediately and an unmounted widget leaks no timer.
+  final KeyRepeatController _repeat = KeyRepeatController();
+
+  @override
+  void dispose() {
+    _repeat.stop();
+    super.dispose();
+  }
+
+  void _onPointerDown(PointerDownEvent _) {
+    final onRepeat = widget.onRepeat;
+    if (onRepeat == null) return; // non-eligible key — never repeats.
+    _repeat.start(onRepeat);
+  }
+
+  void _stopRepeat() => _repeat.stop();
+
   @override
   Widget build(BuildContext context) {
+    final keyData = widget.keyData;
+    final armed = widget.armed;
+    final onTap = widget.onTap;
     final theme = Theme.of(context);
     // #703: a single-character TEXT key (`|`, `/`, `-`, …) gets a narrower min
     // width so it doesn't waste horizontal space. Icon keys and multi-char text
@@ -388,7 +529,7 @@ class _KeybarButton extends StatelessWidget {
             ),
             overflow: TextOverflow.ellipsis,
           );
-    return OutlinedButton(
+    final button = OutlinedButton(
       key: Key('keybar-btn-${keyData.id}'),
       onPressed: onTap,
       style: OutlinedButton.styleFrom(
@@ -427,6 +568,20 @@ class _KeybarButton extends StatelessWidget {
         ),
       ),
       child: child,
+    );
+
+    // #732: a pointer-level Listener drives press-and-hold auto-repeat WITHOUT
+    // interfering with the button's own tap (onPressed still fires exactly once
+    // for a quick tap). For non-eligible keys onRepeat is null and the pointer
+    // handlers are no-ops, so those keys behave exactly as before. Pointer up
+    // AND cancel both stop the repeat so a lifted/slid-off finger halts it
+    // immediately. behavior: deferToChild keeps the button hit-testable.
+    return Listener(
+      onPointerDown: _onPointerDown,
+      onPointerUp: (_) => _stopRepeat(),
+      onPointerCancel: (_) => _stopRepeat(),
+      behavior: HitTestBehavior.deferToChild,
+      child: button,
     );
   }
 }

--- a/native/pubspec.lock
+++ b/native/pubspec.lock
@@ -210,7 +210,7 @@ packages:
     source: hosted
     version: "2.0.8"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -93,6 +93,12 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  # Deterministic virtual time for timer-lifecycle unit tests (#732 keybar
+  # auto-repeat). Already resolved transitively via flutter_test; pinned as a
+  # direct dev dep so the explicit import is lint-clean (depend_on_referenced_
+  # packages).
+  fake_async: ^1.3.3
+
   # On-emulator acceptance: drives the real app (real foreground-task isolate,
   # real platform channels) against test-sshd. Catches bootstrap/IPC bugs the
   # InMemoryGatewayPair-based widget tests can't see (#539). Run via

--- a/native/test/widget/keybar_autorepeat_test.dart
+++ b/native/test/widget/keybar_autorepeat_test.dart
@@ -1,0 +1,254 @@
+// Tests for keybar nav-key auto-repeat on press-and-hold (#732).
+//
+// Press-and-hold a cursor/navigation key (arrows, Home/End, PgUp/PgDn) →
+// auto-repeat the keystroke until release, with a minuscule haptic per tick.
+// A quick tap = exactly ONE send (the tap path), no repeat, no double-send.
+// Modifier / one-shot keys (Esc, Ctrl, Tab, symbols, ^C/^Z/^B/^D, Enter, Paste)
+// do NOT repeat.
+//
+// Following the #694 pattern, the repeat LOGIC is a pure, widget-free holder
+// (`KeyRepeatController`) so the timer lifecycle is unit-testable with
+// `fakeAsync` (NO real delays) — the keybar widget tap path hangs the headless
+// harness on Material ripple animations (see keybar_test.dart). Eligibility is
+// an explicit Set keyed on the key id so it's trivial to extend.
+//
+// The haptic is device-validated (the owner) — the controller fires only the
+// send `onTick`; the widget supplies a tick callback that does send + haptic.
+// These tests assert the TICK COUNT (the send path), not the haptic.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/keybar.dart';
+
+void main() {
+  group('repeat-eligible key set (#732)', () {
+    test('all four arrows are repeat-eligible', () {
+      for (final id in ['keyLeft', 'keyUp', 'keyDown', 'keyRight']) {
+        expect(
+          isRepeatEligibleKeyId(id),
+          isTrue,
+          reason: '$id (a cursor key) must auto-repeat on hold',
+        );
+      }
+    });
+
+    test('Home/End and PgUp/PgDn are repeat-eligible (cursor movement)', () {
+      for (final id in ['keyHome', 'keyEnd', 'keyPgUp', 'keyPgDn']) {
+        expect(
+          isRepeatEligibleKeyId(id),
+          isTrue,
+          reason: '$id is a navigation/cursor key and should repeat',
+        );
+      }
+    });
+
+    test('modifier / one-shot / symbol keys are NOT repeat-eligible', () {
+      for (final id in [
+        'keyEsc',
+        'keyCtrl',
+        'keyTab',
+        'keySlash',
+        'keyDash',
+        'keyPipe',
+        'keyEnter',
+        'keyPaste',
+        'keyCtrlC',
+        'keyCtrlZ',
+        'keyCtrlB',
+        'keyCtrlD',
+      ]) {
+        expect(
+          isRepeatEligibleKeyId(id),
+          isFalse,
+          reason: '$id must NOT auto-repeat — a hold does nothing extra',
+        );
+      }
+    });
+
+    test('the eligible Set is explicit and matches the predicate', () {
+      // The Set is the single source of truth for the predicate.
+      for (final id in kRepeatEligibleKeyIds) {
+        expect(isRepeatEligibleKeyId(id), isTrue);
+      }
+      // An unknown id is never eligible.
+      expect(isRepeatEligibleKeyId('keyDoesNotExist'), isFalse);
+    });
+
+    test('every eligible id actually exists in the default layout', () {
+      final layoutIds = kDefaultKeybarKeys.map((k) => k.id).toSet();
+      for (final id in kRepeatEligibleKeyIds) {
+        expect(
+          layoutIds,
+          contains(id),
+          reason: 'eligible id $id must be a real key on the bar',
+        );
+      }
+    });
+  });
+
+  group('KeyRepeatController timer lifecycle (#732, fakeAsync)', () {
+    test('no tick fires before the initial delay elapses', () {
+      fakeAsync((async) {
+        var ticks = 0;
+        final c = KeyRepeatController(
+          initialDelay: const Duration(milliseconds: 400),
+          interval: const Duration(milliseconds: 60),
+        );
+        c.start(() => ticks++);
+        // Just shy of the initial delay — nothing yet.
+        async.elapse(const Duration(milliseconds: 399));
+        expect(ticks, 0, reason: 'a held key must not repeat before the delay');
+        c.stop();
+        async.flushTimers();
+      });
+    });
+
+    test('after the initial delay, exactly one tick fires per interval', () {
+      fakeAsync((async) {
+        var ticks = 0;
+        final c = KeyRepeatController(
+          initialDelay: const Duration(milliseconds: 400),
+          interval: const Duration(milliseconds: 60),
+        );
+        c.start(() => ticks++);
+
+        // Cross the initial delay → first tick.
+        async.elapse(const Duration(milliseconds: 400));
+        expect(ticks, 1, reason: 'first repeat fires at the initial delay');
+
+        // Each subsequent interval → exactly one more tick.
+        async.elapse(const Duration(milliseconds: 60));
+        expect(ticks, 2);
+        async.elapse(const Duration(milliseconds: 60));
+        expect(ticks, 3);
+
+        // Five more intervals → five more ticks.
+        async.elapse(const Duration(milliseconds: 60 * 5));
+        expect(ticks, 8, reason: 'one tick per interval, steady cadence');
+
+        c.stop();
+        async.flushTimers();
+      });
+    });
+
+    test('stop() before the initial delay = ZERO ticks (quick tap)', () {
+      fakeAsync((async) {
+        var ticks = 0;
+        final c = KeyRepeatController(
+          initialDelay: const Duration(milliseconds: 400),
+          interval: const Duration(milliseconds: 60),
+        );
+        c.start(() => ticks++);
+        // Finger lifts after 120ms — a normal tap.
+        async.elapse(const Duration(milliseconds: 120));
+        c.stop();
+        // Let any (cancelled) timers settle.
+        async.elapse(const Duration(milliseconds: 1000));
+        expect(
+          ticks,
+          0,
+          reason:
+              'a quick tap must never trigger a repeat tick (no double-send)',
+        );
+        async.flushTimers();
+      });
+    });
+
+    test('stop() during the repeat phase halts further ticks immediately', () {
+      fakeAsync((async) {
+        var ticks = 0;
+        final c = KeyRepeatController(
+          initialDelay: const Duration(milliseconds: 400),
+          interval: const Duration(milliseconds: 60),
+        );
+        c.start(() => ticks++);
+        async.elapse(const Duration(milliseconds: 400 + 60 * 3));
+        final atStop = ticks;
+        expect(atStop, 4, reason: 'initial + 3 interval ticks');
+        c.stop();
+        // Plenty of time passes — no more ticks after release.
+        async.elapse(const Duration(milliseconds: 1000));
+        expect(ticks, atStop, reason: 'release stops repeat immediately');
+        async.flushTimers();
+      });
+    });
+
+    test('stop() cleans up all timers (none pending afterward)', () {
+      fakeAsync((async) {
+        final c = KeyRepeatController(
+          initialDelay: const Duration(milliseconds: 400),
+          interval: const Duration(milliseconds: 60),
+        );
+        c.start(() {});
+        async.elapse(const Duration(milliseconds: 400 + 60 * 2));
+        c.stop();
+        expect(
+          async.pendingTimers,
+          isEmpty,
+          reason: 'no leaked timers after stop()',
+        );
+      });
+    });
+
+    test('stop() is idempotent and safe before start / twice', () {
+      fakeAsync((async) {
+        final c = KeyRepeatController(
+          initialDelay: const Duration(milliseconds: 400),
+          interval: const Duration(milliseconds: 60),
+        );
+        // Safe with nothing started.
+        c.stop();
+        c.start(() {});
+        async.elapse(const Duration(milliseconds: 500));
+        c.stop();
+        c.stop(); // double stop — must not throw.
+        expect(async.pendingTimers, isEmpty);
+      });
+    });
+
+    test('start() while already running restarts cleanly (no leak)', () {
+      fakeAsync((async) {
+        var ticks = 0;
+        final c = KeyRepeatController(
+          initialDelay: const Duration(milliseconds: 400),
+          interval: const Duration(milliseconds: 60),
+        );
+        c.start(() => ticks++);
+        async.elapse(const Duration(milliseconds: 450)); // 1 tick in
+        // A fresh pointer-down restarts — old timers must be cancelled, not
+        // accumulated.
+        c.start(() => ticks++);
+        async.elapse(const Duration(milliseconds: 400));
+        // Only ONE controller's worth of cadence — not two overlapping.
+        expect(
+          ticks,
+          2,
+          reason: 'restart cancels the prior schedule; no doubled cadence',
+        );
+        c.stop();
+        expect(async.pendingTimers, isEmpty);
+      });
+    });
+  });
+
+  group('repeat tick reuses the per-key send (#732)', () {
+    test('each tick invokes the supplied send callback once', () {
+      // The widget passes a tick callback that runs the SAME byte-send path a
+      // single tap uses; the controller must call it exactly once per tick.
+      fakeAsync((async) {
+        final sent = <int>[];
+        var n = 0;
+        final c = KeyRepeatController(
+          initialDelay: const Duration(milliseconds: 400),
+          interval: const Duration(milliseconds: 60),
+        );
+        c.start(() => sent.add(++n));
+        async.elapse(const Duration(milliseconds: 400 + 60 * 4));
+        c.stop();
+        // 1 initial + 4 interval ticks, each exactly once, in order.
+        expect(sent, equals([1, 2, 3, 4, 5]));
+        async.flushTimers();
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #732. Press-and-hold a cursor/nav key (arrows + Home/End/PgUp/PgDn) → after a 400ms delay it repeats at ~60ms with a HapticFeedback.selectionClick per tick; release stops. Quick tap = exactly one send (no double-send). Modifiers/symbols don't repeat. 13 unit tests (fakeAsync). keybar.dart only — disjoint from #731.