### PR TITLE
feat(#740): file browser shows which server + back-to-terminal

### DIFF
--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -22,6 +22,7 @@ import '../services/session_messages.dart';
 import '../services/sftp_download.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../state/sessions.dart';
+import '../state/ui_prefs_providers.dart';
 import 'pdf_viewer_screen.dart';
 import 'top_toast.dart';
 
@@ -331,12 +332,67 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     _list(parent);
   }
 
+  /// #740: return to THIS session's terminal — make the browsed session active
+  /// (so the terminal screen's IndexedStack shows the right one in a
+  /// multi-session setup) and pop back to it. Falls back to a plain pop if the
+  /// session has since gone away.
+  void _backToTerminal() {
+    final notifier = ref.read(sessionsProvider.notifier);
+    final exists = ref
+        .read(sessionsProvider)
+        .entries
+        .any((e) => e.id == widget.sessionId);
+    if (exists) notifier.setActive(widget.sessionId);
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     final downloading = _downloadRequestId != null;
+    // #740: resolve which server this browser is for so the header names it and
+    // the swatch matches the session bar (#653). The browser already knows its
+    // [widget.sessionId]; reuse the same label + color sources as terminal_screen.
+    SessionEntry? entry;
+    for (final e in ref.watch(sessionsProvider).entries) {
+      if (e.id == widget.sessionId) {
+        entry = e;
+        break;
+      }
+    }
+    final label = entry?.label ?? 'Files';
+    final swatchColor =
+        ref.watch(sessionColorProvider(widget.sessionId)) ??
+        ref.watch(sessionTerminalThemeProvider(widget.sessionId)).theme.cursor;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Files'),
+        leading: IconButton(
+          key: const Key('file-browser-back-to-terminal'),
+          tooltip: 'Back to terminal',
+          icon: const Icon(Icons.terminal),
+          onPressed: _backToTerminal,
+        ),
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              key: const Key('file-browser-swatch'),
+              width: 12,
+              height: 12,
+              decoration: BoxDecoration(
+                color: swatchColor,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                label,
+                key: const Key('file-browser-title'),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(48),
           child: _PathBar(

--- a/native/test/widget/file_browser_widget_test.dart
+++ b/native/test/widget/file_browser_widget_test.dart
@@ -197,6 +197,132 @@ void main() {
     host.disposeSyncForTest();
   });
 
+  testWidgets('header shows the session label + a color swatch (#740)', (
+    tester,
+  ) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: _stubControllerFactory,
+      sftpOpener: (_) async => _ScriptedSftpSession({'/': const []}, const []),
+      snapshotInterval: const Duration(hours: 1),
+    );
+
+    final container = ProviderContainer(
+      overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+    );
+    addTearDown(container.dispose);
+
+    const params = SshConnectParams(
+      host: 'example.com',
+      port: 2222,
+      username: 'alice',
+      auth: SshAuth.password('p'),
+    );
+    final entry = container
+        .read(sessionsProvider.notifier)
+        .addOrActivate(params, title: 'Prod box');
+    entry.proxy.connect(params);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(home: FileBrowserScreen(sessionId: entry.id)),
+      ),
+    );
+    await _pump(tester);
+
+    // Header reflects WHICH server is being browsed (#740).
+    expect(find.text('Prod box'), findsOneWidget);
+    // Color swatch present.
+    expect(find.byKey(const Key('file-browser-swatch')), findsOneWidget);
+
+    host.disposeSyncForTest();
+  });
+
+  testWidgets(
+    'back-to-terminal returns to the correct session (multi-session) (#740)',
+    (tester) async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(pair.dispose);
+
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: _stubControllerFactory,
+        sftpOpener: (_) async =>
+            _ScriptedSftpSession({'/': const []}, const []),
+        snapshotInterval: const Duration(hours: 1),
+      );
+
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+      );
+      addTearDown(container.dispose);
+
+      const paramsA = SshConnectParams(
+        host: 'a-host',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      );
+      const paramsB = SshConnectParams(
+        host: 'b-host',
+        port: 22,
+        username: 'u',
+        auth: SshAuth.password('p'),
+      );
+      final notifier = container.read(sessionsProvider.notifier);
+      final a = notifier.addOrActivate(paramsA, title: 'Session A');
+      final b = notifier.addOrActivate(paramsB, title: 'Session B');
+      a.proxy.connect(paramsA);
+      b.proxy.connect(paramsB);
+      // A is active; we browse files for B and expect back to land on B.
+      notifier.setActive(a.id);
+      expect(container.read(sessionsProvider).activeId, a.id);
+
+      final navKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            navigatorKey: navKey,
+            home: const Scaffold(
+              body: Center(child: Text('terminal-root')),
+            ),
+          ),
+        ),
+      );
+      // Push the browser for session B onto the terminal-root navigator.
+      unawaited(
+        navKey.currentState!.push(
+          MaterialPageRoute<void>(
+            builder: (_) => FileBrowserScreen(sessionId: b.id),
+          ),
+        ),
+      );
+      await _pump(tester);
+
+      expect(
+        find.byKey(const Key('file-browser-back-to-terminal')),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.byKey(const Key('file-browser-back-to-terminal')),
+      );
+      await _pump(tester);
+
+      // Returned to the terminal root...
+      expect(find.text('terminal-root'), findsOneWidget);
+      // ...with session B made active (the one we were browsing), not A.
+      expect(container.read(sessionsProvider).activeId, b.id);
+
+      host.disposeSyncForTest();
+    },
+  );
+
   testWidgets('a list error renders the error state', (tester) async {
     final pair = InMemoryGatewayPair();
     addTearDown(pair.dispose);


### PR DESCRIPTION
Closes #740. File browser AppBar now shows the session label + color swatch and a back-to-terminal button (setActive(sessionId) + pop → that session's terminal). Reuses the existing sessionId field; no session_menu.dart change (no #739 conflict). 2 widget tests, 776 unit pass. file_browser_screen.dart only.