### PR TITLE
fix(#741): session-bar swipe keeps the soft keyboard up

### DIFF
--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -394,3 +394,18 @@ final activeSessionIdProvider = Provider<String?>((ref) {
 final activeSessionEntryProvider = Provider<SessionEntry?>((ref) {
   return ref.watch(sessionsProvider).active;
 });
+
+/// #741: whether the soft keyboard was UP at the moment the active session last
+/// changed (an app-level session-bar swipe-switch).
+///
+/// A session-bar swipe-switch must leave the keyboard state UNCHANGED — if it
+/// was up it must stay up so the bar doesn't jump down out from under the
+/// swiping finger. But the terminal's keyboard state lives in the flterm
+/// `TerminalController` inside each per-session [GhosttyTerminalView] (created in
+/// initState), which the session bar / [SessionsNotifier] cannot reach. So the
+/// OUTGOING view (the one losing active status) writes its keyboard-up state
+/// here as it stops being active, and the INCOMING view (the one becoming
+/// active) reads it to decide whether to re-show the keyboard on the
+/// newly-active terminal. Defaults false (keyboard down) so a cold first
+/// activation never auto-pops the IME.
+final sessionSwitchKeyboardWasUpProvider = StateProvider<bool>((ref) => false);

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -491,6 +491,63 @@ bool ghosttyShouldCycleFocusForRepaint({
   return active && connected && hasFocus;
 }
 
+/// #741: whether THIS session's view is the one LEAVING active on a session-bar
+/// swipe-switch and so must CAPTURE its current keyboard-up state.
+///
+/// An app-level session-bar swipe switches the active session
+/// (terminal_screen.dart `_SessionBar.onSwipe` → `setActive`). Every session's
+/// terminal is mounted in an `IndexedStack`, so the OUTGOING (focused) view goes
+/// offstage — its `TextInput` connection detaches and the keyboard collapses —
+/// while the INCOMING view is never focused. The bar then jumps down out from
+/// under the finger (the keyboard inset vanished). The keyboard state lives in
+/// each view's flterm controller, unreachable from the bar, so the outgoing view
+/// records whether its keyboard was up (into
+/// [sessionSwitchKeyboardWasUpProvider]) for the incoming view to restore.
+///
+/// True only on a REAL switch AWAY from this session: `prevActiveId` is this
+/// session, `nextActiveId` is a DIFFERENT session. A same-id re-emit (no switch)
+/// and a first-tick `prevActiveId == null` (initial activation, not a switch) do
+/// not capture. Pure (no FFI / no widget) → unit-testable headless.
+bool ghosttyShouldCaptureKeyboardOnSessionSwitch({
+  required String sessionId,
+  required String? prevActiveId,
+  required String? nextActiveId,
+}) {
+  if (prevActiveId == null) return false;
+  if (prevActiveId == nextActiveId) return false;
+  return prevActiveId == sessionId;
+}
+
+/// #741: whether THIS session's view is the one BECOMING active on a session-bar
+/// swipe-switch and so must RE-ATTACH focus (and, per
+/// [ghosttyShouldShowKeyboardOnSessionSwitch], re-show the keyboard) so the IME
+/// never collapses.
+///
+/// True only on a REAL switch INTO this session: `nextActiveId` is this session,
+/// `prevActiveId` is a DIFFERENT non-null session. A same-id re-emit is not a
+/// switch; a first-tick `prevActiveId == null` is the initial activation, which
+/// the #717 connect-focus path already owns (restoring here would fight the
+/// per-connect focus latch and could raise the IME on cold start — the
+/// #693/#717 focus-vs-keyboard separation). Pure → unit-testable headless.
+bool ghosttyShouldRestoreFocusOnSessionSwitch({
+  required String sessionId,
+  required String? prevActiveId,
+  required String? nextActiveId,
+}) {
+  if (prevActiveId == null) return false;
+  if (prevActiveId == nextActiveId) return false;
+  return nextActiveId == sessionId;
+}
+
+/// #741: whether the incoming view must RE-SHOW the keyboard after re-attaching
+/// focus on a session-bar switch. The contract is "leave the keyboard state
+/// UNCHANGED": re-show iff it was up before the switch ([keyboardWasUp], captured
+/// by the outgoing view). When it was down, focus only — the keyboard stays
+/// down. Pure → unit-testable headless.
+bool ghosttyShouldShowKeyboardOnSessionSwitch({required bool keyboardWasUp}) {
+  return keyboardWasUp;
+}
+
 /// The padding flterm's [TerminalView] is built with (`EdgeInsets.all(4)`), in
 /// logical px (#699). flterm wraps its `Scrollable` + render box in a
 /// `Padding(padding: widget.padding)`, so the grid's top-left is offset by this
@@ -2146,6 +2203,77 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     });
   }
 
+  /// #741: keep the keyboard state UNCHANGED across an app-level session-bar
+  /// swipe-switch so the bar never jumps down out from under the finger.
+  ///
+  /// Every session's terminal is mounted in an `IndexedStack`
+  /// (terminal_screen.dart), so switching the active session moves the OUTGOING
+  /// focused view offstage — its `TextInput` connection detaches and the soft
+  /// keyboard collapses — while the INCOMING view is never focused. Each view
+  /// listens to [activeSessionIdProvider] and handles its OWN side of the switch:
+  ///
+  ///   - OUTGOING ([ghosttyShouldCaptureKeyboardOnSessionSwitch]): record whether
+  ///     this terminal's keyboard was UP into [sessionSwitchKeyboardWasUpProvider]
+  ///     so the incoming view can restore it. The capture must happen BEFORE the
+  ///     incoming view's restore reads it; both run synchronously in this same
+  ///     provider tick (one notify → every listener), and the incoming view
+  ///     defers its keyboard show to a post-frame callback, so ordering holds
+  ///     regardless of which view's listener fires first.
+  ///   - INCOMING ([ghosttyShouldRestoreFocusOnSessionSwitch]): re-attach focus
+  ///     to this newly-active terminal and — iff the keyboard was up
+  ///     ([ghosttyShouldShowKeyboardOnSessionSwitch]) — re-show it, so the IME
+  ///     stays up (and the bar stays put). When the keyboard was down, focus
+  ///     only; it stays down. NEVER unconditionally `showKeyboard()` — the
+  ///     #693/#717 focus-vs-IME separation must hold.
+  ///
+  /// The initial activation (`prev == null`) is left to the #717 connect-focus
+  /// path; both gates no-op on it.
+  void _onActiveSessionChanged(String? prev, String? next) {
+    if (!mounted) return;
+    final controller = _controller;
+    if (controller == null) return;
+    if (ghosttyShouldCaptureKeyboardOnSessionSwitch(
+      sessionId: widget.sessionId,
+      prevActiveId: prev,
+      nextActiveId: next,
+    )) {
+      final wasUp = controller.keyboardState == KeyboardState.showing;
+      ref.read(sessionSwitchKeyboardWasUpProvider.notifier).state = wasUp;
+      gtrace('ghostty-session-switch: captured keyboardWasUp=$wasUp');
+    }
+    if (ghosttyShouldRestoreFocusOnSessionSwitch(
+      sessionId: widget.sessionId,
+      prevActiveId: prev,
+      nextActiveId: next,
+    )) {
+      // Re-attach focus synchronously so the IME's input connection follows the
+      // newly-active terminal instead of collapsing with the offstage one.
+      controller.requestFocus();
+      // Read the captured flag and (re-)show the keyboard on a POST-FRAME
+      // callback, NOT synchronously: the outgoing view's capture and this
+      // restore both run in the SAME provider tick (one notify → every
+      // listener), and listener order across the two view instances is
+      // unspecified. Reading at post-frame guarantees the capture (synchronous
+      // in its own listener) has already written the flag, and that the
+      // IndexedStack has put this child onstage so showKeyboard() attaches the
+      // IME to it. NEVER show unconditionally — the #693/#717 focus-vs-IME
+      // separation: keyboard up before → up after; down before → stays down.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final keyboardWasUp = ref.read(sessionSwitchKeyboardWasUpProvider);
+        if (ghosttyShouldShowKeyboardOnSessionSwitch(
+          keyboardWasUp: keyboardWasUp,
+        )) {
+          _controller?.showKeyboard();
+        }
+        gtrace(
+          'ghostty-session-switch: restored focus '
+          '(keyboardWasUp=$keyboardWasUp)',
+        );
+      });
+    }
+  }
+
   /// #705: begin an flterm LOCAL selection at the long-pressed 1-based VIEWPORT
   /// cell. Anchor it (held for the drag) and SET `controller.selection` to a
   /// collapsed span at that cell — mapped to absolute buffer rows by adding the
@@ -2324,6 +2452,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       if (ghosttyShouldRefreshOnLifecycle(effectivePrev, next)) {
         _onResume();
       }
+    });
+    // #741: a session-bar swipe-switch must leave the keyboard state UNCHANGED.
+    // The IndexedStack moves the outgoing focused view offstage (its TextInput
+    // detaches → keyboard collapses) and never focuses the incoming view, so the
+    // bar jumps down out from under the finger. Each view listens for the active
+    // session changing: the OUTGOING view captures its keyboard-up state; the
+    // INCOMING view re-attaches focus and re-shows the keyboard iff it was up.
+    ref.listen<String?>(activeSessionIdProvider, (prev, next) {
+      _onActiveSessionChanged(prev, next);
     });
     final controller = _controller;
     if (controller == null) {

--- a/native/test/ui/ghostty_session_switch_keyboard_test.dart
+++ b/native/test/ui/ghostty_session_switch_keyboard_test.dart
@@ -1,0 +1,151 @@
+// #741 — On the Ghostty backend, swiping the APP-LEVEL session bar to switch
+// sessions DISMISSED the soft keyboard. Every session's terminal is mounted in
+// an IndexedStack (terminal_screen.dart); a swipe-switch changes the visible
+// index, so the outgoing (focused) flterm view goes OFFSTAGE — its TextInput
+// connection detaches and the keyboard collapses — while the incoming view is
+// never focused and never re-shows the keyboard. The bar then jumps down out
+// from under the finger (the keyboard inset vanished mid-gesture).
+//
+// The fix keeps the keyboard state UNCHANGED across a switch:
+//   - the OUTGOING view records whether its keyboard was up (showing) at the
+//     moment it stops being active;
+//   - the INCOMING view re-attaches focus and, if the keyboard WAS up, re-shows
+//     it on the newly-active terminal so the IME never collapses; if it was
+//     down, focus only (the keyboard stays down).
+//
+// flterm/libghostty can't render headless (native .so), so these gate the PURE
+// decisions the switch-focus path uses. The real keyboard NOT dropping (and the
+// bar staying put under the finger) is OWNER-validated on device.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+void main() {
+  group(
+    'ghosttyShouldCaptureKeyboardOnSessionSwitch — outgoing view (#741)',
+    () {
+      test('captures when THIS view is the one LEAVING active (fix case)', () {
+        // prev == this session, next == some OTHER session: this view is the
+        // outgoing one, so it records whether its keyboard was up before the
+        // incoming view restores it.
+        expect(
+          ghosttyShouldCaptureKeyboardOnSessionSwitch(
+            sessionId: 's-old',
+            prevActiveId: 's-old',
+            nextActiveId: 's-new',
+          ),
+          isTrue,
+        );
+      });
+
+      test('does NOT capture for a view that was already inactive', () {
+        // A third, already-background session sees the same provider tick but it
+        // was never active — it must not clobber the captured flag.
+        expect(
+          ghosttyShouldCaptureKeyboardOnSessionSwitch(
+            sessionId: 's-bg',
+            prevActiveId: 's-old',
+            nextActiveId: 's-new',
+          ),
+          isFalse,
+        );
+      });
+
+      test('does NOT capture when the active session did not change', () {
+        // A spurious re-emit of the same active id is not a switch.
+        expect(
+          ghosttyShouldCaptureKeyboardOnSessionSwitch(
+            sessionId: 's-old',
+            prevActiveId: 's-old',
+            nextActiveId: 's-old',
+          ),
+          isFalse,
+        );
+      });
+
+      test('does NOT capture on the FIRST tick (no previous active)', () {
+        // prev == null is the initial activation, not a switch away from a
+        // keyboard-up session.
+        expect(
+          ghosttyShouldCaptureKeyboardOnSessionSwitch(
+            sessionId: 's-old',
+            prevActiveId: null,
+            nextActiveId: 's-old',
+          ),
+          isFalse,
+        );
+      });
+    },
+  );
+
+  group('ghosttyShouldRestoreFocusOnSessionSwitch — incoming view (#741)', () {
+    test('restores when THIS view BECOMES active from another (fix case)', () {
+      // next == this session, prev == a DIFFERENT non-null session: this is
+      // the incoming view of a real swipe-switch, so it re-attaches focus
+      // (and the caller re-shows the keyboard iff it was up).
+      expect(
+        ghosttyShouldRestoreFocusOnSessionSwitch(
+          sessionId: 's-new',
+          prevActiveId: 's-old',
+          nextActiveId: 's-new',
+        ),
+        isTrue,
+      );
+    });
+
+    test('does NOT restore for a view that stays in the background', () {
+      expect(
+        ghosttyShouldRestoreFocusOnSessionSwitch(
+          sessionId: 's-bg',
+          prevActiveId: 's-old',
+          nextActiveId: 's-new',
+        ),
+        isFalse,
+      );
+    });
+
+    test('does NOT restore when the active session did not change', () {
+      expect(
+        ghosttyShouldRestoreFocusOnSessionSwitch(
+          sessionId: 's-new',
+          prevActiveId: 's-new',
+          nextActiveId: 's-new',
+        ),
+        isFalse,
+      );
+    });
+
+    test('does NOT restore on the FIRST activation (no previous session)', () {
+      // The initial connect-focus path (#717) handles first activation. A
+      // switch-restore only applies when there is a PREVIOUS session to switch
+      // away FROM — else it would fight the per-connect focus latch and could
+      // raise the keyboard on cold start (the #693/#717 IME separation).
+      expect(
+        ghosttyShouldRestoreFocusOnSessionSwitch(
+          sessionId: 's-new',
+          prevActiveId: null,
+          nextActiveId: 's-new',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group(
+    'ghosttyShouldShowKeyboardOnSessionSwitch — IME restore gate (#741)',
+    () {
+      test('shows the keyboard only when it was up before the switch', () {
+        // The whole point: leave the keyboard state UNCHANGED. Up before → up
+        // after (re-show on the incoming terminal); down before → stays down.
+        expect(
+          ghosttyShouldShowKeyboardOnSessionSwitch(keyboardWasUp: true),
+          isTrue,
+        );
+        expect(
+          ghosttyShouldShowKeyboardOnSessionSwitch(keyboardWasUp: false),
+          isFalse,
+        );
+      });
+    },
+  );
+}

--- a/native/test/ui/session_switch_keyboard_widget_test.dart
+++ b/native/test/ui/session_switch_keyboard_widget_test.dart
@@ -1,0 +1,212 @@
+// #741 — widget-level proof that an app-level session-bar swipe-switch PRESERVES
+// the keyboard state (focus is retained on the newly-active terminal input, so
+// the soft keyboard never collapses and the bar doesn't jump down under the
+// finger).
+//
+// flterm/libghostty can't render headless (native .so), so the per-session
+// terminal is stood in by a plain focusable input and the keyboard-up state is
+// asserted via `FocusNode.hasFocus` — exactly the proxy the issue prescribes.
+// The harness wires the PRODUCTION decision functions
+// (ghosttyShouldCaptureKeyboardOnSessionSwitch /
+// ghosttyShouldRestoreFocusOnSessionSwitch /
+// ghosttyShouldShowKeyboardOnSessionSwitch) and the PRODUCTION
+// sessionSwitchKeyboardWasUpProvider to the same `ref.listen` shape the real
+// GhosttyTerminalView uses, driven by a REAL horizontal-drag swipe that crosses
+// `kSessionSwipeThreshold`. The real soft keyboard staying up on device is
+// owner-validated.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+import 'package:mobissh/ui/terminal_screen.dart' show kSessionSwipeThreshold;
+
+/// Minimal active-session id store mirroring the real `activeSessionIdProvider`
+/// surface the views listen to. Two ids: 's-a' and 's-b'.
+final _activeIdProvider = StateProvider<String?>((ref) => 's-a');
+
+/// One session "terminal" stand-in: a focusable input whose [FocusNode.hasFocus]
+/// proxies "keyboard up". It runs the SAME switch-focus listen logic the real
+/// GhosttyTerminalView runs (production decision fns + provider), so the test
+/// exercises the real contract, not a reimplementation of the decision.
+class _SwitchFocusKeeper extends ConsumerStatefulWidget {
+  const _SwitchFocusKeeper({required this.sessionId, super.key});
+  final String sessionId;
+
+  @override
+  ConsumerState<_SwitchFocusKeeper> createState() => _SwitchFocusKeeperState();
+}
+
+class _SwitchFocusKeeperState extends ConsumerState<_SwitchFocusKeeper> {
+  final _focusNode = FocusNode();
+
+  /// Stand-in for the flterm controller's keyboard state: the IME is "up" for a
+  /// view exactly while its input holds focus.
+  bool get _keyboardWasUp => _focusNode.hasFocus;
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<String?>(_activeIdProvider, (prev, next) {
+      if (ghosttyShouldCaptureKeyboardOnSessionSwitch(
+        sessionId: widget.sessionId,
+        prevActiveId: prev,
+        nextActiveId: next,
+      )) {
+        ref.read(sessionSwitchKeyboardWasUpProvider.notifier).state =
+            _keyboardWasUp;
+      }
+      if (ghosttyShouldRestoreFocusOnSessionSwitch(
+        sessionId: widget.sessionId,
+        prevActiveId: prev,
+        nextActiveId: next,
+      )) {
+        // Defer to post-frame so the outgoing view's capture (same provider
+        // tick, listener order unspecified) has run and the IndexedStack has put
+        // this child onstage — mirroring the real view's post-frame show.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          final keyboardWasUp = ref.read(sessionSwitchKeyboardWasUpProvider);
+          // Re-attach focus to the incoming input iff the keyboard was up before
+          // the switch — the FocusNode.hasFocus proxy for "keyboard stays up".
+          if (ghosttyShouldShowKeyboardOnSessionSwitch(
+            keyboardWasUp: keyboardWasUp,
+          )) {
+            _focusNode.requestFocus();
+          }
+        });
+      }
+    });
+    return Focus(
+      focusNode: _focusNode,
+      child: SizedBox(
+        key: Key('keeper-${widget.sessionId}'),
+        width: 200,
+        height: 40,
+      ),
+    );
+  }
+}
+
+/// A session bar whose horizontal swipe toggles 's-a' <-> 's-b', mirroring the
+/// real `_SessionBar` swipe → `setActive` wiring (threshold = the production
+/// `kSessionSwipeThreshold`).
+class _Harness extends ConsumerStatefulWidget {
+  const _Harness();
+  @override
+  ConsumerState<_Harness> createState() => _HarnessState();
+}
+
+class _HarnessState extends ConsumerState<_Harness> {
+  double _dragDx = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final activeId = ref.watch(_activeIdProvider);
+    final index = activeId == 's-b' ? 1 : 0;
+    return MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            Expanded(
+              child: IndexedStack(
+                index: index,
+                children: const [
+                  _SwitchFocusKeeper(sessionId: 's-a', key: Key('body-a')),
+                  _SwitchFocusKeeper(sessionId: 's-b', key: Key('body-b')),
+                ],
+              ),
+            ),
+            GestureDetector(
+              key: const Key('bar'),
+              behavior: HitTestBehavior.opaque,
+              onHorizontalDragStart: (_) => _dragDx = 0,
+              onHorizontalDragUpdate: (d) => _dragDx += d.delta.dx,
+              onHorizontalDragEnd: (_) {
+                if (_dragDx.abs() < kSessionSwipeThreshold) return;
+                final current = ref.read(_activeIdProvider);
+                ref.read(_activeIdProvider.notifier).state = current == 's-a'
+                    ? 's-b'
+                    : 's-a';
+              },
+              child: const SizedBox(height: 36, width: double.infinity),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _swipeBar(WidgetTester tester) async {
+  await tester.fling(
+    find.byKey(const Key('bar')),
+    Offset(-(kSessionSwipeThreshold + 40), 0),
+    1000,
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('session-bar swipe-switch preserves keyboard state (#741)', () {
+    testWidgets('keyboard UP: focus follows to the newly-active terminal', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const ProviderScope(child: _Harness()));
+      await tester.pumpAndSettle();
+
+      // Keyboard is "up" on session A: focus its input.
+      final aFocus = Focus.of(
+        tester.element(find.byKey(const Key('keeper-s-a'))),
+      );
+      aFocus.requestFocus();
+      await tester.pumpAndSettle();
+      expect(aFocus.hasFocus, isTrue, reason: 'precondition: keyboard up on A');
+
+      // Swipe the session bar to switch A -> B.
+      await _swipeBar(tester);
+
+      // The incoming session (B) now holds focus — the keyboard stayed up and
+      // moved to the newly-active terminal (it did NOT collapse).
+      final bFocus = Focus.of(
+        tester.element(find.byKey(const Key('keeper-s-b'))),
+      );
+      expect(
+        bFocus.hasFocus,
+        isTrue,
+        reason: 'focus retained on the newly-active terminal (keyboard up)',
+      );
+    });
+
+    testWidgets('keyboard DOWN: switch leaves the new terminal unfocused', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const ProviderScope(child: _Harness()));
+      await tester.pumpAndSettle();
+
+      // No input focused (keyboard down).
+      final aFocus = Focus.of(
+        tester.element(find.byKey(const Key('keeper-s-a'))),
+      );
+      expect(aFocus.hasFocus, isFalse, reason: 'precondition: keyboard down');
+
+      await _swipeBar(tester);
+
+      // The incoming terminal is NOT force-focused — the keyboard stays down.
+      final bFocus = Focus.of(
+        tester.element(find.byKey(const Key('keeper-s-b'))),
+      );
+      expect(
+        bFocus.hasFocus,
+        isFalse,
+        reason: 'keyboard was down → stays down after the switch',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #741. A session-bar swipe-switch no longer dismisses the keyboard (which made the bar jump down out from under the finger). Each terminal listens to activeSessionIdProvider: the outgoing view records keyboard-up into an additive sessionSwitchKeyboardWasUpProvider; the incoming view re-focuses + re-shows the keyboard on a post-frame callback. Ghostty in-terminal gesture router (#693/#719) untouched. 11 tests (9 unit truth-table + 2 widget focus), 785 unit pass. sessions.dart change is a single additive provider (no session/connect logic touched); ghostty_terminal_view.dart focus listen.