### PR TITLE
feat(#734): ghostty URL long-press → Copy/Open menu

### DIFF
--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -181,6 +181,7 @@ import '../state/ui_prefs_providers.dart';
 import 'ghostty_url_detector.dart';
 import 'keybar.dart';
 import 'top_toast.dart';
+import 'url_action_overlay.dart';
 
 /// Apply the shared armed keybar Ctrl modifier (#728) to a SOFT-KEYBOARD
 /// keystroke flowing through flterm's `controller.onOutput`.
@@ -874,6 +875,23 @@ List<String> ghosttyTapClickReports({required int col, required int row}) => [
 /// land as literal text). Pure, so the gating decision is unit-testable.
 bool ghosttyTapShouldForwardClick({required bool active}) => active;
 
+/// Whether a LONG-PRESS should show the URL Copy/Open action menu instead of
+/// starting a selection (#734).
+///
+/// #726 wired single-tap-to-copy on the ghostty (default) terminal, but the
+/// long-press → Copy/Open menu (`showUrlActions` / url_action_overlay.dart) was
+/// only wired into the xterm branch. #734 wires it into the ghostty long-press:
+/// on a long-press the router hit-tests the press cell against the SAME detected
+/// URL ranges tap-copy uses ([ghosttyUrlAtCell] over the parent's `_urlMatches`).
+/// If a URL is at the cell ([urlAtCell] non-null) the router shows the action menu
+/// and SUPPRESSES the #705/#706 selection for that gesture; otherwise the existing
+/// long-press selection starts unchanged. So the URL hit-test WINS over selection.
+///
+/// This trivial predicate factors the decision out of the widget so it's
+/// unit-testable headless (and names the rule at the call site). Pure.
+bool ghosttyLongPressShowsUrlMenu(GhosttyUrlMatch? urlAtCell) =>
+    urlAtCell != null;
+
 /// Map a vertical swipe DELTA (logical px the finger moved this update) to a
 /// scrollback pixel delta to apply to the [TerminalScrollController] (#690).
 ///
@@ -1119,6 +1137,7 @@ class GhosttyPointerGestureRouter extends StatefulWidget {
     required this.onSelectionClear,
     required this.urlAtCell,
     required this.onUrlTap,
+    required this.onUrlLongPress,
   });
 
   /// Whether to intercept touch (the remote has mouse tracking on).
@@ -1204,6 +1223,17 @@ class GhosttyPointerGestureRouter extends StatefulWidget {
   /// selection-dismiss path.
   final void Function(GhosttyUrlMatch match) onUrlTap;
 
+  /// #734: a LONG-PRESS that lands on a detected URL shows the Copy/Open action
+  /// menu (`showUrlActions`) instead of starting a selection. The parent builds
+  /// the highlight rects + anchor and calls `showUrlActions`; [match] is the URL
+  /// at the pressed cell and [globalAnchor] is the long-press global position the
+  /// menu anchors near. When this fires the selection gesture is SUPPRESSED for
+  /// the rest of the long-press (no `onSelectionStart`/`onSelectionExtend`), so
+  /// the URL hit-test WINS over the #705/#706 selection. Off any URL this never
+  /// fires and selection starts as today.
+  final void Function(GhosttyUrlMatch match, Offset globalAnchor)
+  onUrlLongPress;
+
   @override
   State<GhosttyPointerGestureRouter> createState() =>
       _GhosttyPointerGestureRouterState();
@@ -1225,6 +1255,14 @@ class _GhosttyPointerGestureRouterState
   double _panDy = 0;
   GhosttySwipeAxis _axis = GhosttySwipeAxis.none;
   double _windowSwitchDx = 0;
+
+  /// #734: true while the IN-PROGRESS long-press landed on a detected URL and so
+  /// drives the Copy/Open action menu instead of a selection. Set in
+  /// [_onLongPressStart] when the pressed cell hits a URL; while true the
+  /// move/end handlers do NOT extend/finish a selection (the menu owns the
+  /// gesture). Reset on every long-press-start so a later off-URL press selects
+  /// normally.
+  bool _longPressOnUrl = false;
 
   void _onPanStart(DragStartDetails details) {
     _panDx = 0;
@@ -1405,6 +1443,19 @@ class _GhosttyPointerGestureRouterState
     widget.onFocus(); // focus only — a selection must NOT pop the keyboard.
     final local = details.localPosition;
     final (col, row) = _cellAt(local);
+    // #734: URL hit-test WINS over selection. Map the pressed cell to a detected
+    // URL (the SAME 1-based→0-based convention as the tap-copy path, #726). If
+    // the press lands ON a URL, show the Copy/Open action menu and SUPPRESS the
+    // selection for the rest of this long-press; otherwise start the #705/#706
+    // selection unchanged.
+    final url = widget.urlAtCell(col - 1, row - 1);
+    if (ghosttyLongPressShowsUrlMenu(url)) {
+      _longPressOnUrl = true;
+      _trace('longpress-url', local.dx, local.dy, col, row, 'menu');
+      widget.onUrlLongPress(url!, details.globalPosition);
+      return;
+    }
+    _longPressOnUrl = false;
     // #705: drive flterm's LOCAL selection (NOT a tmux SGR drag, which tmux's
     // default copy-and-cancel would clear on release). Anchor a collapsed
     // selection at the pressed cell; the parent adds the scroll offset.
@@ -1413,6 +1464,9 @@ class _GhosttyPointerGestureRouterState
   }
 
   void _onLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
+    // #734: while the URL menu owns this long-press, a drag must NOT extend a
+    // selection (the gesture belongs to the menu).
+    if (_longPressOnUrl) return;
     final local = details.localPosition;
     final (col, row) = _cellAt(local);
     // #705: extend the LOCAL selection's END to the dragged cell so the
@@ -1422,6 +1476,11 @@ class _GhosttyPointerGestureRouterState
   }
 
   void _onLongPressEnd(LongPressEndDetails details) {
+    // #734: a URL-menu long-press has no selection to finalise.
+    if (_longPressOnUrl) {
+      _longPressOnUrl = false;
+      return;
+    }
     final local = details.localPosition;
     final (col, row) = _cellAt(local);
     // #705: do NOTHING that clears the selection — leave `controller.selection`
@@ -1703,6 +1762,12 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// 0 until the first resize is sent.
   int _lastSentCols = 0;
   int _lastSentRows = 0;
+
+  /// #734: the REAL flterm cell size last measured in [build] (via
+  /// [ghosttyMeasureCellSize]), captured so [_showUrlMenu] can build the URL's
+  /// on-screen highlight rects with the SAME geometry the router + highlight
+  /// painter use — without re-reading the per-session font providers off-build.
+  Size _lastCellSize = Size.zero;
 
   /// #705: the long-press selection ANCHOR — the 1-based VIEWPORT cell of the
   /// long-press-start, held while the finger drags so each extend rebuilds the
@@ -2386,6 +2451,57 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     if (mounted) showTopToast(context, 'Copied URL');
   }
 
+  /// #734: show the Copy/Open action menu for a long-pressed URL — the SAME
+  /// `showUrlActions` overlay (`url_action_overlay.dart`, keys `url-action-menu`/
+  /// `url-action-copy`/`url-action-open`) the xterm path uses, so Copy →
+  /// clipboard + toast and Open → `launchUrl` (external). Reuses the detected
+  /// [match] ranges (#726) — no duplicate detection.
+  ///
+  /// Builds the URL's on-screen highlight rects from the match's 0-based viewport
+  /// cell range using the SAME geometry the [GhosttyUrlHighlightPainter] +
+  /// gesture router use: [kGhosttyTerminalPadding] + the live [_lastCellSize],
+  /// then offset by the view's render-box GLOBAL origin (the overlay layer is
+  /// rooted, so it wants global coords). A soft-wrapped URL spans rows → one rect
+  /// per row segment, mirroring [ghosttyCellInUrl]'s geometry.
+  void _showUrlMenu(GhosttyUrlMatch match, Offset globalAnchor) {
+    if (!mounted) return;
+    final rects = _urlGlobalRects(match);
+    showUrlActions(
+      context,
+      match.url,
+      highlightRects: rects,
+      anchor: globalAnchor,
+    );
+  }
+
+  /// The GLOBAL on-screen rects for [match]'s cell range (#734). One per row the
+  /// URL occupies: the start row's tail, every interior row full-width, the end
+  /// row's head — matching [ghosttyCellInUrl]'s hit-test geometry. Empty (the
+  /// menu still shows, anchored at the press) if the layout isn't measurable yet.
+  List<Rect> _urlGlobalRects(GhosttyUrlMatch match) {
+    final cell = _lastCellSize;
+    if (cell.width <= 0 || cell.height <= 0) return const [];
+    final box = context.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) return const [];
+    final origin = box.localToGlobal(Offset.zero);
+    final cols = _cols > 0 ? _cols : _lastSentCols;
+    final rects = <Rect>[];
+    for (var row = match.startRow; row <= match.endRow; row++) {
+      final startCol = row == match.startRow ? match.startCol : 0;
+      final endCol = row == match.endRow
+          ? match.endCol
+          : (cols > 0 ? cols : match.endCol);
+      if (endCol <= startCol) continue;
+      final left = kGhosttyTerminalPadding + startCol * cell.width;
+      final top = kGhosttyTerminalPadding + row * cell.height;
+      final width = (endCol - startCol) * cell.width;
+      rects.add(
+        Rect.fromLTWH(origin.dx + left, origin.dy + top, width, cell.height),
+      );
+    }
+    return rects;
+  }
+
   Future<void> _copySelection() async {
     final controller = _controller;
     if (controller == null) return;
@@ -2503,6 +2619,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       fontFamilyFallback: theme.fontFamilyFallback,
       devicePixelRatio: devicePixelRatio,
     );
+    // #734: remember the live cell size so a long-press URL menu can build its
+    // highlight rects with the same geometry the router maps touches with.
+    _lastCellSize = cellSize;
     return Stack(
       key: Key('ghostty-terminal-${widget.sessionId}'),
       children: [
@@ -2635,6 +2754,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             urlAtCell: (col, row) =>
                 ghosttyUrlAtCell(_urlMatches, col: col, row: row),
             onUrlTap: _copyUrl,
+            // #734: a long-press on a detected URL shows the Copy/Open action
+            // menu (the same `showUrlActions` overlay the xterm path uses). The
+            // parent builds the on-screen highlight rects + anchor from the match
+            // and hands them to the overlay.
+            onUrlLongPress: _showUrlMenu,
           ),
         ),
         // Selection affordances (bottom-right). #712: shown ONLY while a

--- a/native/test/ui/ghostty_resize_source_of_truth_test.dart
+++ b/native/test/ui/ghostty_resize_source_of_truth_test.dart
@@ -72,6 +72,7 @@ void main() {
             onSelectionClear: () {},
             urlAtCell: (_, _) => null,
             onUrlTap: (_) {},
+            onUrlLongPress: (_, _) {},
           ),
         ),
       ),

--- a/native/test/ui/ghostty_swipe_windowswitch_smoke_test.dart
+++ b/native/test/ui/ghostty_swipe_windowswitch_smoke_test.dart
@@ -77,6 +77,7 @@ void main() {
             onSelectionClear: () {},
             urlAtCell: (_, _) => null,
             onUrlTap: (_) {},
+            onUrlLongPress: (_, _) {},
           ),
         ),
       ),

--- a/native/test/ui/ghostty_url_longpress_test.dart
+++ b/native/test/ui/ghostty_url_longpress_test.dart
@@ -1,0 +1,171 @@
+// #734 — Ghostty long-press URL → Copy/Open action-menu DECISION smoke test.
+//
+// #726 wired single-tap-to-copy on the ghostty (default) terminal, but the
+// long-press → Copy/Open action menu (`showUrlActions` / url_action_overlay.dart,
+// keys `url-action-menu`/`url-action-copy`/`url-action-open`) was only wired into
+// the XTERM branch (`terminal_screen.dart` `_onTerminalLongPress`). Under the
+// ghostty default a long-press on a URL did nothing — tap-copy but no Open menu.
+//
+// #734 wires it in: on a long-press the router hit-tests the press cell against
+// the SAME detected URL ranges tap-copy uses (`urlAtCell`, #726). If the press
+// lands ON a URL it fires `onUrlLongPress(match, anchor)` (the parent shows the
+// `showUrlActions` overlay) and SUPPRESSES the #705/#706 selection for that
+// gesture; if it lands OFF any URL the existing long-press SELECTION starts as
+// today. URL hit-test WINS over selection; selection is otherwise unchanged.
+//
+// This pumps the ACTUAL gesture router widget (`GhosttyPointerGestureRouter` —
+// `RawGestureDetector` + callbacks, NO flterm native `.so`), simulates a real
+// long-press at a chosen cell, and asserts the routing decision. The off-URL case
+// pins that #705/#706 selection still starts (no regression).
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+import 'package:mobissh/ui/ghostty_url_detector.dart';
+
+void main() {
+  // A single detected URL occupying viewport cells (col 4..14) on row 2 (0-based).
+  const urlMatch = GhosttyUrlMatch(
+    url: 'https://example.com',
+    startCol: 4,
+    startRow: 2,
+    endCol: 15, // exclusive
+    endRow: 2,
+  );
+
+  // Records of each routing callback the router fires, so a test can assert which
+  // path a long-press took.
+  late List<GhosttyUrlMatch> urlLongPresses;
+  late List<(int, int)> selectionStarts;
+  late List<(int, int)> selectionExtends;
+
+  // Pump the router with the single [urlMatch] detected. cellWidth=8/cellHeight=16
+  // + kGhosttyTerminalPadding(4) so a global tap at (px,py) maps to cell
+  // ((px-4)/8, (py-4)/16) (1-based, then the URL hit-test subtracts 1 back to
+  // 0-based — matching the tap-copy convention).
+  Future<void> pumpRouter(WidgetTester tester) async {
+    urlLongPresses = [];
+    selectionStarts = [];
+    selectionExtends = [];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 400,
+              height: 400,
+              child: GhosttyPointerGestureRouter(
+                active: true,
+                scrollController: TerminalScrollController(),
+                cols: 80,
+                rows: 24,
+                lastSentCols: 80,
+                lastSentRows: 24,
+                cellWidth: 8,
+                cellHeight: 16,
+                mouseTrackingLabel: 'any',
+                onTap: () {},
+                onFocus: () {},
+                onMouseReport: (_) {},
+                onSelectionStart: (c, r) => selectionStarts.add((c, r)),
+                onSelectionExtend: (c, r) => selectionExtends.add((c, r)),
+                hasSelection: () => false,
+                onSelectionClear: () {},
+                urlAtCell: (col, row) =>
+                    ghosttyUrlAtCell(const [urlMatch], col: col, row: row),
+                onUrlTap: (_) {},
+                onUrlLongPress: (m, _) => urlLongPresses.add(m),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Synthesise a stationary long-press (down, hold past the recogniser timeout,
+  // up) at [global] without any drag.
+  Future<void> longPressAt(WidgetTester tester, Offset global) async {
+    final gesture = await tester.startGesture(global);
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  group('#734 long-press ON a URL → action menu, NOT selection', () {
+    testWidgets('fires onUrlLongPress with the matched URL', (tester) async {
+      await pumpRouter(tester);
+      // Cell on the URL: row 2 (0-based) → py in [4+2*16, 4+3*16) = [36,52);
+      // col 6 (0-based, inside 4..14) → px in [4+6*8, 4+7*8) = [52,60).
+      await longPressAt(tester, const Offset(54, 44));
+
+      expect(
+        urlLongPresses,
+        hasLength(1),
+        reason: 'a long-press on a detected URL shows the Copy/Open menu',
+      );
+      expect(urlLongPresses.single.url, 'https://example.com');
+    });
+
+    testWidgets('does NOT start a selection (URL hit-test wins)', (
+      tester,
+    ) async {
+      await pumpRouter(tester);
+      await longPressAt(tester, const Offset(54, 44));
+
+      expect(
+        selectionStarts,
+        isEmpty,
+        reason: 'URL hit-test WINS over selection on long-press',
+      );
+      expect(selectionExtends, isEmpty);
+    });
+  });
+
+  group('#734 long-press OFF any URL → selection unchanged (#705/#706)', () {
+    testWidgets('starts a selection and fires NO onUrlLongPress', (
+      tester,
+    ) async {
+      await pumpRouter(tester);
+      // Cell OFF the URL: row 5 (0-based) → py in [4+5*16, 4+6*16) = [84,100);
+      // col 6 → px [52,60). Row 5 has no URL.
+      await longPressAt(tester, const Offset(54, 92));
+
+      expect(urlLongPresses, isEmpty, reason: 'off a URL there is no menu');
+      expect(
+        selectionStarts,
+        hasLength(1),
+        reason: 'off a URL the existing #705/#706 selection starts as today',
+      );
+    });
+  });
+
+  group('#734 pure decision helper', () {
+    test('ghosttyLongPressShowsUrlMenu true iff a URL is at the cell', () {
+      expect(ghosttyLongPressShowsUrlMenu(urlMatch), isTrue);
+      expect(ghosttyLongPressShowsUrlMenu(null), isFalse);
+    });
+  });
+
+  group('#734 drag after a URL long-press does not extend a selection', () {
+    testWidgets('a long-press-drag on a URL stays on the menu (no extend)', (
+      tester,
+    ) async {
+      await pumpRouter(tester);
+      // Long-press ON the URL, then drag — the menu owns the gesture, so no
+      // selection extend should fire (the #705 drag-select is suppressed).
+      final gesture = await tester.startGesture(const Offset(54, 44));
+      await tester.pump(const Duration(milliseconds: 600));
+      await gesture.moveBy(const Offset(40, 0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(urlLongPresses, hasLength(1));
+      expect(selectionStarts, isEmpty);
+      expect(selectionExtends, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #734. Long-press a URL on the ghostty (default) terminal → the existing showUrlActions Copy/Open menu (Copy→clipboard, Open→launchUrl). URL hit-test (same #726/#723 cell map) wins over selection; off-URL long-press = existing #705/#706 selection unchanged. Reuses url_action_overlay (no dup). 5 new routing tests, 817 unit pass. ui/ only.