### PR TITLE
fix(#752): reduce keybar height (collapse margin + padding, keep fonts)

### DIFF
--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -41,8 +41,16 @@ import '../state/sessions.dart';
 /// button style below.
 ///
 /// Old values (pre-#615): minWidth 48, minHeight 44, icon 18, label 14.
+///
+/// #752: the bar was too TALL — it ate terminal real estate. The 44px height
+/// floor forced ~26px of dead vertical space around an ~18px label. #752
+/// collapses the VERTICAL spacing only (this floor, the scroll-view vertical
+/// padding, and the per-key vertical padding) so each key HUGS its (unchanged)
+/// label. The font (kKeybarLabelFontSize 14) and icon (kKeybarIconSize 18) are
+/// untouched — keys stay just as readable. The horizontal min WIDTHs are
+/// unchanged so keys stay comfortably tappable; only the height shrinks.
 const double kKeybarButtonMinWidth = 44;
-const double kKeybarButtonMinHeight = 44;
+const double kKeybarButtonMinHeight = 32; // #752: was 44 (collapsed dead space)
 const double kKeybarIconSize = 18;
 
 /// Single-character TEXT keys (`|`, `/`, `-` and any other 1-glyph label) are
@@ -70,10 +78,10 @@ const double kKeybarLabelFontSize = 14;
 const double kKeybarEscFontSize = 14;
 
 /// Vertical space (logical px) the keybar occupies, used as the compose-bar
-/// bottom reserve. Button height (44) + the 3px top/bottom scroll-view padding,
+/// bottom reserve. Button height (32) + the 2px top/bottom scroll-view padding,
 /// rounded up for a small safety margin so a docked compose panel clears the
-/// chrome.
-const double kKeybarReserve = 56;
+/// chrome. #752: tracks the collapsed bar height (was 56 for the old 44px bar).
+const double kKeybarReserve = 40;
 
 /// High-contrast keybar palette (#696). Owner device feedback: the old
 /// dark-blue (theme `surfaceContainerHigh`) bar + dim `onSurface` labels were
@@ -417,7 +425,9 @@ class _KeybarState extends ConsumerState<Keybar> {
         child: SingleChildScrollView(
           scrollDirection: Axis.horizontal,
           // #615: tighter vertical padding (was 4) to shrink the strip ~25%.
-          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 3),
+          // #752: trimmed again (3 → 2) to collapse the bar's outer margin so
+          // the keys hug the chrome edges; horizontal padding is unchanged.
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -541,11 +551,13 @@ class _KeybarButtonState extends State<_KeybarButton> {
         foregroundColor: fg,
         // #696: trim the internal padding so the label fits without growing the
         // bar height. The comfortable tap target is preserved via minimumSize
-        // (44px height) below. #703: single-char keys also trim horizontal
-        // padding so they read as tight, narrow keys.
+        // below. #703: single-char keys also trim horizontal padding so they
+        // read as tight, narrow keys. #752: collapse the per-key VERTICAL
+        // padding (2 → 1) so the key hugs its (unchanged) label glyph; the
+        // horizontal padding is untouched so keys stay tappable.
         padding: EdgeInsets.symmetric(
           horizontal: isSingleChar ? 2 : 6,
-          vertical: 2,
+          vertical: 1,
         ),
         // #703: single-char text keys use a narrower min width so they don't
         // waste space; multi-char and icon keys keep the full width. Height is

--- a/native/test/widget/keybar_height_test.dart
+++ b/native/test/widget/keybar_height_test.dart
@@ -1,0 +1,182 @@
+// Tests for keybar height reduction (#752).
+//
+// The keybar was too TALL — it ate terminal real estate. #752 collapses the
+// VERTICAL dead space around the glyphs (outer scroll-view padding, per-key
+// vertical padding, and the key min-height floor) WITHOUT shrinking the
+// font / label / icon sizes (#696/#703). The keys stay just as readable; only
+// the spacing shrinks.
+//
+// These tests pin the contract: the label fontSize / icon size are UNCHANGED
+// from #703 (14 / 18), while the height-driving constants are SMALLER than the
+// old (pre-#752) values. The widget still renders every key, and the
+// auto-repeat (#732) + Ctrl (#694/#728) wiring is intact.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/ctrl_modifier_provider.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/keybar.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Old (pre-#752) height contract, captured here so the test documents exactly
+// what shrank. Font/icon sizes are NOT in this list — they must NOT change.
+const double _kOldButtonMinHeight = 44; // was the 44px floor
+const double _kOldReserve = 56; // was button + 3px scroll pad, rounded up
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 8}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('#752 keybar height reduction — font/icon UNCHANGED', () {
+    test('label fontSize is unchanged from #703 (still 14)', () {
+      // #752 must NOT shrink the text — only the spacing around it. The label
+      // and ESC font sizes stay at the #703 uniform 14.
+      expect(kKeybarLabelFontSize, equals(14));
+      expect(kKeybarEscFontSize, equals(14));
+      expect(
+        kKeybarLabelFontSize,
+        equals(kKeybarEscFontSize),
+        reason: 'all text keys still share the one uniform (#703) size',
+      );
+    });
+
+    test('icon size is unchanged from #703 (still 18)', () {
+      // Glyphs (arrows, Enter, Paste) must stay just as legible — only the
+      // vertical dead space shrinks, never the icon.
+      expect(kKeybarIconSize, equals(18));
+      // The icon stays larger than the (unchanged) text.
+      expect(kKeybarIconSize, greaterThan(kKeybarLabelFontSize));
+    });
+  });
+
+  group('#752 keybar height reduction — spacing/height SHRANK', () {
+    test('button min-height collapsed below the old 44px floor', () {
+      // The 44px floor forced ~26px of dead vertical space around an ~18px
+      // label. #752 collapses it so the key hugs its (unchanged) label.
+      expect(
+        kKeybarButtonMinHeight,
+        lessThan(_kOldButtonMinHeight),
+        reason: '#752: the key must hug its label, not the old 44px floor',
+      );
+      // …but still a usable, tappable touch height (label ~18px + margin).
+      expect(
+        kKeybarButtonMinHeight,
+        greaterThanOrEqualTo(kKeybarLabelFontSize),
+        reason: 'the key must still clear its own (unchanged) label height',
+      );
+      expect(
+        kKeybarButtonMinHeight,
+        greaterThanOrEqualTo(28),
+        reason: 'still a reasonable touch height — keys stay tappable',
+      );
+    });
+
+    test('compose-bar reserve shrank with the bar', () {
+      // The reserve tracks the bar height; it must shrink too, but still cover
+      // the (new) button height plus the scroll-view vertical padding.
+      expect(
+        kKeybarReserve,
+        lessThan(_kOldReserve),
+        reason: '#752: the bar is shorter, so its reserve shrinks too',
+      );
+      expect(
+        kKeybarReserve,
+        greaterThanOrEqualTo(kKeybarButtonMinHeight),
+        reason: 'the reserve must still clear the (new) button height',
+      );
+    });
+
+    test('horizontal touch width is preserved (tappable)', () {
+      // #752 is a VERTICAL reduction only — the horizontal min widths must NOT
+      // shrink (keys stay comfortably tappable).
+      expect(kKeybarButtonMinWidth, greaterThanOrEqualTo(44));
+      expect(kKeybarSingleCharMinWidth, greaterThanOrEqualTo(28));
+    });
+  });
+
+  group('#752 widget still renders all keys + wiring intact', () {
+    testWidgets('every default key renders after the height collapse', (
+      tester,
+    ) async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async {
+        await pair.dispose();
+      });
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+      );
+      addTearDown(container.dispose);
+
+      final entry = container
+          .read(sessionsProvider.notifier)
+          .addOrActivate(
+            const SshConnectParams(
+              host: 'h',
+              port: 22,
+              username: 'u',
+              auth: SshAuth.password('p'),
+            ),
+          );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(body: Keybar(activeEntry: entry)),
+          ),
+        ),
+      );
+      await _pumpFrames(tester);
+
+      expect(find.byKey(const Key('keybar')), findsOneWidget);
+      // Every default key still mounts its button.
+      for (final k in kDefaultKeybarKeys) {
+        expect(
+          find.byKey(Key('keybar-btn-${k.id}')),
+          findsOneWidget,
+          reason: '${k.id} must still render after the height reduction',
+        );
+      }
+    });
+
+    test('auto-repeat (#732) eligibility wiring is intact', () {
+      // The nav keys still auto-repeat; modifiers/symbols still do not.
+      for (final id in ['keyLeft', 'keyUp', 'keyDown', 'keyRight', 'keyHome']) {
+        expect(isRepeatEligibleKeyId(id), isTrue);
+      }
+      for (final id in ['keyEsc', 'keyCtrl', 'keyTab', 'keyCtrlC']) {
+        expect(isRepeatEligibleKeyId(id), isFalse);
+      }
+    });
+
+    test('Ctrl modifier (#694/#728) transform wiring is intact', () {
+      // The sticky Ctrl key is still a modifier, and the pure transform still
+      // maps a letter to its control byte.
+      final ctrl = kDefaultKeybarKeys.firstWhere((k) => k.id == 'keyCtrl');
+      expect(ctrl.isModifier, isTrue);
+      expect(ctrlTransform('c'), equals('\x03'));
+      // The shared provider notifier still arms/consumes one-shot.
+      final m = CtrlModifier();
+      expect(m.armed, isFalse);
+      m.arm();
+      expect(m.armed, isTrue);
+      expect(m.apply('a'), equals('\x01'));
+      expect(m.armed, isFalse, reason: 'one-shot: auto-clears after apply');
+      // Touch the shared provider type so the import is meaningful.
+      expect(ctrlModifierProvider, isNotNull);
+    });
+  });
+}

--- a/native/test/widget/keybar_test.dart
+++ b/native/test/widget/keybar_test.dart
@@ -142,11 +142,22 @@ void main() {
   });
 
   group('keybar sizing (#703 — uniform text size, narrow single-char keys)', () {
-    test('button min height holds the 44px touch-target floor', () {
-      // #615 shrank this to ~33; #696 restored the comfortable 44px tap target.
-      // #703 keeps the height floor — only horizontal width shrinks for
-      // single-char keys, never the tap-target height.
-      expect(kKeybarButtonMinHeight, greaterThanOrEqualTo(44));
+    test('button min height is a tight, tappable touch height (#752)', () {
+      // #615 shrank this to ~33; #696 restored a 44px tap target. #752 collapses
+      // the VERTICAL dead space again — the key now hugs its (unchanged ~18px)
+      // label rather than the old 44px floor — while staying tappable. Only the
+      // height shrinks; the horizontal min-widths are unchanged.
+      expect(kKeybarButtonMinHeight, lessThan(44));
+      expect(
+        kKeybarButtonMinHeight,
+        greaterThanOrEqualTo(kKeybarLabelFontSize),
+        reason: 'must still clear its own (unchanged) label height',
+      );
+      expect(
+        kKeybarButtonMinHeight,
+        greaterThanOrEqualTo(28),
+        reason: 'still a reasonable, tappable touch height',
+      );
     });
 
     test('all text labels share ONE uniform size — the ESC size (#703)', () {
@@ -191,8 +202,8 @@ void main() {
       // The compose-bar bottomReserve consumes this. It must cover the button
       // height plus the scroll-view vertical padding with a small margin.
       expect(kKeybarReserve, greaterThanOrEqualTo(kKeybarButtonMinHeight));
-      // Still meaningfully tighter than the old hardcoded 96.
-      expect(kKeybarReserve, lessThanOrEqualTo(72));
+      // #752: the bar shrank, so the reserve is tighter than the old 56.
+      expect(kKeybarReserve, lessThanOrEqualTo(56));
     });
 
     test('keybar palette is high-contrast and monochrome (#696)', () {


### PR DESCRIPTION
Closes #752. Keybar minHeight 44→32, outer vert padding 3→2, per-key vert padding 2→1, compose reserve 56→40 — keys hug their labels. Font (14) + icon (18) sizes + horizontal min-widths UNCHANGED (still tappable). Auto-repeat (#732) + Ctrl (#694/#728) intact. 829 unit pass. keybar.dart only.