### PR TITLE
feat(#755 1b): additive source-level highlight API in vendored flterm

### DIFF
--- a/native/test/ui/flterm_highlight_api_test.dart
+++ b/native/test/ui/flterm_highlight_api_test.dart
@@ -1,0 +1,111 @@
+// Slice 1b (#755) — verifies the additive highlight API that flterm now
+// exposes for Slice 1c to consume. This pins the PUBLIC surface reachable
+// through `package:flterm/flterm.dart`: the `HighlightRange` model, its
+// `HighlightTheme` default color, and `CellMetrics` (so 1c can map detected
+// viewport cells → highlight ranges using flterm's REAL cell geometry rather
+// than the re-derived overlay metrics that drifted in #748/#699/#723).
+//
+// No FFI: this exercises pure-Dart model + geometry, so it runs on every
+// commit in the fast gate (gate 2), not only the ffi-tagged tier.
+
+import 'dart:ui';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('flterm highlight API (exported surface)', () {
+    test('HighlightRange is constructible with payload and colors', () {
+      const range = HighlightRange(
+        startRow: 3,
+        startCol: 4,
+        endRow: 3,
+        endCol: 18,
+        background: Color(0x330000FF),
+        underline: Color(0xFF0000FF),
+        payload: 'https://example.com',
+      );
+      expect(range.startRow, 3);
+      expect(range.endCol, 18);
+      expect(range.payload, 'https://example.com');
+    });
+
+    test('contains follows the inclusive-start / exclusive-end convention', () {
+      const range = HighlightRange(
+        startRow: 0,
+        startCol: 2,
+        endRow: 0,
+        endCol: 6,
+      );
+      expect(range.contains(0, 2), isTrue);
+      expect(range.contains(0, 5), isTrue);
+      expect(range.contains(0, 6), isFalse);
+      expect(range.contains(0, 1), isFalse);
+    });
+
+    test('contains covers a multi-row range like flowing text', () {
+      // Same shape `controller.highlightAt` hit-tests against (absolute rows).
+      const range = HighlightRange(
+        startRow: 0,
+        startCol: 6,
+        endRow: 2,
+        endCol: 4,
+        payload: 'multi',
+      );
+      // Top row: from startCol to end of line.
+      expect(range.contains(0, 6), isTrue);
+      expect(range.contains(0, 5), isFalse);
+      // Middle row: fully covered.
+      expect(range.contains(1, 0), isTrue);
+      // Bottom row: up to bottomCol (exclusive).
+      expect(range.contains(2, 3), isTrue);
+      expect(range.contains(2, 4), isFalse);
+      // Outside the band.
+      expect(range.contains(3, 0), isFalse);
+    });
+
+    test('normalized accessors are direction-independent', () {
+      const range = HighlightRange(
+        startRow: 4,
+        startCol: 3,
+        endRow: 2,
+        endCol: 10,
+      );
+      expect(range.topRow, 2);
+      expect(range.bottomRow, 4);
+      expect(range.topCol, 10);
+      expect(range.bottomCol, 3);
+    });
+
+    test('scroll re-anchors rows while preserving payload', () {
+      const range = HighlightRange(
+        startRow: 1,
+        startCol: 0,
+        endRow: 1,
+        endCol: 5,
+        payload: 'p',
+      );
+      final scrolled = range.scroll(7);
+      expect(scrolled.startRow, 8);
+      expect(scrolled.endRow, 8);
+      expect(scrolled.payload, 'p');
+    });
+
+    test('HighlightTheme provides a translucent default fill', () {
+      expect(HighlightTheme.defaultBackground.a, lessThan(1.0));
+    });
+
+    test(
+      'CellMetrics.cellRangeRect maps a cell run to pixels (1c geometry)',
+      () {
+        const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+        final rect = metrics.cellRangeRect(2, 1, 4, Offset.zero);
+        // viewport row 2, cols 1..3 inclusive (endCol 4 exclusive).
+        expect(rect.left, 8);
+        expect(rect.top, 32);
+        expect(rect.width, 24);
+        expect(rect.height, 16);
+      },
+    );
+  });
+}

--- a/native/third_party/flterm/lib/flterm.dart
+++ b/native/third_party/flterm/lib/flterm.dart
@@ -22,8 +22,11 @@ export 'package:libghostty/libghostty.dart'
         initializeForWeb;
 
 export 'src/foundation/callbacks.dart' show OnResize;
+export 'src/foundation/cell_metrics.dart' show CellMetrics;
 export 'src/foundation/color_palette.dart' show ColorPalette;
 export 'src/foundation/dynamic_color.dart' show DynamicColor;
+export 'src/foundation/highlight_range.dart'
+    show HighlightRange, HighlightTheme;
 export 'src/foundation/input_types.dart' show KeyboardState, MouseAutoHide;
 export 'src/foundation/terminal_config.dart'
     show ScrollToBottom, TerminalConfig;

--- a/native/third_party/flterm/lib/src/foundation.dart
+++ b/native/third_party/flterm/lib/src/foundation.dart
@@ -2,6 +2,7 @@ export 'foundation/callbacks.dart';
 export 'foundation/cell_metrics.dart';
 export 'foundation/color_palette.dart';
 export 'foundation/dynamic_color.dart';
+export 'foundation/highlight_range.dart';
 export 'foundation/input_types.dart';
 export 'foundation/platform_map.dart';
 export 'foundation/screen_extension.dart';

--- a/native/third_party/flterm/lib/src/foundation/highlight_range.dart
+++ b/native/third_party/flterm/lib/src/foundation/highlight_range.dart
@@ -1,0 +1,145 @@
+import 'dart:ui';
+
+import 'package:meta/meta.dart';
+
+/// A range of terminal cells to draw a structured-text highlight over.
+///
+/// Additive overlay primitive layered on top of the rendered grid (used for
+/// URL / path / regex highlights that the host application detects). It does
+/// not affect terminal state, selection, or text — only the highlight paint
+/// pass reads it.
+///
+/// Rows are ABSOLUTE buffer rows, top-anchored in the same coordinate frame
+/// as [TerminalSelection] (row 0 is the oldest scrollback row). The painter
+/// re-reads the viewport offset each frame, so scroll, reflow, and resize
+/// track for free without recomputing the ranges. Columns follow the
+/// terminal convention: [startCol] is inclusive, [endCol] is exclusive.
+///
+/// Each range carries its own optional [background] fill and [underline]
+/// colors, plus an opaque [payload] the host can hit-test back to (via
+/// `TerminalController.highlightAt`) — e.g. the URL string behind the cells.
+///
+/// ```dart
+/// const range = HighlightRange(
+///   startRow: 4,
+///   startCol: 6,
+///   endRow: 4,
+///   endCol: 30,
+///   payload: 'https://example.com',
+/// );
+/// if (range.contains(4, 10)) print('cell is highlighted');
+/// ```
+@immutable
+final class HighlightRange {
+  /// Absolute buffer row where the range starts (inclusive).
+  final int startRow;
+
+  /// Column where the range starts on [startRow] (inclusive).
+  final int startCol;
+
+  /// Absolute buffer row where the range ends (inclusive).
+  final int endRow;
+
+  /// Column where the range ends on [endRow] (exclusive).
+  final int endCol;
+
+  /// Translucent fill drawn behind the cells. When null the highlight
+  /// painter falls back to [HighlightTheme.defaultBackground].
+  final Color? background;
+
+  /// Underline color drawn under the cells. When null no underline is drawn.
+  final Color? underline;
+
+  /// Opaque value associated with this range, returned by hit-testing.
+  ///
+  /// The host uses this to recover what the cells represent (e.g. the URL
+  /// or path string) when the user taps or long-presses a highlighted cell.
+  final Object? payload;
+
+  const HighlightRange({
+    required this.startRow,
+    required this.startCol,
+    required this.endRow,
+    required this.endCol,
+    this.background,
+    this.underline,
+    this.payload,
+  });
+
+  /// Normalized top row (inclusive). The smaller of [startRow] and [endRow].
+  int get topRow => startRow <= endRow ? startRow : endRow;
+
+  /// Normalized bottom row (inclusive). The larger of [startRow] and [endRow].
+  int get bottomRow => startRow <= endRow ? endRow : startRow;
+
+  /// Normalized top column (inclusive) on [topRow].
+  int get topCol => startRow <= endRow ? startCol : endCol;
+
+  /// Normalized bottom column (exclusive) on [bottomRow].
+  int get bottomCol => startRow <= endRow ? endCol : startCol;
+
+  /// Returns true if the cell at ([row], [col]) falls within this range.
+  ///
+  /// Cells between the top and bottom rows are fully covered; cells on the
+  /// top and bottom rows are range-checked against their respective column
+  /// bounds, matching how contiguous text flows across line breaks.
+  bool contains(int row, int col) {
+    if (row < topRow || row > bottomRow) return false;
+    if (topRow == bottomRow) return col >= topCol && col < bottomCol;
+    if (row == topRow) return col >= topCol;
+    if (row == bottomRow) return col < bottomCol;
+    return true;
+  }
+
+  /// Returns a copy with both rows shifted by [delta].
+  ///
+  /// Used to keep the range anchored to the same content when the viewport
+  /// scrolls. Returns `this` when [delta] is zero.
+  HighlightRange scroll(int delta) {
+    if (delta == 0) return this;
+    return HighlightRange(
+      startRow: startRow + delta,
+      startCol: startCol,
+      endRow: endRow + delta,
+      endCol: endCol,
+      background: background,
+      underline: underline,
+      payload: payload,
+    );
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(startRow, startCol, endRow, endCol, background, underline);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HighlightRange &&
+          startRow == other.startRow &&
+          startCol == other.startCol &&
+          endRow == other.endRow &&
+          endCol == other.endCol &&
+          background == other.background &&
+          underline == other.underline &&
+          payload == other.payload;
+
+  @override
+  String toString() =>
+      'HighlightRange($startRow:$startCol-$endRow:$endCol, '
+      'payload: $payload)';
+}
+
+/// Default colors for the structured-text highlight paint pass.
+///
+/// A [HighlightRange] carries its own optional [HighlightRange.background] and
+/// [HighlightRange.underline] colors. When a range leaves [HighlightRange.background]
+/// null, the highlight painter falls back to [defaultBackground] so a plain
+/// `HighlightRange(...)` still renders a visible translucent fill.
+@immutable
+final class HighlightTheme {
+  /// Translucent fill used when a range omits its own background color.
+  static const Color defaultBackground = Color(0x335B9BD5);
+
+  const HighlightTheme._();
+}

--- a/native/third_party/flterm/lib/src/foundation/terminal_render_observer.dart
+++ b/native/third_party/flterm/lib/src/foundation/terminal_render_observer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import 'highlight_range.dart';
 import 'terminal_selection.dart';
 
 /// Observable selection and focus state for the rendering layer.
@@ -31,4 +32,11 @@ abstract class TerminalRenderObserver implements Listenable {
   /// Updated by the gesture detector as the user drags, double-clicks,
   /// or triple-clicks. Set to null when the selection is cleared.
   TerminalSelection? get selection;
+
+  /// Additive structured-text highlight ranges (URLs, paths, regex matches).
+  ///
+  /// Set by the host via `TerminalController.highlights`. Painters draw a
+  /// translucent fill over these ranges using the real cell metrics. Empty
+  /// when nothing is highlighted.
+  List<HighlightRange> get highlights;
 }

--- a/native/third_party/flterm/lib/src/rendering/paint_state.dart
+++ b/native/third_party/flterm/lib/src/rendering/paint_state.dart
@@ -3,7 +3,8 @@ import 'dart:ui';
 
 import 'package:libghostty/libghostty.dart' show Cursor, TerminalColors;
 
-import '../foundation.dart' show CellMetrics, TerminalSelection, TerminalTheme;
+import '../foundation.dart'
+    show CellMetrics, HighlightRange, TerminalSelection, TerminalTheme;
 import 'atlas/atlas.dart';
 
 /// Mutable state shared between [TerminalRenderBox] and all painters.
@@ -35,6 +36,13 @@ class TerminalPaintState {
   int faintAlpha;
 
   TerminalSelection? selection;
+
+  /// Additive structured-text highlight ranges (URLs, paths, regex matches).
+  ///
+  /// Absolute buffer rows; the highlight painter maps them to viewport rows
+  /// using [viewportOffset] each frame. Empty when nothing is highlighted.
+  List<HighlightRange> highlights = const [];
+
   var viewportOffset = 0;
 
   var cursor = const Cursor();

--- a/native/third_party/flterm/lib/src/rendering/painters/highlight_painter.dart
+++ b/native/third_party/flterm/lib/src/rendering/painters/highlight_painter.dart
@@ -1,0 +1,82 @@
+import 'dart:ui';
+
+import '../../foundation/highlight_range.dart';
+import '../paint_state.dart';
+import 'terminal_painter.dart';
+
+/// Paints the additive structured-text highlight layer.
+///
+/// Draws each [HighlightRange] from [TerminalPaintState.highlights] as a
+/// translucent per-cell-row background fill (and an optional underline),
+/// using the render box's real [CellMetrics] via
+/// [CellMetrics.cellRangeRect] — so the highlight pixel-aligns to the glyph
+/// cells with no separate geometry derivation.
+///
+/// Ranges store ABSOLUTE buffer rows. The painter re-reads
+/// [TerminalPaintState.viewportOffset] each frame and maps each row to a
+/// viewport row (`row - viewportOffset`), clipping to the visible grid. Rows
+/// outside the viewport are skipped, so scroll, reflow, and resize track
+/// without recomputing the ranges.
+class HighlightPainter implements TerminalPainter {
+  final TerminalPaintState _state;
+  final Paint _fillPaint = Paint();
+  final Paint _underlinePaint = Paint();
+
+  HighlightPainter(this._state);
+
+  @override
+  void paint(Canvas canvas) {
+    final highlights = _state.highlights;
+    if (highlights.isEmpty) return;
+
+    final rows = _state.rows;
+    final cols = _state.cols;
+    if (rows == 0 || cols == 0) return;
+
+    final metrics = _state.metrics;
+    final offset = _state.viewportOffset;
+    final underlineTop = metrics.underlinePosition > 0
+        ? metrics.underlinePosition
+        : metrics.cellHeight - metrics.underlineThickness;
+
+    for (final range in highlights) {
+      final topRow = range.topRow;
+      final bottomRow = range.bottomRow;
+
+      for (var absRow = topRow; absRow <= bottomRow; absRow++) {
+        final viewRow = absRow - offset;
+        if (viewRow < 0 || viewRow >= rows) continue;
+
+        final startCol = absRow == topRow ? range.topCol : 0;
+        final endCol = absRow == bottomRow ? range.bottomCol : cols;
+        final clampedStart = startCol.clamp(0, cols);
+        final clampedEnd = endCol.clamp(0, cols);
+        if (clampedEnd <= clampedStart) continue;
+
+        final rect = metrics.cellRangeRect(
+          viewRow,
+          clampedStart,
+          clampedEnd,
+          Offset.zero,
+        );
+
+        _fillPaint.color = range.background ?? HighlightTheme.defaultBackground;
+        canvas.drawRect(rect, _fillPaint);
+
+        final underline = range.underline;
+        if (underline != null) {
+          _underlinePaint.color = underline;
+          canvas.drawRect(
+            Rect.fromLTWH(
+              rect.left,
+              rect.top + underlineTop,
+              rect.width,
+              metrics.underlineThickness,
+            ),
+            _underlinePaint,
+          );
+        }
+      }
+    }
+  }
+}

--- a/native/third_party/flterm/lib/src/rendering/terminal_painter_stack.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_painter_stack.dart
@@ -10,6 +10,7 @@ import 'painters/background_painter.dart';
 import 'painters/cursor_painter.dart';
 import 'painters/decoration_painter.dart';
 import 'painters/emoji_painter.dart';
+import 'painters/highlight_painter.dart';
 import 'painters/kitty_graphics_painter.dart';
 import 'painters/shaped_run_painter.dart';
 import 'painters/sprite_painter.dart';
@@ -28,6 +29,7 @@ final class TerminalPainterStack {
   final List<KittyPlacementSnapshot> _kittyAboveText = [];
 
   final BackgroundPainter _backgroundPainter;
+  final HighlightPainter _highlightPainter;
   final DecorationPainter _decorationPainter;
   late final KittyGraphicsPainter _kittyBelowBgPainter;
   late final KittyGraphicsPainter _kittyBelowTextPainter;
@@ -47,6 +49,7 @@ final class TerminalPainterStack {
   }) : _kittyImageCache = KittyImageCache(onImageReady: onImageReady),
        _shapedRunPainter = ShapedRunPainter(_sprites.shaped),
        _backgroundPainter = BackgroundPainter(_state, _sprites),
+       _highlightPainter = HighlightPainter(_state),
        _decorationPainter = DecorationPainter(_sprites) {
     _kittyBelowBgPainter = KittyGraphicsPainter(
       state: _state,
@@ -81,6 +84,7 @@ final class TerminalPainterStack {
   void paint(Canvas canvas) {
     _kittyBelowBgPainter.paint(canvas);
     _backgroundPainter.paint(canvas);
+    _highlightPainter.paint(canvas);
     _kittyBelowTextPainter.paint(canvas);
     _underlinePainter.paint(canvas);
     _textPainter.paint(canvas);

--- a/native/third_party/flterm/lib/src/rendering/terminal_render_pipeline.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_render_pipeline.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:libghostty/libghostty.dart';
 
+import '../foundation/highlight_range.dart';
 import '../foundation/terminal_selection.dart';
 import 'atlas/atlas.dart';
 import 'atlas/sprite_buffer.dart';
@@ -67,6 +68,18 @@ final class TerminalRenderPipeline {
     final top = selection.topRow - viewportOffset;
     final bottom = selection.bottomRow - viewportOffset;
     _frameBuilder.markRowsDirty(top, bottom + 1);
+  }
+
+  void markHighlightRowsDirty(
+    List<HighlightRange> highlights, {
+    required int viewportOffset,
+  }) {
+    if (highlights.isEmpty || _state.rows == 0) return;
+    for (final range in highlights) {
+      final top = range.topRow - viewportOffset;
+      final bottom = range.bottomRow - viewportOffset;
+      _frameBuilder.markRowsDirty(top, bottom + 1);
+    }
   }
 
   void paint(Canvas canvas) => _painters.paint(canvas);

--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -192,6 +192,7 @@ class TerminalRenderBox extends RenderBox {
   }) : _paintState = TerminalPaintState(theme, metrics)
          ..blinkVisible = blinkVisible
          ..selection = _renderObserver.selection
+         ..highlights = _renderObserver.highlights
          ..cursorFocused = _renderObserver.hasFocus {
     _atlasHandle = _renderCache.acquireAtlas(
       .fromTheme(
@@ -497,6 +498,9 @@ class TerminalRenderBox extends RenderBox {
     final previousSelection = _paintState.selection;
     final newSelection = _renderObserver.selection;
     _paintState.selection = newSelection;
+    final previousHighlights = _paintState.highlights;
+    final newHighlights = _renderObserver.highlights;
+    _paintState.highlights = newHighlights;
     _paintState.cursorFocused = _renderObserver.hasFocus;
     if (previousSelection != newSelection) {
       final viewportOffset = _terminal.scrollbar.offset;
@@ -506,6 +510,17 @@ class TerminalRenderBox extends RenderBox {
       );
       _pipeline.markSelectionRowsDirty(
         newSelection,
+        viewportOffset: viewportOffset,
+      );
+    }
+    if (!identical(previousHighlights, newHighlights)) {
+      final viewportOffset = _terminal.scrollbar.offset;
+      _pipeline.markHighlightRowsDirty(
+        previousHighlights,
+        viewportOffset: viewportOffset,
+      );
+      _pipeline.markHighlightRowsDirty(
+        newHighlights,
         viewportOffset: viewportOffset,
       );
     }

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
@@ -89,6 +89,28 @@ abstract class TerminalController extends ChangeNotifier
   /// Sets the text selection.
   set selection(TerminalSelection? value);
 
+  @override
+  List<HighlightRange> get highlights;
+
+  /// Sets the structured-text highlight ranges drawn over the grid.
+  ///
+  /// Additive overlay used for URL / path / regex highlights detected by the
+  /// host. Ranges use ABSOLUTE buffer rows (same frame as [selection]) and
+  /// are painted with the terminal's real cell metrics, so they pixel-align
+  /// to the glyph cells and track scroll, wrap, and resize for free. Pass an
+  /// empty list to clear. Does not affect terminal state or selection.
+  set highlights(List<HighlightRange> value);
+
+  /// Returns the highlight range covering the viewport cell at ([row], [col]),
+  /// or null when no range covers it.
+  ///
+  /// [row] and [col] are VIEWPORT-relative (row 0 is the top visible row),
+  /// matching the coordinates a gesture detector produces from a pointer
+  /// position. The returned range's [HighlightRange.payload] recovers what the
+  /// cells represent (e.g. the URL behind a tap). When ranges overlap, the
+  /// last matching range in [highlights] wins.
+  HighlightRange? highlightAt({required int row, required int col});
+
   /// Terminal title set by the running program.
   String get title;
 

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -61,6 +61,7 @@ class TerminalControllerImpl extends TerminalController
 
   FocusNode? _focusNode;
   TerminalSelection? _selection;
+  List<HighlightRange> _highlights = const [];
   ScrollController? _scrollController;
 
   TerminalControllerImpl({TerminalConfig config = const TerminalConfig()})
@@ -148,6 +149,27 @@ class TerminalControllerImpl extends TerminalController
     if (_selection == value) return;
     _selection = value;
     notifyListeners();
+  }
+
+  @override
+  List<HighlightRange> get highlights => _highlights;
+
+  @override
+  set highlights(List<HighlightRange> value) {
+    if (identical(_highlights, value)) return;
+    _highlights = value;
+    notifyListeners();
+  }
+
+  @override
+  HighlightRange? highlightAt({required int row, required int col}) {
+    if (_highlights.isEmpty) return null;
+    final absRow = row + scrollbar.offset;
+    HighlightRange? match;
+    for (final range in _highlights) {
+      if (range.contains(absRow, col)) match = range;
+    }
+    return match;
   }
 
   @override

--- a/native/third_party/flterm/test/foundation/highlight_range_test.dart
+++ b/native/third_party/flterm/test/foundation/highlight_range_test.dart
@@ -1,0 +1,128 @@
+import 'dart:ui';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('HighlightRange', () {
+    group('contains (single-row)', () {
+      const range = HighlightRange(
+        startRow: 4,
+        startCol: 6,
+        endRow: 4,
+        endCol: 12,
+      );
+
+      test('a cell inside the range is contained', () {
+        expect(range.contains(4, 6), isTrue);
+        expect(range.contains(4, 11), isTrue);
+      });
+
+      test('endCol is exclusive', () {
+        expect(range.contains(4, 12), isFalse);
+      });
+
+      test('startCol is inclusive', () {
+        expect(range.contains(4, 5), isFalse);
+      });
+
+      test('a cell on a different row is not contained', () {
+        expect(range.contains(3, 8), isFalse);
+        expect(range.contains(5, 8), isFalse);
+      });
+    });
+
+    group('contains (multi-row)', () {
+      const range = HighlightRange(
+        startRow: 2,
+        startCol: 10,
+        endRow: 4,
+        endCol: 3,
+      );
+
+      test('top row is covered from topCol to end of line', () {
+        expect(range.contains(2, 10), isTrue);
+        expect(range.contains(2, 9), isFalse);
+        expect(range.contains(2, 999), isTrue);
+      });
+
+      test('middle rows are fully covered', () {
+        expect(range.contains(3, 0), isTrue);
+        expect(range.contains(3, 500), isTrue);
+      });
+
+      test('bottom row is covered up to bottomCol (exclusive)', () {
+        expect(range.contains(4, 0), isTrue);
+        expect(range.contains(4, 2), isTrue);
+        expect(range.contains(4, 3), isFalse);
+      });
+
+      test('rows outside the band are not covered', () {
+        expect(range.contains(1, 10), isFalse);
+        expect(range.contains(5, 0), isFalse);
+      });
+    });
+
+    test('normalized accessors order rows/cols', () {
+      const range = HighlightRange(
+        startRow: 4,
+        startCol: 3,
+        endRow: 2,
+        endCol: 10,
+      );
+      expect(range.topRow, 2);
+      expect(range.bottomRow, 4);
+      expect(range.topCol, 10);
+      expect(range.bottomCol, 3);
+      // Containment is direction-independent.
+      expect(range.contains(2, 10), isTrue);
+      expect(range.contains(4, 2), isTrue);
+    });
+
+    test('scroll shifts both rows and preserves payload/colors', () {
+      const range = HighlightRange(
+        startRow: 2,
+        startCol: 1,
+        endRow: 2,
+        endCol: 5,
+        background: Color(0xFF112233),
+        underline: Color(0xFF445566),
+        payload: 'https://example.com',
+      );
+      final scrolled = range.scroll(3);
+      expect(scrolled.startRow, 5);
+      expect(scrolled.endRow, 5);
+      expect(scrolled.startCol, 1);
+      expect(scrolled.endCol, 5);
+      expect(scrolled.background, const Color(0xFF112233));
+      expect(scrolled.underline, const Color(0xFF445566));
+      expect(scrolled.payload, 'https://example.com');
+      expect(identical(range.scroll(0), range), isTrue);
+    });
+
+    test('carries an opaque payload', () {
+      final url = Uri.parse('https://example.com/a');
+      final range = HighlightRange(
+        startRow: 0,
+        startCol: 0,
+        endRow: 0,
+        endCol: 4,
+        payload: url,
+      );
+      expect(range.payload, same(url));
+    });
+
+    test('equality compares geometry and colors', () {
+      const a = HighlightRange(startRow: 1, startCol: 2, endRow: 1, endCol: 6);
+      const b = HighlightRange(startRow: 1, startCol: 2, endRow: 1, endCol: 6);
+      const c = HighlightRange(startRow: 1, startCol: 2, endRow: 1, endCol: 7);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+
+    test('HighlightTheme exposes a default translucent background', () {
+      expect(HighlightTheme.defaultBackground.a, lessThan(1.0));
+    });
+  });
+}

--- a/native/third_party/flterm/test/rendering/cursor_layer_test.dart
+++ b/native/third_party/flterm/test/rendering/cursor_layer_test.dart
@@ -351,6 +351,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   TerminalSelection? get selection => null;
 
   @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/emoji_golden_test.dart
+++ b/native/third_party/flterm/test/rendering/emoji_golden_test.dart
@@ -463,6 +463,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   const _TestRenderObserver({this.selection, this.hasFocus = true});
 
   @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/sprites_golden_test.dart
+++ b/native/third_party/flterm/test/rendering/sprites_golden_test.dart
@@ -335,6 +335,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   TerminalSelection? get selection => null;
 
   @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/terminal_render_pipeline_test.dart
+++ b/native/third_party/flterm/test/rendering/terminal_render_pipeline_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flterm/src/foundation/cell_metrics.dart';
+import 'package:flterm/src/foundation/highlight_range.dart';
 import 'package:flterm/src/foundation/terminal_selection.dart';
 import 'package:flterm/src/foundation/terminal_theme.dart';
 import 'package:flterm/src/rendering/atlas/atlas.dart';
@@ -103,6 +104,59 @@ void main() {
       pipeline.sync(terminal, terminalDirty: false);
 
       paint(pipeline);
+    });
+
+    test('highlight dirtying can repaint without terminal changes', () {
+      writeUtf8(terminal, 'hello');
+      pipeline.sync(terminal, terminalDirty: true);
+
+      state.highlights = const [
+        HighlightRange(startRow: 0, startCol: 1, endRow: 0, endCol: 3),
+      ];
+      pipeline.markHighlightRowsDirty(state.highlights, viewportOffset: 0);
+
+      pipeline.sync(terminal, terminalDirty: false);
+
+      paint(pipeline);
+    });
+
+    test('highlight painter fills the highlighted cells', () async {
+      writeUtf8(terminal, 'hello');
+      pipeline.sync(terminal, terminalDirty: true);
+
+      state.highlights = const [
+        HighlightRange(
+          startRow: 0,
+          startCol: 1,
+          endRow: 0,
+          endCol: 3,
+          background: Color(0xFFFF0000),
+        ),
+      ];
+
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      pipeline.paint(canvas);
+      final image = recorder.endRecording().toImageSync(
+        (8 * metrics.cellWidth).round(),
+        (2 * metrics.cellHeight).round(),
+      );
+      addTearDown(image.dispose);
+
+      // The red highlight fill covers cols 1..2 on row 0. Sample near the
+      // top edge of the cell (above the glyph baseline, so no text ink) to
+      // read the fill directly: col 1 is red, col 5 (outside the range) is not.
+      final bytes = (await image.toByteData())!.buffer.asUint8List();
+      int rgbAt(int x, int y) {
+        final i = (y * image.width + x) * 4;
+        return (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+      }
+
+      const sampleY = 1;
+      final insideX = (1 * metrics.cellWidth + metrics.cellWidth / 2).round();
+      final outsideX = (5 * metrics.cellWidth + metrics.cellWidth / 2).round();
+      expect(rgbAt(insideX, sampleY), 0xFF0000);
+      expect(rgbAt(outsideX, sampleY), isNot(0xFF0000));
     });
   });
 }

--- a/native/third_party/flterm/test/rendering/terminal_renderer_golden_test.dart
+++ b/native/third_party/flterm/test/rendering/terminal_renderer_golden_test.dart
@@ -973,6 +973,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   const _TestRenderObserver({this.selection, this.hasFocus = true});
 
   @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/terminal_renderer_test.dart
+++ b/native/third_party/flterm/test/rendering/terminal_renderer_test.dart
@@ -241,6 +241,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   const _TestRenderObserver({this.selection, this.hasFocus = true});
 
   @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/transparent_background_golden_test.dart
+++ b/native/third_party/flterm/test/rendering/transparent_background_golden_test.dart
@@ -161,6 +161,9 @@ class _Observer implements TerminalRenderObserver {
   TerminalSelection? get selection => null;
 
   @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/widgets/terminal_controller_highlight_test.dart
+++ b/native/third_party/flterm/test/widgets/terminal_controller_highlight_test.dart
@@ -1,0 +1,116 @@
+@Tags(['ffi'])
+library;
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/widgets/terminal_controller_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TerminalController highlights', () {
+    late TerminalControllerImpl controller;
+
+    setUp(() => controller = TerminalControllerImpl());
+    tearDown(() => controller.dispose());
+
+    test('starts with no highlights', () {
+      expect(controller.highlights, isEmpty);
+      expect(controller.highlightAt(row: 0, col: 0), isNull);
+    });
+
+    test('setting highlights notifies listeners once', () {
+      var notifications = 0;
+      controller.addListener(() => notifications++);
+
+      controller.highlights = const [
+        HighlightRange(startRow: 0, startCol: 0, endRow: 0, endCol: 4),
+      ];
+
+      expect(controller.highlights, hasLength(1));
+      expect(notifications, 1);
+    });
+
+    test('setting the identical list does not notify', () {
+      const ranges = [
+        HighlightRange(startRow: 0, startCol: 0, endRow: 0, endCol: 4),
+      ];
+      controller.highlights = ranges;
+
+      var notifications = 0;
+      controller.addListener(() => notifications++);
+      controller.highlights = ranges;
+
+      expect(notifications, 0);
+    });
+
+    test('highlightAt returns the covering range with its payload', () {
+      controller.highlights = const [
+        HighlightRange(
+          startRow: 1,
+          startCol: 3,
+          endRow: 1,
+          endCol: 9,
+          payload: 'https://example.com',
+        ),
+      ];
+
+      final hit = controller.highlightAt(row: 1, col: 5);
+      expect(hit, isNotNull);
+      expect(hit!.payload, 'https://example.com');
+    });
+
+    test('highlightAt returns null outside every range', () {
+      controller.highlights = const [
+        HighlightRange(startRow: 1, startCol: 3, endRow: 1, endCol: 9),
+      ];
+
+      expect(controller.highlightAt(row: 1, col: 2), isNull);
+      expect(controller.highlightAt(row: 1, col: 9), isNull);
+      expect(controller.highlightAt(row: 0, col: 5), isNull);
+    });
+
+    test('highlightAt resolves a multi-row range', () {
+      controller.highlights = const [
+        HighlightRange(
+          startRow: 0,
+          startCol: 6,
+          endRow: 2,
+          endCol: 4,
+          payload: 'multi',
+        ),
+      ];
+
+      // Top row: only from startCol onward.
+      expect(controller.highlightAt(row: 0, col: 6)?.payload, 'multi');
+      expect(controller.highlightAt(row: 0, col: 5), isNull);
+      // Middle row: fully covered.
+      expect(controller.highlightAt(row: 1, col: 0)?.payload, 'multi');
+      // Bottom row: up to bottomCol (exclusive).
+      expect(controller.highlightAt(row: 2, col: 3)?.payload, 'multi');
+      expect(controller.highlightAt(row: 2, col: 4), isNull);
+    });
+
+    test('the last overlapping range wins', () {
+      controller.highlights = const [
+        HighlightRange(
+          startRow: 0,
+          startCol: 0,
+          endRow: 0,
+          endCol: 10,
+          payload: 'under',
+        ),
+        HighlightRange(
+          startRow: 0,
+          startCol: 2,
+          endRow: 0,
+          endCol: 6,
+          payload: 'over',
+        ),
+      ];
+
+      expect(controller.highlightAt(row: 0, col: 4)?.payload, 'over');
+      expect(controller.highlightAt(row: 0, col: 8)?.payload, 'under');
+    });
+  });
+}


### PR DESCRIPTION
#755 Slice 1b (of 1a/1b/1c). Adds HighlightRange + HighlightPainter pass (real CellMetrics.cellRangeRect, re-reads viewportOffset → scroll/wrap track for free) + controller.highlights/highlightAt, mirroring flterm's selection plumbing. Strictly additive (net 1 deletion, ~100 insertions; no existing logic modified; painter early-returns when empty). 843 tests green. 1c will feed URL matches into this API + delete the overlay. Does NOT close #755 (arc stays open for 1c).