### PR TITLE
fix(#759): end-to-end resume liveness — detect frozen sessions on unlock

### DIFF
--- a/native/lib/diagnostics/connect_trace.dart
+++ b/native/lib/diagnostics/connect_trace.dart
@@ -27,7 +27,18 @@ import 'package:flutter/foundation.dart';
 /// lines are dropped once the cap is exceeded.
 const int connectLogCapacity = 200;
 
+/// Maximum number of lines retained by the dedicated [lifecycleLog] ring
+/// buffer (#759). Lifecycle events (resume-liveness probe OUTCOME, reconnect
+/// decisions) are LOW-frequency but HIGH-signal, and the 200-event connect ring
+/// churns them off the tail before the +Ns probe RESULT lands (the original
+/// #759 telemetry gap: the report was filed DURING the 4s probe, the outcome
+/// fell off the buffer). This second, smaller ring is reserved for those events
+/// so the NEXT occurrence is unambiguous from telemetry alone. The feedback
+/// bundle ships both rings.
+const int lifecycleLogCapacity = 80;
+
 final List<String> _ring = <String>[];
+final List<String> _lifecycleRing = <String>[];
 
 // Consecutive-duplicate suppression: when the same `[where] msg` repeats
 // back-to-back (e.g. keepalive `recv`/`send` pings), collapse it into the last
@@ -49,6 +60,20 @@ ValueListenable<List<String>> get connectLog => _connectLog;
 /// assembler, #553) can read the log without holding a listener or mutating
 /// the underlying ring.
 List<String> connectLogSnapshot() => List<String>.unmodifiable(_ring);
+
+final ValueNotifier<List<String>> _lifecycleLog = ValueNotifier<List<String>>(
+  const <String>[],
+);
+
+/// Live, read-only view of the dedicated lifecycle-event ring (#759). The
+/// newest line is last.
+ValueListenable<List<String>> get lifecycleLog => _lifecycleLog;
+
+/// Read-only snapshot of the lifecycle-event ring, newest line last (#759).
+/// Bundled into the feedback upload alongside [connectLogSnapshot] so the
+/// resume-liveness probe outcome survives the connect-ring churn.
+List<String> lifecycleLogSnapshot() =>
+    List<String>.unmodifiable(_lifecycleRing);
 
 String _timestamp(DateTime now) {
   String two(int n) => n.toString().padLeft(2, '0');
@@ -82,10 +107,42 @@ void ctrace(String where, String msg) {
   _connectLog.value = List<String>.unmodifiable(_ring);
 }
 
-/// Clears the on-device connect-log ring buffer. Does not affect logcat.
+/// Record a HIGH-signal lifecycle event (#759): resume-liveness probe outcome,
+/// reconnect decision. Appends to the dedicated [lifecycleLog] ring (which
+/// survives the 200-event connect-ring churn) AND to the connect ring (so the
+/// event also appears in-context) AND to logcat. Never suppressed/collapsed —
+/// every lifecycle decision is its own line.
+void clifecycle(String where, String msg) {
+  final key = '[$where] $msg';
+  final ts = _timestamp(DateTime.now());
+  final line = '$ts $key';
+
+  // Dedicated lifecycle ring — the durable record.
+  _lifecycleRing.add(line);
+  while (_lifecycleRing.length > lifecycleLogCapacity) {
+    _lifecycleRing.removeAt(0);
+  }
+  _lifecycleLog.value = List<String>.unmodifiable(_lifecycleRing);
+
+  // Also surface in the connect ring + logcat for in-context reading. Reset the
+  // collapse state so this line is never merged into a preceding ` (×N)` run.
+  _lastKey = null;
+  _lastCount = 0;
+  debugPrint('[CONNECT]$key');
+  _ring.add(line);
+  while (_ring.length > connectLogCapacity) {
+    _ring.removeAt(0);
+  }
+  _connectLog.value = List<String>.unmodifiable(_ring);
+}
+
+/// Clears the on-device connect-log + lifecycle-event ring buffers. Does not
+/// affect logcat.
 void clearConnectLog() {
   _ring.clear();
+  _lifecycleRing.clear();
   _lastKey = null;
   _lastCount = 0;
   _connectLog.value = const <String>[];
+  _lifecycleLog.value = const <String>[];
 }

--- a/native/lib/diagnostics/feedback_bundle.dart
+++ b/native/lib/diagnostics/feedback_bundle.dart
@@ -72,12 +72,19 @@ String assembleFeedbackBundle({
   required CrashEnvironmentInfo info,
   required List<String> connectLog,
   List<String> gestureLog = const <String>[],
+  List<String> lifecycleLog = const <String>[],
   String? crashJson,
 }) {
   final scrubbedLog = connectLog.map(scrubSecrets).toList(growable: false);
   // #699: gesture-trace ring (touch->cell mapping diagnostics) carried off the
   // device for the Ghostty selection-offset bug. Scrubbed like the connect log.
   final scrubbedGestureLog = gestureLog
+      .map(scrubSecrets)
+      .toList(growable: false);
+  // #759: dedicated lifecycle-event ring (resume-liveness probe outcomes,
+  // reconnect decisions). Survives the 200-event connect-ring churn so the next
+  // wake-frozen occurrence is diagnosable from the bundle alone.
+  final scrubbedLifecycleLog = lifecycleLog
       .map(scrubSecrets)
       .toList(growable: false);
 
@@ -104,6 +111,7 @@ String assembleFeedbackBundle({
     'deviceModel': info.deviceModel,
     'connectLog': scrubbedLog,
     'gestureLog': scrubbedGestureLog,
+    'lifecycleLog': scrubbedLifecycleLog,
     'lastCrash': lastCrash,
     // Null-aware element: the entry is omitted entirely when there is no raw
     // (non-JSON) crash blob to preserve.

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -58,11 +58,15 @@ class SessionHost {
     SftpSessionOpener? sftpOpener,
     HostShellOpener? shellOpener,
     this.snapshotInterval = const Duration(seconds: 2),
-    this.resumeProbeTimeout = const Duration(seconds: 4),
+    this.resumeProbeTimeout = const Duration(seconds: 2),
+    this.resumeStaleThreshold = const Duration(seconds: 20),
+    this.resumeNudgeWindow = const Duration(seconds: 2),
+    int Function()? nowMs,
   }) : _gateway = gateway,
        _factory = controllerFactory ?? _defaultControllerFactory,
        _sftpOpener = sftpOpener,
-       _shellOpener = shellOpener ?? _defaultShellOpener {
+       _shellOpener = shellOpener ?? _defaultShellOpener,
+       _nowMs = nowMs ?? (() => DateTime.now().millisecondsSinceEpoch) {
     _commandSub = _gateway.incoming.listen(_dispatch);
     _snapshotTimer = Timer.periodic(snapshotInterval, (_) => _pushSnapshots());
     ctrace('task.host', 'ctor: listening; sending SshTaskReadyEvent');
@@ -92,7 +96,27 @@ class SessionHost {
   /// Timeout for the resume liveness probe (#737). A `connected` session whose
   /// ping doesn't reply within this window is declared dead → reconnect. Short
   /// so a frozen wake recovers in a few seconds, not "never". Tests shrink it.
+  /// Shortened 4s → 2s (#759) so detection is faster and the stale window does
+  /// not let a green dot sit over frozen content for long.
   final Duration resumeProbeTimeout;
+
+  /// How long with NO fresh remote bytes before a session is considered "stale
+  /// going into resume" (#759). Only a session that is BOTH stale-before AND
+  /// unresponsive to the nudge is reconnected — a session that produced fresh
+  /// bytes within this window is left connected even if the nudge is silent
+  /// (conservative gate against churning a healthy idle session).
+  final Duration resumeStaleThreshold;
+
+  /// How long to wait after sending the end-to-end nudge (a benign channel
+  /// resize that makes a live tmux/shell REDRAW) for fresh remote bytes to
+  /// arrive (#759). Bounded so the resume decision resolves quickly. If no fresh
+  /// bytes arrive in this window the session is declared STALE → reconnect.
+  final Duration resumeNudgeWindow;
+
+  /// Injectable monotonic-ish clock (ms since epoch). Real production uses
+  /// `DateTime.now()`; tests inject a controllable clock so the staleness gate
+  /// is deterministic under `fakeAsync` (#759).
+  final int Function() _nowMs;
 
   StreamSubscription<Map<String, dynamic>>? _commandSub;
   Timer? _snapshotTimer;
@@ -161,15 +185,11 @@ class SessionHost {
         // re-emitting ready so the contract is honoured everywhere.
         _gateway.send(const SshTaskReadyEvent().toJson());
       case SshResumeProbeCommand():
-        // #737: actively verify the session's socket survived Doze rather than
-        // trusting the cached `connected` state. The controller pings with a
-        // short timeout; a dead half-open socket → softDisconnected → reconnect.
-        final hosted = _sessions[cmd.sessionId];
-        if (hosted != null) {
-          unawaited(
-            hosted.controller.probeLiveness(timeout: resumeProbeTimeout),
-          );
-        }
+        // #737/#759: actively verify the session survived Doze rather than
+        // trusting the cached `connected` state. Transport ping (#737) PLUS an
+        // end-to-end nudge check (#759) for the transport-alive-but-shell-frozen
+        // case a ping cannot catch.
+        _handleResumeProbe(cmd.sessionId);
       case SftpListCommand():
         _handleSftpList(cmd);
       case SftpDownloadCommand():
@@ -186,6 +206,123 @@ class SessionHost {
       hosted.controller.acceptHostKey();
     } else {
       hosted.controller.rejectHostKey();
+    }
+  }
+
+  /// End-to-end resume liveness (#759).
+  ///
+  /// The #737 transport ping answers whenever SSH is up — but after deep Doze
+  /// the link can be a zombie that still ACKs at the transport layer while the
+  /// remote tmux/shell is FROZEN, or the real link dropped and a stale socket
+  /// lingers. A transport ping cannot catch an app-level freeze. So:
+  ///
+  ///   1. Capture the fresh-remote-byte counter + whether the session was STALE
+  ///      going into resume (no remote output for [resumeStaleThreshold]).
+  ///   2. Run the transport ping ([SshSessionController.probeLiveness]). If it
+  ///      FAILS the controller already drove softDisconnected → reconnect
+  ///      (#737) — done. Telemetry: `ping-failed → reconnect`.
+  ///   3. Ping answered. If the session was NOT stale (produced fresh bytes
+  ///      recently) leave it connected — `alive(recent-bytes)`. (Conservative:
+  ///      never churn a healthy idle session.)
+  ///   4. Ping answered AND stale-before: send a benign NUDGE (a no-op channel
+  ///      resize that makes a live tmux/shell REDRAW → fresh bytes) and wait
+  ///      [resumeNudgeWindow]:
+  ///        - fresh bytes arrived → `alive(fresh-bytes-after-nudge)`, stay.
+  ///        - NO fresh bytes → STALE/FROZEN → `softDisconnectForResume()` drives
+  ///          softDisconnected → reconnect. Telemetry:
+  ///          `STALE(no-bytes-after-nudge) → reconnect`.
+  ///
+  /// Only the (stale-before AND no-bytes-after-nudge) combination triggers the
+  /// NEW reconnect path; everything else stays connected. Reconnect is cheap for
+  /// tmux (re-attach) but we deliberately do not churn responsive sessions.
+  Future<void> _handleResumeProbe(String sessionId) async {
+    final hosted = _sessions[sessionId];
+    if (hosted == null) return;
+    final controller = hosted.controller;
+
+    final countBefore = hosted.remoteByteEvents;
+    final lastByteAt = hosted.lastRemoteByteAtMs;
+    final now = _nowMs();
+    // Stale-before: never saw a remote byte, OR the last one is older than the
+    // threshold. A brand-new connection with no output yet counts as stale (it
+    // has nothing to prove it's responsive), but it will answer the nudge if
+    // healthy.
+    final staleBefore =
+        lastByteAt == null ||
+        (now - lastByteAt) >= resumeStaleThreshold.inMilliseconds;
+
+    // (1)+(2): transport ping (#737). Returns false when it failed and the
+    // session was already driven into reconnect.
+    final pingAlive = await controller.probeLiveness(
+      timeout: resumeProbeTimeout,
+    );
+    if (!pingAlive) {
+      // Controller emitted the `ping-failed → reconnect` lifecycle line.
+      return;
+    }
+
+    // (3): ping answered but session was responsive recently — leave connected.
+    if (!staleBefore) {
+      clifecycle('task.host', 'resume-liveness: alive(recent-bytes)');
+      return;
+    }
+
+    // The session may have been torn down or moved off connected while we
+    // awaited the ping. If it's no longer hosted/connected, nothing to nudge.
+    if (!_sessions.containsKey(sessionId) ||
+        controller.data.state != SshSessionState.connected) {
+      return;
+    }
+
+    // Conservative: the end-to-end check needs a live shell channel to nudge and
+    // to observe redraw bytes. With no shell open (the session reached connected
+    // but the PTY isn't up yet, or this is a #737-style controller-only test)
+    // there is nothing to nudge — fall back to the #737 ping-only verdict and
+    // leave the (ping-alive) session connected rather than false-reconnecting.
+    if (hosted.shell == null) {
+      clifecycle('task.host', 'resume-liveness: alive(no-shell, ping-only)');
+      return;
+    }
+
+    // (4): stale-before — send the end-to-end nudge and watch for fresh bytes.
+    _sendLivenessNudge(hosted);
+    await Future<void>.delayed(resumeNudgeWindow);
+
+    // Re-resolve: a real close / reconnect could have raced in.
+    final after = _sessions[sessionId];
+    if (after == null) return;
+    if (after.controller.data.state != SshSessionState.connected) return;
+
+    if (after.remoteByteEvents > countBefore) {
+      clifecycle(
+        'task.host',
+        'resume-liveness: alive(fresh-bytes-after-nudge)',
+      );
+      return;
+    }
+    // Stale-before AND no fresh bytes after the nudge → frozen/dead end-to-end.
+    after.controller.softDisconnectForResume();
+  }
+
+  /// Send a benign channel nudge that forces a live remote tmux/shell to redraw
+  /// (#759): a window-resize toggling the columns by one and back. Non-intrusive
+  /// (no keystrokes injected into the shell, no command run), but a responsive
+  /// PTY answers with a repaint → fresh remote bytes the nudge check can see.
+  /// A frozen shell / dead link produces nothing. No-op when no shell is open.
+  void _sendLivenessNudge(_HostedSession hosted) {
+    final shell = hosted.shell;
+    if (shell == null) return;
+    final cols = hosted.metrics.lastCols ?? 80;
+    final rows = hosted.metrics.lastRows ?? 24;
+    try {
+      // Toggle off-by-one then back to the real dims so the final geometry is
+      // unchanged but the remote sees a resize → SIGWINCH → redraw.
+      shell.resize(cols + 1, rows);
+      shell.resize(cols, rows);
+    } catch (_) {
+      // dartssh2 throws on non-positive dims / closed channel; a closed channel
+      // means the transport is already gone and the controller's own close path
+      // will drive reconnect. Swallow — the nudge is best-effort.
     }
   }
 
@@ -379,6 +516,11 @@ class SessionHost {
       hosted.shellSub = transport.output.listen(
         (bytes) {
           hosted.metrics.bytesIn += bytes.length;
+          // Record a fresh-remote-byte event for the #759 resume-liveness check.
+          // This is the ground truth that the REMOTE (not just the transport) is
+          // producing output — the nudge check watches this counter advance.
+          hosted.remoteByteEvents += 1;
+          hosted.lastRemoteByteAtMs = _nowMs();
           hosted.appendScrollback(bytes);
           _gateway.send(
             SshOutputEvent(sessionId: sessionId, bytes: bytes).toJson(),
@@ -630,6 +772,10 @@ class SessionHost {
     final hosted = _sessions[sessionId];
     if (hosted == null) return;
     hosted.metrics.bytesIn += bytes.length;
+    // Mirror the live listener so the #759 resume-liveness check sees fresh
+    // remote bytes through the test ingest seam too.
+    hosted.remoteByteEvents += 1;
+    hosted.lastRemoteByteAtMs = _nowMs();
     hosted.appendScrollback(bytes);
     _gateway.send(SshOutputEvent(sessionId: sessionId, bytes: bytes).toJson());
   }
@@ -742,6 +888,20 @@ class _HostedSession {
   SshShellTransport? shell;
   StreamSubscription<Uint8List>? shellSub;
   bool shellOpening = false;
+
+  /// Monotonic count of remote-output CHUNKS actually received from the shell
+  /// (#759). Bumped only by the live shell-output listener (and the test
+  /// ingest seam) — NOT by snapshot replay or scrollback hydration — so it is a
+  /// faithful "fresh bytes from the remote" signal. The resume-liveness check
+  /// captures this before nudging and re-reads it after the nudge window to
+  /// decide whether a transport-alive session is actually responsive end-to-end.
+  int remoteByteEvents = 0;
+
+  /// Wall-clock (ms since epoch) of the most recent remote-output chunk, or
+  /// null if none has arrived yet (#759). Drives the `staleBefore` gate: a
+  /// session that produced fresh bytes recently is NOT escalated to the nudge
+  /// check on resume (conservative — don't churn a healthy idle session).
+  int? lastRemoteByteAtMs;
 
   /// Monotonic token bumped each time the shell is dropped (#590). An in-flight
   /// [SessionHost._ensureShell] open captures this before awaiting and discards

--- a/native/lib/ssh/ssh_session.dart
+++ b/native/lib/ssh/ssh_session.dart
@@ -455,12 +455,21 @@ class SshSessionController {
   ///
   /// No-op unless currently `connected` (nothing to probe otherwise) or if the
   /// user has disconnected. Safe to call repeatedly (e.g. on every resume).
-  Future<void> probeLiveness({
+  ///
+  /// Returns `true` when the transport ping replied (link answered — the
+  /// session is left `connected`), `false` when the ping failed/timed out and
+  /// the session was driven into the reconnect path (#737). The caller
+  /// ([SessionHost]) uses the return value to decide whether to escalate to the
+  /// END-TO-END nudge check (#759): a ping that answers does NOT prove the
+  /// REMOTE shell/tmux is responsive — only that SSH is up — so when the session
+  /// was already stale going into resume the host nudges the channel and watches
+  /// for fresh remote bytes.
+  Future<bool> probeLiveness({
     Duration timeout = const Duration(seconds: 4),
   }) async {
-    if (_userDisconnected) return;
-    if (_data.state != SshSessionState.connected) return;
-    if (_lastParams == null) return;
+    if (_userDisconnected) return false;
+    if (_data.state != SshSessionState.connected) return false;
+    if (_lastParams == null) return false;
 
     final probe = _livenessProbe ?? _defaultLivenessProbe;
     var alive = false;
@@ -470,15 +479,42 @@ class SshSessionController {
     } catch (e) {
       // TimeoutException (half-open socket — no reply) or a transport error
       // (broken pipe). Either way the link is dead.
-      ctrace('task.ssh', 'probeLiveness: FAILED — $e → softDisconnected');
+      clifecycle('task.ssh', 'probeLiveness: ping-failed → reconnect ($e)');
     }
     if (alive) {
-      ctrace('task.ssh', 'probeLiveness: alive');
-      return;
+      // Transport answered. This is NOT proof the remote shell is live (#759);
+      // the host decides whether to escalate to the nudge check. Stay connected.
+      ctrace('task.ssh', 'probeLiveness: ping-alive (transport answered)');
+      return true;
     }
     // Re-check state: a real transport close could have raced in while we
     // awaited the probe and already moved us off `connected`.
-    if (_userDisconnected || _data.state != SshSessionState.connected) return;
+    if (_userDisconnected || _data.state != SshSessionState.connected) {
+      return false;
+    }
+    _lastErrorUnreachable = false;
+    _emit(_data.copyWith(state: SshSessionState.softDisconnected));
+    _scheduleReconnect(null);
+    return false;
+  }
+
+  /// Declare the current `connected` session STALE/DEAD at the APPLICATION layer
+  /// (#759) and drive it through the existing reconnect path. Used by
+  /// [SessionHost] when the transport ping answered but an end-to-end nudge
+  /// produced NO fresh remote bytes (a frozen tmux/shell over a live socket).
+  ///
+  /// No-op unless currently `connected` (the ping-fail path in [probeLiveness]
+  /// may already have moved us off `connected`) or if the user disconnected.
+  /// Reuses the same `connected → softDisconnected → reconnect` machinery as a
+  /// clean server close, so #517/#590 reconnect behaviour is unchanged.
+  void softDisconnectForResume() {
+    if (_userDisconnected) return;
+    if (_data.state != SshSessionState.connected) return;
+    if (_lastParams == null) return;
+    clifecycle(
+      'task.ssh',
+      'probeLiveness: STALE(no-bytes-after-nudge) → reconnect',
+    );
     _lastErrorUnreachable = false;
     _emit(_data.copyWith(state: SshSessionState.softDisconnected));
     _scheduleReconnect(null);

--- a/native/lib/ui/diagnostics_section.dart
+++ b/native/lib/ui/diagnostics_section.dart
@@ -89,6 +89,7 @@ class _DiagnosticsSectionState extends State<DiagnosticsSection> {
         info: info,
         connectLog: connectLogSnapshot(),
         gestureLog: gestureLogSnapshot(),
+        lifecycleLog: lifecycleLogSnapshot(),
         crashJson: crashJson,
       );
 

--- a/native/lib/ui/feedback_overlay.dart
+++ b/native/lib/ui/feedback_overlay.dart
@@ -70,6 +70,7 @@ Map<String, Object?> buildFeedbackPayload({
   String? screenshotDataUrl,
   List<String> connectLog = const <String>[],
   List<String> gestureLog = const <String>[],
+  List<String> lifecycleLog = const <String>[],
 }) {
   final fullComment = comment;
   // First non-empty line → title summary. Never truncate the comment itself.
@@ -105,6 +106,14 @@ Map<String, Object?> buildFeedbackPayload({
       .map(scrubSecrets)
       .toList(growable: false);
 
+  // #759: dedicated lifecycle-event ring (resume-liveness probe outcomes,
+  // reconnect decisions) — the durable record that survives the connect-ring
+  // churn so a wake-frozen report carries the probe outcome. Scrubbed like the
+  // others (defense in depth; lifecycle lines carry no credentials).
+  final scrubbedLifecycleLog = lifecycleLog
+      .map(scrubSecrets)
+      .toList(growable: false);
+
   return <String, Object?>{
     'title': title,
     // FULL comment — the server stores this untruncated (#661).
@@ -117,6 +126,7 @@ Map<String, Object?> buildFeedbackPayload({
       'screenshot': screenshotDataUrl,
     if (scrubbedLog.isNotEmpty) 'connectLog': scrubbedLog,
     if (scrubbedGestureLog.isNotEmpty) 'gestureLog': scrubbedGestureLog,
+    if (scrubbedLifecycleLog.isNotEmpty) 'lifecycleLog': scrubbedLifecycleLog,
   };
 }
 
@@ -257,6 +267,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     // affordance pill appearing in its own screenshot is an acceptable trade.
     final connectLog = connectLogSnapshot();
     final gestureLog = gestureLogSnapshot();
+    final lifecycleLog = lifecycleLogSnapshot();
     final dpr = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0;
     final bytes = await widget.screenshotCapturer(_captureKey, dpr);
     if (!mounted) return;
@@ -270,6 +281,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       version: version,
       connectLog: connectLog,
       gestureLog: gestureLog,
+      lifecycleLog: lifecycleLog,
     );
   }
 
@@ -278,6 +290,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     required String version,
     required List<String> connectLog,
     required List<String> gestureLog,
+    required List<String> lifecycleLog,
   }) async {
     // Show the sheet from the Navigator's OVERLAY context — NOT this overlay's
     // own context, which sits above the Navigator (mounted via
@@ -301,6 +314,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       screenshotDataUrl: dataUrl,
       connectLog: connectLog,
       gestureLog: gestureLog,
+      lifecycleLog: lifecycleLog,
     );
     final ok = await widget.submitter.submit(payload);
     // Confirmation as a TOP toast (#667) so it doesn't occlude the bottom

--- a/native/test/diagnostics/connect_trace_test.dart
+++ b/native/test/diagnostics/connect_trace_test.dart
@@ -19,10 +19,16 @@ void main() {
     final lines = connectLog.value;
     expect(lines.length, n, reason: 'buffer must cap at $n');
     // Oldest 10 (line 0..9) dropped; newest retained at the end.
-    expect(lines.first, contains('line 10'),
-        reason: 'oldest lines should be dropped');
-    expect(lines.last, contains('line ${n + 9}'),
-        reason: 'newest line should be retained at the end');
+    expect(
+      lines.first,
+      contains('line 10'),
+      reason: 'oldest lines should be dropped',
+    );
+    expect(
+      lines.last,
+      contains('line ${n + 9}'),
+      reason: 'newest line should be retained at the end',
+    );
   });
 
   test('lines are appended in call order, newest last', () {
@@ -40,7 +46,10 @@ void main() {
   test('line includes a HH:mm:ss.SSS timestamp and the where tag', () {
     ctrace('ui.proxy', 'hello');
     final line = connectLog.value.single;
-    expect(line, matches(RegExp(r'^\d{2}:\d{2}:\d{2}\.\d{3} \[ui\.proxy\] hello$')));
+    expect(
+      line,
+      matches(RegExp(r'^\d{2}:\d{2}:\d{2}\.\d{3} \[ui\.proxy\] hello$')),
+    );
   });
 
   test('appending notifies listeners with a fresh list instance', () {
@@ -54,8 +63,11 @@ void main() {
     final after = connectLog.value;
 
     expect(notifications, 1, reason: 'a single append fires one notification');
-    expect(identical(before, after), isFalse,
-        reason: 'value must be a new list so ValueListenableBuilder rebuilds');
+    expect(
+      identical(before, after),
+      isFalse,
+      reason: 'value must be a new list so ValueListenableBuilder rebuilds',
+    );
   });
 
   test('consecutive identical lines collapse into one with a ×N count', () {
@@ -78,8 +90,11 @@ void main() {
     expect(lines.length, 3);
     expect(lines[0], contains('[ui.gw] recv output (×2)'));
     expect(lines[1], contains('[ui.gw] send input'));
-    expect(lines[1], isNot(contains('×')),
-        reason: 'a single occurrence has no count suffix');
+    expect(
+      lines[1],
+      isNot(contains('×')),
+      reason: 'a single occurrence has no count suffix',
+    );
     expect(lines[2], contains('[ui.gw] recv output'));
     expect(lines[2], isNot(contains('×')));
   });
@@ -93,8 +108,11 @@ void main() {
     ctrace('ui.gw', 'recv output');
     ctrace('ui.gw', 'recv output');
 
-    expect(notifications, 2,
-        reason: 'each call notifies, even when collapsing the line');
+    expect(
+      notifications,
+      2,
+      reason: 'each call notifies, even when collapsing the line',
+    );
   });
 
   test('clearConnectLog empties the buffer and notifies', () {
@@ -110,5 +128,62 @@ void main() {
     clearConnectLog();
     expect(connectLog.value, isEmpty);
     expect(cleared, isTrue);
+  });
+
+  group('lifecycle ring (#759)', () {
+    test(
+      'clifecycle appends to BOTH the lifecycle ring and the connect ring',
+      () {
+        clifecycle('task.host', 'resume-liveness: alive(recent-bytes)');
+
+        expect(
+          lifecycleLog.value.single,
+          contains('resume-liveness: alive(recent-bytes)'),
+        );
+        expect(
+          connectLog.value.single,
+          contains('resume-liveness: alive(recent-bytes)'),
+          reason: 'the event must also show in-context in the connect ring',
+        );
+      },
+    );
+
+    test('a lifecycle event SURVIVES the connect-ring churn', () {
+      clifecycle(
+        'task.host',
+        'resume-liveness: STALE(no-bytes-after-nudge) '
+            '→ reconnect',
+      );
+      // Flood the connect ring past its cap so the lifecycle line is evicted
+      // from the connect ring — but the dedicated ring must still retain it.
+      for (var i = 0; i < connectLogCapacity + 50; i++) {
+        ctrace('ui.gw', 'recv $i');
+      }
+
+      expect(
+        lifecycleLogSnapshot().join('\n'),
+        contains('STALE(no-bytes-after-nudge)'),
+        reason:
+            'the dedicated ring must outlive the connect-ring churn — the '
+            'whole point of #759 telemetry retention',
+      );
+    });
+
+    test('clifecycle is never collapsed into a preceding ×N run', () {
+      ctrace('ui.gw', 'recv output');
+      ctrace('ui.gw', 'recv output');
+      clifecycle('task.host', 'resume-liveness: ping-failed → reconnect');
+
+      final lines = connectLog.value;
+      expect(lines.last, contains('ping-failed → reconnect'));
+      expect(lines.last, isNot(contains('×')));
+    });
+
+    test('clearConnectLog also clears the lifecycle ring', () {
+      clifecycle('task.host', 'resume-liveness: alive(recent-bytes)');
+      expect(lifecycleLog.value, isNotEmpty);
+      clearConnectLog();
+      expect(lifecycleLog.value, isEmpty);
+    });
   });
 }

--- a/native/test/diagnostics/feedback_bundle_test.dart
+++ b/native/test/diagnostics/feedback_bundle_test.dart
@@ -94,6 +94,38 @@ void main() {
       expect((decoded['gestureLog'] as List).single, contains('cell=(13,24)'));
     });
 
+    test('includes the lifecycle-event log when supplied (#759)', () {
+      final blob = assembleFeedbackBundle(
+        info: info,
+        connectLog: const [],
+        lifecycleLog: const [
+          '19:22:19.001 [task.host] resume-liveness: '
+              'STALE(no-bytes-after-nudge) → reconnect',
+        ],
+        crashJson: null,
+      );
+      final decoded = jsonDecode(blob) as Map<String, Object?>;
+      expect(decoded['lifecycleLog'], isA<List<Object?>>());
+      expect(
+        (decoded['lifecycleLog'] as List).single,
+        contains('STALE(no-bytes-after-nudge)'),
+        reason:
+            'the resume-liveness outcome must survive into the bundle so '
+            'the next wake-frozen report is diagnosable (#759)',
+      );
+    });
+
+    test('lifecycleLog defaults to an empty list when omitted (#759)', () {
+      final blob = assembleFeedbackBundle(
+        info: info,
+        connectLog: const [],
+        crashJson: null,
+      );
+      final decoded = jsonDecode(blob) as Map<String, Object?>;
+      expect(decoded['lifecycleLog'], isA<List<Object?>>());
+      expect((decoded['lifecycleLog'] as List), isEmpty);
+    });
+
     test('gestureLog defaults to an empty list when omitted (#699)', () {
       final blob = assembleFeedbackBundle(
         info: info,

--- a/native/test/services/resume_liveness_e2e_test.dart
+++ b/native/test/services/resume_liveness_e2e_test.dart
@@ -1,0 +1,368 @@
+// End-to-end resume liveness (#759).
+//
+// The #737 transport ping answers whenever SSH is up. But after deep Doze the
+// link can be a zombie that still ACKs at the transport layer while the remote
+// tmux/shell is FROZEN — a transport ping CANNOT catch an app-level freeze. The
+// reported bug: on unlock after a long time away the session sat FROZEN with a
+// green/connected dot until the user manually acted.
+//
+// The fix (owner CONFIRMED cause B): an END-TO-END liveness check on resume.
+// When the transport ping answers but the session was STALE going into resume
+// (no fresh remote bytes for a meaningful interval), the host sends a benign
+// channel NUDGE (a no-op resize that makes a live tmux/shell REDRAW → fresh
+// bytes) and waits a bounded window. A responsive shell answers with bytes →
+// stays connected; a frozen one produces nothing → softDisconnected → reconnect.
+//
+// Conservative gate: ONLY (stale-before AND no-bytes-after-nudge) reconnects.
+// A recently-active session, or one that answers the nudge, stays connected.
+//
+// Deterministic: real socket/network/wall-clock are all faked. A controllable
+// clock (`nowMs`) drives the staleness gate; the fake shell transport optionally
+// emits a redraw byte on resize to simulate a live vs frozen remote.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_shell.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// Silent socket so a real [SSHClient] can be constructed (non-null
+/// `controller.client`) without any network IO or pending timers.
+class _SilentSocket implements SSHSocket {
+  final _outbound = StreamController<List<int>>();
+  final _doneCompleter = Completer<void>();
+
+  @override
+  Stream<Uint8List> get stream => const Stream<Uint8List>.empty();
+
+  @override
+  StreamSink<List<int>> get sink => _outbound.sink;
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() async {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    await _outbound.close();
+    return done;
+  }
+
+  @override
+  void destroy() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+}
+
+/// Controller exposing a non-null [client] sentinel + an injectable liveness
+/// probe, with an inert `connect()` so the test owns the `connected` transition.
+class _DrivableController extends SshSessionController {
+  _DrivableController(
+    this._client, {
+    super.reconnectDelay,
+    super.maxReconnectAttempts,
+    super.livenessProbeOverride,
+    super.reconnectAttemptOverride,
+  });
+
+  final SSHClient _client;
+
+  @override
+  SSHClient? get client => _client;
+
+  @override
+  Future<void> connect(SshConnectParams params) async {
+    // Inert — tests drive `connected` via debugSetConnectedForTest.
+  }
+}
+
+/// Fake PTY transport. Optionally emits a "redraw" byte each time it is resized
+/// (a live tmux/shell answering the nudge). A frozen shell is constructed with
+/// [redrawOnResize] = false → the nudge produces nothing.
+class _FakeShellTransport implements SshShellTransport {
+  _FakeShellTransport({required this.redrawOnResize});
+
+  final bool redrawOnResize;
+  final _outCtrl = StreamController<Uint8List>.broadcast();
+  final _doneCompleter = Completer<void>();
+  int resizeCount = 0;
+
+  void emitByte() {
+    if (!_outCtrl.isClosed) _outCtrl.add(Uint8List.fromList(const [0x40]));
+  }
+
+  @override
+  Stream<Uint8List> get output => _outCtrl.stream;
+
+  @override
+  void send(Uint8List bytes) {}
+
+  @override
+  void resize(int cols, int rows, {int pixelWidth = 0, int pixelHeight = 0}) {
+    resizeCount += 1;
+    // A live remote redraws on SIGWINCH; the nudge toggles dims twice but one
+    // redraw byte is enough to prove responsiveness.
+    if (redrawOnResize) scheduleMicrotask(emitByte);
+  }
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  void close() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    if (!_outCtrl.isClosed) _outCtrl.close();
+  }
+}
+
+void main() {
+  setUp(clearConnectLog);
+
+  /// Build a hosted, connected session with a fake shell open. Returns the
+  /// controller + transport + a mutable clock so each test can drive staleness.
+  Future<
+    ({
+      SessionHost host,
+      InMemoryGatewayPair pair,
+      _DrivableController controller,
+      _FakeShellTransport transport,
+      void Function(int) setClock,
+      List<String> reconnects,
+    })
+  >
+  buildConnected({
+    required bool redrawOnResize,
+    required LivenessProbe probe,
+  }) async {
+    const sid = 'h:22:u:1';
+    final socket = _SilentSocket();
+    final sentinel = SSHClient(socket, username: 'u');
+
+    var clock = 0;
+    final reconnects = <String>[];
+
+    late _DrivableController controller;
+    _DrivableController factory() {
+      controller = _DrivableController(
+        sentinel,
+        reconnectDelay: Duration.zero,
+        maxReconnectAttempts: 3,
+        livenessProbeOverride: probe,
+        reconnectAttemptOverride: (p) async {
+          reconnects.add('reconnect:${p.host}');
+          return true;
+        },
+      );
+      return controller;
+    }
+
+    final transport = _FakeShellTransport(redrawOnResize: redrawOnResize);
+    Future<SshShellTransport?> opener(SSHClient c, int cols, int rows) async =>
+        transport;
+
+    final pair = InMemoryGatewayPair();
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: factory,
+      shellOpener: opener,
+      snapshotInterval: const Duration(hours: 1),
+      resumeProbeTimeout: const Duration(milliseconds: 30),
+      resumeStaleThreshold: const Duration(seconds: 20),
+      resumeNudgeWindow: const Duration(milliseconds: 60),
+      nowMs: () => clock,
+    );
+
+    pair.uiSide.send(
+      const SshConnectCommand(
+        sessionId: sid,
+        host: 'h',
+        port: 22,
+        username: 'u',
+        authJson: {'type': 'password', 'password': 'p'},
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    controller.debugSetConnectedForTest(_params);
+    // Let the state listener open the shell.
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(controller.data.state, SshSessionState.connected);
+
+    return (
+      host: host,
+      pair: pair,
+      controller: controller,
+      transport: transport,
+      setClock: (int v) => clock = v,
+      reconnects: reconnects,
+    );
+  }
+
+  void sendResume(InMemoryGatewayPair pair) {
+    pair.uiSide.send(
+      const SshResumeProbeCommand(sessionId: 'h:22:u:1').toJson(),
+    );
+  }
+
+  test(
+    'ping-alive + STALE + no-bytes-after-nudge → softDisconnected → reconnect '
+    '(#759)',
+    () async {
+      final ctx = await buildConnected(
+        redrawOnResize: false, // frozen shell — nudge produces nothing
+        probe: () async {}, // transport ping answers
+      );
+      addTearDown(() async {
+        await ctx.host.dispose();
+        await ctx.pair.dispose();
+      });
+
+      // Advance the clock past the stale threshold since the last (open-prompt)
+      // byte so the session is STALE going into resume.
+      ctx.setClock(60000);
+
+      final states = <SshSessionState>[];
+      final sub = ctx.controller.stream.listen((d) => states.add(d.state));
+      addTearDown(sub.cancel);
+
+      sendResume(ctx.pair);
+      for (var i = 0; i < 60; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        if (ctx.reconnects.isNotEmpty) break;
+      }
+
+      expect(
+        states,
+        contains(SshSessionState.softDisconnected),
+        reason: 'a transport-alive but frozen shell must soft-disconnect',
+      );
+      expect(
+        ctx.reconnects,
+        contains('reconnect:h'),
+        reason: 'the #759 stale-no-redraw case must reconnect',
+      );
+      expect(
+        lifecycleLogSnapshot().join('\n'),
+        contains('STALE(no-bytes-after-nudge) → reconnect'),
+        reason: 'the stale-reconnect outcome must be in the lifecycle ring',
+      );
+    },
+  );
+
+  test(
+    'ping-alive + STALE + fresh-bytes-after-nudge → stays connected (#759)',
+    () async {
+      final ctx = await buildConnected(
+        redrawOnResize: true, // live shell answers the nudge
+        probe: () async {},
+      );
+      addTearDown(() async {
+        await ctx.host.dispose();
+        await ctx.pair.dispose();
+      });
+
+      ctx.setClock(60000); // stale-before
+
+      sendResume(ctx.pair);
+      for (var i = 0; i < 30; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+
+      expect(
+        ctx.controller.data.state,
+        SshSessionState.connected,
+        reason: 'a live shell that redraws on the nudge must stay connected',
+      );
+      expect(ctx.reconnects, isEmpty);
+      expect(
+        lifecycleLogSnapshot().join('\n'),
+        contains('alive(fresh-bytes-after-nudge)'),
+      );
+    },
+  );
+
+  test('ping-FAILS → reconnect (#737 still works)', () async {
+    final ctx = await buildConnected(
+      redrawOnResize: false,
+      probe: () => Completer<void>().future, // dead half-open socket
+    );
+    addTearDown(() async {
+      await ctx.host.dispose();
+      await ctx.pair.dispose();
+    });
+
+    ctx.setClock(60000);
+    sendResume(ctx.pair);
+    for (var i = 0; i < 60; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      if (ctx.reconnects.isNotEmpty) break;
+    }
+
+    expect(
+      ctx.reconnects,
+      contains('reconnect:h'),
+      reason: 'a failed transport ping must still reconnect (#737)',
+    );
+    expect(
+      lifecycleLogSnapshot().join('\n'),
+      contains('ping-failed → reconnect'),
+    );
+  });
+
+  test(
+    'recently-active session (NOT stale) → no spurious reconnect, no nudge',
+    () async {
+      final ctx = await buildConnected(
+        redrawOnResize: false, // even a "silent" shell must NOT reconnect here
+        probe: () async {},
+      );
+      addTearDown(() async {
+        await ctx.host.dispose();
+        await ctx.pair.dispose();
+      });
+
+      // Ingest a fresh remote byte right before resume so lastRemoteByteAtMs is
+      // recent relative to the (unchanged) clock — NOT stale.
+      ctx.setClock(1000);
+      ctx.host.ingestOutputForTest(
+        'h:22:u:1',
+        Uint8List.fromList(const [0x41]),
+      );
+
+      final resizesBefore = ctx.transport.resizeCount;
+      sendResume(ctx.pair);
+      for (var i = 0; i < 30; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+
+      expect(
+        ctx.controller.data.state,
+        SshSessionState.connected,
+        reason: 'a recently-active session must not be reconnected on resume',
+      );
+      expect(ctx.reconnects, isEmpty);
+      expect(
+        ctx.transport.resizeCount,
+        resizesBefore,
+        reason: 'a non-stale session must NOT be nudged (conservative gate)',
+      );
+      expect(
+        lifecycleLogSnapshot().join('\n'),
+        contains('alive(recent-bytes)'),
+      );
+    },
+  );
+}

--- a/native/test/ssh/resume_liveness_probe_test.dart
+++ b/native/test/ssh/resume_liveness_probe_test.dart
@@ -178,6 +178,106 @@ void main() {
       },
     );
 
+    test('probeLiveness returns TRUE when the ping answers (#759)', () async {
+      final controller = SshSessionController(
+        reconnectDelay: Duration.zero,
+        livenessProbeOverride: () async {}, // answers immediately
+      );
+      controller.debugSetConnectedForTest(_params);
+
+      final alive = await controller.probeLiveness(
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      expect(
+        alive,
+        isTrue,
+        reason:
+            'a transport ping that answers reports alive so the host '
+            'can decide whether to escalate to the nudge check',
+      );
+      expect(controller.data.state, SshSessionState.connected);
+
+      await controller.dispose();
+    });
+
+    test('probeLiveness returns FALSE when the ping fails (#759)', () async {
+      final controller = SshSessionController(
+        reconnectDelay: Duration.zero,
+        maxReconnectAttempts: 3,
+        livenessProbeOverride: () => Completer<void>().future,
+        reconnectAttemptOverride: (_) async => true,
+      );
+      controller.debugSetConnectedForTest(_params);
+
+      final alive = await controller.probeLiveness(
+        timeout: const Duration(milliseconds: 10),
+      );
+
+      expect(
+        alive,
+        isFalse,
+        reason: 'a failed ping reports dead AND drives the reconnect path',
+      );
+
+      await controller.dispose();
+    });
+
+    test(
+      'softDisconnectForResume drives connected → softDisconnected → reconnect '
+      '(#759)',
+      () async {
+        final reconnects = <String>[];
+        final controller = SshSessionController(
+          reconnectDelay: Duration.zero,
+          maxReconnectAttempts: 3,
+          reconnectAttemptOverride: (p) async {
+            reconnects.add('reconnect:${p.host}');
+            return true;
+          },
+        );
+        controller.debugSetConnectedForTest(_params);
+
+        final states = <SshSessionState>[];
+        final sub = controller.stream.listen((d) => states.add(d.state));
+
+        controller.softDisconnectForResume();
+        for (var i = 0; i < 20; i++) {
+          await Future<void>.delayed(Duration.zero);
+          if (controller.data.state == SshSessionState.connected) break;
+        }
+
+        expect(states, contains(SshSessionState.softDisconnected));
+        expect(reconnects, contains('reconnect:example'));
+
+        await sub.cancel();
+        await controller.dispose();
+      },
+    );
+
+    test('softDisconnectForResume is a no-op when NOT connected', () async {
+      var reconnectCalled = false;
+      final controller = SshSessionController(
+        reconnectDelay: Duration.zero,
+        reconnectAttemptOverride: (_) async {
+          reconnectCalled = true;
+          return true;
+        },
+      );
+      // Never connected.
+      expect(controller.data.state, SshSessionState.idle);
+
+      controller.softDisconnectForResume();
+      for (var i = 0; i < 10; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(controller.data.state, SshSessionState.idle);
+      expect(reconnectCalled, isFalse);
+
+      await controller.dispose();
+    });
+
     test('a user-disconnected session is not probed/reconnected', () async {
       var reconnectCalled = false;
       final controller = SshSessionController(


### PR DESCRIPTION
Closes #759. Transport ping alone reported 'alive' for a frozen/zombie session on unlock. Now: ping-fail → reconnect (#737); ping-alive + stale 20s + shell-open → benign resize nudge, no fresh bytes in 2s → reconnect (catches frozen-shell), else stay. Conservatively gated so healthy/idle/nudge-answering sessions never false-reconnect. Dedicated lifecycle telemetry ring (survives the 200-event churn, bundled into feedback). 864 unit tests incl. 4 deterministic e2e cases. Emulator gate: 14/15 — ALL connect-critical green (connect/connect_key/reconnect_cycle/shell_bytes/hostkey); the 1 failure is multi_session_lifecycle, an environmental stale-state/slow-emulator overlay-timing flake in a UI #759 doesn't touch (re-confirmed via single re-run on a degraded emulator). Frozen-shell-on-unlock is device-only → owner validates.