### PR TITLE
fix(#764): wrapped-URL detection uses the terminal's authoritative rowWrap (no heuristic)

### DIFF
--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -2047,7 +2047,14 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         formatter.dispose();
       }
       final rows = text.split('\n');
-      next = detectGhosttyUrls(rows, cols: _cols);
+      // #764: join soft-wrapped rows by libghostty's AUTHORITATIVE per-row wrap
+      // flag (`controller.viewportRowWraps`), never the old row-width guess —
+      // so a wrapped URL spans exactly its rows and adjacent URLs don't bleed.
+      next = detectGhosttyUrls(
+        rows,
+        cols: _cols,
+        rowWraps: controller.viewportRowWraps,
+      );
     } catch (_) {
       // A formatter/FFI hiccup must not crash the session — drop highlights.
       next = const [];

--- a/native/lib/ui/ghostty_url_detector.dart
+++ b/native/lib/ui/ghostty_url_detector.dart
@@ -10,21 +10,24 @@
 // the view passes that text + grid metrics in.
 //
 // How the view reads the visible buffer text (the flterm API found, #726):
-// flterm 0.0.3's public `TerminalController` exposes `createFormatter(format:
-// plain, unwrap: false).format()`, which returns the ACTIVE SCREEN (the visible
+// the forked `TerminalController` exposes `createFormatter(format: plain,
+// unwrap: false).format()`, which returns the ACTIVE SCREEN (the visible
 // viewport — NOT scrollback) as plain text, one VISIBLE ROW per `\n`-separated
-// line. (The internal `terminal`/`GridRef`/`lineBoundaryAt` row API and the
-// libghostty `Selection`/`PointTag` types are NOT exported, so per-row grid
-// reads aren't available publicly — the row-joined formatter output is.) The
-// view splits that on `\n` to get the per-row strings this matcher consumes.
+// line. The view splits that on `\n` to get the per-row strings this matcher
+// consumes.
 //
-// SOFT-WRAP joining (like the PWA #570): a terminal soft-wraps a long logical
-// line across several viewport rows with NO break character. `unwrap: false`
-// keeps those as separate rows, so this matcher RE-JOINS them: a row whose
-// trimmed-right content fills the FULL grid width ([cols]) is treated as
-// soft-wrapped into the next row, and a URL spanning the wrap is detected on the
-// joined logical line, then mapped back to a multi-row cell range. This is the
-// standard width heuristic (flterm's own `rowWrap` flag is internal/unexported).
+// SOFT-WRAP joining — AUTHORITATIVE (#764, replacing the #751 width heuristic):
+// a terminal soft-wraps a long logical line across several viewport rows with NO
+// break character. `unwrap: false` keeps those as separate rows, so this matcher
+// RE-JOINS them — but it no longer GUESSES the wrap from row width. The fork now
+// surfaces libghostty's own per-row soft-wrap flag (`rowGetWrap`) as
+// `controller.viewportRowWraps`: element `[r]` is true iff visible row `r` is
+// soft-wrapped onto row `r + 1`. The view passes that list in as [rowWraps], and
+// this matcher joins row `r` into `r + 1` IFF `rowWraps[r]` is true. A URL
+// spanning a wrap is detected on the joined logical line, then mapped back to a
+// multi-row cell range that terminates at the URL's real end — so two adjacent
+// URLs yield two separate ranges and a full-width-but-NOT-wrapped row (the case
+// the old width heuristic mis-joined) is never merged.
 //
 // OUT OF SCOPE for Slice 1 (do NOT add here): long-press options menu / Open
 // (Slice 2), file paths (Slice 3), scrollback URLs. Visible buffer + URLs only.
@@ -130,47 +133,43 @@ class _LogicalLine {
   }
 }
 
-/// Whether viewport [row] (its right-trimmed text [content]) soft-wraps into the
-/// next row — i.e. its content fills the FULL grid width [cols] with no trailing
-/// blank (the standard width heuristic, since flterm's `rowWrap` flag isn't
-/// exported). A row shorter than [cols] ended naturally (a real line break).
-bool _rowSoftWraps(String content, int cols) =>
-    cols > 0 && content.length >= cols;
-
 /// Assemble visible [rows] (one string per viewport row, top-first) into
-/// logical lines, joining soft-wrapped rows by the [cols]-width heuristic.
+/// logical lines, joining soft-wrapped rows by the AUTHORITATIVE [rowWraps]
+/// flags (#764): row `i` continues onto row `i + 1` IFF `rowWraps[i]` is true.
 ///
-/// Each row is right-padded to [cols] when joined so a character offset in the
-/// joined text maps cleanly to (offset % cols, rows[offset ~/ cols]) — a URL
-/// that wraps mid-row then continues on the next row keeps contiguous cells.
-List<_LogicalLine> _logicalLines(List<String> rows, int cols) {
+/// Each joined row contributes its FULL [cols] cells (right-padded to [cols]) so
+/// a character offset in the joined text maps cleanly to
+/// `(offset % cols, rows[offset ~/ cols])` — a URL that wraps mid-row then
+/// continues on the next row keeps contiguous cells. The FINAL row of a logical
+/// line is NOT padded (its real length terminates the line), so a URL ending on
+/// that row maps to its true end column. A missing/short [rowWraps] entry is
+/// treated as `false` (no wrap) — never guessed from width.
+List<_LogicalLine> _logicalLines(
+  List<String> rows,
+  int cols,
+  List<bool> rowWraps,
+) {
+  bool wrapsInto(int i) => i >= 0 && i < rowWraps.length && rowWraps[i];
+
   final lines = <_LogicalLine>[];
   var i = 0;
   while (i < rows.length) {
     final memberRows = <int>[i];
     final buffer = StringBuffer();
-    // A soft-wrapped row contributes its FULL [cols] cells (right-padded) so the
-    // next row's text continues at a clean row boundary in the flat offset map.
-    var current = rows[i];
-    while (_rowSoftWraps(_trimRight(current), cols) && i + 1 < rows.length) {
-      buffer.write(_padRight(current, cols));
+    // While the AUTHORITATIVE flag says this row soft-wraps into the next, pad
+    // it to a full [cols] row and continue assembling the same logical line.
+    while (wrapsInto(i) && i + 1 < rows.length) {
+      buffer.write(_padRight(rows[i], cols));
       i++;
-      current = rows[i];
       memberRows.add(i);
     }
-    buffer.write(current);
+    // The terminating row contributes its real text (NOT padded) so the line
+    // ends exactly where the on-screen content ends.
+    buffer.write(rows[i]);
     lines.add(_LogicalLine(buffer.toString(), memberRows, cols));
     i++;
   }
   return lines;
-}
-
-String _trimRight(String s) {
-  var end = s.length;
-  while (end > 0 && (s.codeUnitAt(end - 1) == 0x20)) {
-    end--;
-  }
-  return s.substring(0, end);
 }
 
 String _padRight(String s, int width) {
@@ -185,23 +184,32 @@ String _normalizeUrl(String raw) {
   return 'https://$raw';
 }
 
-/// Detect http/https/www URLs in the VISIBLE viewport [rows] (#726).
+/// Detect http/https/www URLs in the VISIBLE viewport [rows] (#726, #764).
 ///
 /// [rows] is one string per visible viewport row (top-first), as read from
 /// `controller.createFormatter(format: plain, unwrap: false).format()` split on
-/// `\n`. [cols] is the grid width, used to (a) re-join soft-wrapped rows into a
-/// logical line and (b) map a URL's character offset back to viewport cells.
+/// `\n`. [cols] is the grid width, used to map a URL's character offset back to
+/// viewport cells.
+///
+/// [rowWraps] is the AUTHORITATIVE per-row soft-wrap flag list from
+/// `controller.viewportRowWraps` (libghostty's `rowGetWrap`): `rowWraps[r]` is
+/// true iff visible row `r` is soft-wrapped onto row `r + 1`. Soft-wrapped rows
+/// are joined into one logical line by THIS flag — never guessed from row width
+/// (the #751/#764 over/under-capture bug). When omitted (e.g. a caller that has
+/// no wrap info), every row is treated as a self-contained line (no joining).
 ///
 /// Returns one [GhosttyUrlMatch] per URL with its 0-based viewport cell range
-/// ([endCol] exclusive). A URL spanning a soft-wrap yields a multi-row range.
+/// ([endCol] exclusive). A URL spanning a soft-wrap yields a multi-row range
+/// terminating at the URL's real end; two adjacent URLs yield two ranges.
 /// Pure (no FFI / no widget) → unit-testable headless.
 List<GhosttyUrlMatch> detectGhosttyUrls(
   List<String> rows, {
   required int cols,
+  List<bool> rowWraps = const [],
 }) {
   if (cols <= 0 || rows.isEmpty) return const [];
   final matches = <GhosttyUrlMatch>[];
-  for (final line in _logicalLines(rows, cols)) {
+  for (final line in _logicalLines(rows, cols, rowWraps)) {
     for (final m in _kUrlPattern.allMatches(line.text)) {
       var raw = m.group(0)!;
       // Trim trailing sentence punctuation / unbalanced closers from the END.

--- a/native/test/ui/ghostty_url_detector_test.dart
+++ b/native/test/ui/ghostty_url_detector_test.dart
@@ -70,15 +70,19 @@ void main() {
     });
   });
 
-  group('detectGhosttyUrls — soft-wrap join (#726, #570 parity)', () {
+  group('detectGhosttyUrls — soft-wrap join (#726, #570 parity, #764)', () {
     test('a URL across a soft-wrap → joined into one multi-row range', () {
-      // cols=10: row 0 is FULL (10 chars, soft-wraps) and the URL continues on
-      // row 1. The matcher joins them and detects the whole URL across the wrap.
-      // row0: "x http://e"  (10 chars, fills the grid → soft-wrapped)
-      // row1: "x.co/p end"  (continues the URL: ".co/p" then " end")
+      // cols=10: row 0 soft-wraps (authoritative rowWraps[0]=true) and the URL
+      // continues on row 1. The matcher joins them and detects the whole URL.
+      // row0: "x http://e"  (soft-wrapped)
+      // row1: "x.co/p end"  (continues the URL: "x.co/p" then " end")
       const row0 = 'x http://e';
       const row1 = 'x.co/p end';
-      final matches = detectGhosttyUrls([row0, row1], cols: 10);
+      final matches = detectGhosttyUrls(
+        [row0, row1],
+        cols: 10,
+        rowWraps: const [true, false],
+      );
       expect(matches, hasLength(1));
       final m = matches.single;
       expect(m.url, 'http://ex.co/p');
@@ -91,18 +95,22 @@ void main() {
       expect(m.endCol, 6);
     });
 
-    test('a full row that ends a natural line is NOT joined to the next', () {
-      // row0 is full width BUT row1 starts a brand-new logical line; the width
-      // heuristic still joins (no rowWrap flag available) — documented limit.
-      // Here we assert the URL on row1 alone is detected with the joined offset.
-      const row0 = '0123456789'; // 10 chars, full → treated as wrapped
+    test('a full-width row that is NOT wrapped is NOT joined (#764 fix)', () {
+      // row0 exactly fills cols=10 BUT libghostty reports rowWrap=false: row1
+      // starts a brand-new logical line. The OLD width heuristic wrongly joined
+      // them (over-capture); the authoritative flag keeps them separate, so the
+      // URL on row1 is detected on row1 with its real column.
+      const row0 = '0123456789'; // 10 chars, full but NOT a soft-wrap
       const row1 = 'go https://z.io';
-      final matches = detectGhosttyUrls([row0, row1], cols: 10);
+      final matches = detectGhosttyUrls(
+        [row0, row1],
+        cols: 10,
+        rowWraps: const [false, false],
+      );
       expect(matches, hasLength(1));
       final m = matches.single;
       expect(m.url, 'https://z.io');
-      // Joined text = row0(10) + row1; "https://z.io" starts at joined offset
-      // 10 + 3 = 13 → row 1, col 3.
+      // NOT joined → the URL starts on row 1 at its true column (after "go ").
       expect(m.startRow, 1);
       expect(m.startCol, 3);
     });

--- a/native/test/ui/ghostty_url_wrap_test.dart
+++ b/native/test/ui/ghostty_url_wrap_test.dart
@@ -1,14 +1,17 @@
-// #751 — wrapped URL must highlight/detect BOTH rows.
+// #751 / #764 — wrapped URL must highlight/detect BOTH rows, and ONLY its rows.
 //
 // `detectGhosttyUrls` reads per-VISIBLE-ROW strings (flterm's `unwrap:false`
-// formatter, one row per `\n`) and must JOIN soft-wrapped rows (a row exactly
-// `cols` wide with no soft break continues onto the next), run the URL regex on
-// the joined logical line, then map each match back to per-(row,startCol,endCol)
-// ranges spanning the wrapped rows — so a URL wrapping row N→N+1 yields a match
-// covering BOTH rows, and the hit-test resolves a tap on EITHER half.
+// formatter, one row per `\n`) AND the AUTHORITATIVE per-row soft-wrap flags
+// (`controller.viewportRowWraps`, libghostty's `rowGetWrap`). It joins row N
+// into N+1 IFF `rowWraps[N]` is true — never guessed from row width. It runs the
+// URL regex on the joined logical line, then maps each match back to
+// per-(row,startCol,endCol) ranges spanning exactly the wrapped rows — so a URL
+// wrapping row N→N+1 yields a match covering BOTH rows, the hit-test resolves a
+// tap on EITHER half, and a full-width row that is NOT wrapped is never joined.
 //
-// Don't OVER-join: a non-full row (or a full row whose trailing cell is a space)
-// ended naturally and does NOT continue onto the next row.
+// #764 is the robust replacement for #751's width heuristic: a row that exactly
+// fills `cols` but is NOT a soft-wrap (rowWrap=false) must NOT join the next row
+// (the case the old `row.length >= cols` guess got wrong → over-capture).
 //
 // Pure matcher (no FFI / no flterm widget) → unit-testable headless. The owner
 // device-validates the rendered underline; this gates the join + range math.
@@ -17,10 +20,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/ui/ghostty_url_detector.dart';
 
 void main() {
-  group('detectGhosttyUrls — wrapped URL spans BOTH rows (#751)', () {
+  group('detectGhosttyUrls — wrapped URL spans BOTH rows (#751/#764)', () {
     test('single-row URL is unchanged (no spurious wrap)', () {
       const row = 'open https://example.com/path here';
-      final matches = detectGhosttyUrls([row], cols: 80);
+      final matches = detectGhosttyUrls(
+        [row],
+        cols: 80,
+        rowWraps: const [false],
+      );
       expect(matches, hasLength(1));
       final m = matches.single;
       expect(m.url, 'https://example.com/path');
@@ -30,15 +37,19 @@ void main() {
       expect(m.endCol, 'open '.length + 'https://example.com/path'.length);
     });
 
-    test('URL wrapping row N→N+1 (full-width row N) covers BOTH rows', () {
-      // cols=20. Row 0 is EXACTLY 20 chars (full-width → soft-wrapped); the URL
-      // begins on row 0 and continues onto row 1.
-      //   row0: "go https://example." (length must be 20 — full)
-      //   row1: "com/p done"
-      const row0 = 'go https://example.c'; // 20 chars, full → wraps
+    test('URL wrapping row N→N+1 (rowWraps[N]=true) covers BOTH rows', () {
+      // cols=20. Row 0 soft-wraps (authoritative flag) and the URL continues on
+      // row 1. Row 0 is padded to cols=20 when joined.
+      //   row0: "go https://example.c" (rowWraps[0]=true → soft-wrapped)
+      //   row1: "om/p done"
+      const row0 = 'go https://example.c'; // 20 chars
       const row1 = 'om/p done';
       expect(row0.length, 20);
-      final matches = detectGhosttyUrls([row0, row1], cols: 20);
+      final matches = detectGhosttyUrls(
+        [row0, row1],
+        cols: 20,
+        rowWraps: const [true, false],
+      );
       expect(matches, hasLength(1));
       final m = matches.single;
       expect(m.url, 'https://example.com/p');
@@ -53,9 +64,13 @@ void main() {
     });
 
     test('hit-test resolves a tap on EITHER half of a wrapped URL', () {
-      const row0 = 'go https://example.c'; // 20 chars, full → wraps
+      const row0 = 'go https://example.c'; // 20 chars
       const row1 = 'om/p done';
-      final matches = detectGhosttyUrls([row0, row1], cols: 20);
+      final matches = detectGhosttyUrls(
+        [row0, row1],
+        cols: 20,
+        rowWraps: const [true, false],
+      );
       final m = matches.single;
       // A cell in the tail of row 0 (inside the URL) resolves.
       expect(ghosttyUrlAtCell(matches, col: 10, row: 0)?.url, m.url);
@@ -69,50 +84,82 @@ void main() {
       expect(ghosttyUrlAtCell(matches, col: 4, row: 1), isNull);
     });
 
-    test('URL at the end of a NON-full row (trailing space) is single-row', () {
-      // Row 0 has a trailing space → it ended naturally, NOT a soft-wrap, so the
-      // URL must NOT be joined with row 1 (don't over-join).
-      //   row0: "see https://a.io " (trailing space; length 17 < cols)
-      //   row1: "next line text"
-      const row0 = 'see https://a.io ';
-      const row1 = 'next line text';
-      final matches = detectGhosttyUrls([row0, row1], cols: 80);
+    test(
+      'URL on a row that does NOT wrap (rowWraps[N]=false) is single-row',
+      () {
+        // Row 0's authoritative wrap flag is false → it ended naturally, so the
+        // URL must NOT be joined with row 1 (don't over-join).
+        //   row0: "see https://a.io " (rowWraps[0]=false)
+        //   row1: "next line text"
+        const row0 = 'see https://a.io ';
+        const row1 = 'next line text';
+        final matches = detectGhosttyUrls(
+          [row0, row1],
+          cols: 80,
+          rowWraps: const [false, false],
+        );
+        expect(matches, hasLength(1));
+        final m = matches.single;
+        expect(m.url, 'https://a.io');
+        expect(m.startRow, 0);
+        expect(m.endRow, 0); // single row — NOT joined onto row 1
+        expect(m.startCol, 'see '.length);
+        expect(m.endCol, 'see '.length + 'https://a.io'.length);
+      },
+    );
+
+    test('a full-width row that is NOT wrapped is NOT joined (#764)', () {
+      // The #764 case the old width heuristic got WRONG: row 0 exactly fills
+      // `cols` (a line break padded to width) but libghostty reports rowWrap =
+      // FALSE. The authoritative flag must win → row 1 is a separate line.
+      const cols = 16;
+      const row0 = 'go https://a.io '; // EXACTLY 16 chars, fills the grid
+      expect(row0.length, cols);
+      final matches = detectGhosttyUrls(
+        [row0, 'X next'],
+        cols: cols,
+        rowWraps: const [false, false], // authoritative: row 0 did NOT wrap
+      );
       expect(matches, hasLength(1));
       final m = matches.single;
       expect(m.url, 'https://a.io');
       expect(m.startRow, 0);
-      expect(m.endRow, 0); // single row — NOT joined onto row 1
-      expect(m.startCol, 'see '.length);
-      expect(m.endCol, 'see '.length + 'https://a.io'.length);
+      expect(m.endRow, 0); // NOT joined — rowWrap=false despite full width
     });
 
-    test('a full row whose last cell is a SPACE is NOT a soft-wrap', () {
-      // Row 0 is exactly cols wide but its final cell is a blank — a real line
-      // break padded to width, NOT a soft-wrap. Must not join onto row 1.
+    test('a full-width row that IS wrapped joins (the inverse #764 case)', () {
+      // Same full-width row, but now libghostty reports rowWrap = TRUE: the URL
+      // really does continue onto row 1. Width alone could not tell these apart;
+      // the flag does.
       const cols = 16;
-      const row0 = 'see https://a.io '; // 17? trim → 16 content then space
-      // Build a row that is exactly cols long but ends in a space.
-      const padded = 'go https://a.io '; // 16 chars, last is a space
-      expect(padded.length, cols);
-      final matches = detectGhosttyUrls([padded, 'X next'], cols: cols);
+      const row0 = 'go https://ab.io'; // 16 chars, fills the grid, wraps
+      expect(row0.length, cols);
+      const row1 = '/p rest';
+      final matches = detectGhosttyUrls(
+        [row0, row1],
+        cols: cols,
+        rowWraps: const [true, false],
+      );
       expect(matches, hasLength(1));
       final m = matches.single;
-      expect(m.url, 'https://a.io');
-      expect(m.endRow, 0); // NOT joined — trailing space ended the row
-      // (row0 unused beyond constructing the realistic case)
-      expect(row0.isNotEmpty, isTrue);
+      expect(m.url, 'https://ab.io/p');
+      expect(m.startRow, 0);
+      expect(m.endRow, 1);
     });
 
     test('mixed: a plain single-row URL AND a wrapped URL each detected', () {
       const cols = 20;
-      // Row 0: a complete single-row URL (short, NOT full-width).
+      // Row 0: a complete single-row URL (does NOT wrap).
       const row0 = 'a http://one.test x';
-      // Row 1 full-width → wraps into row 2 carrying a second URL.
-      const row1 = 'then http://two.tes'; // length 19 < 20? make it 20
-      const row1full = 'then http://two.test'; // 20 chars, full → wraps
+      // Row 1 soft-wraps into row 2 carrying a second URL.
+      const row1 = 'then http://two.test'; // 20 chars, wraps
       const row2 = '/p end';
-      expect(row1full.length, 20);
-      final matches = detectGhosttyUrls([row0, row1full, row2], cols: cols);
+      expect(row1.length, 20);
+      final matches = detectGhosttyUrls(
+        [row0, row1, row2],
+        cols: cols,
+        rowWraps: const [false, true, false],
+      );
       expect(matches, hasLength(2));
       // First URL: single row 0.
       expect(matches[0].url, 'http://one.test');
@@ -122,8 +169,80 @@ void main() {
       expect(matches[1].url, 'http://two.test/p');
       expect(matches[1].startRow, 1);
       expect(matches[1].endRow, 2);
-      // row1 was a deliberately-too-short draft; keep the analyzer quiet.
-      expect(row1.isNotEmpty, isTrue);
+    });
+
+    test('the screenshot case: wrapped URL adjacent to shorter URLs (#764)', () {
+      // Reproduces the device report: a long .apk URL wraps across two rows,
+      // with shorter native.html URLs on the rows below. The OLD width heuristic
+      // over-captured — the wrapped URL's range bled into the adjacent URLs. The
+      // authoritative flags must give: ONE 2-row range for the long URL, and a
+      // SEPARATE single-row range for each shorter URL, no merge.
+      const cols = 40;
+      // Row 0 (40 chars) soft-wraps onto row 1 — one long URL.
+      const row0 = 'get https://mobissh.ts.net/native-2026060'; // 41? trim
+      // Keep row0 exactly cols wide:
+      const row0fix = 'get https://mobissh.ts.net/native-202606'; // 40 chars
+      expect(row0fix.length, cols);
+      const row1 = '05T001621.apk done';
+      // Row 2 and row 3 each hold a shorter, complete URL (no wrap).
+      const row2 = 'a https://mobissh.ts.net/native.html b';
+      const row3 = 'c https://mobissh.ts.net/native.html d';
+      final matches = detectGhosttyUrls(
+        [row0fix, row1, row2, row3],
+        cols: cols,
+        rowWraps: const [true, false, false, false],
+      );
+      expect(matches, hasLength(3));
+
+      // The long wrapped URL: spans rows 0→1, terminates at ".apk".
+      final wrapped = matches[0];
+      expect(wrapped.url, 'https://mobissh.ts.net/native-20260605T001621.apk');
+      expect(wrapped.startRow, 0);
+      expect(wrapped.endRow, 1);
+      // It must NOT bleed into row 2's URL.
+      expect(
+        ghosttyUrlAtCell(matches, col: 0, row: 2)?.url,
+        isNot(wrapped.url),
+      );
+
+      // The two shorter URLs: each its OWN single-row range.
+      expect(matches[1].url, 'https://mobissh.ts.net/native.html');
+      expect(matches[1].startRow, 2);
+      expect(matches[1].endRow, 2);
+      expect(matches[2].url, 'https://mobissh.ts.net/native.html');
+      expect(matches[2].startRow, 3);
+      expect(matches[2].endRow, 3);
+
+      // Hit-test: either half of the wrapped URL → the wrapped URL; a cell in
+      // the row-2 URL → that URL, not the wrapped one.
+      expect(ghosttyUrlAtCell(matches, col: 10, row: 0)?.url, wrapped.url);
+      expect(ghosttyUrlAtCell(matches, col: 3, row: 1)?.url, wrapped.url);
+      final row2Hit = ghosttyUrlAtCell(matches, col: 5, row: 2);
+      expect(row2Hit?.url, 'https://mobissh.ts.net/native.html');
+      expect(row2Hit?.startRow, 2);
+
+      expect(row0.isNotEmpty, isTrue); // keep the draft constant referenced
+    });
+
+    test('three-row wrap: URL spanning rows N, N+1, N+2', () {
+      const cols = 12;
+      const row0 = 'x https://ab'; // 12 chars, wraps
+      const row1 = 'cdefghijklmn'; // 12 chars, wraps
+      const row2 = '.io/p tail';
+      expect(row0.length, cols);
+      expect(row1.length, cols);
+      final matches = detectGhosttyUrls(
+        [row0, row1, row2],
+        cols: cols,
+        rowWraps: const [true, true, false],
+      );
+      expect(matches, hasLength(1));
+      final m = matches.single;
+      expect(m.url, 'https://abcdefghijklmn.io/p');
+      expect(m.startRow, 0);
+      expect(m.endRow, 2);
+      // Hit-test the interior (fully-covered) middle row.
+      expect(ghosttyUrlAtCell(matches, col: 5, row: 1)?.url, m.url);
     });
   });
 }

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
@@ -111,6 +111,22 @@ abstract class TerminalController extends ChangeNotifier
   /// last matching range in [highlights] wins.
   HighlightRange? highlightAt({required int row, required int col});
 
+  /// The AUTHORITATIVE per-visible-row soft-wrap flags for the active screen.
+  ///
+  /// Element `[r]` is `true` iff visible row `r` is soft-wrapped onto row
+  /// `r + 1` (a long logical line continued with no break character), as
+  /// reported by libghostty's `rowGetWrap` — the same source the selection
+  /// logic walks for logical-line boundaries. The list length equals the
+  /// viewport row count; the last element is always `false` (no row below to
+  /// wrap into).
+  ///
+  /// Callers pair this with the per-row text from
+  /// `createFormatter(unwrap: false)` to join soft-wrapped rows EXACTLY (no
+  /// width/trailing-pad guessing): join row `r` into `r + 1` iff
+  /// `viewportRowWraps[r]` is true. Used by the URL detector (#764) so a
+  /// wrapped URL spans precisely its rows and adjacent URLs never bleed.
+  List<bool> get viewportRowWraps;
+
   /// Terminal title set by the running program.
   String get title;
 

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -173,6 +173,22 @@ class TerminalControllerImpl extends TerminalController
   }
 
   @override
+  List<bool> get viewportRowWraps {
+    _renderState.update(terminal);
+    final rows = _renderState.rows;
+    if (rows <= 0) return const [];
+    final wraps = List<bool>.filled(rows, false);
+    // The bottom visible row can never soft-wrap into a row below the viewport,
+    // so leave its flag false and only probe rows above it.
+    for (var r = 0; r < rows - 1; r++) {
+      final ref = GridRef.at(terminal, col: 0, row: r);
+      wraps[r] = ref.rowWrap;
+      ref.dispose();
+    }
+    return wraps;
+  }
+
+  @override
   String get title => terminal.title;
 
   @override


### PR DESCRIPTION
Closes #764 (hardens #751). Surfaces controller.viewportRowWraps (libghostty rowGetWrap — the authoritative per-row soft-wrap flag flterm already uses for selection); detectGhosttyUrls joins soft-wrapped rows by that flag, deleting the width/trailing-pad heuristic. Each URL → its own precise multi-row range: wrapped URLs captured fully, adjacent URLs no longer bleed together. Key regression test: a full-width-but-NOT-wrapped line is no longer falsely joined (the old heuristic's bug). 870 unit tests. ui/ + additive flterm accessor (selection/highlight/OSC8/formatter untouched). On-ramp to OSC-8 (Slice 2). Owner device-validates.