### PR TITLE
fix(#766): forward FGS-isolate lifecycle telemetry to UI feedback bundle

### DIFF
--- a/native/lib/diagnostics/connect_trace.dart
+++ b/native/lib/diagnostics/connect_trace.dart
@@ -40,6 +40,21 @@ const int lifecycleLogCapacity = 80;
 final List<String> _ring = <String>[];
 final List<String> _lifecycleRing = <String>[];
 
+/// Optional sink invoked with every formatted lifecycle line as it is recorded
+/// by [clifecycle] (#766). The lifecycle ring is written ONLY in the
+/// foreground-task isolate, but the feedback bundle is assembled in the UI
+/// isolate — a SEPARATE per-isolate copy of [_lifecycleRing] the bundle reads
+/// is otherwise always empty (the #766 meta-bug: real device reports shipped
+/// with NO lifecycle log). The task isolate sets this forwarder (see
+/// `SessionHost`) so each lifecycle line is shipped across the UI↔task gateway
+/// to the UI isolate, where the gateway calls [recordLifecycleLine] to land it
+/// in the UI-side ring the bundle reads.
+///
+/// Null by default: pure diagnostics with NO IPC coupling. Only the task
+/// isolate's host arms it; clearing it (set to null) on host dispose detaches
+/// the forwarder.
+void Function(String line)? lifecycleForwarder;
+
 // Consecutive-duplicate suppression: when the same `[where] msg` repeats
 // back-to-back (e.g. keepalive `recv`/`send` pings), collapse it into the last
 // line as ` (×N)` instead of spamming a new line per occurrence — both in the
@@ -129,6 +144,43 @@ void clifecycle(String where, String msg) {
   _lastKey = null;
   _lastCount = 0;
   debugPrint('[CONNECT]$key');
+  _ring.add(line);
+  while (_ring.length > connectLogCapacity) {
+    _ring.removeAt(0);
+  }
+  _connectLog.value = List<String>.unmodifiable(_ring);
+
+  // Ship the formatted line across the isolate boundary if a forwarder is armed
+  // (#766). Defensive: a forwarder failure must never break telemetry capture.
+  final forward = lifecycleForwarder;
+  if (forward != null) {
+    try {
+      forward(line);
+    } catch (_) {
+      // Swallow — diagnostics must not throw into the lifecycle hot path.
+    }
+  }
+}
+
+/// Records an already-formatted lifecycle [line] (`HH:mm:ss.SSS [where] msg`)
+/// into the dedicated [lifecycleLog] ring AND the connect ring (#766).
+///
+/// Counterpart to [clifecycle] for lines that ORIGINATED in another isolate:
+/// the foreground-task isolate forwards each lifecycle line across the gateway,
+/// and the UI-side gateway calls this so the line lands in the UI isolate's
+/// ring — the one the feedback bundle reads. The line is stored verbatim (its
+/// original task-side timestamp preserved), and the forwarder is NOT re-invoked
+/// (no echo back across the boundary). Never collapsed into a preceding ×N run.
+void recordLifecycleLine(String line) {
+  _lifecycleRing.add(line);
+  while (_lifecycleRing.length > lifecycleLogCapacity) {
+    _lifecycleRing.removeAt(0);
+  }
+  _lifecycleLog.value = List<String>.unmodifiable(_lifecycleRing);
+
+  _lastKey = null;
+  _lastCount = 0;
+  debugPrint('[CONNECT]$line');
   _ring.add(line);
   while (_ring.length > connectLogCapacity) {
     _ring.removeAt(0);

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -69,6 +69,17 @@ class SessionHost {
        _nowMs = nowMs ?? (() => DateTime.now().millisecondsSinceEpoch) {
     _commandSub = _gateway.incoming.listen(_dispatch);
     _snapshotTimer = Timer.periodic(snapshotInterval, (_) => _pushSnapshots());
+    // #766: arm the lifecycle forwarder so every `clifecycle` line written in
+    // THIS (task) isolate is shipped across the gateway to the UI isolate, where
+    // it lands in the UI-side lifecycle ring the feedback bundle actually reads.
+    // Without this, the bundle (assembled UI-side) ships an EMPTY lifecycle log
+    // even though the task isolate recorded the probe outcomes — the meta-bug.
+    // Held in [_lifecycleForward] so dispose can detach exactly our closure.
+    _lifecycleForward = (line) {
+      if (_disposed) return;
+      _gateway.send(SshLifecycleEvent(line: line).toJson());
+    };
+    lifecycleForwarder = _lifecycleForward;
     ctrace('task.host', 'ctor: listening; sending SshTaskReadyEvent');
     // Announce readiness as the FIRST task → UI payload (#539). The host is the
     // component that actually consumes commands, so its existence is the true
@@ -121,6 +132,12 @@ class SessionHost {
   StreamSubscription<Map<String, dynamic>>? _commandSub;
   Timer? _snapshotTimer;
   bool _disposed = false;
+
+  /// The exact lifecycle-forwarder closure this host installed into the global
+  /// [lifecycleForwarder] (#766). Held so dispose detaches OUR closure only —
+  /// it won't clobber a forwarder a different host installed afterward (matters
+  /// for the desktop / in-process path where hosts share one isolate).
+  void Function(String line)? _lifecycleForward;
 
   final Map<String, _HostedSession> _sessions = {};
 
@@ -780,9 +797,20 @@ class SessionHost {
     _gateway.send(SshOutputEvent(sessionId: sessionId, bytes: bytes).toJson());
   }
 
+  /// Detach this host's lifecycle forwarder from the global hook (#766) — but
+  /// only if it is still ours (a later host in the same isolate may have armed
+  /// its own). Idempotent.
+  void _detachLifecycleForwarder() {
+    if (identical(lifecycleForwarder, _lifecycleForward)) {
+      lifecycleForwarder = null;
+    }
+    _lifecycleForward = null;
+  }
+
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
+    _detachLifecycleForwarder();
     _snapshotTimer?.cancel();
     _snapshotTimer = null;
     await _commandSub?.cancel();
@@ -801,6 +829,7 @@ class SessionHost {
   @visibleForTesting
   void disposeSyncForTest() {
     _disposed = true;
+    _detachLifecycleForwarder();
     _snapshotTimer?.cancel();
     _snapshotTimer = null;
     _commandSub?.cancel();

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -80,6 +80,16 @@ enum SshTaskEventKind {
   /// An SFTP operation failed (list or download). Carries the request id so
   /// the UI can match it to the in-flight op without tearing down the session.
   sftpError,
+
+  /// Task → UI: one HIGH-signal lifecycle telemetry line (#759/#766). The
+  /// `clifecycle` writers (resume-liveness probe OUTCOME, reconnect decisions)
+  /// run in the foreground-task isolate, whose `lifecycleLog` ring is a SEPARATE
+  /// per-isolate copy the UI never reads. The feedback bundle is assembled in
+  /// the UI isolate, so without forwarding the lifecycle ring it ships EMPTY
+  /// (#766 meta-bug). This event carries each lifecycle line across the boundary
+  /// so the UI-side ring — the one the bundle reads — actually contains them.
+  /// Task-global, so [sessionId] is the empty sentinel (mirrors ready).
+  lifecycle,
 }
 
 /// One remote filesystem entry surfaced to the file browser (#559). Kept small
@@ -528,6 +538,8 @@ sealed class SshTaskEvent {
           requestId: json['requestId'] as String,
           message: json['message'] as String,
         );
+      case SshTaskEventKind.lifecycle:
+        return SshLifecycleEvent(line: json['line'] as String);
     }
   }
 }
@@ -714,6 +726,43 @@ class SshShellReadyEvent extends SshTaskEvent {
 
   @override
   Map<String, dynamic> toJson() => {'kind': kind.name, 'sessionId': sessionId};
+}
+
+/// Task → UI: one already-formatted lifecycle telemetry line (#759/#766).
+///
+/// The lifecycle ring (`clifecycle` / `lifecycleLog`) is written ONLY in the
+/// foreground-task isolate (resume-liveness probe outcomes, reconnect
+/// decisions). Its ring is a per-isolate static, so the copy the UI-side
+/// feedback bundle reads is otherwise EMPTY — the #766 meta-bug where every
+/// real device report shipped with NO lifecycle log. The task forwards each
+/// `clifecycle` line as one of these events; the UI-side gateway records it
+/// into the UI isolate's lifecycle ring so the bundle (assembled in the UI
+/// isolate) actually carries it.
+///
+/// [line] is the fully-formatted ring line (`HH:mm:ss.SSS [where] msg`). It is
+/// recorded verbatim on the UI side rather than re-timestamped so the original
+/// task-side timestamp is preserved. Task-global, so [sessionId] is the empty
+/// sentinel (mirrors [SshTaskReadyEvent]).
+///
+/// [SYNC] single-codebase wire contract (both isolates are this Dart module);
+/// the round-trip test in `task_ipc_test.dart` is the sync check. Keep the
+/// forwarder (SessionHost) and the UI-side recorder (FlutterForegroundSshGateway)
+/// in step.
+class SshLifecycleEvent extends SshTaskEvent {
+  const SshLifecycleEvent({required this.line}) : super('');
+
+  /// The fully-formatted lifecycle ring line, preserved verbatim.
+  final String line;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.lifecycle;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'line': line,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/native/lib/services/task_ssh_gateway.dart
+++ b/native/lib/services/task_ssh_gateway.dart
@@ -389,6 +389,19 @@ class FlutterForegroundSshGateway implements TaskSshGateway {
       ctrace('ui.gw', 'recv: uncoercible payload ${data.runtimeType}');
       return;
     }
+    // #766: lifecycle telemetry forwarded from the task isolate. Record the
+    // (already-formatted) line into THIS (UI) isolate's lifecycle ring — the
+    // copy the feedback bundle reads — then return. It is NOT a session event,
+    // so it never reaches the proxy/_incoming. Intercepting here (where every
+    // inbound payload passes, session-agnostic) avoids the per-session proxy's
+    // sessionId filter dropping a task-global line. A lifecycle line must also
+    // count as proof-of-life: it can't flip _ready (only the ready handshake /
+    // a real event does that), but if we're already ready it lands cleanly.
+    if (map['kind'] == SshTaskEventKind.lifecycle.name) {
+      final line = map['line'];
+      if (line is String) recordLifecycleLine(line);
+      return;
+    }
     // First inbound payload proves the task isolate is alive and listening:
     // flush anything we buffered during spin-up, in order (#539).
     if (!_ready) {

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -320,6 +320,11 @@ class SshSessionProxy {
         // It only reaches here for the matching (empty) sessionId, which no
         // real proxy uses, but handle it for switch exhaustiveness.
         break;
+      case SshLifecycleEvent():
+        // Task-global lifecycle telemetry (#766). The UI-side gateway already
+        // recorded it into the lifecycle ring before _incoming, so a per-session
+        // proxy has nothing to do — handle it for switch exhaustiveness only.
+        break;
       case SftpListingEvent():
       case SftpDownloadChunkEvent():
       case SftpDownloadDoneEvent():

--- a/native/test/diagnostics/connect_trace_test.dart
+++ b/native/test/diagnostics/connect_trace_test.dart
@@ -186,4 +186,90 @@ void main() {
       expect(lifecycleLog.value, isEmpty);
     });
   });
+
+  group('lifecycle forwarder (#766)', () {
+    tearDown(() => lifecycleForwarder = null);
+
+    test('clifecycle invokes the forwarder with the formatted line', () {
+      final forwarded = <String>[];
+      lifecycleForwarder = forwarded.add;
+
+      clifecycle('task.host', 'resume-liveness: STALE → reconnect');
+
+      expect(forwarded, hasLength(1));
+      // The forwarded line is the SAME formatted line stored in the ring, so the
+      // task-side timestamp is preserved across the boundary.
+      expect(forwarded.single, lifecycleLog.value.single);
+      expect(forwarded.single, contains('[task.host]'));
+      expect(forwarded.single, contains('STALE → reconnect'));
+    });
+
+    test('ctrace does NOT invoke the lifecycle forwarder', () {
+      final forwarded = <String>[];
+      lifecycleForwarder = forwarded.add;
+
+      ctrace('ui.gw', 'recv state');
+
+      expect(
+        forwarded,
+        isEmpty,
+        reason: 'only lifecycle events forward, not ordinary connect traces',
+      );
+    });
+
+    test('a throwing forwarder never breaks clifecycle recording', () {
+      lifecycleForwarder = (_) => throw StateError('boom');
+
+      // Must not throw, and must still record locally.
+      clifecycle('task.host', 'resume-liveness: alive(recent-bytes)');
+
+      expect(
+        lifecycleLog.value.single,
+        contains('alive(recent-bytes)'),
+        reason: 'a forwarder failure is swallowed; local capture is preserved',
+      );
+    });
+
+    test(
+      'recordLifecycleLine lands a pre-formatted line in BOTH rings verbatim',
+      () {
+        const line = '12:34:56.789 [task.ssh] probeLiveness: ping-failed';
+
+        recordLifecycleLine(line);
+
+        // Stored verbatim — NOT re-timestamped — so the originating isolate's
+        // timestamp survives.
+        expect(lifecycleLogSnapshot().single, line);
+        expect(connectLog.value.single, line);
+      },
+    );
+
+    test('recordLifecycleLine does NOT re-invoke the forwarder (no echo)', () {
+      final forwarded = <String>[];
+      lifecycleForwarder = forwarded.add;
+
+      recordLifecycleLine('12:00:00.000 [task.host] alive');
+
+      expect(
+        forwarded,
+        isEmpty,
+        reason:
+            'a forwarded line recorded on the receiving side must not bounce '
+            'back across the boundary',
+      );
+    });
+
+    test('recordLifecycleLine survives connect-ring churn', () {
+      recordLifecycleLine('09:00:00.000 [task.host] STALE → reconnect');
+      for (var i = 0; i < connectLogCapacity + 50; i++) {
+        ctrace('ui.gw', 'recv $i');
+      }
+
+      expect(
+        lifecycleLogSnapshot().join('\n'),
+        contains('STALE → reconnect'),
+        reason: 'the dedicated ring outlives the connect-ring churn',
+      );
+    });
+  });
 }

--- a/native/test/diagnostics/lifecycle_telemetry_landing_test.dart
+++ b/native/test/diagnostics/lifecycle_telemetry_landing_test.dart
@@ -1,0 +1,232 @@
+// End-to-end: lifecycle telemetry must reach the UI-isolate feedback bundle
+// (#766 chunk 1).
+//
+// The meta-bug: `clifecycle` lifecycle lines (resume-liveness probe OUTCOME,
+// reconnect decisions) are written ONLY in the foreground-task isolate. Its
+// `lifecycleLog` ring is a per-isolate static. The feedback bundle is assembled
+// in the UI isolate, reading the UI isolate's (separate, EMPTY) copy — so every
+// real device report shipped with NO lifecycle log even though the task isolate
+// recorded the events.
+//
+// The fix forwards each lifecycle line across the UI↔task gateway:
+//   task: SessionHost arms `lifecycleForwarder` → sends `SshLifecycleEvent`.
+//   UI:   FlutterForegroundSshGateway._onData → `recordLifecycleLine`.
+//
+// These tests prove each link AND the assembled bundle carries the line. They
+// use the real production gateways over a StubFftTransport pair (the same seam
+// task_isolate_handover_test uses) so the FFT IPC boundary is faithfully
+// exercised without binding to platform method channels.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/diagnostics/crash_environment.dart';
+import 'package:mobissh/diagnostics/feedback_bundle.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) async {
+      throw Exception('stub socket opener — bypass real connect');
+    },
+  );
+}
+
+Future<void> _drain() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(const Duration(milliseconds: 10));
+}
+
+void main() {
+  setUp(() {
+    clearConnectLog();
+    lifecycleForwarder = null;
+  });
+  tearDown(() {
+    clearConnectLog();
+    lifecycleForwarder = null;
+  });
+
+  test(
+    'constructing a SessionHost arms the global lifecycle forwarder (prod path)',
+    () {
+      final pair = InMemoryGatewayPair();
+      addTearDown(pair.dispose);
+
+      expect(
+        lifecycleForwarder,
+        isNull,
+        reason: 'no host yet → no forwarder',
+      );
+
+      final host = SessionHost(gateway: pair.taskSide);
+      addTearDown(host.disposeSyncForTest);
+
+      expect(
+        lifecycleForwarder,
+        isNotNull,
+        reason:
+            'the host arms the forwarder in its ctor — this is the PROD path, '
+            'not a test-only seam (#766)',
+      );
+    },
+  );
+
+  test('disposing the SessionHost detaches its forwarder', () {
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+
+    final host = SessionHost(gateway: pair.taskSide);
+    expect(lifecycleForwarder, isNotNull);
+
+    host.disposeSyncForTest();
+    expect(
+      lifecycleForwarder,
+      isNull,
+      reason: 'dispose must detach the forwarder it installed',
+    );
+  });
+
+  test(
+    'a clifecycle on the task side is forwarded as an SshLifecycleEvent over '
+    'the task gateway transport',
+    () async {
+      final taskTransport = _CapturingTaskTransport();
+      final taskGateway = TaskSideForegroundGateway(transport: taskTransport);
+      addTearDown(taskGateway.dispose);
+
+      final host = SessionHost(
+        gateway: taskGateway,
+        controllerFactory: _stubControllerFactory,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(host.disposeSyncForTest);
+      // Drop the ctor's SshTaskReadyEvent so only the lifecycle send remains.
+      taskTransport.sent.clear();
+
+      // Now a lifecycle event written "in the task isolate".
+      clifecycle('task.host', 'resume-liveness: STALE → reconnect');
+      await _drain();
+
+      final lifecycleMsgs = taskTransport.sent
+          .whereType<Map>()
+          .map((m) => m.map((k, v) => MapEntry(k.toString(), v)))
+          .where((m) => m['kind'] == SshTaskEventKind.lifecycle.name)
+          .toList();
+      expect(
+        lifecycleMsgs,
+        isNotEmpty,
+        reason: 'the lifecycle line must be forwarded across the boundary',
+      );
+      expect(lifecycleMsgs.last['line'], contains('STALE → reconnect'));
+    },
+  );
+
+  test(
+    'the UI-side gateway records a forwarded SshLifecycleEvent into the '
+    'lifecycle ring the feedback bundle reads',
+    () {
+      // Drive the UI gateway directly with a forwarded event (bypassing the
+      // shared static a clifecycle would also touch in-process), proving the
+      // RECEIVE side is what lands the line in the UI ring.
+      final transport = _CapturingUiTransport();
+      final uiGateway = FlutterForegroundSshGateway(transport: transport);
+      addTearDown(uiGateway.dispose);
+
+      expect(lifecycleLogSnapshot(), isEmpty);
+
+      const line = '08:00:00.000 [task.ssh] probeLiveness: ping-failed';
+      transport.deliver(
+        const SshLifecycleEvent(line: line).toJson(),
+      );
+
+      expect(
+        lifecycleLogSnapshot(),
+        contains(line),
+        reason:
+            'the UI gateway must record the forwarded line into the UI '
+            'isolate lifecycle ring',
+      );
+
+      // And the bundle assembled from that ring carries it.
+      final bundle = assembleFeedbackBundle(
+        info: const CrashEnvironmentInfo(
+          appVersion: '1.0.0',
+          buildSha: 'deadbee',
+          platformVersion: 'Android 14',
+          deviceModel: 'Pixel',
+        ),
+        connectLog: connectLogSnapshot(),
+        lifecycleLog: lifecycleLogSnapshot(),
+      );
+      expect(
+        bundle,
+        contains('probeLiveness: ping-failed'),
+        reason: 'the feedback bundle must now include the lifecycle log (#766)',
+      );
+    },
+  );
+
+  test(
+    'a forwarded lifecycle event does NOT flip the gateway to ready or leak '
+    'to session consumers',
+    () {
+      final transport = _CapturingUiTransport();
+      final uiGateway = FlutterForegroundSshGateway(transport: transport);
+      addTearDown(uiGateway.dispose);
+
+      final incoming = <Map<String, dynamic>>[];
+      uiGateway.incoming.listen(incoming.add);
+
+      transport.deliver(
+        const SshLifecycleEvent(line: '00:00:00.000 [task.host] x').toJson(),
+      );
+
+      expect(
+        uiGateway.isReady,
+        isFalse,
+        reason:
+            'telemetry must not be mistaken for the readiness handshake — only '
+            'a real task event flips ready',
+      );
+      expect(
+        incoming,
+        isEmpty,
+        reason: 'lifecycle telemetry is intercepted, never a session event',
+      );
+    },
+  );
+}
+
+/// Minimal UI-side FFT transport stub: records nothing outbound, lets the test
+/// push inbound payloads via [deliver].
+class _CapturingUiTransport implements FftTransport {
+  void Function(Object data)? _onData;
+
+  void deliver(Object data) => _onData?.call(data);
+
+  @override
+  void send(Object payload) {}
+
+  @override
+  void Function() registerReceiver(void Function(Object data) onData) {
+    _onData = onData;
+    return () => _onData = null;
+  }
+}
+
+/// Minimal task-side transport stub: records every outbound payload (what the
+/// task isolate would push toward the UI) so the test can assert the lifecycle
+/// line crossed the boundary. Extends [TaskSideFftTransport] (the concrete type
+/// [TaskSideForegroundGateway] requires) and overrides [send] to capture rather
+/// than hit FFT statics.
+class _CapturingTaskTransport extends TaskSideFftTransport {
+  final List<Object> sent = <Object>[];
+
+  @override
+  void send(Object payload) => sent.add(payload);
+}

--- a/native/test/services/task_ipc_test.dart
+++ b/native/test/services/task_ipc_test.dart
@@ -133,6 +133,16 @@ void main() {
       final restored = SshTaskEvent.fromJson(ev.toJson()) as SshOutputEvent;
       expect(restored.bytes, bytes);
     });
+
+    test('SshLifecycleEvent preserves the formatted line verbatim (#766)', () {
+      const line = '12:34:56.789 [task.host] resume-liveness: STALE → reconnect';
+      const ev = SshLifecycleEvent(line: line);
+      final restored = SshTaskEvent.fromJson(ev.toJson()) as SshLifecycleEvent;
+      expect(restored.line, line);
+      // Task-global: empty sentinel sessionId (mirrors SshTaskReadyEvent).
+      expect(restored.sessionId, '');
+      expect(restored.kind, SshTaskEventKind.lifecycle);
+    });
   });
 
   group('SessionHost.encodeAuth', () {


### PR DESCRIPTION
## #766 chunk 1: lifecycle telemetry landing (telemetry-landing ONLY)

Fixes the meta-bug where the #759 lifecycle ring never reached production feedback uploads, leaving every resume/keepalive/disconnect fix blind.

### Root cause
The `clifecycle` lifecycle ring (`lifecycleLog`) is written ONLY in the foreground-task isolate (`session_host.dart` `task.host`, `ssh_session.dart` `task.ssh`). On Android prod the `SessionHost` lives in that isolate. The ring is a top-level static — **per-isolate in Dart**. The feedback bundle is assembled in the **UI isolate** (`feedback_overlay.dart`), reading the UI isolate's **separate, always-empty** copy of the ring. So real device reports shipped with NO lifecycle log. (connect-log lands because the UI emits `ctrace('ui.*')` UI-side; lifecycle events had no UI-side writer.)

This was candidate **(c)** from the issue — empty because nothing writes to the UI-isolate copy — not a bundle-collection omission (the bundle/payload already handle `lifecycleLog` fully, from #759).

### Fix (additive, on the existing diagnostics + gateway seam)
- `session_messages.dart`: new task-global `SshLifecycleEvent` (carries the formatted line verbatim).
- `connect_trace.dart`: settable `lifecycleForwarder` invoked by `clifecycle`; `recordLifecycleLine(line)` appends a pre-formatted line into the ring (UI receiver). Forwarder null by default (no IPC coupling in pure diagnostics); a throwing forwarder never breaks capture.
- `session_host.dart`: arms the forwarder in its ctor (sends `SshLifecycleEvent` over the gateway), detaches its own closure on dispose.
- `task_ssh_gateway.dart`: UI-side `FlutterForegroundSshGateway._onData` intercepts lifecycle payloads → `recordLifecycleLine`, session-agnostic (avoids the per-session proxy sid filter); never flips `_ready`, never leaks to session consumers.

### Tests (TDD)
- `connect_trace_test.dart`: forwarder invoked with the formatted line; `ctrace` does not forward; throwing forwarder swallowed + local capture preserved; `recordLifecycleLine` lands verbatim in both rings, no echo, survives ring churn.
- `task_ipc_test.dart`: `SshLifecycleEvent` round-trips.
- `lifecycle_telemetry_landing_test.dart` (new, **end-to-end**): constructing a `SessionHost` arms the forwarder (prod path, not a test-only seam) and dispose detaches it; a task-side `clifecycle` is forwarded as an `SshLifecycleEvent` over the gateway transport; the UI-side gateway records a forwarded event into the lifecycle ring **and the assembled feedback bundle includes it**; a forwarded event does not flip `_ready` or leak to session consumers.

Existing #759/#699 diagnostics + bundle tests stay green.

### Gate
`scripts/native-fast-gate.sh` PASSED (882 tests, analyze clean).

### Scope / caveat
Telemetry-landing ONLY — NOT the indicator / manual-reconnect / liveness-extension parts of #766 (separate follow-up chunks).

⚠️ Touches the IPC envelope (`SshLifecycleEvent`) + the UI↔task gateway — **#589-sensitive** (services/state/ssh). The change is additive telemetry with no session state-machine change, but the orchestrator should run the **emulator integration suite** before merge per `.claude/rules/testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)