### PR TITLE
feat(#767): OSC-8 hyperlink detection as PRIMARY exact URL source (Slice B)

### DIFF
--- a/native/integration_test/ghostty_osc8_hyperlink_test.dart
+++ b/native/integration_test/ghostty_osc8_hyperlink_test.dart
@@ -1,0 +1,189 @@
+// On-emulator GHOSTTY OSC-8 hyperlink detection smoke (#767 Slice B).
+//
+// #767 Slice B makes the OSC-8 HYPERLINK the PRIMARY, exact URL source. Many
+// tools (Claude CLI, gh, …) emit OSC-8 hyperlinks — `ESC]8;;<FULL-URI>ESC\
+// <visible text>ESC]8;;ESC\` — and libghostty attaches the FULL exact URI to
+// EVERY cell of the link, including the wrapped continuation rows. Reading the
+// URI off the cells (`GridRef.hyperlinkUri` → `CellReader.hyperlinkAt` → the
+// `osc8` scanner source) yields an EXACT match that spans all wrapped rows by
+// construction — no regex, no wrap/width heuristic — and copy/open get the real
+// full URL even when the VISIBLE text wraps and is itself only a partial URL.
+//
+// This validates the device-class behaviour a headless test cannot: print an
+// OSC-8 hyperlink whose VISIBLE text WRAPS across rows but whose URI is the full
+// link, then assert the controller exposes ONE `osc8` anchor whose payload is
+// the EXACT full URI spanning the wrapped rows, and `matchAt` on the
+// CONTINUATION row resolves that same full URI (the copy-partial bug fixed).
+//
+// The ghostty backend is the DEFAULT (#727), so no backend override is needed.
+// GhosttyTerminalView.debugControllers (test-only) exposes the live controller.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/ghostty_osc8_hyperlink_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'an OSC-8 hyperlink whose visible text wraps is detected as ONE osc8 anchor '
+    'carrying the EXACT full URI spanning the wrapped rows (#767 Slice B)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      // Ghostty is the default backend (#727) — no override needed.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      // Reach the terminal screen, accepting the host-key prompt if shown.
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      // The ghostty view exposes its controller for the test.
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller for session');
+
+      // Wait for a live shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // The EXACT full URI behind the hyperlink. The VISIBLE text is long enough
+      // to WRAP across terminal rows, but the URI stays the full link on every
+      // cell — so the osc8 source must recover the full URI, not the (wrapping)
+      // visible text. The visible text is deliberately a long path so it spans
+      // multiple rows on the emulator's grid width.
+      const fullUri =
+          'https://mobissh.example.ts.net/mobissh-native-20260605T131127.apk';
+      const visible =
+          'short visible text that is intentionally long enough to wrap across '
+          'several terminal rows on a typical phone grid width abcdefghijklmnop';
+
+      // Emit an OSC-8 hyperlink: ESC]8;;<URI>ESC\<VISIBLE>ESC]8;;ESC\ . We send a
+      // shell `printf` whose backslash-escapes the shell expands into the real
+      // ESC bytes. (Dart string: each '\\' is one literal backslash for printf.)
+      final printfCmd =
+          "printf '\\033]8;;$fullUri\\033\\\\$visible\\033]8;;\\033\\\\\\n'\n";
+      entry.proxy.sendInput(Uint8List.fromList(utf8.encode(printfCmd)));
+
+      // Wait until the terminal detects the hyperlink as an `osc8` anchor whose
+      // payload is the EXACT full URI (NOT the wrapping visible text).
+      bool detected() => controller!.anchors.any(
+            (a) => a.patternId == 'osc8' && a.payload == fullUri,
+          );
+      for (var i = 0; i < 50 && !detected(); i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(
+        detected(),
+        isTrue,
+        reason:
+            'OSC-8 hyperlink was not detected as an osc8 anchor carrying the '
+            'exact full URI (#767 Slice B)',
+      );
+
+      // EXACTLY ONE anchor carries the full URI (the de-dup suppressed any
+      // partial regex `url` match over the same hyperlinked cells, so there is
+      // no second partial bubble beside it).
+      final osc8Anchors = controller!.anchors
+          .where((a) => a.payload == fullUri)
+          .toList();
+      expect(
+        osc8Anchors,
+        hasLength(1),
+        reason: 'the hyperlink yielded more than one anchor (de-dup failed)',
+      );
+      final anchor = osc8Anchors.single;
+      expect(anchor.patternId, 'osc8');
+
+      // The anchor SPANS the wrapped rows: more than one per-row range, since the
+      // long visible text wraps across the grid width.
+      expect(
+        anchor.ranges.length,
+        greaterThan(1),
+        reason:
+            'the wrapping hyperlink did not span multiple rows — the osc8 run '
+            'should cover every wrapped row (#767 Slice B)',
+      );
+
+      // matchAt on the CONTINUATION row (a non-first range) resolves the SAME
+      // exact full URI — the copy-partial bug is fixed: a tap/long-press on the
+      // wrapped continuation gets the real, full link.
+      final offset = controller.scrollbar.offset;
+      final continuation = anchor.ranges.last;
+      final viewRow = continuation.startRow - offset;
+      expect(
+        viewRow,
+        greaterThanOrEqualTo(0),
+        reason: 'continuation row scrolled out of view — cannot hit-test it',
+      );
+      final match = controller.matchAt(
+        row: viewRow,
+        col: continuation.startCol,
+      );
+      expect(
+        match?.payload,
+        fullUri,
+        reason:
+            'matchAt on the CONTINUATION row did not resolve the full URI — '
+            'copy/open would get a partial link (#767 Slice B)',
+      );
+    },
+  );
+}

--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -31,6 +31,12 @@ import 'package:flterm/flterm.dart';
 /// view registers on the controller so the registry can route URL anchors here.
 const String kGhosttyUrlPatternId = 'url';
 
+/// The id of the OSC-8 HYPERLINK pattern/decorator (#767 Slice B). The PRIMARY,
+/// exact URL source: the terminal reads the OSC-8 URI off its own cells (no
+/// regex), so a wrapped link spans all its rows and the payload is the exact
+/// full URI. Its anchor renders the SAME bubble affordance as a regex URL.
+const String kGhosttyOsc8PatternId = 'osc8';
+
 /// Per-anchor render input handed to a [GhosttyTerminalDecorator] (#767 B).
 ///
 /// [rects] are the anchor's CURRENT viewport pixel rects (one per visible
@@ -79,7 +85,12 @@ class GhosttyDecoratorRegistry {
   /// commit shas / issue refs #631) register additional decorators here, each
   /// with its own glyph/chip styling, alongside a matching controller pattern.
   factory GhosttyDecoratorRegistry.defaults() {
-    return GhosttyDecoratorRegistry(const [UrlBubbleDecorator()]);
+    return GhosttyDecoratorRegistry(const [
+      UrlBubbleDecorator(),
+      // #767 Slice B: an OSC-8 hyperlink anchor renders the SAME bubble as a
+      // regex URL — same affordance, exact full URI behind it.
+      UrlBubbleDecorator(patternId: kGhosttyOsc8PatternId),
+    ]);
   }
 
   final Map<String, GhosttyTerminalDecorator> _byPattern;
@@ -95,10 +106,13 @@ class GhosttyDecoratorRegistry {
 /// The default URL decorator: a rounded-rect OUTLINE BUBBLE hugging the URL's
 /// cells, joined visually across wrap rows (#767 Slice B). Never an opaque fill.
 class UrlBubbleDecorator extends GhosttyTerminalDecorator {
-  const UrlBubbleDecorator();
+  /// [patternId] selects which pattern's anchors this bubble renders — the
+  /// regex `url` pattern by default, or the OSC-8 `osc8` source (#767 Slice B),
+  /// which draws the identical bubble over the exact-URI hyperlink anchors.
+  const UrlBubbleDecorator({this.patternId = kGhosttyUrlPatternId});
 
   @override
-  String get patternId => kGhosttyUrlPatternId;
+  final String patternId;
 
   @override
   Widget build(BuildContext context, List<GhosttyDecoratedAnchor> anchors) {

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -1773,7 +1773,13 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
 
   /// #767: the URL pattern id registered on the controller, so a theme-recolour
   /// (clear + re-register) and the initial registration share one identity.
-  static const String _kUrlPatternId = 'url';
+  static const String _kUrlPatternId = kGhosttyUrlPatternId;
+
+  /// #767 Slice B: the OSC-8 hyperlink source id — the PRIMARY, exact URL
+  /// source registered ALONGSIDE the regex `url` pattern. The terminal reads the
+  /// OSC-8 URI off its own cells, so a wrapped link spans all rows and copy/open
+  /// get the exact full URI; an OSC-8 match wins over an overlapping regex one.
+  static const String _kOsc8PatternId = kGhosttyOsc8PatternId;
 
   /// #702: the session proxy, resolved once in [initState] so the shellReady
   /// subscription + forced resize re-sync don't re-walk the sessions list.
@@ -1944,6 +1950,13 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// draws the affordance instead. The bubble colour comes from the decorator
   /// layer ([_lastHighlightColor]); this registration is theme-independent.
   void _registerUrlPattern(TerminalController controller) {
+    // #767 Slice B: register the OSC-8 hyperlink source as the PRIMARY, exact
+    // URL source ALONGSIDE the regex `url` pattern. The scanner runs both and
+    // an OSC-8 match WINS over an overlapping regex one (the partial first-row
+    // `https://…` over a hyperlink's visible text is suppressed), so a
+    // hyperlinked URL yields ONE exact anchor spanning all its wrapped rows. A
+    // plain-text URL (no OSC-8) still falls to the regex pattern unchanged.
+    controller.registerTextPattern(TextPattern.osc8(id: _kOsc8PatternId));
     controller.registerTextPattern(TextPattern.url(id: _kUrlPatternId));
   }
 

--- a/native/test/ui/ghostty_terminal_decorators_test.dart
+++ b/native/test/ui/ghostty_terminal_decorators_test.dart
@@ -87,6 +87,16 @@ void main() {
       expect(decorator!.patternId, kGhosttyUrlPatternId);
     });
 
+    test('defaults registers the OSC-8 bubble decorator (#767 Slice B)', () {
+      final registry = GhosttyDecoratorRegistry.defaults();
+      expect(registry.patternIds, contains(kGhosttyOsc8PatternId));
+      final decorator = registry.forPattern(kGhosttyOsc8PatternId);
+      // The OSC-8 anchor renders the SAME bubble affordance as a regex URL,
+      // routed by its own pattern id.
+      expect(decorator, isA<UrlBubbleDecorator>());
+      expect(decorator!.patternId, kGhosttyOsc8PatternId);
+    });
+
     test('returns null for an unregistered pattern (e.g. future path/sha)', () {
       final registry = GhosttyDecoratorRegistry.defaults();
       expect(registry.forPattern('path'), isNull);

--- a/native/third_party/flterm/lib/src/foundation/structured_text.dart
+++ b/native/third_party/flterm/lib/src/foundation/structured_text.dart
@@ -81,12 +81,25 @@ final class TextPattern {
   /// detector's sentence-punctuation / unbalanced-closer trim.
   final String trailingTrim;
 
+  /// Whether this pattern is the regex-FREE OSC-8 HYPERLINK source (#767 Slice
+  /// B) rather than a [regex]-driven text matcher. When true the scanner
+  /// IGNORES [regex]/[trailingTrim]/[normalize] and instead walks the reader's
+  /// cells, grouping MAXIMAL runs of adjacent cells that share the SAME non-null
+  /// [CellReader.hyperlinkAt] URI into one [StructuredMatch] (payload = the URI).
+  /// Because libghostty attaches the full OSC-8 URI to EVERY visible cell of the
+  /// link — including soft/hard-wrapped continuation rows — a wrapped link spans
+  /// its rows by construction, with NO regex, width, or wrap heuristic, and the
+  /// payload is the EXACT full URI (so copy/open get the real link). An OSC-8
+  /// match always WINS over an overlapping [regex] match (see [StructuredTextScanner.scan]).
+  final bool isOsc8Source;
+
   const TextPattern({
     required this.id,
     required this.regex,
     this.style = const HighlightStyle(),
     this.normalize,
     this.trailingTrim = '',
+    this.isOsc8Source = false,
   });
 
   /// The built-in URL pattern (#726/#764 moved in-fork, #767).
@@ -105,7 +118,36 @@ final class TextPattern {
       normalize: _normalizeUrl,
     );
   }
+
+  /// The built-in OSC-8 HYPERLINK source (#767 Slice B) — the PRIMARY, exact
+  /// URL source.
+  ///
+  /// Unlike [TextPattern.url] (a regex over the visible glyph text), this reads
+  /// the OSC-8 hyperlink URI libghostty attaches to each cell
+  /// ([CellReader.hyperlinkAt]). The scanner groups maximal same-URI cell runs
+  /// into one match whose payload is the EXACT full URI — so a wrapped link
+  /// spans all its rows by construction and copy/open get the real link, with no
+  /// regex / wrap / width heuristic. An OSC-8 match WINS over an overlapping
+  /// regex URL match (the partial first-row `https://…` the regex would catch is
+  /// suppressed on the hyperlinked cells), so a hyperlinked URL yields ONE exact
+  /// anchor, not a partial regex bubble beside it. [style] supplies the highlight
+  /// color (omitted by the app — the widget-layer bubble draws the affordance).
+  factory TextPattern.osc8({String id = 'osc8', HighlightStyle style =
+      const HighlightStyle()}) {
+    return TextPattern(
+      id: id,
+      // Unused for an OSC-8 source — the scanner walks cells, not text. A
+      // never-matching regex keeps [regex] non-null without false positives.
+      regex: _kNeverMatch,
+      style: style,
+      isOsc8Source: true,
+    );
+  }
 }
+
+/// A regex that matches nothing — the placeholder [TextPattern.regex] for an
+/// OSC-8 source, whose detection walks cells rather than running a regex.
+final RegExp _kNeverMatch = RegExp(r'(?!x)x');
 
 /// The URL regex (moved verbatim from the app's `ghostty_url_detector.dart`,
 /// #767). Matches absolute http/https URLs and bare `www.` hosts; the
@@ -243,6 +285,17 @@ abstract interface class CellReader {
 
   /// Whether local [row] is soft-wrapped onto local [row]+1 (authoritative).
   bool rowWrap(int row);
+
+  /// The OSC-8 HYPERLINK URI attached to the cell at local ([row], [col]), or
+  /// null when the cell carries no hyperlink (#767 Slice B).
+  ///
+  /// libghostty attaches the FULL OSC-8 URI to EVERY visible cell of a link —
+  /// including soft/hard-wrapped continuation rows — so the OSC-8 source can
+  /// group maximal same-URI runs into one match spanning all wrapped rows by
+  /// construction. The real controller reads `GridRef.hyperlinkUri`; the test
+  /// fake supplies a per-cell URI map. A blank/spacer-tail cell carries no
+  /// hyperlink (null), so a non-link gap naturally breaks a run.
+  String? hyperlinkAt(int row, int col);
 }
 
 /// One character of a logical line, tagged with the absolute cell it came from.
@@ -295,12 +348,36 @@ class StructuredTextScanner {
     final cols = reader.cols;
     if (rows <= 0 || cols <= 0) return const [];
 
-    final lines = _assembleLines(reader, rows, cols);
+    final regexPatterns = [for (final p in patterns) if (!p.isOsc8Source) p];
+    final osc8Patterns = [for (final p in patterns) if (p.isOsc8Source) p];
+
+    // OSC-8 FIRST: it is the PRIMARY, exact source and WINS over any overlapping
+    // regex match. Collect the hyperlinked cells so an overlapping regex match
+    // (the partial first-row `https://…` over the link's visible text) is
+    // suppressed — yielding ONE exact anchor, not a partial bubble beside it.
     final matches = <StructuredMatch>[];
+    final hyperlinkedCells = <int, Set<int>>{}; // absRow -> set of cols
+    if (osc8Patterns.isNotEmpty) {
+      for (final pattern in osc8Patterns) {
+        for (final m in _scanOsc8(reader, rows, cols, pattern)) {
+          matches.add(m);
+          for (final range in m.ranges) {
+            final set = hyperlinkedCells.putIfAbsent(range.startRow, () => {});
+            for (var c = range.startCol; c < range.endCol; c++) {
+              set.add(c);
+            }
+          }
+        }
+      }
+    }
+
+    if (regexPatterns.isEmpty) return matches;
+
+    final lines = _assembleLines(reader, rows, cols);
     for (final line in lines) {
       final text = line.text;
       if (text.isEmpty) continue;
-      for (final pattern in patterns) {
+      for (final pattern in regexPatterns) {
         for (final m in pattern.regex.allMatches(text)) {
           var start = m.start;
           var end = m.end; // exclusive
@@ -311,6 +388,14 @@ class StructuredTextScanner {
             end--;
           }
           if (end <= start) continue;
+          // De-dup: OSC-8 wins. Drop a regex match that overlaps ANY OSC-8
+          // hyperlinked cell, so a hyperlinked URL (whose visible text is also
+          // URL-shaped) yields only the exact OSC-8 anchor. A plain-text URL
+          // (no OSC-8) is unaffected — the map is empty, so this never fires.
+          if (hyperlinkedCells.isNotEmpty &&
+              _overlapsHyperlink(line.glyphs, start, end, hyperlinkedCells)) {
+            continue;
+          }
           final raw = text.substring(start, end);
           final payload = pattern.normalize?.call(raw) ?? raw;
           final ranges = _rangesFor(
@@ -331,6 +416,85 @@ class StructuredTextScanner {
         }
       }
     }
+    return matches;
+  }
+
+  /// Whether the regex match spanning glyphs `[start, end)` overlaps any cell in
+  /// [hyperlinkedCells] (absRow → covered cols). Used to SUPPRESS a regex match
+  /// over OSC-8-hyperlinked cells so OSC-8 wins the de-dup (#767 Slice B).
+  bool _overlapsHyperlink(
+    List<_Glyph> glyphs,
+    int start,
+    int end,
+    Map<int, Set<int>> hyperlinkedCells,
+  ) {
+    for (var i = start; i < end; i++) {
+      final cols = hyperlinkedCells[glyphs[i].absRow];
+      if (cols != null && cols.contains(glyphs[i].col)) return true;
+    }
+    return false;
+  }
+
+  /// Scan the reader's cells for OSC-8 hyperlink runs (#767 Slice B).
+  ///
+  /// Walks cells in READING ORDER (row 0..rows-1, col 0..cols-1) and groups each
+  /// MAXIMAL contiguous run of cells sharing the SAME non-null
+  /// [CellReader.hyperlinkAt] URI into one [StructuredMatch] (payload = the URI).
+  /// "Contiguous" follows reading order: the next col on the same row, or col 0
+  /// of the next row when the run reaches the row end — so a wrapped link (the
+  /// same URI on row N's tail and row N+1's head) is ONE run spanning both rows
+  /// by construction. A URI CHANGE or a non-link (null) cell ends the run, and a
+  /// run is emitted as per-row [HighlightRange]s in absolute coordinates.
+  List<StructuredMatch> _scanOsc8(
+    CellReader reader,
+    int rows,
+    int cols,
+    TextPattern pattern,
+  ) {
+    final base = reader.baseAbsRow;
+    final matches = <StructuredMatch>[];
+    String? runUri;
+    var runGlyphs = <_Glyph>[];
+
+    void flush() {
+      if (runUri == null || runGlyphs.isEmpty) {
+        runUri = null;
+        runGlyphs = [];
+        return;
+      }
+      final ranges = _rangesFor(runGlyphs, 0, runGlyphs.length, pattern.style,
+          runUri!);
+      if (ranges.isNotEmpty) {
+        matches.add(
+          StructuredMatch(
+            patternId: pattern.id,
+            ranges: ranges,
+            payload: runUri!,
+          ),
+        );
+      }
+      runUri = null;
+      runGlyphs = [];
+    }
+
+    for (var r = 0; r < rows; r++) {
+      final absRow = base + r;
+      for (var c = 0; c < cols; c++) {
+        final uri = reader.hyperlinkAt(r, c);
+        if (uri == null) {
+          flush();
+          continue;
+        }
+        if (runUri != null && uri != runUri) {
+          // A different URI begins on this cell — close the prior run and start
+          // a fresh one at this cell.
+          flush();
+        }
+        runUri = uri;
+        runGlyphs.add(_Glyph(uri, absRow, c));
+      }
+    }
+    flush();
     return matches;
   }
 

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -1215,4 +1215,26 @@ class _ScreenCellReader implements CellReader {
       ref?.dispose();
     }
   }
+
+  @override
+  String? hyperlinkAt(int row, int col) {
+    final absRow = _startAbsRow + row;
+    GridRef? ref;
+    try {
+      ref = GridRef.at(
+        terminal,
+        col: col,
+        row: absRow,
+        pointTag: PointTag.screen,
+      );
+      // libghostty attaches the FULL OSC-8 URI to every cell of the link
+      // (including wrapped continuation rows), so reading it per-cell yields the
+      // exact link that spans all wrapped rows by construction (#767 Slice B).
+      return ref.hyperlinkUri;
+    } catch (_) {
+      return null;
+    } finally {
+      ref?.dispose();
+    }
+  }
 }

--- a/native/third_party/flterm/test/foundation/structured_text_test.dart
+++ b/native/third_party/flterm/test/foundation/structured_text_test.dart
@@ -15,7 +15,10 @@ class _FakeCellReader implements CellReader {
     required this.cols,
     List<bool>? wraps,
     this.baseAbsRow = 0,
-  }) : _rows = [
+    List<List<String?>>? hyperlinks,
+    // ignore: prefer_initializing_formals
+  }) : _hyperlinks = hyperlinks,
+       _rows = [
          for (final t in rowTexts)
            List<String>.generate(
              cols,
@@ -26,6 +29,11 @@ class _FakeCellReader implements CellReader {
 
   final List<List<String>> _rows;
   final List<bool> _wraps;
+
+  /// Per-cell OSC-8 hyperlink URIs: `_hyperlinks[row][col]` is the full URI or
+  /// null when the cell carries no hyperlink. Null overall → no hyperlinks at
+  /// all (the plain-text case), matching a terminal that emitted no OSC-8.
+  final List<List<String?>>? _hyperlinks;
 
   @override
   final int cols;
@@ -44,6 +52,42 @@ class _FakeCellReader implements CellReader {
 
   @override
   bool rowWrap(int row) => row >= 0 && row < _wraps.length && _wraps[row];
+
+  @override
+  String? hyperlinkAt(int row, int col) {
+    final links = _hyperlinks;
+    if (links == null) return null;
+    if (row < 0 || row >= links.length) return null;
+    final rowLinks = links[row];
+    if (col < 0 || col >= rowLinks.length) return null;
+    return rowLinks[col];
+  }
+}
+
+/// Build a per-cell hyperlink map for [_FakeCellReader] from a list of
+/// per-row [uri] strings: every cell on a row whose text is non-blank (and
+/// within `uri.length`) carries [rowUris]'s URI; blanks/out-of-range cells are
+/// null. A `null` row URI means the row carries no hyperlink at all.
+///
+/// This mirrors how libghostty attaches the SAME OSC-8 URI to EVERY visible
+/// cell of the link — including wrapped continuation rows — so a maximal
+/// same-URI run spans the wrap by construction.
+List<List<String?>> _hyperlinkMap(
+  List<String> rowTexts,
+  List<String?> rowUris, {
+  required int cols,
+}) {
+  return [
+    for (var r = 0; r < rowTexts.length; r++)
+      List<String?>.generate(cols, (c) {
+        final uri = r < rowUris.length ? rowUris[r] : null;
+        if (uri == null) return null;
+        final t = rowTexts[r];
+        // A cell carries the URI iff it holds a visible glyph of the link.
+        if (c >= t.length) return null;
+        return t[c] == ' ' ? null : uri;
+      }),
+  ];
 }
 
 void main() {
@@ -373,6 +417,202 @@ void main() {
       );
       expect(scanner.scan(reader, [urlPattern]), isEmpty);
     });
+  });
+
+  group('OSC-8 hyperlink source (#767 Slice B)', () {
+    final osc8 = TextPattern.osc8();
+
+    test(
+      'a hyperlink run spanning TWO rows → ONE osc8 match, payload = the full '
+      'URI, ranges span both rows',
+      () {
+        // The VISIBLE text wraps ('short visi' / 'ble') but EVERY cell carries
+        // the SAME full URI — libghostty attaches it to the wrapped cells too.
+        const uri = 'https://example.com/a/very/long/path/that/wraps';
+        final rowTexts = ['short visi', 'ble rest'];
+        final reader = _FakeCellReader(
+          rowTexts,
+          cols: 10,
+          // The link covers 'short visi' on row 0 and 'ble' on row 1.
+          hyperlinks: [
+            [for (var c = 0; c < 10; c++) c < 'short visi'.length ? uri : null],
+            [for (var c = 0; c < 10; c++) c < 'ble'.length ? uri : null],
+          ],
+        );
+        final matches = scanner.scan(reader, [osc8]);
+        expect(matches, hasLength(1), reason: 'one maximal same-URI run');
+        final m = matches.single;
+        expect(m.patternId, 'osc8');
+        expect(m.payload, uri, reason: 'payload is the exact full URI');
+        expect(m.ranges, hasLength(2), reason: 'one range per wrapped row');
+        expect(m.ranges[0].startRow, 0);
+        expect(m.ranges[0].startCol, 0);
+        expect(m.ranges[0].endCol, 'short visi'.length);
+        expect(m.ranges[1].startRow, 1);
+        expect(m.ranges[1].startCol, 0);
+        expect(m.ranges[1].endCol, 'ble'.length);
+        // The continuation row resolves the FULL URI by hit-test.
+        expect(m.contains(1, 1), isTrue);
+      },
+    );
+
+    test(
+      'two DIFFERENT URIs on adjacent cells → TWO separate osc8 matches',
+      () {
+        const a = 'https://a.example/one';
+        const b = 'https://b.example/two';
+        // 'AAABBB': cols 0-2 carry uri a, cols 3-5 carry uri b — adjacent, no gap.
+        final reader = _FakeCellReader(
+          ['AAABBB'],
+          cols: 6,
+          hyperlinks: [
+            [a, a, a, b, b, b],
+          ],
+        );
+        final matches = scanner.scan(reader, [osc8]);
+        expect(matches, hasLength(2), reason: 'a URI change splits the run');
+        final byPayload = {for (final m in matches) m.payload: m};
+        expect(byPayload.keys, containsAll(<String>[a, b]));
+        expect(byPayload[a]!.ranges.single.startCol, 0);
+        expect(byPayload[a]!.ranges.single.endCol, 3);
+        expect(byPayload[b]!.ranges.single.startCol, 3);
+        expect(byPayload[b]!.ranges.single.endCol, 6);
+      },
+    );
+
+    test('a blank (non-hyperlinked) cell BREAKS a run into two matches', () {
+      const uri = 'https://x.example/p';
+      // Same URI on cols 0-1 and 3-4, with a non-link gap at col 2 → two runs.
+      final reader = _FakeCellReader(
+        ['ab cd'],
+        cols: 5,
+        hyperlinks: [
+          [uri, uri, null, uri, uri],
+        ],
+      );
+      final matches = scanner.scan(reader, [uri == uri ? osc8 : osc8]);
+      expect(matches, hasLength(2), reason: 'a non-link gap splits the run');
+      expect(matches.every((m) => m.payload == uri), isTrue);
+    });
+
+    test('no hyperlinks at all → no osc8 matches', () {
+      final reader = _FakeCellReader(['plain text'], cols: 20);
+      expect(scanner.scan(reader, [osc8]), isEmpty);
+    });
+  });
+
+  group('OSC-8 wins over the regex URL pattern (de-dup, #767 Slice B)', () {
+    final osc8 = TextPattern.osc8();
+    final urlPattern = TextPattern.url();
+
+    test(
+      'a hyperlinked URL whose VISIBLE text is ALSO URL-shaped → only the osc8 '
+      'match (regex suppressed on those cells, no double-cover)',
+      () {
+        // The visible text is itself a URL the regex would match, but its cells
+        // carry a DIFFERENT, fuller OSC-8 URI. OSC-8 must win: ONE osc8 match,
+        // the regex match over the same cells is suppressed.
+        const visible = 'https://ex.io/2026';
+        const fullUri = 'https://ex.io/2026-06-05/full/real/target.apk';
+        final reader = _FakeCellReader(
+          [visible],
+          cols: visible.length,
+          hyperlinks: [
+            [for (var c = 0; c < visible.length; c++) fullUri],
+          ],
+        );
+        // Run BOTH sources together (the controller registers both).
+        final matches = scanner.scan(reader, [urlPattern, osc8]);
+        expect(
+          matches,
+          hasLength(1),
+          reason: 'osc8 wins; the overlapping regex match is suppressed',
+        );
+        final m = matches.single;
+        expect(m.patternId, 'osc8');
+        expect(m.payload, fullUri, reason: 'the exact full OSC-8 URI');
+      },
+    );
+
+    test(
+      'a hyperlinked URL spanning a wrap suppresses the PARTIAL first-row regex '
+      'match → ONE anchor spanning both rows, not a partial bubble beside it',
+      () {
+        // Row 0 holds a URL-shaped head the regex would match on its own; the
+        // full link wraps to row 1. Every cell carries the full URI.
+        const fullUri = 'https://mobissh.example/mobissh-native-20260605.apk';
+        final rowTexts = ['https://mobis', 'sh.example/x'];
+        final reader = _FakeCellReader(
+          rowTexts,
+          cols: 13,
+          wraps: [true, false],
+          hyperlinks: _hyperlinkMap(
+            rowTexts,
+            [fullUri, fullUri],
+            cols: 13,
+          ),
+        );
+        final matches = scanner.scan(reader, [urlPattern, osc8]);
+        expect(
+          matches,
+          hasLength(1),
+          reason: 'one osc8 anchor; the partial regex head is suppressed',
+        );
+        final m = matches.single;
+        expect(m.patternId, 'osc8');
+        expect(m.payload, fullUri);
+        expect(m.ranges, hasLength(2), reason: 'spans both wrapped rows');
+      },
+    );
+
+    test(
+      'a PLAIN-TEXT URL with NO OSC-8 still detected by the regex (de-dup does '
+      'not break plain-text-only detection)',
+      () {
+        // No hyperlink map at all → the regex behaves exactly as today.
+        final reader = _FakeCellReader(
+          ['see https://plain.example here'],
+          cols: 40,
+        );
+        final matches = scanner.scan(reader, [urlPattern, osc8]);
+        expect(matches, hasLength(1));
+        expect(matches.single.patternId, 'url');
+        expect(matches.single.payload, 'https://plain.example');
+      },
+    );
+
+    test(
+      'a plain-text URL on ONE row and a hyperlinked URL on ANOTHER → both '
+      'detected (regex for the plain one, osc8 for the linked one)',
+      () {
+        const fullUri = 'https://linked.example/full/path';
+        final reader = _FakeCellReader(
+          [
+            'plain https://plain.example x',
+            'https://visible.example',
+          ],
+          cols: 30,
+          hyperlinks: [
+            // Row 0: no hyperlink (plain text).
+            List<String?>.filled(30, null),
+            // Row 1: the whole visible URL is hyperlinked to a fuller URI.
+            [
+              for (var c = 0; c < 30; c++)
+                c < 'https://visible.example'.length ? fullUri : null,
+            ],
+          ],
+        );
+        final matches = scanner.scan(reader, [urlPattern, osc8]);
+        final byId = <String, List<StructuredMatch>>{};
+        for (final m in matches) {
+          byId.putIfAbsent(m.patternId, () => []).add(m);
+        }
+        expect(byId['url'], hasLength(1), reason: 'the plain URL via regex');
+        expect(byId['url']!.single.payload, 'https://plain.example');
+        expect(byId['osc8'], hasLength(1), reason: 'the linked URL via osc8');
+        expect(byId['osc8']!.single.payload, fullUri);
+      },
+    );
   });
 
   group('edge cases', () {


### PR DESCRIPTION
## #767 Slice B — OSC-8 hyperlink detection as the PRIMARY, exact URL source

Fixes the two device-confirmed 0.1.10+23 bugs: a wrapped URL only bubbled its first row, and copy returned a partial URL.

### Why this is the fix
OSC-8 hyperlinks (emitted by Claude CLI, `gh`, many tools) attach the **FULL exact URI to EVERY cell** of the link — including the wrapped continuation rows. libghostty already parses it (`GridRef.hyperlinkUri`). Reading the URI off the cells gives an EXACT match that spans all wrapped rows by construction — no regex, no wrap/width heuristic — and copy/open get the real full URL.

### What changed (additive on top of Slice A — fork patch stays clean for re-vendoring)
- **`CellReader.hyperlinkAt(row, col) -> String?`** — real controller reader via `GridRef.hyperlinkUri`; the fake test reader takes a per-cell URI map.
- **`TextPattern.osc8()` + `isOsc8Source`** — a regex-FREE scanner source that walks cells and groups MAXIMAL runs of cells sharing the SAME non-null `hyperlinkUri` into one `StructuredMatch` (patternId `osc8`, payload = the URI), emitting per-row `HighlightRange`s. Runs ALONGSIDE the existing regex `url` pattern.
- **De-dup (OSC-8 wins):** a regex match overlapping any OSC-8-hyperlinked cell is suppressed, so a hyperlinked URL yields ONE exact anchor spanning both wrapped rows — not a partial regex bubble beside it. Plain-text URLs (no OSC-8) behave exactly as today.
- **Copy/open** already use `matchAt.payload` → the exact full URI (fixes the copy-partial bug).
- **Registration:** the `osc8` source is registered by default on the controller alongside `url`; the bubble decorator renders `osc8` anchors the same as `url` anchors.

### Scope
`structured_text.dart` (scanner + osc8 source + CellReader.hyperlinkAt) · `terminal_controller_impl.dart` (real reader hyperlinkAt) · `ghostty_terminal_view.dart` (register osc8 source) · `ghostty_terminal_decorators.dart` (route osc8 anchors to the bubble) · new integration test · unit/widget tests. No services/ssh/state touched. The regex URL pattern still detects plain-text URLs (a connected-components upgrade for those is a separate later slice).

### Tests (TDD red→green)
- **Fork unit** (fake `hyperlinkAt` map): a 2-row run → ONE `osc8` match, payload = full URI, ranges span both rows; two URIs adjacent → two matches; a hyperlinked URL whose visible text is also URL-shaped → only the `osc8` match (regex suppressed); plain-text URL with no OSC-8 still detected by regex.
- **App decorator test:** defaults registers the `osc8` bubble decorator.
- **Integration** (`native/integration_test/ghostty_osc8_hyperlink_test.dart`, orchestrator runs on emulator): `printf` an OSC-8 hyperlink whose visible text wraps but whose URI is the full link; assert `controller.anchors` contains an `osc8` anchor with payload == the full URI spanning the wrapped rows, and `matchAt` on the continuation row resolves the full URI.

### Gate
- `scripts/native-fork-test.sh` (701 tests) green.
- `scripts/native-fast-gate.sh` (analyze + 858 tests) green.
- **Device-validation-required:** the orchestrator runs the emulator OSC-8 integration test before merge. NOT claimed device-validated.

Closes #767 (Slice B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)