### PR TITLE
feat(osc8): advertise tmux hyperlinks via DA2 so OSC-8 links are forwarded

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -23,6 +23,7 @@ import 'package:flutter/foundation.dart';
 import 'package:dartssh2/dartssh2.dart';
 
 import '../diagnostics/connect_trace.dart';
+import '../ssh/da2_responder.dart';
 import '../ssh/ssh_connect_params.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_shell.dart';
@@ -522,6 +523,9 @@ class SessionHost {
         return;
       }
       hosted.shell = transport;
+      // Fresh attach => fresh DA2 handshake: clear any buffered partial query
+      // from a prior shell so we answer THIS attach's `ESC[>c` cleanly (#osc8).
+      hosted.da2Responder.reset();
       // Wire the output listener BEFORE announcing shell-ready (#619). The UI's
       // run-on-connect command fires on shell-ready, writes to stdin, and the
       // shell echoes + runs it immediately. If we announced ready first (the
@@ -538,9 +542,24 @@ class SessionHost {
           // producing output — the nudge check watches this counter advance.
           hosted.remoteByteEvents += 1;
           hosted.lastRemoteByteAtMs = _nowMs();
-          hosted.appendScrollback(bytes);
+          // Intercept tmux's DA2 query and answer as `tmux` so tmux forwards
+          // OSC-8 hyperlinks to us (the query is swallowed; our reply goes back
+          // over stdin). On non-tmux hosts no query arrives and `forward` is the
+          // input untouched. See [Da2HyperlinkResponder].
+          final scan = hosted.da2Responder.scan(bytes);
+          if (scan.hasReply) {
+            final shell = hosted.shell;
+            if (shell != null) {
+              for (final reply in scan.replies) {
+                shell.send(reply);
+              }
+            }
+          }
+          final forward = scan.forward;
+          if (forward.isEmpty) return;
+          hosted.appendScrollback(forward);
           _gateway.send(
-            SshOutputEvent(sessionId: sessionId, bytes: bytes).toJson(),
+            SshOutputEvent(sessionId: sessionId, bytes: forward).toJson(),
           );
         },
         onError: (Object e, StackTrace st) {
@@ -917,6 +936,13 @@ class _HostedSession {
   SshShellTransport? shell;
   StreamSubscription<Uint8List>? shellSub;
   bool shellOpening = false;
+
+  /// Intercepts tmux's DA2 (Secondary Device Attributes) query in the remote
+  /// byte stream and answers as a `tmux`-class terminal so tmux advertises the
+  /// `hyperlinks` feature and FORWARDS OSC-8 links (instead of stripping them)
+  /// to this client. See [Da2HyperlinkResponder]. Reset per shell open so a
+  /// reconnect re-answers the fresh attach's query.
+  final Da2HyperlinkResponder da2Responder = Da2HyperlinkResponder();
 
   /// Monotonic count of remote-output CHUNKS actually received from the shell
   /// (#759). Bumped only by the live shell-output listener (and the test

--- a/native/lib/ssh/da2_responder.dart
+++ b/native/lib/ssh/da2_responder.dart
@@ -1,0 +1,187 @@
+// Makes tmux forward OSC-8 hyperlinks to MobiSSH without any per-user
+// `~/.tmux.conf`.
+//
+// THE PROBLEM (spike, verified on tmux 3.4)
+// ----------------------------------------
+// tmux PARSES and STORES OSC-8 hyperlinks but only FORWARDS them to a client
+// whose terminal-features include `hyperlinks`. tmux decides that feature via
+// the DA2 (Secondary Device Attributes) handshake, NOT via TERM:
+//
+//   * At attach, tmux sends the DA2 query  ESC [ > c  to the client.
+//   * tmux's `tty_keys_device_attributes2` maps the reply's first parameter:
+//       'T' (84) -> tmux,  'M' (77) -> mintty,  'U' (82) -> rxvt-unicode
+//     and applies that terminal's built-in default-features. The "tmux" set
+//     INCLUDES `hyperlinks`.
+//   * Changing TERM does nothing useful here: TERM=xterm-256color/tmux do not
+//     enable hyperlinks on their own, and exotic TERMs (xterm-ghostty, iTerm2,
+//     wezterm, foot) have no terminfo entry on a typical host, so the client
+//     cannot attach at all.
+//
+// xterm.dart answers DA2 with  ESC [ > 0 ; 0 ; 0 c  (model 0) — which tmux
+// maps to nothing, so `hyperlinks` is never enabled and the OSC-8 sequences
+// our (already-shipped) scanner looks for are stripped before they reach us.
+//
+// THE FIX
+// -------
+// Sit at the SSH byte boundary (above whichever terminal backend renders).
+// When the remote sends the DA2 query, SWALLOW it (so the UI terminal never
+// emits its own `>0` reply — tmux honors the FIRST reply it sees) and answer
+// with  ESC [ > 84 ; 0 ; 0 c  ('T' = tmux). tmux then advertises `hyperlinks`
+// to this client and forwards OSC-8 links unstripped.
+//
+// This is transparent and reversible: it is exactly the handshake tmux
+// expects; we simply give the answer that advertises hyperlink support. It
+// does not touch TERM, so colors, keys and mouse are unaffected. When the
+// remote is NOT tmux (e.g. a bare shell), nothing sends the DA2 query, so the
+// responder is inert.
+
+import 'dart:typed_data';
+
+/// The DA2 (Secondary Device Attributes) query a host terminal sends to ask
+/// "what kind of terminal are you?": `ESC [ > c`. Some hosts include an
+/// explicit `0` parameter (`ESC [ > 0 c`); both are handled.
+const int _esc = 0x1b; // ESC
+const int _lbracket = 0x5b; // [
+const int _gt = 0x3e; // >
+const int _c = 0x63; // c
+
+/// The reply that makes tmux treat us as a `tmux`-class terminal and therefore
+/// enable the `hyperlinks` feature: `ESC [ > 84 ; 0 ; 0 c` (84 = 'T').
+final Uint8List kTmuxDa2Reply = Uint8List.fromList(<int>[
+  _esc, _lbracket, _gt, // ESC [ >
+  0x38, 0x34, // "84"
+  0x3b, 0x30, // ";0"
+  0x3b, 0x30, // ";0"
+  _c, // c
+]);
+
+/// Result of feeding a chunk of remote bytes through [Da2HyperlinkResponder].
+class Da2ScanResult {
+  const Da2ScanResult(this.forward, this.replies);
+
+  /// Bytes to forward on to the terminal/UI — the input with any DA2 query
+  /// removed.
+  final Uint8List forward;
+
+  /// Reply chunks to write back to the remote (each is [kTmuxDa2Reply]), one
+  /// per DA2 query detected. Empty when no query was seen.
+  final List<Uint8List> replies;
+
+  bool get hasReply => replies.isNotEmpty;
+}
+
+/// Stateful, chunk-boundary-safe detector for the tmux DA2 query in a stream
+/// of remote PTY bytes.
+///
+/// The query (`ESC [ > [0] c`) can be split across [scan] calls, so a small
+/// suffix of unmatched-but-still-possibly-a-prefix bytes is buffered until the
+/// next call. Everything that cannot be the start of the query is forwarded
+/// immediately.
+class Da2HyperlinkResponder {
+  /// Bytes held back because they form a proper prefix of the query and the
+  /// rest may arrive in the next chunk.
+  final List<int> _pending = <int>[];
+
+  /// Whether we have already answered a DA2 query for the current shell. tmux
+  /// only queries once per attach, but a reconnect re-attaches and re-queries,
+  /// so the responder is reused per-shell and reset via [reset]. We still
+  /// answer every query we see (cheap + correct); this flag is exposed only
+  /// for observability/telemetry.
+  int repliesSent = 0;
+
+  /// Feed a chunk of remote bytes. Returns the bytes to forward to the
+  /// terminal and any DA2 replies to send back to the remote.
+  Da2ScanResult scan(Uint8List chunk) {
+    // Work over [pending tail] + [chunk] so a query split across chunks is
+    // still matched.
+    final buf = <int>[..._pending, ...chunk];
+    _pending.clear();
+
+    final out = <int>[];
+    final replies = <Uint8List>[];
+    var i = 0;
+    while (i < buf.length) {
+      final b = buf[i];
+      if (b != _esc) {
+        out.add(b);
+        i++;
+        continue;
+      }
+      // Potential start of `ESC [ > [params] c`. Try to match from here.
+      final match = _matchDa2(buf, i);
+      if (match.kind == _MatchKind.full) {
+        // Swallow the query; queue a reply. Advance past the matched bytes.
+        replies.add(kTmuxDa2Reply);
+        repliesSent++;
+        i += match.length;
+      } else if (match.kind == _MatchKind.partial) {
+        // A proper prefix that runs to the end of the buffer — buffer it and
+        // wait for the next chunk.
+        _pending.addAll(buf.sublist(i));
+        i = buf.length;
+      } else {
+        // ESC that is not the start of a DA2 query (e.g. a normal escape
+        // sequence). Forward the ESC and continue scanning after it.
+        out.add(b);
+        i++;
+      }
+    }
+
+    return Da2ScanResult(Uint8List.fromList(out), replies);
+  }
+
+  /// Flush any buffered partial bytes (e.g. on shell close) so they are not
+  /// lost. Returns whatever was held back, to be forwarded as-is.
+  Uint8List flush() {
+    if (_pending.isEmpty) return Uint8List(0);
+    final out = Uint8List.fromList(_pending);
+    _pending.clear();
+    return out;
+  }
+
+  /// Reset state for a fresh shell/attach (e.g. after reconnect).
+  void reset() {
+    _pending.clear();
+    repliesSent = 0;
+  }
+
+  /// Attempt to match `ESC [ > [params] c` starting at [start].
+  _Da2Match _matchDa2(List<int> buf, int start) {
+    var i = start;
+    // ESC
+    if (i >= buf.length) return const _Da2Match(_MatchKind.partial, 0);
+    if (buf[i] != _esc) return const _Da2Match(_MatchKind.none, 0);
+    i++;
+    // [
+    if (i >= buf.length) return const _Da2Match(_MatchKind.partial, 0);
+    if (buf[i] != _lbracket) return const _Da2Match(_MatchKind.none, 0);
+    i++;
+    // >
+    if (i >= buf.length) return const _Da2Match(_MatchKind.partial, 0);
+    if (buf[i] != _gt) return const _Da2Match(_MatchKind.none, 0);
+    i++;
+    // Optional run of parameter digits/semicolons. tmux itself sends a bare
+    // `ESC[>c`, but tolerate `ESC[>0c` / `ESC[>0;0c` defensively.
+    while (i < buf.length && (_isDigit(buf[i]) || buf[i] == 0x3b)) {
+      i++;
+    }
+    if (i >= buf.length) return const _Da2Match(_MatchKind.partial, 0);
+    // terminator c
+    if (buf[i] == _c) {
+      return _Da2Match(_MatchKind.full, (i - start) + 1);
+    }
+    return const _Da2Match(_MatchKind.none, 0);
+  }
+
+  bool _isDigit(int b) => b >= 0x30 && b <= 0x39;
+}
+
+enum _MatchKind { none, partial, full }
+
+/// Outcome of [_matchDa2]: the match kind plus, for a full match, how many
+/// bytes the query occupied.
+class _Da2Match {
+  const _Da2Match(this.kind, this.length);
+  final _MatchKind kind;
+  final int length;
+}

--- a/native/test/services/da2_hyperlink_host_test.dart
+++ b/native/test/services/da2_hyperlink_host_test.dart
@@ -1,0 +1,217 @@
+// SessionHost DA2 hyperlink-advertise wiring (#osc8-tmux-advertise).
+//
+// Verifies the host intercepts tmux's DA2 (Secondary Device Attributes) query
+// in the live shell's output stream and:
+//   1. ANSWERS it on the shell's stdin with the `tmux` reply (ESC[>84;0;0c) so
+//      tmux advertises `hyperlinks` and forwards OSC-8 links to this client;
+//   2. SWALLOWS the query so it is NOT forwarded to the UI terminal (the UI
+//      terminal would otherwise emit its own `>0` reply, which tmux honors
+//      FIRST, defeating the advertise).
+//
+// Reuses the #619 harness shape (silent socket + drivable controller + a
+// recording shell transport whose output we can drive directly).
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/ssh/ssh_shell.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+
+class _SilentSocket implements SSHSocket {
+  final _outbound = StreamController<List<int>>();
+  final _doneCompleter = Completer<void>();
+
+  @override
+  Stream<Uint8List> get stream => const Stream<Uint8List>.empty();
+
+  @override
+  StreamSink<List<int>> get sink => _outbound.sink;
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() async {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    await _outbound.close();
+    return done;
+  }
+
+  @override
+  void destroy() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+}
+
+class _DrivableController extends SshSessionController {
+  _DrivableController(this._client);
+  final SSHClient _client;
+  @override
+  SSHClient? get client => _client;
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+/// Shell transport with a driveable output stream + recorded stdin (`sent`).
+class _DriveableShellTransport implements SshShellTransport {
+  final _outCtrl = StreamController<Uint8List>.broadcast();
+  final _doneCompleter = Completer<void>();
+  final BytesBuilder sent = BytesBuilder(copy: false);
+  bool closed = false;
+
+  void emit(Uint8List bytes) => _outCtrl.add(bytes);
+
+  @override
+  Stream<Uint8List> get output => _outCtrl.stream;
+
+  @override
+  void send(Uint8List bytes) => sent.add(bytes);
+
+  @override
+  void resize(int cols, int rows, {int pixelWidth = 0, int pixelHeight = 0}) {}
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  void close() {
+    closed = true;
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    if (!_outCtrl.isClosed) _outCtrl.close();
+  }
+}
+
+Uint8List _b(String s) => Uint8List.fromList(s.codeUnits);
+String _s(List<int> b) => String.fromCharCodes(b);
+
+void main() {
+  Future<
+      ({
+        SessionHost host,
+        SshSessionProxy proxy,
+        InMemoryGatewayPair pair,
+        List<_DriveableShellTransport> opened,
+        StringBuffer forwarded,
+      })> setUpConnectedShell(String sid) async {
+    final socket = _SilentSocket();
+    final sentinelClient = SSHClient(socket, username: 'u');
+    addTearDown(() {
+      try {
+        sentinelClient.close();
+      } catch (_) {}
+      socket.destroy();
+    });
+
+    late _DrivableController controller;
+    _DrivableController factory() {
+      controller = _DrivableController(sentinelClient);
+      return controller;
+    }
+
+    final opened = <_DriveableShellTransport>[];
+    Future<SshShellTransport?> opener(SSHClient c, int cols, int rows) async {
+      final t = _DriveableShellTransport();
+      opened.add(t);
+      return t;
+    }
+
+    final pair = InMemoryGatewayPair();
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: factory,
+      shellOpener: opener,
+      snapshotInterval: const Duration(hours: 1),
+    );
+    final proxy = SshSessionProxy(sessionId: sid, gateway: pair.uiSide);
+
+    // The forwarded terminal byte stream the UI would render.
+    final forwarded = StringBuffer();
+    proxy.output.listen((bytes) => forwarded.write(_s(bytes)));
+
+    proxy.connect(const SshConnectParams(
+      host: 'h',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    ));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    controller.debugSetConnectedForTest(const SshConnectParams(
+      host: 'h',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    ));
+    // Let the shell open + output listener wire up.
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+
+    addTearDown(() async {
+      await proxy.dispose();
+      await host.dispose();
+      await pair.dispose();
+    });
+    return (
+      host: host,
+      proxy: proxy,
+      pair: pair,
+      opened: opened,
+      forwarded: forwarded,
+    );
+  }
+
+  test('answers tmux DA2 query on stdin and swallows it from UI output',
+      () async {
+    final ctx = await setUpConnectedShell('da2:22:u:1');
+    expect(ctx.opened, hasLength(1), reason: 'one shell opened');
+    final shell = ctx.opened.first;
+
+    // Remote (tmux) sends some output, the DA2 query, then more output.
+    shell.emit(_b('prompt\$ \x1b[>cmore'));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    // 1) We replied as tmux on the shell's stdin.
+    expect(_s(shell.sent.toBytes()), '\x1b[>84;0;0c',
+        reason: 'host must answer DA2 with the tmux (T=84) reply');
+
+    // 2) The query must NOT appear in the bytes forwarded to the UI terminal.
+    final forwarded = ctx.forwarded.toString();
+    expect(forwarded.contains('\x1b[>c'), isFalse,
+        reason: 'DA2 query must be swallowed, not forwarded to the terminal');
+    // 3) The surrounding bytes still reach the UI.
+    expect(forwarded.contains('prompt\$ '), isTrue);
+    expect(forwarded.contains('more'), isTrue);
+  });
+
+  test('non-tmux output is forwarded verbatim with no DA2 reply', () async {
+    final ctx = await setUpConnectedShell('plain:22:u:1');
+    final shell = ctx.opened.first;
+
+    shell.emit(_b('\x1b[32mhello\x1b[0m\r\n'));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(shell.sent.length, 0, reason: 'no DA2 query => no reply');
+    expect(ctx.forwarded.toString().contains('\x1b[32mhello\x1b[0m\r\n'),
+        isTrue);
+  });
+
+  test('DA2 query split across two output chunks is still answered', () async {
+    final ctx = await setUpConnectedShell('split:22:u:1');
+    final shell = ctx.opened.first;
+
+    shell.emit(_b('x\x1b[>'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    shell.emit(_b('cy'));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(_s(shell.sent.toBytes()), '\x1b[>84;0;0c');
+    final forwarded = ctx.forwarded.toString();
+    expect(forwarded.contains('\x1b[>c'), isFalse);
+    expect(forwarded.contains('x'), isTrue);
+    expect(forwarded.contains('y'), isTrue);
+  });
+}

--- a/native/test/ssh/da2_responder_test.dart
+++ b/native/test/ssh/da2_responder_test.dart
@@ -1,0 +1,151 @@
+// Unit tests for [Da2HyperlinkResponder] — the byte-stream interceptor that
+// answers tmux's DA2 query as a `tmux`-class terminal so tmux forwards OSC-8
+// hyperlinks. See native/lib/ssh/da2_responder.dart.
+//
+// THE MECHANISM (verified against tmux 3.4): tmux enables the `hyperlinks`
+// client feature only when the client answers the DA2 query `ESC [ > c` with
+// `ESC [ > 84 ; ... c` (84 = 'T'). tmux honors the FIRST reply, so we must
+// SWALLOW the query (the UI terminal would otherwise emit its own `>0` reply
+// first) and send ours.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ssh/da2_responder.dart';
+
+Uint8List _b(String s) => Uint8List.fromList(s.codeUnits);
+String _s(Uint8List b) => String.fromCharCodes(b);
+
+void main() {
+  group('Da2HyperlinkResponder', () {
+    test('the tmux reply is ESC [ > 84 ; 0 ; 0 c', () {
+      expect(_s(kTmuxDa2Reply), '\x1b[>84;0;0c');
+    });
+
+    test('passes ordinary bytes through untouched, no reply', () {
+      final r = Da2HyperlinkResponder();
+      final res = r.scan(_b('hello world\r\n'));
+      expect(_s(res.forward), 'hello world\r\n');
+      expect(res.hasReply, isFalse);
+      expect(res.replies, isEmpty);
+    });
+
+    test('passes other escape sequences (colors, primary DA) through', () {
+      final r = Da2HyperlinkResponder();
+      // SGR color + primary DA query ESC[?1;2c + cursor move — none is DA2.
+      final input = '\x1b[31mred\x1b[0m\x1b[?1;2c\x1b[2A';
+      final res = r.scan(_b(input));
+      expect(_s(res.forward), input);
+      expect(res.hasReply, isFalse);
+    });
+
+    test('detects the bare tmux DA2 query ESC[>c, swallows it, replies', () {
+      final r = Da2HyperlinkResponder();
+      final res = r.scan(_b('before\x1b[>cafter'));
+      // Query removed from the forwarded stream.
+      expect(_s(res.forward), 'beforeafter');
+      // Exactly one tmux reply.
+      expect(res.replies, hasLength(1));
+      expect(_s(res.replies.first), '\x1b[>84;0;0c');
+      expect(r.repliesSent, 1);
+    });
+
+    test('tolerates parameterized DA2 queries ESC[>0c and ESC[>0;0c', () {
+      for (final q in ['\x1b[>0c', '\x1b[>0;0c', '\x1b[>1;2;3c']) {
+        final r = Da2HyperlinkResponder();
+        final res = r.scan(_b('x${q}y'));
+        expect(_s(res.forward), 'xy', reason: 'query $q should be swallowed');
+        expect(res.replies, hasLength(1), reason: 'query $q should reply');
+      }
+    });
+
+    test('handles the query split across two chunks', () {
+      final r = Da2HyperlinkResponder();
+      // Split right in the middle of ESC [ > c.
+      final res1 = r.scan(_b('out\x1b[>'));
+      // The partial query is buffered, not forwarded.
+      expect(_s(res1.forward), 'out');
+      expect(res1.hasReply, isFalse);
+
+      final res2 = r.scan(_b('cmore'));
+      // Completing the query swallows it and replies.
+      expect(_s(res2.forward), 'more');
+      expect(res2.replies, hasLength(1));
+    });
+
+    test('handles the query split byte-by-byte', () {
+      final r = Da2HyperlinkResponder();
+      final query = '\x1b[>c';
+      final collected = StringBuffer();
+      var replies = 0;
+      for (final byte in [...'A'.codeUnits, ...query.codeUnits, ...'B'.codeUnits]) {
+        final res = r.scan(Uint8List.fromList([byte]));
+        collected.write(_s(res.forward));
+        replies += res.replies.length;
+      }
+      expect(collected.toString(), 'AB');
+      expect(replies, 1);
+    });
+
+    test('a lone ESC that is not a DA2 prefix is forwarded', () {
+      final r = Da2HyperlinkResponder();
+      // ESC followed by a non-[ byte — a different escape. Should pass through.
+      final res = r.scan(_b('\x1bM')); // reverse index
+      expect(_s(res.forward), '\x1bM');
+      expect(res.hasReply, isFalse);
+    });
+
+    test('ESC[> that is NOT a DA2 query (different final byte) passes through', () {
+      final r = Da2HyperlinkResponder();
+      // ESC[>4m is a real sequence (some modifyOtherKeys-ish); final byte != c.
+      final res = r.scan(_b('\x1b[>4m'));
+      expect(_s(res.forward), '\x1b[>4m');
+      expect(res.hasReply, isFalse);
+    });
+
+    test('multiple DA2 queries in one chunk each get a reply', () {
+      final r = Da2HyperlinkResponder();
+      final res = r.scan(_b('\x1b[>ca\x1b[>cb'));
+      expect(_s(res.forward), 'ab');
+      expect(res.replies, hasLength(2));
+      expect(r.repliesSent, 2);
+    });
+
+    test('flush returns buffered partial bytes', () {
+      final r = Da2HyperlinkResponder();
+      final res = r.scan(_b('tail\x1b['));
+      expect(_s(res.forward), 'tail');
+      // The partial \x1b[ was buffered; flush returns it.
+      expect(_s(r.flush()), '\x1b[');
+      // Second flush is empty.
+      expect(r.flush(), isEmpty);
+    });
+
+    test('reset clears pending buffer and counter', () {
+      final r = Da2HyperlinkResponder();
+      r.scan(_b('\x1b[>')); // buffers a partial
+      r.scan(_b('c')); // completes -> reply; counter = 1
+      expect(r.repliesSent, 1);
+      r.reset();
+      expect(r.repliesSent, 0);
+      // After reset, a fresh 'c' is just a literal 'c' (no dangling prefix).
+      final res = r.scan(_b('c'));
+      expect(_s(res.forward), 'c');
+      expect(res.hasReply, isFalse);
+    });
+
+    test('does not corrupt UTF-8 multibyte content around a query', () {
+      final r = Da2HyperlinkResponder();
+      // "café" then DA2 then "naïve".
+      final bytes = <int>[
+        ...utf8.encode('café'),
+        ...'\x1b[>c'.codeUnits,
+        ...utf8.encode('naïve'),
+      ];
+      final res = r.scan(Uint8List.fromList(bytes));
+      expect(utf8.decode(res.forward), 'cafénaïve');
+      expect(res.replies, hasLength(1));
+    });
+  });
+}

--- a/scripts/probe-tmux-da2-order.sh
+++ b/scripts/probe-tmux-da2-order.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Does injecting a tmux('T') DA2 reply work even when xterm's own generic
+# reply (>0;0;0c) is ALSO sent? Tests reply ordering, because in MobiSSH the
+# real terminal (xterm.dart) will still emit its own >0 reply alongside our
+# injected >84 reply. We must know which one tmux honors.
+set -euo pipefail
+
+PROBE_OUT_DIR="${PROBE_OUT_DIR:-/tmp/mobissh/tmux-probe}"
+mkdir -p "$PROBE_OUT_DIR"
+exec > >(tee -a "$PROBE_OUT_DIR/order.log") 2>&1
+
+SOCK="ordprobe$$"
+cleanup() { tmux -L "$SOCK" kill-server 2>/dev/null || true; }
+trap cleanup EXIT
+
+probe() {
+  # $1 label, $2 reply-bytes-hex (sent as a single write in response to >c)
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  tmux -L "$SOCK" -f /dev/null new-session -d -s s -x 80 -y 24
+  local resfile="$PROBE_OUT_DIR/ord-feat.txt"; rm -f "$resfile"
+  SOCK="$SOCK" REPLYHEX="$2" RESFILE="$resfile" TERM="xterm-256color" python3 - <<'PY'
+import os, pty, time, select, subprocess
+sock=os.environ["SOCK"]; reply=bytes.fromhex(os.environ["REPLYHEX"]); resfile=os.environ["RESFILE"]
+pid,fd=pty.fork()
+if pid==0:
+    os.execvp("tmux",["tmux","-L",sock,"-f","/dev/null","attach","-t","s"]); os._exit(127)
+buf=b""; answered=False; queried=False; deadline=time.time()+4.0
+while time.time()<deadline:
+    r,_,_=select.select([fd],[],[],0.1)
+    if fd in r:
+        try: data=os.read(fd,8192)
+        except OSError: break
+        if not data: break
+        buf+=data
+        if not answered and b"\x1b[>c" in buf:
+            os.write(fd, reply); answered=True
+    if not queried and answered:
+        time.sleep(0.4)
+        out=subprocess.run(["tmux","-L",sock,"list-clients","-F","#{client_termfeatures}"],capture_output=True,text=True)
+        open(resfile,"w").write(out.stdout.strip()); queried=True; break
+PY
+  local feats; feats="$(cat "$resfile" 2>/dev/null || true)"
+  [ -z "$feats" ] && feats="(empty)"
+  local has="NO"; case ",$feats," in *,hyperlinks,*) has="YES";; esac
+  printf '%-34s hyperlinks=%-3s  %s\n' "$1" "$has" "$feats"
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+}
+
+# >84 = ESC[>84;0;0c = 1b5b3e38343b303b3063 ; >0 = ESC[>0;0;0c = 1b5b3e303b303b3063
+echo "tmux version: $(tmux -V)"
+probe "ours-first: >84 then >0"  "1b5b3e38343b303b30631b5b3e303b303b3063"
+probe "xterm-first: >0 then >84" "1b5b3e303b303b30631b5b3e38343b303b3063"
+probe "only >84"                  "1b5b3e38343b303b3063"
+probe "only >0 (xterm default)"   "1b5b3e303b303b3063"

--- a/scripts/probe-tmux-da2.sh
+++ b/scripts/probe-tmux-da2.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Prove that the tmux `hyperlinks` client feature is enabled via the DA2
+# (Secondary Device Attributes) auto-detection path, NOT via TERM.
+#
+# tmux sends a DA2 query (ESC [ > c) to the client at attach. If the client
+# replies "\e[>84;...c" (84='T'=tmux) tmux applies its built-in "tmux"
+# default-features set, which includes `hyperlinks`. ('M'=77=mintty also does.)
+#
+# The pty client answers tmux's DA2 query with a chosen reply, polls
+# client_termfeatures from inside the same process (so it reads while the
+# client is attached), and writes the result to a file.
+set -euo pipefail
+
+PROBE_OUT_DIR="${PROBE_OUT_DIR:-/tmp/mobissh/tmux-probe}"
+mkdir -p "$PROBE_OUT_DIR"
+LOGFILE="$PROBE_OUT_DIR/da2.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+SOCK="da2probe$$"
+cleanup() { tmux -L "$SOCK" kill-server 2>/dev/null || true; }
+trap cleanup EXIT
+
+probe() {
+  # $1 label, $2 TERM, $3 mode(none|tmux|mintty)
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  tmux -L "$SOCK" -f /dev/null new-session -d -s s -x 80 -y 24
+  local resfile="$PROBE_OUT_DIR/feat-$3.txt"
+  rm -f "$resfile"
+  TERM="$2" SOCK="$SOCK" MODE="$3" RESFILE="$resfile" python3 - <<'PY'
+import os, pty, sys, time, select, subprocess
+
+sock = os.environ["SOCK"]; mode = os.environ["MODE"]; resfile = os.environ["RESFILE"]
+REPLIES = {"tmux": b"\x1b[>84;0;0c", "mintty": b"\x1b[>77;20000;0c"}
+reply = REPLIES.get(mode)
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.execvp("tmux", ["tmux","-L",sock,"-f","/dev/null","attach","-t","s"])
+    os._exit(127)
+
+buf = b""; answered = False; queried = False
+deadline = time.time() + 4.0
+while time.time() < deadline:
+    r,_,_ = select.select([fd], [], [], 0.1)
+    if fd in r:
+        try:
+            data = os.read(fd, 8192)
+        except OSError:
+            break
+        if not data:
+            break
+        buf += data
+        if reply and not answered and b"\x1b[>c" in buf:
+            os.write(fd, reply); answered = True
+    # Once we've answered (or for none-mode, after 1.5s), read features.
+    if not queried and (answered or (mode == "none" and time.time() > deadline-2.5)):
+        time.sleep(0.4)  # let tmux process the reply
+        out = subprocess.run(
+            ["tmux","-L",sock,"list-clients","-F","#{client_termfeatures}"],
+            capture_output=True, text=True)
+        with open(resfile, "w") as f:
+            f.write(out.stdout.strip())
+        queried = True
+        break
+# detach
+try:
+    os.write(fd, b"\x1b")  # nudge
+except OSError:
+    pass
+PY
+  local feats
+  feats="$(cat "$resfile" 2>/dev/null | tail -1 || true)"
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  [ -z "$feats" ] && feats="(empty)"
+  local has="NO"
+  case ",$feats," in *,hyperlinks,*) has="YES" ;; esac
+  printf '%-30s hyperlinks=%-3s  %s\n' "$1" "$has" "$feats"
+}
+
+echo "tmux version: $(tmux -V)"
+echo "da2 probe started $(date +%Y%m%dT%H%M%S%z)"
+probe "xterm256 no-DA2-reply" "xterm-256color" "none"
+probe "xterm256 DA2=tmux(T)"  "xterm-256color" "tmux"
+probe "xterm256 DA2=mintty(M)" "xterm-256color" "mintty"
+echo "da2 probe done"

--- a/scripts/probe-tmux-hyperlinks.sh
+++ b/scripts/probe-tmux-hyperlinks.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Probe which TERM value makes tmux 3.4 enable the `hyperlinks` client feature.
+#
+# For each candidate TERM, start a throwaway tmux server, attach a real pty
+# client (via `script`) carrying that TERM, and read back
+# #{client_termfeatures}. Prints a table of TERM -> features and whether
+# `hyperlinks` is present.
+#
+# Background: tmux only FORWARDS OSC-8 hyperlinks to clients whose
+# terminal-features include `hyperlinks`. flterm advertises TERM=xterm-256color
+# (no hyperlinks). We want a TERM the built-in default-features table maps to
+# `hyperlinks` with no ~/.tmux.conf.
+set -euo pipefail
+
+PROBE_OUT_DIR="${PROBE_OUT_DIR:-/tmp/mobissh/tmux-probe}"
+mkdir -p "$PROBE_OUT_DIR"
+LOGFILE="$PROBE_OUT_DIR/probe.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+SOCK="probe$$"
+
+cleanup() {
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Candidates. xterm-256color is flterm's current value (baseline).
+CANDIDATES=(
+  "xterm-256color"
+  "tmux-256color"
+  "tmux"
+  "xterm-ghostty"
+  "iterm2"
+  "iTerm2"
+  "wezterm"
+  "foot"
+  "contour"
+  "rxvt-unicode-256color"
+  "vte-256color"
+)
+
+probe_one() {
+  local term="$1"
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  tmux -L "$SOCK" -f /dev/null new-session -d -s s -x 80 -y 24 2>/dev/null || {
+    echo "$term -> SERVER_START_FAILED"
+    return
+  }
+  # Attach a real pty client carrying $term in the background; it just holds
+  # the attach open via a long-lived shell command. We query features from a
+  # SEPARATE control command so display-message output isn't swallowed by the
+  # attached client's screen.
+  local capfile="$PROBE_OUT_DIR/cap-$term.txt"
+  TERM="$term" script -qfc \
+    "tmux -L $SOCK -f /dev/null attach -t s" /dev/null > "$capfile" 2>&1 &
+  local spid=$!
+  # Give the client time to attach and feature-detect.
+  sleep 1.5
+  local feats
+  feats="$(tmux -L "$SOCK" list-clients -F '#{client_termfeatures}' 2>/dev/null | tail -1 || true)"
+  # Tear down the backgrounded attach.
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  kill "$spid" 2>/dev/null || true
+  wait "$spid" 2>/dev/null || true
+  if [ -z "$feats" ]; then
+    feats="(no client attached; see $capfile)"
+  fi
+  local has="NO"
+  case ",$feats," in
+    *,hyperlinks,*) has="YES" ;;
+  esac
+  printf '%-26s hyperlinks=%-3s  %s\n' "$term" "$has" "$feats"
+}
+
+echo "tmux version: $(tmux -V)"
+echo "probe started $(date +%Y%m%dT%H%M%S%z)"
+for t in "${CANDIDATES[@]}"; do
+  probe_one "$t"
+done
+echo "probe done"

--- a/scripts/probe-tmux-osc8-forward.sh
+++ b/scripts/probe-tmux-osc8-forward.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# End-to-end proof: with the `hyperlinks` feature enabled (via DA2='T'), a
+# tmux pane that emits an OSC-8 hyperlink has that hyperlink FORWARDED to the
+# client (not stripped). We compare the bytes tmux draws to two clients:
+#   - baseline (no DA2 reply)  -> OSC-8 stripped (no "\e]8;" in client stream)
+#   - DA2='T' (tmux)           -> OSC-8 present in client stream
+set -euo pipefail
+
+PROBE_OUT_DIR="${PROBE_OUT_DIR:-/tmp/mobissh/tmux-probe}"
+mkdir -p "$PROBE_OUT_DIR"
+LOGFILE="$PROBE_OUT_DIR/osc8.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+SOCK="osc8probe$$"
+cleanup() { tmux -L "$SOCK" kill-server 2>/dev/null || true; }
+trap cleanup EXIT
+
+probe() {
+  # $1 label, $2 mode(none|tmux)
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+  tmux -L "$SOCK" -f /dev/null new-session -d -s s -x 80 -y 24
+  local dump="$PROBE_OUT_DIR/osc8-client-$2.bin"
+  rm -f "$dump"
+  TERM="xterm-256color" SOCK="$SOCK" MODE="$2" DUMP="$dump" python3 - <<'PY'
+import os, pty, time, select
+
+sock=os.environ["SOCK"]; mode=os.environ["MODE"]; dump=os.environ["DUMP"]
+reply = b"\x1b[>84;0;0c" if mode=="tmux" else None
+
+pid, fd = pty.fork()
+if pid==0:
+    os.execvp("tmux", ["tmux","-L",sock,"-f","/dev/null","attach","-t","s"])
+    os._exit(127)
+
+f=open(dump,"wb"); buf=b""; answered=False; emitted=False
+deadline=time.time()+5.0
+while time.time()<deadline:
+    r,_,_=select.select([fd],[],[],0.1)
+    if fd in r:
+        try: data=os.read(fd,8192)
+        except OSError: break
+        if not data: break
+        f.write(data); f.flush(); buf+=data
+        if reply and not answered and b"\x1b[>c" in buf:
+            os.write(fd, reply); answered=True
+    # After features are negotiated, emit an OSC-8 link in the pane.
+    if not emitted and time.time()>deadline-3.0:
+        import subprocess
+        subprocess.run(["tmux","-L",sock,"send-keys","-t","s",
+            r"printf '\e]8;;https://example.com/x\e\\LINKTEXT\e]8;;\e\\\n'", "Enter"])
+        emitted=True
+f.close()
+PY
+  # Did the OSC-8 introducer reach the client?
+  local n
+  n="$(grep -c $'\x1b]8;' "$dump" 2>/dev/null || true)"
+  # grep -c counts lines; use a byte search instead.
+  if LC_ALL=C grep -q $'\x1b]8;' "$dump"; then
+    printf '%-22s OSC8-forwarded=YES\n' "$1"
+  else
+    printf '%-22s OSC8-forwarded=NO\n' "$1"
+  fi
+  tmux -L "$SOCK" kill-server 2>/dev/null || true
+}
+
+echo "tmux version: $(tmux -V)"
+echo "osc8 forward probe $(date +%Y%m%dT%H%M%S%z)"
+probe "baseline(no-DA2)" "none"
+probe "DA2=tmux(T)"       "tmux"
+echo "osc8 forward done"


### PR DESCRIPTION
## Problem

MobiSSH's terminal connects over SSH to a host running tmux. The host app
(Claude CLI, `gh`, `ls --hyperlink`) emits OSC-8 hyperlinks; tmux **parses and
stores** them but only **forwards** them to a client whose `terminal-features`
include `hyperlinks`. Our client advertised `TERM=xterm-256color` with no
`hyperlinks` feature, so tmux **stripped** every OSC-8 before drawing — the
already-shipped OSC-8 scanner found nothing. We needed this universally, with
**no `~/.tmux.conf` edit**.

## Spike: how does tmux enable `hyperlinks`?

Verified empirically against local **tmux 3.4** (`scripts/probe-tmux-*.sh`):

- **It's DA2, not TERM.** tmux sends a DA2 (Secondary Device Attributes) query
  `ESC [ > c` to the client at attach. `tty_keys_device_attributes2` maps the
  reply's first parameter — `'T'`(84)=tmux, `'M'`(77)=mintty, `'U'`(82)=rxvt —
  to `tty_default_features(...)`. The built-in **`tmux`** feature set includes
  `hyperlinks`.
- **TERM is a dead end.** `TERM=tmux`/`tmux-256color`/`xterm-256color` do not
  enable hyperlinks on their own. Exotic TERMs (`xterm-ghostty`, `iTerm2`,
  `wezterm`, `foot`) have no terminfo entry on a typical host — the client
  can't even attach (`missing or unsuitable terminal`). So changing TERM is
  fragile and risks colors/keys/mouse.
- **tmux honors the FIRST DA2 reply.** Proven: `>84 then >0` → `hyperlinks`
  YES; `>0 then >84` → NO.
- **End-to-end:** with the `>84` reply on `TERM=xterm-256color`,
  `client_termfeatures` gains `hyperlinks` AND an in-tmux OSC-8 link is
  forwarded to the client (baseline: stripped).

## The lever (cleanest available)

xterm.dart answers DA2 with `ESC[>0;0;0c` (model 0 → matches nothing).
flterm/libghostty parses DA2 inside a prebuilt `.so` (not Dart-patchable). So
the clean, **backend-agnostic** point is the SSH byte boundary in the task
isolate (`session_host.dart`), which sits above whichever terminal renders.

`Da2HyperlinkResponder` (new, chunk-boundary-safe) intercepts tmux's DA2 query
in the shell's output stream, **swallows** it (so the UI terminal never emits
its own `>0` reply — which tmux would honor first), and answers
`ESC[>84;0;0c` (`'T'` = tmux) on stdin. tmux then advertises `hyperlinks` and
forwards OSC-8 links unstripped to the existing scanner.

- No TERM change → **no color/key/mouse regression**.
- **Inert on non-tmux hosts** (a bare shell never sends the DA2 query).
- Minimal and reversible. Does **not** touch the OSC-8 scanner.

## Tests

- `native/test/ssh/da2_responder_test.dart` — 13 unit tests: bare + parameterized
  queries, chunk-split (two-chunk and byte-by-byte), non-DA2 escapes pass
  through, UTF-8 multibyte safety, `flush`/`reset`, multiple queries per chunk.
- `native/test/services/da2_hyperlink_host_test.dart` — 3 host-wiring tests:
  reply sent on stdin, query swallowed from the UI output stream, split-chunk
  query still answered.
- `scripts/native-fast-gate.sh` green (875 tests).

## Validation status

- Proven on local tmux 3.4 that the change yields `hyperlinks` in
  `client_termfeatures` and forwards an in-tmux OSC-8 link (not stripped).
- **NOT device-validated.** On-device confirmation (owner re-renders a URL in
  tmux → OSC-8 detected) is for the orchestrator. This change touches the
  connect/session-output path, so the **integration suite is REQUIRED on the
  emulator before merge** (per `.claude/rules/testing.md` #589).

🤖 Generated with [Claude Code](https://claude.com/claude-code)