### PR TITLE
feat: detect & open absolute file paths from terminal (paths Slice 1) (#778)

### DIFF
--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -55,10 +55,19 @@ final pdfTapInterceptorProvider = Provider<PdfTapInterceptor?>(
 
 /// Push the file browser for [sessionId]. The session menu's "Files" item and
 /// any future caller use this single entry point (#559 bullet 4).
-Future<void> openFileBrowser(BuildContext context, String sessionId) {
+///
+/// [initialPath] (#778) opens the browser AT a directory other than `/` — a tap
+/// on a detected absolute file path passes the path so the explorer lands there.
+/// Defaults to `/` (the unchanged session-menu behaviour).
+Future<void> openFileBrowser(
+  BuildContext context,
+  String sessionId, {
+  String initialPath = '/',
+}) {
   return Navigator.of(context).push(
     MaterialPageRoute<void>(
-      builder: (_) => FileBrowserScreen(sessionId: sessionId),
+      builder: (_) =>
+          FileBrowserScreen(sessionId: sessionId, initialPath: initialPath),
     ),
   );
 }

--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -37,6 +37,11 @@ const String kGhosttyUrlPatternId = 'url';
 /// full URI. Its anchor renders the SAME bubble affordance as a regex URL.
 const String kGhosttyOsc8PatternId = 'osc8';
 
+/// The id of the absolute FILE PATH pattern/decorator (#778, paths Slice 1).
+/// Mirrors the pattern id the view registers so the registry routes path anchors
+/// to [PathDecorator] (a distinct treatment from the URL bubble).
+const String kGhosttyPathPatternId = 'path';
+
 /// Per-anchor render input handed to a [GhosttyTerminalDecorator] (#767 B).
 ///
 /// [rects] are the anchor's CURRENT viewport pixel rects (one per visible
@@ -90,6 +95,9 @@ class GhosttyDecoratorRegistry {
       // #767 Slice B: an OSC-8 hyperlink anchor renders the SAME bubble as a
       // regex URL — same affordance, exact full URI behind it.
       UrlBubbleDecorator(patternId: kGhosttyOsc8PatternId),
+      // #778 paths Slice 1: a file-path anchor gets a DISTINCT treatment — a
+      // leading folder glyph + a thin dotted underline, NOT the URL bubble.
+      PathDecorator(),
     ]);
   }
 
@@ -170,6 +178,126 @@ class _UrlBubblePainter extends CustomPainter {
     // Repaint whenever the anchors (rects/color/payload) differ. The list is
     // rebuilt each frame from the live geometry, so identity is enough to catch
     // scroll/resize/detection changes cheaply.
+    if (identical(old.anchors, anchors)) return false;
+    if (old.anchors.length != anchors.length) return true;
+    for (var i = 0; i < anchors.length; i++) {
+      final a = anchors[i];
+      final b = old.anchors[i];
+      if (a.color != b.color || a.payload != b.payload) return true;
+      if (a.rects.length != b.rects.length) return true;
+      for (var j = 0; j < a.rects.length; j++) {
+        if (a.rects[j] != b.rects[j]) return true;
+      }
+    }
+    return false;
+  }
+}
+
+/// The file-PATH decorator (#778, paths Slice 1) — DISTINCT from the URL bubble.
+///
+/// A path anchor must NOT reuse the URL's outline bubble (so the two affordances
+/// read differently) and must avoid the two paints the fork's painter notes are
+/// wrong for text: an opaque BACKGROUND FILL (hides the glyphs) and a SOLID
+/// UNDERLINE (collides with SGR-4 underline). Instead it draws a leading
+/// monochrome FOLDER glyph in the anchor color (memory
+/// feedback_monochrome_icons_no_emoji — Material icon, currentColor, never an
+/// emoji) plus a thin DOTTED underline in a faded secondary accent. Paint-only;
+/// taps/long-presses fall through to the gesture router.
+class PathDecorator extends GhosttyTerminalDecorator {
+  const PathDecorator({this.patternId = kGhosttyPathPatternId});
+
+  @override
+  final String patternId;
+
+  @override
+  Widget build(BuildContext context, List<GhosttyDecoratedAnchor> anchors) {
+    return IgnorePointer(
+      child: CustomPaint(
+        painter: _PathPainter(anchors),
+        size: Size.infinite,
+      ),
+    );
+  }
+}
+
+/// Paints each path anchor: a leading folder glyph at the first row segment and a
+/// thin dotted underline under every row segment.
+class _PathPainter extends CustomPainter {
+  _PathPainter(this.anchors);
+
+  final List<GhosttyDecoratedAnchor> anchors;
+
+  /// Underline offset below the cell baseline-ish bottom, stroke width, the
+  /// dotted dash/gap, and the folder-glyph size cap, in logical px.
+  static const double _underlineGap = 1.0;
+  static const double _stroke = 1.2;
+  static const double _dash = 2.0;
+  static const double _space = 2.0;
+  static const double _glyphMaxSize = 14.0;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    for (final anchor in anchors) {
+      if (anchor.rects.isEmpty) continue;
+      // Secondary accent: a faded version of the anchor color so the path reads
+      // as DISTINCT from the (full-strength outline) URL bubble.
+      final underline = Paint()
+        ..color = anchor.color.withValues(alpha: 0.65)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = _stroke
+        ..strokeCap = StrokeCap.round
+        ..isAntiAlias = true;
+      for (final rect in anchor.rects) {
+        if (rect.width <= 0 || rect.height <= 0) continue;
+        final y = rect.bottom + _underlineGap;
+        // Dotted underline: short dashes left→right under the row segment.
+        var x = rect.left;
+        while (x < rect.right) {
+          final end = (x + _dash).clamp(rect.left, rect.right);
+          canvas.drawLine(Offset(x, y), Offset(end, y), underline);
+          x += _dash + _space;
+        }
+      }
+      // Leading folder glyph at the first (top-most) row segment, sized to the
+      // row height but capped so it never dominates.
+      final first = anchor.rects.first;
+      final glyphSize = first.height.clamp(8.0, _glyphMaxSize);
+      _paintFolderGlyph(canvas, first, glyphSize, anchor.color);
+    }
+  }
+
+  /// Draw a monochrome folder OUTLINE glyph to the LEFT of the path's first cell
+  /// rect, in the anchor color. Hand-drawn outline (no font dependency) so it is
+  /// theme-compliant currentColor and never an emoji.
+  void _paintFolderGlyph(Canvas canvas, Rect cell, double s, Color color) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.2
+      ..strokeJoin = StrokeJoin.round
+      ..isAntiAlias = true;
+    final w = s * 0.9;
+    final h = s * 0.72;
+    // Position the glyph just left of the path, vertically centered on the row.
+    final left = cell.left - w - 2.0;
+    if (left < 0) return; // no room at the screen edge — skip the glyph
+    final top = cell.top + (cell.height - h) / 2;
+    final tabW = w * 0.45;
+    final tabH = h * 0.22;
+    final path = Path()
+      ..moveTo(left, top + tabH)
+      ..lineTo(left, top + h)
+      ..lineTo(left + w, top + h)
+      ..lineTo(left + w, top + tabH)
+      ..lineTo(left + tabW, top + tabH)
+      ..lineTo(left + tabW - tabH, top)
+      ..lineTo(left + tabH, top)
+      ..close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _PathPainter old) {
     if (identical(old.anchors, anchors)) return false;
     if (old.anchors.length != anchors.length) return true;
     for (var i = 0; i < anchors.length; i++) {

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -178,8 +178,10 @@ import '../state/ctrl_modifier_provider.dart';
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
+import 'file_browser_screen.dart';
 import 'ghostty_terminal_decorators.dart';
 import 'keybar.dart';
+import 'path_action_overlay.dart';
 import 'top_toast.dart';
 import 'url_action_overlay.dart';
 
@@ -921,6 +923,18 @@ bool ghosttyTapShouldForwardClick({required bool active}) => active;
 /// unit-testable headless (and names the rule at the call site). Pure.
 bool ghosttyLongPressShowsUrlMenu(StructuredMatch? urlAtCell) =>
     urlAtCell != null;
+
+/// Whether a LONG-PRESS should show the PATH Open/Copy action menu instead of
+/// starting a selection (#778, paths Slice 1).
+///
+/// Mirrors [ghosttyLongPressShowsUrlMenu]: a long-press on a detected absolute
+/// file path ([matchAtCell] non-null AND its [StructuredMatch.patternId] is
+/// `path`) shows the path action menu (`showPathActions`) and SUPPRESSES the
+/// selection for that gesture. A URL/OSC-8 match is NOT a path, so this returns
+/// false for those (the URL menu owns them) — the two are mutually exclusive at
+/// a single cell. Pure, so the routing decision is unit-testable headless.
+bool ghosttyLongPressShowsPathMenu(StructuredMatch? matchAtCell) =>
+    matchAtCell != null && matchAtCell.patternId == kGhosttyPathPatternId;
 
 /// Map a vertical swipe DELTA (logical px the finger moved this update) to a
 /// scrollback pixel delta to apply to the [TerminalScrollController] (#690).
@@ -1781,6 +1795,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// get the exact full URI; an OSC-8 match wins over an overlapping regex one.
   static const String _kOsc8PatternId = kGhosttyOsc8PatternId;
 
+  /// #778 paths Slice 1: the absolute file-path pattern id, registered alongside
+  /// the URL patterns so the terminal also detects/anchors paths over its own
+  /// cells. A `path` match routes a tap to the SFTP explorer (not clipboard).
+  static const String _kPathPatternId = kGhosttyPathPatternId;
+
   /// #702: the session proxy, resolved once in [initState] so the shellReady
   /// subscription + forced resize re-sync don't re-walk the sessions list.
   SshSessionProxy? _proxy;
@@ -1958,6 +1977,10 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // plain-text URL (no OSC-8) still falls to the regex pattern unchanged.
     controller.registerTextPattern(TextPattern.osc8(id: _kOsc8PatternId));
     controller.registerTextPattern(TextPattern.url(id: _kUrlPatternId));
+    // #778 paths Slice 1: also detect absolute file paths. A `path` anchor gets
+    // its own decorator (folder glyph + dotted underline) and routes a tap to
+    // the SFTP explorer; `://` contexts are rejected so a URL stays a URL.
+    controller.registerTextPattern(TextPattern.path(id: _kPathPatternId));
   }
 
   /// #712: mirror whether a selection is active into [_hasSelection], rebuilding
@@ -2460,12 +2483,28 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     if (invalidate) _clearSelection();
   }
 
-  /// #726: copy a tapped URL to the clipboard + confirm via a top-toast. Invoked
-  /// when a single tap lands on a highlighted URL (the tap is swallowed). #767:
-  /// the match is a flterm [StructuredMatch]; its payload is the URL string.
+  /// Handle a single-TAP that landed on a detected structured match (the tap is
+  /// swallowed by the router). #726: a `url`/`osc8` match COPIES the URL + shows
+  /// a top-toast. #778: a `path` match OPENS the SFTP explorer at that path
+  /// instead (the primary affordance for a file path is "go there", not copy —
+  /// Copy path lives on the long-press menu). Routed by [StructuredMatch.patternId].
   Future<void> _copyUrl(StructuredMatch match) async {
+    if (match.patternId == _kPathPatternId) {
+      _openPath('${match.payload}');
+      return;
+    }
     await Clipboard.setData(ClipboardData(text: '${match.payload}'));
     if (mounted) showTopToast(context, 'Copied URL');
+  }
+
+  /// #778 paths Slice 1: open the SFTP file explorer AT [path] (the tapped /
+  /// long-press-Open absolute file path). Absolute paths resolve without a pwd,
+  /// so the explorer lands directly at [path]; relative/pwd resolution is a later
+  /// slice. Routes through the single [openFileBrowser] entry point.
+  Future<bool> _openPath(String path) async {
+    if (!mounted) return false;
+    await openFileBrowser(context, widget.sessionId, initialPath: path);
+    return true;
   }
 
   /// #734: show the Copy/Open action menu for a long-pressed URL — the SAME
@@ -2483,6 +2522,19 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   void _showUrlMenu(StructuredMatch match, Offset globalAnchor) {
     if (!mounted) return;
     final rects = _urlGlobalRects(match);
+    // #778: a `path` long-press shows the PATH menu (Open → explorer, Copy path)
+    // — the file-path analogue of the URL menu. A url/osc8 match keeps the URL
+    // Copy/Open menu. The router suppresses selection for both.
+    if (match.patternId == _kPathPatternId) {
+      showPathActions(
+        context,
+        '${match.payload}',
+        highlightRects: rects,
+        anchor: globalAnchor,
+        onOpen: _openPath,
+      );
+      return;
+    }
     showUrlActions(
       context,
       '${match.payload}',

--- a/native/lib/ui/path_action_overlay.dart
+++ b/native/lib/ui/path_action_overlay.dart
@@ -1,0 +1,271 @@
+// Path action overlay (#778, paths Slice 1) — the file-path analogue of
+// url_action_overlay.dart.
+//
+// On a long-press that lands on a detected absolute file PATH, show:
+//   * a transient HIGHLIGHT over the path's on-screen cell rect(s) (a
+//     soft-wrapped path spans multiple rendered rows → multiple rects), and
+//   * a small popup menu with OPEN (in the SFTP file explorer) and COPY PATH.
+//
+// Open → an injectable opener (the view passes one that calls openFileBrowser
+// with the path as initialPath); injectable so the widget test never pushes a
+// real route. Copy → Clipboard.setData + a top toast (NOT a bottom SnackBar —
+// that covers the keybar/compose bar, see top_toast.dart).
+//
+// The overlay dismisses on: an action tap, a tap outside the menu, or a short
+// timeout. Single root-overlay OverlayEntry, mirroring the URL overlay; only one
+// is live at a time (it reuses the URL overlay's lifecycle, so opening one
+// dismisses the other).
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'top_toast.dart';
+
+/// Pluggable path opener so the widget test can assert "Open was invoked with
+/// this path" without pushing a route. Returns true on success.
+typedef PathOpener = Future<bool> Function(String path);
+
+/// Test seam: overrides the opener used by [showPathActions] when non-null.
+@visibleForTesting
+PathOpener? debugPathOpenerOverride;
+
+/// The single live overlay entry, so a new long-press replaces the old one.
+OverlayEntry? _activeEntry;
+Timer? _activeTimer;
+
+void _dismiss() {
+  _activeTimer?.cancel();
+  _activeTimer = null;
+  _activeEntry?.remove();
+  _activeEntry = null;
+}
+
+/// Test seam: tear down any live overlay + its auto-dismiss timer so a widget
+/// test that leaves the menu open doesn't trip the "Timer still pending" check.
+@visibleForTesting
+void debugDismissPathActions() => _dismiss();
+
+/// Show the Open/Copy action menu + transient highlight for [path].
+///
+/// [highlightRects] are the path's on-screen cell rectangles in GLOBAL
+/// coordinates (one per rendered row). [anchor] is the global point the menu is
+/// positioned near (typically the long-press location). [onOpen] performs the
+/// explorer navigation; when null the [debugPathOpenerOverride] (tests) or a
+/// no-op is used.
+///
+/// Safe to call from any context under an [Overlay]. No-op if no overlay.
+void showPathActions(
+  BuildContext context,
+  String path, {
+  required List<Rect> highlightRects,
+  required Offset anchor,
+  Future<bool> Function(String path)? onOpen,
+  Duration timeout = const Duration(seconds: 6),
+}) {
+  final overlay = Overlay.maybeOf(context, rootOverlay: true);
+  if (overlay == null) return;
+
+  _dismiss();
+
+  final opener =
+      debugPathOpenerOverride ?? onOpen ?? ((String _) async => false);
+
+  late final OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (ctx) => _PathActionLayer(
+      path: path,
+      highlightRects: highlightRects,
+      anchor: anchor,
+      onCopy: () {
+        Clipboard.setData(ClipboardData(text: path));
+        if (identical(_activeEntry, entry)) _dismiss();
+        showTopToastInOverlay(overlay, 'Copied: $path');
+      },
+      onOpen: () async {
+        if (identical(_activeEntry, entry)) _dismiss();
+        final ok = await opener(path);
+        if (!ok) {
+          showTopToastInOverlay(overlay, 'Could not open: $path');
+        }
+      },
+      onDismiss: () {
+        if (identical(_activeEntry, entry)) _dismiss();
+      },
+    ),
+  );
+  _activeEntry = entry;
+  overlay.insert(entry);
+
+  _activeTimer = Timer(timeout, () {
+    if (identical(_activeEntry, entry)) _dismiss();
+  });
+}
+
+/// Full-screen layer: tap-outside scrim + highlight painter + action menu card.
+class _PathActionLayer extends StatelessWidget {
+  const _PathActionLayer({
+    required this.path,
+    required this.highlightRects,
+    required this.anchor,
+    required this.onCopy,
+    required this.onOpen,
+    required this.onDismiss,
+  });
+
+  final String path;
+  final List<Rect> highlightRects;
+  final Offset anchor;
+  final VoidCallback onCopy;
+  final Future<void> Function() onOpen;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final media = MediaQuery.of(context);
+    final accent = theme.colorScheme.primary;
+
+    final below = highlightRects.isEmpty
+        ? anchor.dy + 24
+        : highlightRects.map((r) => r.bottom).reduce((a, b) => a > b ? a : b) +
+              8;
+    const estMenuWidth = 220.0;
+    const menuHeight = 56.0;
+    var left = anchor.dx - estMenuWidth / 2;
+    left = left.clamp(8.0, math.max(8.0, media.size.width - estMenuWidth - 8));
+    var top = below;
+    if (top + menuHeight > media.size.height - 8) {
+      final aboveTop = highlightRects.isEmpty
+          ? anchor.dy - menuHeight - 24
+          : highlightRects.map((r) => r.top).reduce((a, b) => a < b ? a : b) -
+                menuHeight -
+                8;
+      top = aboveTop.clamp(8.0, media.size.height - menuHeight - 8);
+    }
+
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: GestureDetector(
+            key: const Key('path-action-scrim'),
+            behavior: HitTestBehavior.translucent,
+            onTap: onDismiss,
+          ),
+        ),
+        Positioned.fill(
+          child: IgnorePointer(
+            child: CustomPaint(
+              painter: _PathHighlightPainter(
+                rects: highlightRects,
+                color: accent,
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          left: left,
+          top: top,
+          child: Material(
+            key: const Key('path-action-menu'),
+            color: theme.colorScheme.surfaceContainerHighest,
+            elevation: 8,
+            borderRadius: BorderRadius.circular(10),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: math.min(media.size.width - 16, 320),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _ActionButton(
+                      key: const Key('path-action-open'),
+                      icon: Icons.folder_open,
+                      label: 'Open',
+                      onTap: () {
+                        onOpen();
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    _ActionButton(
+                      key: const Key('path-action-copy'),
+                      icon: Icons.content_copy,
+                      label: 'Copy path',
+                      onTap: onCopy,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurface;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 18, color: color),
+            const SizedBox(width: 6),
+            Text(label, style: TextStyle(color: color, fontSize: 14)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Paints a translucent rounded highlight over each path cell rect.
+class _PathHighlightPainter extends CustomPainter {
+  _PathHighlightPainter({required this.rects, required this.color});
+
+  final List<Rect> rects;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final fill = Paint()..color = color.withValues(alpha: 0.28);
+    final stroke = Paint()
+      ..color = color.withValues(alpha: 0.9)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.2;
+    for (final r in rects) {
+      final rr = RRect.fromRectAndRadius(
+        r.inflate(1),
+        const Radius.circular(3),
+      );
+      canvas.drawRRect(rr, fill);
+      canvas.drawRRect(rr, stroke);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_PathHighlightPainter old) =>
+      old.rects != rects || old.color != color;
+}

--- a/native/test/fixtures/replay/paths_prose_55col.cast.json
+++ b/native/test/fixtures/replay/paths_prose_55col.cast.json
@@ -1,0 +1,7 @@
+{
+  "cols": 55,
+  "rows": 46,
+  "source": "capture-pane:main:0.0",
+  "capturedAt": "20260606T231339+0000",
+  "chunks": [{ "b64": "G1sxbRtbMzJtZGV2QGZkLWRldhtbMG06G1sxbRtbMzRtfhtbMG0kIGVjaG8gJ1RoZSBxdWljayBicm93biBmb3gganVtcHMgb3ZlciB0aGUKbGF6eSBkb2cuIFdlIHNob3VsZCByZXZpZXcgdGhlIGRlc2lnbiBiZWZvcmUgbWVyZ2luZyBpdAosIHRoZW4gc2hpcCB0aGUgcmVsZWFzZSBhbmQgdGVsbCBldmVyeW9uZSBhYm91dCB0aGUgbmV3CiBmZWF0dXJlIHRvZGF5LicKVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZy4gV2Ugc2hvdWxkCnJldmlldyB0aGUgZGVzaWduIGJlZm9yZSBtZXJnaW5nIGl0LCB0aGVuIHNoaXAgdGhlIHJlbGUKYXNlIGFuZCB0ZWxsIGV2ZXJ5b25lIGFib3V0IHRoZSBuZXcgZmVhdHVyZSB0b2RheS4KG1sxbRtbMzJtZGV2QGZkLWRldhtbMG06G1sxbRtbMzRtfhtbMG0kCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoK" }]
+}

--- a/native/test/fixtures/replay/paths_shell_55col.cast.json
+++ b/native/test/fixtures/replay/paths_shell_55col.cast.json
@@ -1,0 +1,7 @@
+{
+  "cols": 55,
+  "rows": 46,
+  "source": "capture-pane:main:0.0",
+  "capturedAt": "20260606T231329+0000",
+  "chunks": [{ "b64": "G1sxbRtbMzJtZGV2QGZkLWRldhtbMG06G1sxbRtbMzRtfhtbMG0kIGxzIC1kIC9ob21lL2Rldi93b3Jrc3BhY2UvbW9iaXNzaC9uYXRpdmUvCmxpYi91aS9naG9zdHR5X3Rlcm1pbmFsX3ZpZXcuZGFydCAvZXRjL3NzaC9zc2hkX2NvbmZpZwp+L3dvcmtzcGFjZS9kZXZsb29wL3J1bGVzL2NvbW1hbmQtaHlnaWVuZS5tZAovZXRjL3NzaC9zc2hkX2NvbmZpZwovaG9tZS9kZXYvd29ya3NwYWNlL2Rldmxvb3AvcnVsZXMvY29tbWFuZC1oeWdpZW5lLm1kCi9ob21lL2Rldi93b3Jrc3BhY2UvbW9iaXNzaC9uYXRpdmUvbGliL3VpL2dob3N0dHlfdGVybWkKbmFsX3ZpZXcuZGFydAobWzFtG1szMm1kZXZAZmQtZGV2G1swbTobWzFtG1szNG1+G1swbSQKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgo=" }]
+}

--- a/native/test/terminal/replay_path_detection_test.dart
+++ b/native/test/terminal/replay_path_detection_test.dart
@@ -1,0 +1,164 @@
+@Tags(['ffi'])
+library;
+
+// REPLAY-based acceptance for ABSOLUTE FILE PATH detection (#778, paths Slice 1).
+//
+// Clone of replay_url_detection_test.dart: feed a REAL captured tmux grid
+// (scripts/capture-terminal-corpus.sh) into a real flterm TerminalController with
+// TextPattern.path() registered, and assert path detection over the OWNER'S
+// ACTUAL grid — never synthetic printf (the +22..+28 lesson, memory
+// reference_grid_url_extraction §0).
+//
+// Headless: the real libghostty VT parser loads under `flutter test` on the host
+// VM (ffi-tagged), so `controller.write(bytes)` → `controller.anchors` runs in the
+// fast gate on EVERY commit — no emulator. The bytes ARE the real grid.
+//
+// Coverage:
+//   * absolute paths are detected as `path` anchors (positive);
+//   * a path wrapped at the content width spans >1 buffer row (the wrap case);
+//   * an ENGLISH-PROSE grid yields NO path anchors (the over-match NEGATIVE).
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A captured terminal grid: pane size + ordered raw byte chunks (the format
+/// scripts/capture-terminal-corpus.sh emits).
+class ReplayCast {
+  ReplayCast(this.cols, this.rows, this.chunks);
+  final int cols;
+  final int rows;
+  final List<Uint8List> chunks;
+}
+
+/// Map bare LF to CRLF so a captured visual row returns to column 0 when written
+/// to the terminal (capture-pane emits LF-only row separators). Idempotent.
+Uint8List _lfToCrlf(Uint8List bytes) {
+  final out = <int>[];
+  var prev = 0;
+  for (final b in bytes) {
+    if (b == 0x0a && prev != 0x0d) out.add(0x0d);
+    out.add(b);
+    prev = b;
+  }
+  return Uint8List.fromList(out);
+}
+
+ReplayCast loadCast(String path) {
+  final json = jsonDecode(File(path).readAsStringSync()) as Map<String, dynamic>;
+  final chunks = [
+    for (final c in json['chunks'] as List)
+      base64Decode((c as Map<String, dynamic>)['b64'] as String),
+  ];
+  return ReplayCast(json['cols'] as int, json['rows'] as int, chunks);
+}
+
+/// Build a controller sized to the fixture, register the PATH pattern, replay the
+/// captured chunks, and wait past the detection debounce.
+Future<TerminalController> replayCast(ReplayCast cast) async {
+  final controller = TerminalController(
+    config: TerminalConfig(cols: cast.cols, rows: cast.rows),
+  );
+  controller.registerTextPattern(TextPattern.path());
+  for (final chunk in cast.chunks) {
+    controller.write(_lfToCrlf(chunk));
+  }
+  // Detection re-scan is debounced (~120ms); mirror the URL replay test's 250ms.
+  await Future<void>.delayed(const Duration(milliseconds: 250));
+  return controller;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('REPLAY real captured grid — absolute path detection (#778)', () {
+    test(
+      'absolute paths in a real shell grid are detected as `path` anchors',
+      () async {
+        final cast = loadCast(
+          'test/fixtures/replay/paths_shell_55col.cast.json',
+        );
+        final controller = await replayCast(cast);
+        addTearDown(controller.dispose);
+
+        final pathPayloads = controller.anchors
+            .where((a) => a.patternId == 'path')
+            .map((a) => '${a.payload}')
+            .toList();
+
+        expect(
+          pathPayloads,
+          contains('/etc/ssh/sshd_config'),
+          reason: 'a single-row absolute path must be a `path` anchor',
+        );
+        expect(
+          pathPayloads,
+          contains('/home/dev/workspace/devloop/rules/command-hygiene.md'),
+          reason: 'a long single-row absolute path must be a `path` anchor',
+        );
+      },
+    );
+
+    test(
+      'an absolute path wrapped at the content width is ONE anchor spanning '
+      'BOTH rows carrying the FULL path',
+      () async {
+        final cast = loadCast(
+          'test/fixtures/replay/paths_shell_55col.cast.json',
+        );
+        final controller = await replayCast(cast);
+        addTearDown(controller.dispose);
+
+        const fullPath =
+            '/home/dev/workspace/mobissh/native/lib/ui/'
+            'ghostty_terminal_view.dart';
+
+        // The fixture contains this path twice — once on the `ls` command line
+        // (single row) and once in the wrapped `ls` OUTPUT (two rows). Both are
+        // legitimately detected, each carrying the FULL path; the wrapped one is
+        // the case under test, so assert at least one spans >1 buffer row.
+        final hits = controller.anchors
+            .where((a) => a.patternId == 'path' && a.payload == fullPath)
+            .toList();
+        expect(
+          hits,
+          isNotEmpty,
+          reason: 'the wrapped path must be detected carrying the FULL path '
+              '(not just the first physical row)',
+        );
+        final wrapped = hits.where(
+          (a) => {for (final r in a.ranges) r.startRow}.length >= 2,
+        );
+        expect(
+          wrapped,
+          isNotEmpty,
+          reason: 'at least one anchor for the wrapped path must span BOTH '
+              'wrapped rows (copy = full path)',
+        );
+      },
+    );
+
+    test(
+      'an English-prose grid yields NO path anchors (the over-match negative)',
+      () async {
+        final cast = loadCast(
+          'test/fixtures/replay/paths_prose_55col.cast.json',
+        );
+        final controller = await replayCast(cast);
+        addTearDown(controller.dispose);
+
+        final pathHits =
+            controller.anchors.where((a) => a.patternId == 'path').toList();
+        expect(
+          pathHits,
+          isEmpty,
+          reason: 'prose with no leading /, ~/, ./ or ../ tokens must not '
+              'produce path anchors — Slice 1 defers bare relative tokens',
+        );
+      },
+    );
+  });
+}

--- a/native/test/ui/ghostty_path_tap_test.dart
+++ b/native/test/ui/ghostty_path_tap_test.dart
@@ -1,0 +1,165 @@
+// #778 paths Slice 1 — a tap/long-press on a detected absolute file PATH routes
+// to the SFTP file explorer (Open), not the URL clipboard path.
+//
+// Three layers, all headless (NO flterm native `.so`):
+//   1. the pure routing decision `ghosttyLongPressShowsPathMenu` (path-only);
+//   2. the gesture router fires its match callback with a `path` StructuredMatch
+//      when a tap/long-press lands on a path cell (mirrors the URL router test);
+//   3. `openFileBrowser(..., initialPath:)` actually pushes a FileBrowserScreen
+//      AT that path — the acceptance that a path tap opens the explorer there.
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+void main() {
+  const pathMatch = StructuredMatch(
+    patternId: kGhosttyPathPatternId,
+    payload: '/etc/ssh/sshd_config',
+    ranges: [
+      HighlightRange(startRow: 2, startCol: 4, endRow: 2, endCol: 24),
+    ],
+  );
+  const urlMatch = StructuredMatch(
+    patternId: kGhosttyUrlPatternId,
+    payload: 'https://example.com',
+    ranges: [
+      HighlightRange(startRow: 2, startCol: 4, endRow: 2, endCol: 15),
+    ],
+  );
+
+  group('#778 pure routing decision', () {
+    test('ghosttyLongPressShowsPathMenu true ONLY for a `path` match', () {
+      expect(ghosttyLongPressShowsPathMenu(pathMatch), isTrue);
+      expect(
+        ghosttyLongPressShowsPathMenu(urlMatch),
+        isFalse,
+        reason: 'a URL match is owned by the URL menu, not the path menu',
+      );
+      expect(ghosttyLongPressShowsPathMenu(null), isFalse);
+    });
+  });
+
+  group('#778 gesture router fires its callback for a path cell', () {
+    late List<StructuredMatch> tapMatches;
+    late List<StructuredMatch> longPresses;
+
+    Future<void> pumpRouter(WidgetTester tester) async {
+      tapMatches = [];
+      longPresses = [];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 400,
+                height: 400,
+                child: GhosttyPointerGestureRouter(
+                  active: false, // plain shell: tap-copy/open path is wired here too
+                  scrollController: TerminalScrollController(),
+                  cols: 80,
+                  rows: 24,
+                  lastSentCols: 80,
+                  lastSentRows: 24,
+                  cellWidth: 8,
+                  cellHeight: 16,
+                  mouseTrackingLabel: 'any',
+                  onTap: () {},
+                  onFocus: () {},
+                  onMouseReport: (_) {},
+                  onSelectionStart: (_, _) {},
+                  onSelectionExtend: (_, _) {},
+                  hasSelection: () => false,
+                  onSelectionClear: () {},
+                  urlAtCell: (col, row) =>
+                      pathMatch.contains(row, col) ? pathMatch : null,
+                  onUrlTap: tapMatches.add,
+                  onUrlLongPress: (m, _) => longPresses.add(m),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('a tap on a path cell fires onUrlTap with the path match', (
+      tester,
+    ) async {
+      await pumpRouter(tester);
+      // Cell row 2 (0-based) → py [36,52); col 6 (inside 4..23) → px [52,60).
+      await tester.tapAt(const Offset(54, 44));
+      await tester.pumpAndSettle();
+
+      expect(tapMatches, hasLength(1));
+      expect(tapMatches.single.patternId, kGhosttyPathPatternId);
+      expect(tapMatches.single.payload, '/etc/ssh/sshd_config');
+    });
+  });
+
+  group('#778 openFileBrowser(initialPath:) opens the explorer at the path', () {
+    testWidgets('pushes a FileBrowserScreen whose initialPath is the path', (
+      tester,
+    ) async {
+      FileBrowserScreen? pushed;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => openFileBrowser(
+                    context,
+                    'sess-1',
+                    initialPath: '/etc/ssh/sshd_config',
+                  ),
+                  child: const Text('go'),
+                ),
+              ),
+            ),
+            navigatorObservers: [_CaptureObserver((route) {
+              final w = (route as MaterialPageRoute).builder(
+                _DummyContext(),
+              );
+              if (w is FileBrowserScreen) pushed = w;
+            })],
+          ),
+        ),
+      );
+      await tester.tap(find.text('go'));
+      await tester.pump();
+
+      expect(pushed, isNotNull, reason: 'openFileBrowser must push the screen');
+      expect(pushed!.initialPath, '/etc/ssh/sshd_config');
+      expect(pushed!.sessionId, 'sess-1');
+    });
+  });
+}
+
+/// Captures each pushed route so the test can inspect the screen it builds.
+class _CaptureObserver extends NavigatorObserver {
+  _CaptureObserver(this.onPush);
+  final void Function(Route<dynamic> route) onPush;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route is MaterialPageRoute) onPush(route);
+    super.didPush(route, previousRoute);
+  }
+}
+
+/// A throwaway BuildContext for building the pushed route's widget in the test.
+class _DummyContext extends StatelessElement {
+  _DummyContext() : super(const _DummyWidget());
+}
+
+class _DummyWidget extends StatelessWidget {
+  const _DummyWidget();
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/native/test/ui/ghostty_terminal_decorators_test.dart
+++ b/native/test/ui/ghostty_terminal_decorators_test.dart
@@ -97,18 +97,26 @@ void main() {
       expect(decorator!.patternId, kGhosttyOsc8PatternId);
     });
 
-    test('returns null for an unregistered pattern (e.g. future path/sha)', () {
+    test('defaults registers the path decorator (#778 paths Slice 1)', () {
       final registry = GhosttyDecoratorRegistry.defaults();
-      expect(registry.forPattern('path'), isNull);
+      expect(registry.patternIds, contains(kGhosttyPathPatternId));
+      final decorator = registry.forPattern(kGhosttyPathPatternId);
+      // A path anchor gets the DISTINCT path treatment, not the URL bubble.
+      expect(decorator, isA<PathDecorator>());
+      expect(decorator!.patternId, kGhosttyPathPatternId);
+    });
+
+    test('returns null for an unregistered pattern (e.g. future sha)', () {
+      final registry = GhosttyDecoratorRegistry.defaults();
       expect(registry.forPattern('commit-sha'), isNull);
     });
 
     test('is extensible with additional decorators', () {
       final registry = GhosttyDecoratorRegistry(const [
         UrlBubbleDecorator(),
-        _StubDecorator('path'),
+        _StubDecorator('commit-sha'),
       ]);
-      expect(registry.forPattern('path'), isA<_StubDecorator>());
+      expect(registry.forPattern('commit-sha'), isA<_StubDecorator>());
       expect(registry.forPattern(kGhosttyUrlPatternId), isA<UrlBubbleDecorator>());
     });
   });
@@ -239,8 +247,8 @@ void main() {
       final controller = await pumpLayer(tester);
       controller.setAnchors([
         StructuredAnchor(
-          patternId: 'path', // no decorator registered in defaults()
-          payload: '/etc/hosts',
+          patternId: 'commit-sha', // no decorator registered in defaults()
+          payload: 'deadbeef',
           ranges: const [
             HighlightRange(startRow: 2, startCol: 0, endRow: 2, endCol: 10),
           ],

--- a/native/third_party/flterm/lib/src/foundation/structured_text.dart
+++ b/native/third_party/flterm/lib/src/foundation/structured_text.dart
@@ -119,6 +119,36 @@ final class TextPattern {
     );
   }
 
+  /// The built-in ABSOLUTE FILE PATH pattern (#778, paths Slice 1).
+  ///
+  /// Matches ONLY paths that resolve WITHOUT a working directory, so Slice 1 can
+  /// ship the whole detect→anchor→decorate→tap→explorer pipeline and defer
+  /// pwd-relative resolution to a later slice:
+  ///   * absolute — a leading `/` followed by one or more `/`-separated segments
+  ///     of path chars (`[\w.\-~@+]`), e.g. `/etc/ssh/sshd_config`;
+  ///   * home — `~/…` (a `~` followed by `/` and segments) or a BARE `~`;
+  ///   * explicit-relative — `./x`, `../x`, or a `../` chain, e.g. `../../lib`.
+  /// BARE relative tokens (`src/foo`) are DEFERRED to Slice 3 — including them
+  /// would over-match ordinary prose like `and/or`.
+  ///
+  /// A `://` context is rejected by [_validatePath] so `file://…` (and any other
+  /// scheme whose authority starts with `//`) stays a URL — the URL/OSC-8 source
+  /// wins the de-dup, and this pattern simply declines that span.
+  ///
+  /// Reuses the scanner's wrap-join + `_rangesFor` machinery UNCHANGED — only the
+  /// regex and validate differ from [TextPattern.url]. [style] supplies the
+  /// highlight color (the widget-layer decorator draws the affordance, #767 B).
+  factory TextPattern.path({String id = 'path', HighlightStyle style =
+      const HighlightStyle()}) {
+    return TextPattern(
+      id: id,
+      regex: _kPathPattern,
+      style: style,
+      trailingTrim: _kPathTrailingTrim,
+      normalize: _validatePath,
+    );
+  }
+
   /// The built-in OSC-8 HYPERLINK source (#767 Slice B) — the PRIMARY, exact
   /// URL source.
   ///
@@ -148,6 +178,40 @@ final class TextPattern {
 /// A regex that matches nothing — the placeholder [TextPattern.regex] for an
 /// OSC-8 source, whose detection walks cells rather than running a regex.
 final RegExp _kNeverMatch = RegExp(r'(?!x)x');
+
+/// The ABSOLUTE FILE PATH regex (#778, paths Slice 1). Matches three shapes that
+/// resolve WITHOUT a working directory:
+///   * absolute — `/` + one-or-more `/`-separated segments of path chars;
+///   * home — `~/…` or a BARE `~` (word-bounded so it isn't a stray tilde in
+///     prose like `approx ~3s` — a bare `~` matches only when not followed by a
+///     path char other than `/`);
+///   * explicit-relative — `./…`, `../…`, or a `../` chain.
+/// A path char is `[\w.\-~@+]` (mirrors the issue's class). A NEGATIVE LOOKBEHIND
+/// `(?<![\w.\-~@+:/])` keeps the match from starting MID-token — critically it
+/// rejects the `//` after a `:` (so `https://`/`file://` never starts a path at
+/// the `//`) and from inside another path char run. The match stops at the same
+/// stop set URLs use (whitespace and the few chars shells never put mid-path).
+/// BARE relative tokens (`src/foo`) are deliberately NOT matched (deferred to
+/// Slice 3) — only a leading `/`, `~`, `.` anchors a match.
+final RegExp _kPathPattern = RegExp(
+  r'(?<![\w.\-~@+:/])'
+  r'(?:'
+  r'/(?:[\w.\-~@+]+/?)+' // absolute: /a/b/c
+  r'|~/(?:[\w.\-~@+]+/?)*' // home: ~/a/b
+  r'|~(?![\w.\-@+])' // bare ~ (not ~word)
+  r'|\.\.?/(?:[\w.\-~@+]+/?|\.\.?/)*' // ./x ../x ../../ chains
+  r')',
+);
+
+/// Trailing characters trimmed off the END of a raw path match — a path that
+/// ends a sentence picks up `.,;:!?` and closers; mirrors the URL trim.
+const String _kPathTrailingTrim = '.,;:!?)]}>\'"';
+
+/// Validate a raw path match. Returns the path as its own payload, or null only
+/// for a malformed match the regex can let through (defensive — the regex is the
+/// real gate). A null payload is treated by the scanner as "use raw", so this
+/// never SUPPRESSES a match on its own; the `://` rejection is in the lookbehind.
+String _validatePath(String raw) => raw;
 
 /// The URL regex (moved verbatim from the app's `ghostty_url_detector.dart`,
 /// #767). Matches absolute http/https URLs and bare `www.` hosts; the


### PR DESCRIPTION
## Summary
- Detect ABSOLUTE file paths in the terminal and make them tappable to open in the SFTP file explorer (paths Slice 1 of #777).
- Full detect→anchor→decorate→tap→explorer pipeline, reusing the #767/#778 structured-text machinery. Tap a path → opens the explorer at that path; long-press → Open / Copy path menu.
- Conservative match set (absolute `/…`, home `~/…`/bare `~`, explicit-relative `./` `../` chains). Bare relative tokens (`src/foo`) deferred to Slice 3 to avoid prose over-match. `file://…` stays a URL (URL/OSC-8 wins de-dup).

## TDD Analysis
- Type: feature
- Behavior change: yes
- TDD approach: full (replay detection over REAL captured grids) + smoketest (router/predicate/openFileBrowser wiring)

## Test coverage
- **Existing tests updated**: `ghostty_terminal_decorators_test.dart` — `path` is now a REGISTERED decorator (was used as the "unregistered" stand-in); swapped those negatives to `commit-sha` and added a positive `PathDecorator` registration assertion.
- **New tests added (fail→pass)**:
  - `replay_path_detection_test.dart` (ffi) — replays REAL captured 55-col tmux grids: absolute paths detected as `path` anchors; a path wrapped at the content width spans >1 buffer row carrying the FULL path; an English-prose grid yields NO path anchors (the over-match negative).
  - `ghostty_path_tap_test.dart` — pure predicate `ghosttyLongPressShowsPathMenu` (path-only); gesture router fires its callback for a path cell; `openFileBrowser(initialPath:)` pushes a `FileBrowserScreen` AT the path.
- **Smoketest**: predicate + router routing + explorer entry-point wiring.

## Implementation notes
- `TextPattern.path()` adds only a regex + trailing-trim; scanner/wrap-join/`_rangesFor`/anchoring are UNCHANGED.
- `://` rejection is in the regex negative lookbehind `(?<![\w.\-~@+:/])`, NOT in `normalize` — the scanner treats a null normalize result as "use raw", so normalize cannot suppress a match.
- `PathDecorator`: leading monochrome folder glyph (currentColor) + thin dotted underline in a faded secondary accent — distinct from the URL outline bubble, and avoids background fill (hides glyphs) / solid underline (collides with SGR-4).

## Test results
- analyzer: PASS
- native fast gate: PASS (885 tests, 5 skipped, 6 new)

## Diff stats
- Files changed: 10 (5 source, 5 test/fixture)
- Lines: +886 / -11

Closes #778

## Cycles used
1/3