### PR TITLE
fix: structured-text outline mispositioned in scrollback (#784)

### DIFF
--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -385,8 +385,21 @@ class TerminalControllerImpl extends TerminalController
         _textInput.ensureAttached(keyboardAppearance: _brightness);
       }
     }
+    _scrollController?.removeListener(_onScrollChanged);
     _scrollController = scrollController;
+    _scrollController!.addListener(_onScrollChanged);
   }
+
+  /// #784: a scrollback scroll moves the viewport via the [ScrollController] →
+  /// the render object's `_onScroll` → `terminal.scrollViewport`, which does NOT
+  /// fire the terminal's listeners, so this controller never re-notified and the
+  /// widget-layer structured-text decorators kept rects resolved at the OLD
+  /// offset while the fork's painter (reading the offset from the frame snapshot)
+  /// moved — the outline drifted off its glyphs in scrollback. Forwarding the
+  /// scroll notify here rebuilds the decorator layer, which re-resolves
+  /// [anchorRects] against the live offset in the next build (after the render
+  /// object has applied the scroll), so the outline tracks the glyphs.
+  void _onScrollChanged() => notifyListeners();
 
   @override
   void clear() {
@@ -429,6 +442,7 @@ class TerminalControllerImpl extends TerminalController
     _wasFocused = false;
     _keyboardState = .hidden;
     _preeditText = '';
+    _scrollController?.removeListener(_onScrollChanged);
     _scrollController = null;
     _textInput.detach();
   }

--- a/native/third_party/flterm/test/widgets/terminal_controller_detection_test.dart
+++ b/native/third_party/flterm/test/widgets/terminal_controller_detection_test.dart
@@ -2,11 +2,11 @@
 library;
 
 import 'dart:typed_data';
-import 'dart:ui';
 
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/widgets/terminal_controller_impl.dart';
-import 'package:flutter/painting.dart' show EdgeInsets;
+import 'package:flterm/src/widgets/terminal_scroll_controller.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -155,6 +155,83 @@ void main() {
       expect(urlRanges, isNotEmpty);
       expect(urlRanges.every((r) => r.background == const Color(0xFF000002)),
           isTrue);
+    });
+  });
+
+  // #784: the structured-text decorator OUTLINE (URL bubble / path underline)
+  // drifts off its glyphs WHEN SCROLLED BACK. Root cause: the widget-layer
+  // decorator resolves its ABSOLUTE-row anchors to viewport rects against the
+  // LIVE `scrollbar.offset` ([anchorRects]) but only RE-resolves when this
+  // controller notifies. A scrollback SCROLL moves the viewport via the
+  // ScrollController → the render object's `_onScroll` → `terminal.scrollViewport`,
+  // which does NOT fire the terminal's listeners — so the controller never
+  // re-notified on scroll and the decorator kept rects at the OLD offset while
+  // the fork's own painter (offset from the frame snapshot) moved. The contract:
+  // a scroll that changes the viewport offset MUST notify so the decorator
+  // re-resolves and tracks the glyphs.
+  group('TerminalController scroll notify for anchor tracking (#784)', () {
+    Widget host(TerminalScrollController scrollController) => MaterialApp(
+          home: SizedBox(
+            height: 200,
+            child: ListView(
+              controller: scrollController,
+              children: [const SizedBox(height: 2000)],
+            ),
+          ),
+        );
+
+    testWidgets('a scrollback scroll notifies the controller', (tester) async {
+      final controller = TerminalControllerImpl();
+      addTearDown(controller.dispose);
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final scrollController = TerminalScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(host(scrollController));
+      // Wire the controller to the focus node + scroll controller exactly as the
+      // TerminalView does on mount.
+      controller.attach(focusNode, scrollController);
+
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      // A pure scrollback scroll — no terminal output. Before the fix this fired
+      // ZERO controller notifies, so the decorator's rects went stale.
+      scrollController.jumpTo(120);
+      await tester.pump();
+
+      expect(
+        notified,
+        isTrue,
+        reason: 'scrolling must notify so the decorator re-resolves anchorRects '
+            'against the live offset (else the outline drifts off its glyphs)',
+      );
+    });
+
+    testWidgets('detach stops forwarding scroll notifies', (tester) async {
+      final controller = TerminalControllerImpl();
+      addTearDown(controller.dispose);
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final scrollController = TerminalScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(host(scrollController));
+      controller.attach(focusNode, scrollController);
+      controller.detach();
+
+      var notified = false;
+      controller.addListener(() => notified = true);
+      scrollController.jumpTo(120);
+      await tester.pump();
+
+      expect(
+        notified,
+        isFalse,
+        reason: 'after detach the controller must not react to its old scroll '
+            'controller',
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- Fixes the structured-text decorator outline (URL bubble / path underline) drifting off its glyphs by N rows **when scrolled back** (#784). Correct live / near-bottom, off in scrollback.
- Root cause is a NOTIFY gap, not the geometry math: the widget-layer decorator (`GhosttyTerminalDecoratorLayer`) resolves its absolute-row anchors to viewport rects against the **live** `scrollbar.offset` via `controller.anchorRects`, but only re-resolves when the controller notifies. A scrollback scroll moves the viewport through the ScrollController → render object `_onScroll` → `terminal.scrollViewport`, which does **not** fire the terminal's listeners — so the controller never re-notified, the decorator kept rects at the old offset, and the fork's own painter (offset from the frame snapshot) moved without it.
- Fix: `TerminalControllerImpl` now listens to its attached `ScrollController` and forwards the scroll as a `notifyListeners()`, so the decorator rebuilds and re-resolves `anchorRects` against the live offset on the next build. URL and path decorators share this path, so both are fixed.

The issue's lead (a units mismatch in `AnchorGeometry.rectsFor`) was verified to be a red herring — that geometry is pure and already correct (`viewRow = absRow - viewportOffset`, identical to the `HighlightPainter`). The headless repro confirmed a `ScrollController.jumpTo` fired ZERO controller notifies before the fix.

## TDD Analysis
- Type: bug fix
- Behavior change: no (restores correct overlay tracking)
- TDD approach: full — RED then GREEN headless

## Test coverage
- **Existing tests updated**: none (all `terminal_controller_*` / `anchor_geometry` tests still pass unchanged)
- **New tests added (fail→pass)** in `terminal_controller_detection_test.dart`, group `TerminalController scroll notify for anchor tracking (#784)`:
  - `a scrollback scroll notifies the controller` — attaches the controller to a real `TerminalScrollController` (as `TerminalView` does), `jumpTo`s, asserts the controller notifies. **RED before fix** (0 notifies), GREEN after.
  - `detach stops forwarding scroll notifies` — after `detach`, a scroll must not notify (listener cleanup).

## Test results
- flutter analyze: PASS (0 issues)
- flutter test (native fast gate, excl. integration): PASS — 900 passed / 5 skipped
- native-fast-gate.sh: PASS

## Diff stats
- Files changed: 2
- Lines: +93 / -2

## Device validation
Headless-fixable (overlay notify wiring + pure geometry). Device confirmation of the outline hugging URLs/paths while scrolling back is the orchestrator/owner's step (memory `feedback_device_run_not_headless_green`).

Closes #784

## Cycles used
1/3