### PR TITLE
fix(native): detect structured text in the visible scrollback region, not just near the bottom (#787)

### DIFF
--- a/native/test/terminal/replay_url_detection_test.dart
+++ b/native/test/terminal/replay_url_detection_test.dart
@@ -72,8 +72,89 @@ Future<TerminalController> replayCast(ReplayCast cast) async {
   return controller;
 }
 
+/// Build a controller with [rows]/[cols], write [url] near the TOP of history,
+/// then push it far up with [trailingRows] of filler so it sits BEYOND the
+/// bottom-anchored detection window. Returns the controller scrolled to TOP so
+/// the URL is on-screen. Registers the pattern AFTER scrolling so the (sync)
+/// re-scan runs at the scrolled-up offset — the #787 condition.
+Future<TerminalController> _scrolledUpUrlController({
+  required String url,
+  required int rows,
+  required int cols,
+  required int trailingRows,
+}) async {
+  final controller = TerminalController(
+    config: TerminalConfig(cols: cols, rows: rows),
+  );
+  // The URL on its own line near the top of history, followed by a blank line
+  // so its soft-wrap flag doesn't join it to the filler below (that wrap-join
+  // behaviour is issue #767's concern, orthogonal to this scan-window test).
+  controller.write(Uint8List.fromList(utf8.encode('$url\r\n\r\n')));
+  // Push it far above the live viewport with many filler rows so it falls
+  // outside a window measured from the bottom of the scrollback.
+  final filler = StringBuffer();
+  for (var i = 0; i < trailingRows; i++) {
+    filler.write('filler row $i\r\n');
+  }
+  controller.write(Uint8List.fromList(utf8.encode(filler.toString())));
+  // Scroll so the URL is back on screen at the top of the viewport.
+  controller.scrollToTop();
+  // Register AFTER scrolling: registration scans synchronously at the current
+  // (scrolled-up) offset.
+  controller.registerTextPattern(TextPattern.url());
+  // Detection re-scan can be debounced; mirror the replay test's settle window.
+  await Future<void>.delayed(const Duration(milliseconds: 250));
+  return controller;
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('scroll-window detection coverage (#787)', () {
+    const url = 'https://mobissh.tailbe5094.ts.net/'
+        'mobissh-native-20260607T213707+0000.apk';
+
+    test(
+      'a URL scrolled UP to, far beyond the bottom-anchored scan window, is '
+      'detected at the current scroll position (the #787 miss)',
+      () async {
+        // 250 filler rows >> the 200-row detection window, so the URL near the
+        // top is outside any range measured from the bottom of scrollback.
+        final controller = await _scrolledUpUrlController(
+          url: url,
+          rows: 24,
+          cols: 80,
+          trailingRows: 250,
+        );
+        addTearDown(controller.dispose);
+
+        final hits = controller.anchors.where((a) => a.payload == url).toList();
+        expect(
+          hits,
+          hasLength(1),
+          reason: 'the on-screen URL must be detected wherever the viewport '
+              'sits in scrollback — the scan region follows the viewport, not '
+              'a window anchored to the bottom (#787)',
+        );
+      },
+    );
+
+    test(
+      'near-bottom detection still works (no regression from the window move)',
+      () async {
+        final controller = TerminalController(
+          config: const TerminalConfig(cols: 80, rows: 24),
+        );
+        addTearDown(controller.dispose);
+        controller.registerTextPattern(TextPattern.url());
+        controller.write(Uint8List.fromList(utf8.encode('$url\r\n')));
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        final hits = controller.anchors.where((a) => a.payload == url).toList();
+        expect(hits, hasLength(1));
+      },
+    );
+  });
 
   group('REPLAY real captured tmux grid — URL detection (#767)', () {
     test(

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -304,15 +304,26 @@ class TerminalControllerImpl extends TerminalController
       if (visibleRows <= 0 || cols <= 0) {
         matches = const [];
       } else {
-        // The active viewport occupies screen rows [scrollbackRows,
-        // scrollbackRows + visibleRows). Scan that plus up to
-        // _detectionScrollbackWindow rows of recent scrollback above it, so a
-        // URL just scrolled near is picked up without an O(scrollback) walk.
+        // Scan the region that is ACTUALLY ON SCREEN wherever the viewport
+        // currently sits in scrollback, not a range anchored only to the bottom.
+        // The viewport's top absolute row is the scroll offset; it occupies
+        // [viewportTop, viewportTop + visibleRows). Scan that plus up to
+        // _detectionScrollbackWindow rows of margin ABOVE and BELOW it, so a URL
+        // the user scrolled far up to (#787) — or just scrolled near — is picked
+        // up, while the bounded margin keeps this off an O(scrollback) walk.
+        // (Anchored-to-bottom previously missed anything scrolled past the
+        // window.) The margin also gives the wrap-join enough context rows above
+        // the first visible row to assemble a URL that wraps across the boundary.
         final scrollback = terminal.scrollbackRows;
-        final startAbs = scrollback - _detectionScrollbackWindow < 0
+        final viewportTop = scrollbar.offset;
+        final startAbs = viewportTop - _detectionScrollbackWindow < 0
             ? 0
-            : scrollback - _detectionScrollbackWindow;
-        final endAbs = scrollback + visibleRows; // exclusive
+            : viewportTop - _detectionScrollbackWindow;
+        // Clamp the bottom to the last buffer row so we never read past the
+        // active screen (defensive; the reader also guards per-cell).
+        final maxEndAbs = scrollback + visibleRows; // exclusive
+        var endAbs = viewportTop + visibleRows + _detectionScrollbackWindow;
+        if (endAbs > maxEndAbs) endAbs = maxEndAbs;
         final reader = _ScreenCellReader(
           terminal: terminal,
           cols: cols,
@@ -399,7 +410,16 @@ class TerminalControllerImpl extends TerminalController
   /// scroll notify here rebuilds the decorator layer, which re-resolves
   /// [anchorRects] against the live offset in the next build (after the render
   /// object has applied the scroll), so the outline tracks the glyphs.
-  void _onScrollChanged() => notifyListeners();
+  ///
+  /// #787: a scroll also moves the visible region, so the detection scan window
+  /// (now centred on the viewport, not anchored to the bottom) must be
+  /// re-evaluated — otherwise a URL the user scrolled UP to, beyond the last
+  /// scanned range, is never detected. Schedule the same debounced rescan the
+  /// output path uses so a scroll burst coalesces into one scan.
+  void _onScrollChanged() {
+    _scheduleDetectionRescan();
+    notifyListeners();
+  }
 
   @override
   void clear() {


### PR DESCRIPTION
## Summary
- `_rescanDetections` scanned a window anchored to the BOTTOM of scrollback (`[scrollback - 200, scrollback + visibleRows)`). A URL the user scrolled UP to, beyond that 200-row window, was outside the scanned range → never detected/bubbled (#787).
- Fix: derive the scan range from the current viewport (`scrollbar.offset` = top visible absolute row) → scan `[offset - window, offset + visibleRows + window)` clamped to the buffer. The on-screen region is always covered wherever the viewport sits, with a bounded margin (perf intent preserved, ≤ visibleRows + 2*200 rows).
- Wired `_onScrollChanged` to schedule the debounced detection rescan (it previously only re-resolved rects via `notifyListeners` per #784), so scrolling to new content triggers a fresh scan. Both URL and path patterns benefit (shared rescan).

## TDD Analysis
- Type: bug fix
- Behavior change: no (restores detection coverage)
- TDD approach: full (RED→GREEN confirmed by stashing the impl fix)

## Test coverage
- **Existing tests updated**: none needed — existing #767 wrapped-URL replay stays green.
- **New tests added (fail→pass)** in `native/test/terminal/replay_url_detection_test.dart`:
  - "a URL scrolled UP to, far beyond the bottom-anchored scan window, is detected at the current scroll position" — writes the URL near the top, pushes it 250 rows up (>> the 200-row window), `scrollToTop()`, asserts the anchor is found. RED with the old window, GREEN with the fix.
  - "near-bottom detection still works (no regression from the window move)".
- **Isolation note**: the scroll-up case separates the URL with a blank line so the soft-wrap flag doesn't over-join it into the filler below — that wrap-join behaviour is #767's concern, orthogonal to this scan-window gap.

## Test results
- flutter analyze: PASS
- native fast gate: PASS (902 tests)
- new + existing URL detection tests: PASS

## Diff stats
- Files changed: 2
- Lines: +109 / -8

Closes #787

## Cycles used
1/3