### PR TITLE
feat(native): in-app byte + scroll-event recorder (#790)

### DIFF
--- a/native/lib/diagnostics/session_byte_recorder.dart
+++ b/native/lib/diagnostics/session_byte_recorder.dart
@@ -1,0 +1,240 @@
+// In-app byte + scroll-event recorder (#790) — replay-harness TRACE PRODUCER.
+//
+// The Feedback FRAME recorder captures rendered OUTPUT (pixels, forward ~10s).
+// It can't REPRODUCE a scrollback-render bug (#789 scroll-stuck, #772 cursor
+// block, #773 delayed paint, outline-drift) because it never captured the INPUT
+// — the raw byte stream flterm/Terminal received — or the scroll gestures that
+// produced the buggy frame. This module records both, per active session, into
+// a continuously-running, bounded, BACKWARD-looking ring, so a captured trace
+// can later be replayed (#791, the SEPARATE follow-up slice) into a real
+// Terminal widget headlessly and the bug reproduced + fixed at the source.
+//
+// Design (mirrors connect_trace.dart / gesture_trace.dart):
+//   - One [SessionByteRecorder] per live session, kept in a global registry
+//     keyed by sessionId, with a single "active" pointer the feedback overlay
+//     reads at Feedback time (`activeByteTraceSnapshot()` etc.).
+//   - The byte ring stores the raw [Uint8List] reference + a relative-ms
+//     timestamp — ALLOCATION-LIGHT on the hot path (this records the very scroll
+//     path #789 suspects of jank; no per-event copy, no per-event base64). The
+//     b64 encoding + secret scrub happen ONCE at SNAPSHOT time (cold path).
+//   - Bounded by total bytes (~256 KB) AND age (~30 s), whichever evicts first —
+//     it's backward-looking so the bytes that produced the current buggy state
+//     are present when the user hits Feedback.
+//   - The scroll ring stores `{tMs, offset}` bounded by event count + age. Grid
+//     `{cols, rows}` tracks the latest viewport (updated on resize).
+//
+// SECURITY (rules/security.md / #553 contract): the byte stream is terminal
+// OUTPUT and MAY contain secrets (an echoed token, a sudo prompt echo). The
+// snapshot decodes each chunk, runs it through [scrubSecrets] (shared with the
+// feedback bundle), and re-encodes — so credential-looking lines NEVER leave the
+// device. Scrubbing at snapshot (cold path) keeps the hot path allocation-light.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'feedback_bundle.dart' show scrubSecrets;
+
+/// Default byte-ring cap: ~256 KB of the most recent terminal output. Past this
+/// the oldest chunks are evicted (backward-looking — newest always wins).
+const int kByteRecorderMaxBytes = 256 * 1024;
+
+/// Default byte-ring event cap (defense against a flood of tiny chunks blowing
+/// the list length even under the byte cap).
+const int kByteRecorderMaxEvents = 4096;
+
+/// Default age cap for BOTH rings: ~30 s. Events older than this (relative to
+/// the newest event) are evicted.
+const Duration kByteRecorderMaxAge = Duration(seconds: 30);
+
+/// Default scroll-ring event cap.
+const int kScrollRecorderMaxEvents = 2048;
+
+class _ByteEvent {
+  _ByteEvent(this.tMs, this.bytes);
+  final int tMs;
+  final Uint8List bytes;
+}
+
+class _ScrollEvent {
+  _ScrollEvent(this.tMs, this.offset);
+  final int tMs;
+  final int offset;
+}
+
+/// A bounded, backward-looking recorder of the raw bytes written to ONE
+/// session's terminal plus its scroll-offset events. See the file header.
+class SessionByteRecorder {
+  SessionByteRecorder({
+    this.maxBytes = kByteRecorderMaxBytes,
+    this.maxEvents = kByteRecorderMaxEvents,
+    this.maxAge = kByteRecorderMaxAge,
+    this.maxScrollEvents = kScrollRecorderMaxEvents,
+    int Function()? nowMs,
+  }) : _nowMs = nowMs ?? _defaultNowMs;
+
+  final int maxBytes;
+  final int maxEvents;
+  final Duration maxAge;
+  final int maxScrollEvents;
+
+  /// Monotonic relative-ms clock. Injected in tests for determinism; production
+  /// uses an epoch-anchored elapsed millis.
+  final int Function() _nowMs;
+
+  // Ring buffers. Plain growable lists used as FIFO queues — eviction is from
+  // the FRONT (oldest). Allocation-light: no per-event wrapper churn beyond the
+  // small _ByteEvent/_ScrollEvent holders, and crucially NO byte copy/encode on
+  // the hot path.
+  final List<_ByteEvent> _bytes = <_ByteEvent>[];
+  int _byteTotal = 0;
+  final List<_ScrollEvent> _scroll = <_ScrollEvent>[];
+
+  int? _cols;
+  int? _rows;
+
+  static final int _epoch = DateTime.now().millisecondsSinceEpoch;
+  static int _defaultNowMs() =>
+      DateTime.now().millisecondsSinceEpoch - _epoch;
+
+  /// Append a chunk of raw terminal-output [chunk]. Hot path: stores the
+  /// reference + a timestamp, then evicts past the byte/event/age caps. No
+  /// copy, no encode here.
+  void recordBytes(Uint8List chunk) {
+    if (chunk.isEmpty) return;
+    final t = _nowMs();
+    _bytes.add(_ByteEvent(t, chunk));
+    _byteTotal += chunk.length;
+    _evictBytes(t);
+  }
+
+  void _evictBytes(int nowMs) {
+    final ageFloor = nowMs - maxAge.inMilliseconds;
+    // Age + byte-cap + event-cap eviction, oldest-first.
+    while (_bytes.isNotEmpty &&
+        (_bytes.first.tMs < ageFloor ||
+            _byteTotal > maxBytes ||
+            _bytes.length > maxEvents)) {
+      // Never evict the only (newest) chunk on the byte cap — a single chunk
+      // larger than the cap must still be retained so the newest output is
+      // present. Age eviction may still drop it once it's stale.
+      if (_bytes.length == 1 && _bytes.first.tMs >= ageFloor) break;
+      _byteTotal -= _bytes.first.bytes.length;
+      _bytes.removeAt(0);
+    }
+  }
+
+  /// Append a scroll-offset event. Hot path on every scroll change.
+  void recordScroll(int offset) {
+    final t = _nowMs();
+    _scroll.add(_ScrollEvent(t, offset));
+    final ageFloor = t - maxAge.inMilliseconds;
+    while (_scroll.isNotEmpty &&
+        (_scroll.first.tMs < ageFloor || _scroll.length > maxScrollEvents)) {
+      if (_scroll.length == 1 && _scroll.first.tMs >= ageFloor) break;
+      _scroll.removeAt(0);
+    }
+  }
+
+  /// Record the latest viewport grid (cols × rows). Cheap; called on resize.
+  void recordGrid(int cols, int rows) {
+    _cols = cols;
+    _rows = rows;
+  }
+
+  /// Snapshot the byte ring as a list of `{tMs, b64}`, oldest first. SCRUBS each
+  /// chunk's UTF-8 projection of credential material before re-encoding, so no
+  /// secret leaves the device (rules/security.md). Cold path — encode + scrub
+  /// happen here, not on the hot path.
+  List<Map<String, Object?>> snapshotByteTrace() {
+    final out = <Map<String, Object?>>[];
+    for (final ev in _bytes) {
+      // Decode lossily, scrub, re-encode. A scrub that changes nothing is the
+      // common case; the round-trip preserves valid UTF-8 exactly.
+      final text = utf8.decode(ev.bytes, allowMalformed: true);
+      final scrubbed = scrubSecrets(text);
+      final bytes = identical(scrubbed, text) || scrubbed == text
+          ? ev.bytes
+          : Uint8List.fromList(utf8.encode(scrubbed));
+      out.add(<String, Object?>{'tMs': ev.tMs, 'b64': base64Encode(bytes)});
+    }
+    return out;
+  }
+
+  /// Snapshot the scroll ring as a list of `{tMs, offset}`, oldest first.
+  List<Map<String, Object?>> snapshotScrollTrace() {
+    return _scroll
+        .map((e) => <String, Object?>{'tMs': e.tMs, 'offset': e.offset})
+        .toList(growable: false);
+  }
+
+  /// The latest viewport grid `{cols, rows}`, or null if never recorded.
+  Map<String, Object?>? grid() {
+    if (_cols == null || _rows == null) return null;
+    return <String, Object?>{'cols': _cols, 'rows': _rows};
+  }
+
+  /// Drop all buffered events (e.g. on session teardown).
+  void clear() {
+    _bytes.clear();
+    _byteTotal = 0;
+    _scroll.clear();
+    _cols = null;
+    _rows = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Global registry + active pointer. Mirrors the connect/gesture trace pattern:
+// the feedback overlay reads `activeByteTraceSnapshot()` etc. for whichever
+// session is currently on screen, without a Riverpod dependency in its
+// above-the-Navigator context.
+// ---------------------------------------------------------------------------
+
+final Map<String, SessionByteRecorder> _recorders =
+    <String, SessionByteRecorder>{};
+String? _activeSessionId;
+
+/// Register (or fetch) the recorder for [sessionId]. Idempotent: returns the
+/// existing recorder if one is already registered for that id.
+SessionByteRecorder registerByteRecorder(String sessionId) {
+  return _recorders.putIfAbsent(sessionId, SessionByteRecorder.new);
+}
+
+/// The recorder for [sessionId], or null if none is registered.
+SessionByteRecorder? byteRecorderFor(String sessionId) => _recorders[sessionId];
+
+/// Drop the recorder for [sessionId] (session teardown). Clears the active
+/// pointer if it referenced this session.
+void unregisterByteRecorder(String sessionId) {
+  _recorders.remove(sessionId)?.clear();
+  if (_activeSessionId == sessionId) _activeSessionId = null;
+}
+
+/// Mark [sessionId] as the active (on-screen) session whose rings the feedback
+/// overlay snapshots. Pass null when no terminal is foregrounded.
+void setActiveByteRecorder(String? sessionId) {
+  _activeSessionId = sessionId;
+}
+
+SessionByteRecorder? get _active {
+  final id = _activeSessionId;
+  if (id == null) return null;
+  return _recorders[id];
+}
+
+/// Byte trace of the active session, or empty when none is active.
+List<Map<String, Object?>> activeByteTraceSnapshot() =>
+    _active?.snapshotByteTrace() ?? const <Map<String, Object?>>[];
+
+/// Scroll trace of the active session, or empty when none is active.
+List<Map<String, Object?>> activeScrollTraceSnapshot() =>
+    _active?.snapshotScrollTrace() ?? const <Map<String, Object?>>[];
+
+/// Grid `{cols, rows}` of the active session, or null when none is active.
+Map<String, Object?>? activeGridSnapshot() => _active?.grid();
+
+/// Clear the whole registry + active pointer (tests).
+void clearAllByteRecorders() {
+  _recorders.clear();
+  _activeSessionId = null;
+}

--- a/native/lib/ui/feedback_overlay.dart
+++ b/native/lib/ui/feedback_overlay.dart
@@ -29,6 +29,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:mobissh/diagnostics/connect_trace.dart';
 import 'package:mobissh/diagnostics/feedback_bundle.dart' show scrubSecrets;
 import 'package:mobissh/diagnostics/gesture_trace.dart';
+import 'package:mobissh/diagnostics/session_byte_recorder.dart';
 import 'package:mobissh/ui/top_toast.dart';
 
 /// Prod endpoint that ingests bug reports (same one the web form posts to).
@@ -72,6 +73,9 @@ Map<String, Object?> buildFeedbackPayload({
   List<String> connectLog = const <String>[],
   List<String> gestureLog = const <String>[],
   List<String> lifecycleLog = const <String>[],
+  List<Map<String, Object?>> byteTrace = const <Map<String, Object?>>[],
+  List<Map<String, Object?>> scrollTrace = const <Map<String, Object?>>[],
+  Map<String, Object?>? grid,
 }) {
   final fullComment = comment;
   // First non-empty line → title summary. Never truncate the comment itself.
@@ -132,6 +136,17 @@ Map<String, Object?> buildFeedbackPayload({
     if (scrubbedLog.isNotEmpty) 'connectLog': scrubbedLog,
     if (scrubbedGestureLog.isNotEmpty) 'gestureLog': scrubbedGestureLog,
     if (scrubbedLifecycleLog.isNotEmpty) 'lifecycleLog': scrubbedLifecycleLog,
+    // #790: the replay-harness trace. byteTrace = raw bytes that reached the
+    // Terminal ({tMs,b64}); scrollTrace = scroll-offset events ({tMs,offset});
+    // grid = the active session's viewport {cols,rows}. The server (#790)
+    // persists these as `${ts}-bug-report.byte-trace.json` so the captured trace
+    // can be replayed (#791) to reproduce a scrollback-render bug. The byte
+    // stream is ALREADY scrubbed by SessionByteRecorder.snapshotByteTrace() at
+    // snapshot time (rules/security.md). Omitted entirely when no session is
+    // active (no empty-array / null noise).
+    if (byteTrace.isNotEmpty) 'byteTrace': byteTrace,
+    if (scrollTrace.isNotEmpty) 'scrollTrace': scrollTrace,
+    'grid': ?grid,
   };
 }
 
@@ -291,6 +306,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     final connectLog = connectLogSnapshot();
     final gestureLog = gestureLogSnapshot();
     final lifecycleLog = lifecycleLogSnapshot();
+    // #790: the byte/scroll recorder is BACKWARD-looking, so snapshot it at the
+    // END (just before the sheet) where the trace covers the bug the owner just
+    // reproduced. Captured below after the frame burst.
 
     setState(() {
       _recording = true;
@@ -334,6 +352,11 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       connectLog: connectLog,
       gestureLog: gestureLog,
       lifecycleLog: lifecycleLog,
+      // #790: backward-looking — snapshot NOW so the trace covers the bug just
+      // reproduced during the burst.
+      byteTrace: activeByteTraceSnapshot(),
+      scrollTrace: activeScrollTraceSnapshot(),
+      grid: activeGridSnapshot(),
     );
   }
 
@@ -353,6 +376,12 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     final connectLog = connectLogSnapshot();
     final gestureLog = gestureLogSnapshot();
     final lifecycleLog = lifecycleLogSnapshot();
+    // #790: snapshot the byte/scroll recorder at the EXACT moment of tap — it's
+    // backward-looking, so the rings hold the input + scroll that produced the
+    // current (buggy) frame the owner is reporting.
+    final byteTrace = activeByteTraceSnapshot();
+    final scrollTrace = activeScrollTraceSnapshot();
+    final grid = activeGridSnapshot();
     final dpr = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0;
     final bytes = await widget.screenshotCapturer(_captureKey, dpr);
     if (!mounted) return;
@@ -367,6 +396,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       connectLog: connectLog,
       gestureLog: gestureLog,
       lifecycleLog: lifecycleLog,
+      byteTrace: byteTrace,
+      scrollTrace: scrollTrace,
+      grid: grid,
     );
   }
 
@@ -377,6 +409,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     required List<String> gestureLog,
     required List<String> lifecycleLog,
     List<String> frameDataUrls = const <String>[],
+    List<Map<String, Object?>> byteTrace = const <Map<String, Object?>>[],
+    List<Map<String, Object?>> scrollTrace = const <Map<String, Object?>>[],
+    Map<String, Object?>? grid,
   }) async {
     // Show the sheet from the Navigator's OVERLAY context — NOT this overlay's
     // own context, which sits above the Navigator (mounted via
@@ -402,6 +437,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       connectLog: connectLog,
       gestureLog: gestureLog,
       lifecycleLog: lifecycleLog,
+      byteTrace: byteTrace,
+      scrollTrace: scrollTrace,
+      grid: grid,
     );
     final ok = await widget.submitter.submit(payload);
     // Confirmation as a TOP toast (#667) so it doesn't occlude the bottom

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -172,6 +172,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart' as xterm;
 
 import '../diagnostics/gesture_trace.dart';
+import '../diagnostics/session_byte_recorder.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../state/ctrl_modifier_provider.dart';
@@ -1833,6 +1834,20 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// focus fires; reset false on disconnect so a reconnect re-focuses.
   bool _focusedThisConnect = false;
 
+  /// #790: per-session byte + scroll recorder (replay-harness trace producer).
+  /// Captures the raw bytes that reach the terminal and the scroll-offset events
+  /// into a bounded backward-looking ring, snapshotted into the bug report so a
+  /// scrollback-render bug can be replayed (#791). Allocation-light: stores the
+  /// existing output Uint8List + a timestamp, no copy on the hot path.
+  late final SessionByteRecorder _byteRecorder = registerByteRecorder(
+    widget.sessionId,
+  );
+
+  /// #790: track the last scroll offset pushed to the recorder so a controller
+  /// notify that didn't move the viewport (mouse-mode / selection / redraw)
+  /// doesn't spam the scroll ring with identical offsets.
+  int _lastRecordedScrollOffset = -1;
+
   @override
   void initState() {
     super.initState();
@@ -1861,6 +1876,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         // can never diverge from what the window-switch wheel targets (#719).
         _cols = cols;
         _rows = rows;
+        // #790: record the live viewport grid so the replay harness can lay out
+        // the captured byte stream at the SAME cols×rows the bug occurred at.
+        _byteRecorder.recordGrid(cols, rows);
         _sendResize(cols, rows);
         // #767: a resize changes the cell ranges, but the URL re-detect now lives
         // INSIDE the terminal — the controller re-scans on its own notify cycle,
@@ -1870,6 +1888,12 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // dispose() cancels it.
       _outputSub = proxy.output.listen((bytes) {
         try {
+          // #790: record the raw output chunk BEFORE writing it to the terminal
+          // — this is the single seam where proxy.output bytes reach the
+          // Terminal, so the recorder captures EXACTLY the input that produced
+          // the rendered (possibly buggy) state. Allocation-light: the recorder
+          // keeps the reference + a timestamp; no copy/encode here.
+          _byteRecorder.recordBytes(bytes);
           // #760: mark that the imminent controller notify is driven by fresh
           // REMOTE output (not a local scroll), so _onControllerChanged can
           // invalidate a selection whose covered content was just redrawn.
@@ -1934,6 +1958,19 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // absolute-row frame can't track that), clear the now-stale selection. A
     // pure local scrollback scroll (no write → remoteOutput false) is retained.
     _invalidateSelectionOnRedraw(remoteOutput);
+    // #790: record a scroll-offset event when the viewport actually moved. This
+    // notify fires on scroll AND on output/mouse-mode/selection; only an offset
+    // CHANGE is a real scroll, so we de-dupe against the last recorded value to
+    // keep the scroll ring a faithful record of the scroll path (#789) without a
+    // flood of identical offsets.
+    final controller = _controller;
+    if (controller != null) {
+      final offset = _viewportOffsetOf(controller);
+      if (offset != _lastRecordedScrollOffset) {
+        _lastRecordedScrollOffset = offset;
+        _byteRecorder.recordScroll(offset);
+      }
+    }
     _syncMouseTracking();
     _syncHasSelection();
     // #767: URL re-detection now lives INSIDE the terminal. The controller
@@ -2625,6 +2662,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     _controller?.onResize = null;
     _controller?.dispose();
     _scrollController.dispose();
+    // #790: this session's terminal is gone — drop its recorder ring (and clear
+    // the active pointer if it referenced us, so a stale snapshot can't leak).
+    unregisterByteRecorder(widget.sessionId);
     super.dispose();
   }
 

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -29,6 +29,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
 
 import '../diagnostics/connect_trace.dart';
+import '../diagnostics/session_byte_recorder.dart';
 import '../ssh/ssh_session.dart';
 import '../state/sessions.dart';
 import '../state/terminal_backend.dart';
@@ -108,6 +109,13 @@ class TerminalScreen extends ConsumerWidget {
 
     final activeEntry = sessions.active ?? entries.first;
     final activeIndex = entries.indexWhere((e) => e.id == activeEntry.id);
+
+    // #790: point the byte/scroll recorder registry at the on-screen session so
+    // the feedback overlay (which has no Riverpod scope of its own) snapshots the
+    // RIGHT session's rings. All sessions are mounted in the IndexedStack, so
+    // this — not each view's initState — is the single place that knows which is
+    // foregrounded. The recorder itself is created lazily by each view.
+    setActiveByteRecorder(activeEntry.id);
 
     // #573: keybar visibility is PER-SESSION — read the ACTIVE session's flag.
     // Switching sessions re-watches the new active id, so each session shows

--- a/native/test/diagnostics/session_byte_recorder_test.dart
+++ b/native/test/diagnostics/session_byte_recorder_test.dart
@@ -1,0 +1,178 @@
+// Unit tests for the in-app byte + scroll-event recorder (#790).
+//
+// The recorder is the replay-harness TRACE PRODUCER: a continuously-running,
+// bounded, BACKWARD-looking ring that captures (a) the raw bytes written to the
+// terminal and (b) scroll-offset events, per active session, so a captured
+// trace can later be replayed (#791) to reproduce a scrollback-render bug.
+//
+// These tests lock the ring contract:
+//   - byte ring evicts oldest past the byte cap;
+//   - byte ring evicts oldest past the age cap;
+//   - relative-ms timestamps are monotonic non-decreasing;
+//   - b64 round-trips the exact bytes;
+//   - the snapshot scrubs credential-looking lines out of the byte stream;
+//   - scroll ring evicts oldest past the count cap, timestamps monotonic;
+//   - the active-recorder registry routes snapshots to the active session.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobissh/diagnostics/session_byte_recorder.dart';
+
+void main() {
+  setUp(clearAllByteRecorders);
+  tearDown(clearAllByteRecorders);
+
+  group('byte ring', () {
+    test('appends bytes as {tMs, b64} that round-trips', () {
+      final rec = SessionByteRecorder();
+      rec.recordBytes(Uint8List.fromList([0, 1, 2, 250, 255]));
+      final snap = rec.snapshotByteTrace();
+      expect(snap, hasLength(1));
+      final ev = snap.single;
+      expect(ev['tMs'], isA<int>());
+      final decoded = base64Decode(ev['b64'] as String);
+      expect(decoded, [0, 1, 2, 250, 255]);
+    });
+
+    test('evicts oldest chunks once the byte cap is exceeded', () {
+      // Cap small so a few chunks overflow it deterministically.
+      final rec = SessionByteRecorder(maxBytes: 100, maxEvents: 1000);
+      // 8 chunks of 25 bytes = 200 bytes; cap 100 → only the newest ~100 survive.
+      for (var i = 0; i < 8; i++) {
+        rec.recordBytes(Uint8List(25)..fillRange(0, 25, i));
+      }
+      final snap = rec.snapshotByteTrace();
+      var total = 0;
+      for (final ev in snap) {
+        total += base64Decode(ev['b64'] as String).length;
+      }
+      expect(total, lessThanOrEqualTo(100));
+      // The NEWEST chunk (filled with 7) must still be present — backward-looking.
+      final last = base64Decode(snap.last['b64'] as String);
+      expect(last.every((b) => b == 7), isTrue);
+    });
+
+    test('evicts chunks older than the age cap', () {
+      var clock = 0;
+      final rec = SessionByteRecorder(
+        maxAge: const Duration(milliseconds: 1000),
+        nowMs: () => clock,
+      );
+      rec.recordBytes(Uint8List.fromList([1])); // t=0
+      clock = 500;
+      rec.recordBytes(Uint8List.fromList([2])); // t=500
+      clock = 2000; // now 2000ms; the t=0 chunk is 2000ms old → evicted
+      rec.recordBytes(Uint8List.fromList([3])); // t=2000
+      final snap = rec.snapshotByteTrace();
+      // Only chunks within 1000ms of the latest (2000) survive: t=2000 (and the
+      // t=500 chunk is 1500ms old → evicted too).
+      final values = snap
+          .map((e) => base64Decode(e['b64'] as String).first)
+          .toList();
+      expect(values, isNot(contains(1)));
+      expect(values, contains(3));
+    });
+
+    test('relative-ms timestamps are monotonic non-decreasing', () {
+      var clock = 0;
+      final rec = SessionByteRecorder(nowMs: () => clock);
+      rec.recordBytes(Uint8List.fromList([1]));
+      clock = 10;
+      rec.recordBytes(Uint8List.fromList([2]));
+      clock = 10; // same instant
+      rec.recordBytes(Uint8List.fromList([3]));
+      final ts = rec.snapshotByteTrace().map((e) => e['tMs'] as int).toList();
+      for (var i = 1; i < ts.length; i++) {
+        expect(ts[i], greaterThanOrEqualTo(ts[i - 1]));
+      }
+    });
+
+    test('snapshot scrubs credential-looking lines out of the byte stream', () {
+      final rec = SessionByteRecorder();
+      // Terminal OUTPUT may echo a secret (e.g. a pasted token, a sudo prompt
+      // echo). rules/security.md: it must NOT leave the device.
+      rec.recordBytes(
+        Uint8List.fromList(utf8.encode('login ok\npassword=hunter2\n')),
+      );
+      final snap = rec.snapshotByteTrace();
+      final allText = snap
+          .map((e) => utf8.decode(base64Decode(e['b64'] as String)))
+          .join();
+      expect(allText.contains('hunter2'), isFalse);
+      expect(allText.contains('[REDACTED]'), isTrue);
+    });
+  });
+
+  group('scroll ring', () {
+    test('appends scroll offsets as {tMs, offset}', () {
+      var clock = 0;
+      final rec = SessionByteRecorder(nowMs: () => clock);
+      rec.recordScroll(0);
+      clock = 16;
+      rec.recordScroll(120);
+      final snap = rec.snapshotScrollTrace();
+      expect(snap, hasLength(2));
+      expect(snap.first['offset'], 0);
+      expect(snap.last['offset'], 120);
+      expect(snap.last['tMs'], 16);
+    });
+
+    test('evicts oldest scroll events past the count cap', () {
+      final rec = SessionByteRecorder(maxScrollEvents: 3);
+      for (var i = 0; i < 6; i++) {
+        rec.recordScroll(i * 10);
+      }
+      final snap = rec.snapshotScrollTrace();
+      expect(snap, hasLength(3));
+      // Newest three offsets survive (30,40,50).
+      expect(snap.map((e) => e['offset']).toList(), [30, 40, 50]);
+    });
+
+    test('records grid {cols,rows} and resizes', () {
+      final rec = SessionByteRecorder();
+      rec.recordGrid(80, 24);
+      expect(rec.grid(), {'cols': 80, 'rows': 24});
+      rec.recordGrid(120, 40);
+      expect(rec.grid(), {'cols': 120, 'rows': 40});
+    });
+  });
+
+  group('active recorder registry', () {
+    test('snapshots route to the registered active session', () {
+      final a = registerByteRecorder('session-a');
+      final b = registerByteRecorder('session-b');
+      a.recordBytes(Uint8List.fromList([1]));
+      b.recordBytes(Uint8List.fromList([2, 3]));
+
+      setActiveByteRecorder('session-a');
+      expect(activeByteTraceSnapshot(), hasLength(1));
+      expect(base64Decode(activeByteTraceSnapshot().single['b64'] as String), [
+        1,
+      ]);
+
+      setActiveByteRecorder('session-b');
+      expect(base64Decode(activeByteTraceSnapshot().single['b64'] as String), [
+        2,
+        3,
+      ]);
+    });
+
+    test('snapshots are empty (not null) when no session is active', () {
+      setActiveByteRecorder(null);
+      expect(activeByteTraceSnapshot(), isEmpty);
+      expect(activeScrollTraceSnapshot(), isEmpty);
+      expect(activeGridSnapshot(), isNull);
+    });
+
+    test('unregister drops the recorder and clears active if it was it', () {
+      registerByteRecorder('gone');
+      setActiveByteRecorder('gone');
+      unregisterByteRecorder('gone');
+      expect(activeByteTraceSnapshot(), isEmpty);
+      expect(activeGridSnapshot(), isNull);
+    });
+  });
+}

--- a/native/test/ui/feedback_payload_test.dart
+++ b/native/test/ui/feedback_payload_test.dart
@@ -191,6 +191,39 @@ void main() {
         expect(log.any((l) => l.contains('[REDACTED]')), isTrue);
       },
     );
+
+    test(
+      'attaches byteTrace / scrollTrace / grid when present, omits when empty '
+      '(#790)',
+      () {
+        final withTrace = buildFeedbackPayload(
+          comment: 'scroll stuck',
+          version: '[v]',
+          byteTrace: const [
+            {'tMs': 0, 'b64': 'aGVsbG8='}, // "hello"
+            {'tMs': 16, 'b64': 'd29ybGQ='}, // "world"
+          ],
+          scrollTrace: const [
+            {'tMs': 0, 'offset': 0},
+            {'tMs': 32, 'offset': 120},
+          ],
+          grid: const {'cols': 80, 'rows': 24},
+        );
+        final bytes = withTrace['byteTrace'] as List;
+        expect(bytes, hasLength(2));
+        expect((bytes.first as Map)['b64'], 'aGVsbG8=');
+        final scroll = withTrace['scrollTrace'] as List;
+        expect(scroll, hasLength(2));
+        expect((scroll.last as Map)['offset'], 120);
+        expect(withTrace['grid'], {'cols': 80, 'rows': 24});
+
+        // No trace → all three fields omitted (no empty-array / null noise).
+        final without = buildFeedbackPayload(comment: 'x', version: '[v]');
+        expect(without.containsKey('byteTrace'), isFalse);
+        expect(without.containsKey('scrollTrace'), isFalse);
+        expect(without.containsKey('grid'), isFalse);
+      },
+    );
   });
 
   group('pngBytesToDataUrl', () {

--- a/server/index.js
+++ b/server/index.js
@@ -900,7 +900,7 @@ const server = http.createServer((req, res) => {
     req.on('end', () => {
       try {
         const data = JSON.parse(body);
-        const { screenshot, frames, logs, title, comment, userAgent, url, version, connectLog, gestureLog } = data;
+        const { screenshot, frames, logs, title, comment, userAgent, url, version, connectLog, gestureLog, byteTrace, scrollTrace, grid } = data;
         const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
         const reportDir = path.join(__dirname, '..', 'test-results', 'uploads');
         fs.mkdirSync(reportDir, { recursive: true });
@@ -977,6 +977,37 @@ const server = http.createServer((req, res) => {
           console.log(`[bug-report] gesture log: ${gestureLogFile} (${gestureLog.length} events)`);
         }
 
+        // #790: the replay-harness trace — the raw bytes that reached the
+        // terminal (byteTrace: [{tMs,b64}]) + the scroll-offset events
+        // (scrollTrace: [{tMs,offset}]) + the viewport grid ({cols,rows}). Saved
+        // to a single sidecar so the replay harness (#791) can feed the captured
+        // bytes into a real Terminal at the same grid and replay the scroll to
+        // reproduce a scrollback-render bug. Mirrors the `frames` branch; capped
+        // (the client already bounds the rings, this is a server-side backstop).
+        let byteTraceFile = '';
+        let byteTraceEventCount = 0;
+        let scrollTraceEventCount = 0;
+        const hasByteTrace = Array.isArray(byteTrace) && byteTrace.length > 0;
+        const hasScrollTrace = Array.isArray(scrollTrace) && scrollTrace.length > 0;
+        if (hasByteTrace || hasScrollTrace) {
+          const MAX_BYTE_EVENTS = 8192;
+          const MAX_SCROLL_EVENTS = 8192;
+          const cappedBytes = hasByteTrace ? byteTrace.slice(-MAX_BYTE_EVENTS) : [];
+          const cappedScroll = hasScrollTrace ? scrollTrace.slice(-MAX_SCROLL_EVENTS) : [];
+          byteTraceEventCount = cappedBytes.length;
+          scrollTraceEventCount = cappedScroll.length;
+          byteTraceFile = `${ts}-bug-report.byte-trace.json`;
+          fs.writeFileSync(
+            path.join(reportDir, byteTraceFile),
+            JSON.stringify({
+              grid: (grid && typeof grid === 'object') ? grid : null,
+              byteTrace: cappedBytes,
+              scrollTrace: cappedScroll,
+            }, null, 2),
+          );
+          console.log(`[bug-report] byte trace: ${byteTraceFile} (${byteTraceEventCount} byte events, ${scrollTraceEventCount} scroll events)`);
+        }
+
         // Save metadata
         const meta = {
           title: title || `Bug report ${ts}`,
@@ -995,6 +1026,11 @@ const server = http.createServer((req, res) => {
           connectLogEventCount: Array.isArray(connectLog) ? connectLog.length : 0,
           gestureLogFile,
           gestureLogEventCount: Array.isArray(gestureLog) ? gestureLog.length : 0,
+          // #790: replay-harness trace sidecar + counts + the captured grid.
+          byteTraceFile,
+          byteTraceEventCount,
+          scrollTraceEventCount,
+          grid: (grid && typeof grid === 'object') ? grid : null,
         };
         fs.writeFileSync(path.join(reportDir, `${ts}-bug-report.json`), JSON.stringify(meta, null, 2));
 


### PR DESCRIPTION
## What

Replay-harness Slice 3 — the in-app **byte + scroll-event recorder** (#790), the trace PRODUCER. The Feedback FRAME recorder captures rendered OUTPUT (pixels); it can't reproduce a scrollback-render bug (#789 scroll-stuck, #772 cursor block, #773 delayed paint) because it never captured the INPUT — the byte stream the terminal received — or the scroll gestures. This adds a continuously-running, bounded, BACKWARD-looking recorder of both, per active session, snapshotted into the bug report so a captured trace can be replayed (#791, separate slice) to reproduce the bug at the source.

## How

- **New `native/lib/diagnostics/session_byte_recorder.dart`** — per-session ring:
  - byte ring `{tMs, b64}` bounded by ~256 KB AND ~30 s (whichever evicts first);
  - scroll ring `{tMs, offset}` bounded by count + age; grid `{cols, rows}`;
  - global registry keyed by sessionId + an active pointer (mirrors connect/gesture trace), so the above-the-Navigator feedback overlay can snapshot the right session with no Riverpod scope.
  - **Allocation-light hot path:** stores the output `Uint8List` *reference* + a relative-ms timestamp; b64 encode + secret scrub happen ONCE at snapshot (cold path) — no per-event copy/encode/alloc storm (this records the very scroll path #789 suspects of jank).
- **Seams (no fork of `third_party/flterm`):** byte tap at the single UI-side `GhosttyTerminalView` `proxy.output.listen → controller.write` point; scroll recorded from `_onControllerChanged` (already fires on scroll, reads `controller.scrollbar.offset`, de-duped against the last offset); grid on `onResize`. `setActiveByteRecorder` driven from `TerminalScreen.build` (knows the foreground session — all are IndexedStack-mounted, so each view's `initState` can't decide).
- **`buildFeedbackPayload`** gains `byteTrace`/`scrollTrace`/`grid`; the overlay snapshots the active session's rings on tap AND long-press (backward-looking).
- **Scrub (rules/security.md):** `snapshotByteTrace` decodes each chunk, runs `scrubSecrets`, re-encodes — terminal output that echoes a credential never leaves the device.
- **Server `/api/bug-report`:** saves `byteTrace`/`scrollTrace`/`grid` to `${ts}-bug-report.byte-trace.json` + event counts in the report JSON, mirroring the `frames` branch; capped.

## Tests (TDD, red→green)

- Ring: append past byte/age/count caps → oldest evicted (newest always retained); timestamps monotonic; b64 round-trips exact bytes; snapshot scrubs a seeded `password=hunter2`. Registry routes snapshots to the active session, empty (not null) when none.
- `buildFeedbackPayload`: attaches byteTrace/scrollTrace/grid when present, omits all three when empty.
- Native fast gate green (914 tests, analyzer clean). `server/index.js` parses (`node --check`).

## Scope

Trace PRODUCER only — the replay harness (feed the captured trace into a real Terminal + replay scroll) is the separate follow-up #791. Device validation that a Feedback tap attaches the trace is deferred to the owner.

Refs #789, #772, #773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)