### PR TITLE
feat(native): recorder v2 — sent wheel-SGR + gesture retention + O(1) (#793)

### DIFF
--- a/native/lib/diagnostics/gesture_trace.dart
+++ b/native/lib/diagnostics/gesture_trace.dart
@@ -26,6 +26,29 @@ import 'package:flutter/foundation.dart';
 /// long-press-drag plus surrounding taps/swipes.
 const int gestureLogCapacity = 120;
 
+/// #793: the number of MOST-RECENT user-input gesture lines (swipe/scroll) the
+/// ring guarantees to retain even under a flood of non-gesture churn. The real
+/// #790 capture had ~68 `ghostty-resync`/resume/refit/focus lines that pushed
+/// the actual `swipe-vertical` gestures out of the bounded ring. Eviction now
+/// drops the oldest NON-gesture line first; a gesture line is only dropped once
+/// this many newer gesture lines exist — so a resume burst can't drown swipes.
+const int gestureLogGestureRetention = 32;
+
+/// #793: a line is a protected USER-INPUT gesture (vs resync/resume/refit/focus
+/// churn) iff its type token (the first whitespace-delimited word, after the
+/// timestamp prefix the ring adds) starts with `swipe` or `scroll`. Pure.
+bool _isProtectedGestureLine(String stored) {
+  // Stored lines are `"<ts> <type> ..."`; the type is the 2nd token. A raw
+  // pre-format line (no ts) has the type as the 1st token — accept either.
+  for (final token in stored.split(' ')) {
+    if (token.isEmpty) continue;
+    // Skip a leading timestamp token (`HH:MM:SS.mmm`).
+    if (token.length >= 8 && token[2] == ':' && token[5] == ':') continue;
+    return token.startsWith('swipe') || token.startsWith('scroll');
+  }
+  return false;
+}
+
 final List<String> _ring = <String>[];
 
 // Consecutive-duplicate suppression: a long-press-drag held still, or a stream
@@ -118,6 +141,43 @@ String formatGestureEvent({
       'by=$handledBy';
 }
 
+/// #793: cap the ring to [gestureLogCapacity], but protect recent user-input
+/// gesture lines (swipe/scroll) from a non-gesture flood. While over capacity,
+/// evict the OLDEST non-protected line. If none remains to evict (the ring is
+/// all protected gestures), evict the oldest protected line — but only the ones
+/// beyond [gestureLogGestureRetention] newest, so the most recent swipes win and
+/// the protected segment is itself bounded. Allocation-light: a single forward
+/// scan per eviction, no copies.
+void _capRing() {
+  while (_ring.length > gestureLogCapacity) {
+    var evictAt = -1;
+    // Prefer the oldest NON-protected (churn) line.
+    for (var i = 0; i < _ring.length; i++) {
+      if (!_isProtectedGestureLine(_ring[i])) {
+        evictAt = i;
+        break;
+      }
+    }
+    if (evictAt < 0) {
+      // All lines are protected gestures — drop the oldest so the newest
+      // [gestureLogGestureRetention] survive (bounded protected segment).
+      evictAt = 0;
+    }
+    _ring.removeAt(evictAt);
+  }
+  // Bound the protected segment too: keep only the newest
+  // [gestureLogGestureRetention] protected lines so an endless swipe stream
+  // can't itself grow unbounded within the capacity.
+  var protectedCount = 0;
+  for (var i = _ring.length - 1; i >= 0; i--) {
+    if (!_isProtectedGestureLine(_ring[i])) continue;
+    protectedCount++;
+    if (protectedCount > gestureLogGestureRetention) {
+      _ring.removeAt(i);
+    }
+  }
+}
+
 /// Append a raw pre-formatted gesture line to the ring (and logcat). Most call
 /// sites use [gevent] instead; this is the low-level primitive (and what the
 /// duplicate-collapse logic keys on).
@@ -137,9 +197,7 @@ void gtrace(String line) {
   debugPrint('[GESTURE]$line');
 
   _ring.add('$ts $line');
-  while (_ring.length > gestureLogCapacity) {
-    _ring.removeAt(0);
-  }
+  _capRing();
   _gestureLog.value = List<String>.unmodifiable(_ring);
 }
 

--- a/native/lib/diagnostics/session_byte_recorder.dart
+++ b/native/lib/diagnostics/session_byte_recorder.dart
@@ -29,6 +29,7 @@
 // feedback bundle), and re-encodes — so credential-looking lines NEVER leave the
 // device. Scrubbing at snapshot (cold path) keeps the hot path allocation-light.
 
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -49,6 +50,10 @@ const Duration kByteRecorderMaxAge = Duration(seconds: 30);
 /// Default scroll-ring event cap.
 const int kScrollRecorderMaxEvents = 2048;
 
+/// Default sent-SGR-ring event cap (#793). The synthesized mouse/wheel reports
+/// the app SENDS are short and infrequent; a modest cap holds a full swipe burst.
+const int kSentSgrRecorderMaxEvents = 1024;
+
 class _ByteEvent {
   _ByteEvent(this.tMs, this.bytes);
   final int tMs;
@@ -61,6 +66,31 @@ class _ScrollEvent {
   final int offset;
 }
 
+/// #793: true iff [chunk] is a synthesized SGR-1006 mouse/wheel report — the
+/// ONLY bytes the sent ring is allowed to capture. An SGR-1006 mouse report is
+/// `ESC [ < ... M` (press/motion) or `ESC [ < ... m` (release): byte sequence
+/// `0x1b 0x5b 0x3c` (`ESC[<`) terminated by `M` (0x4d) or `m` (0x6d). A typed
+/// keystroke, password, control char, or Enter is NOT this shape, so it can
+/// never enter the ring — typed secrets are never recorded (rules/security.md).
+/// Pure + allocation-free (byte scan, no decode).
+bool isSentSgrMouseReport(Uint8List chunk) {
+  // Need at least `ESC[<` + terminator.
+  if (chunk.length < 4) return false;
+  if (chunk[0] != 0x1b || chunk[1] != 0x5b || chunk[2] != 0x3c) return false;
+  final last = chunk[chunk.length - 1];
+  if (last != 0x4d && last != 0x6d) return false; // not M / m terminated
+  // Between the prefix and the terminator only digits and ';' are valid in an
+  // SGR-1006 mouse report — reject anything else so a crafted-looking prefix
+  // that actually carries other bytes (and could embed typed content) is dropped.
+  for (var i = 3; i < chunk.length - 1; i++) {
+    final b = chunk[i];
+    final isDigit = b >= 0x30 && b <= 0x39;
+    final isSemi = b == 0x3b;
+    if (!isDigit && !isSemi) return false;
+  }
+  return true;
+}
+
 /// A bounded, backward-looking recorder of the raw bytes written to ONE
 /// session's terminal plus its scroll-offset events. See the file header.
 class SessionByteRecorder {
@@ -69,6 +99,7 @@ class SessionByteRecorder {
     this.maxEvents = kByteRecorderMaxEvents,
     this.maxAge = kByteRecorderMaxAge,
     this.maxScrollEvents = kScrollRecorderMaxEvents,
+    this.maxSentSgrEvents = kSentSgrRecorderMaxEvents,
     int Function()? nowMs,
   }) : _nowMs = nowMs ?? _defaultNowMs;
 
@@ -76,18 +107,26 @@ class SessionByteRecorder {
   final int maxEvents;
   final Duration maxAge;
   final int maxScrollEvents;
+  final int maxSentSgrEvents;
 
   /// Monotonic relative-ms clock. Injected in tests for determinism; production
   /// uses an epoch-anchored elapsed millis.
   final int Function() _nowMs;
 
-  // Ring buffers. Plain growable lists used as FIFO queues — eviction is from
-  // the FRONT (oldest). Allocation-light: no per-event wrapper churn beyond the
-  // small _ByteEvent/_ScrollEvent holders, and crucially NO byte copy/encode on
-  // the hot path.
-  final List<_ByteEvent> _bytes = <_ByteEvent>[];
+  // Ring buffers. ListQueue (#793) used as FIFO queues — eviction is from the
+  // FRONT (oldest) via O(1) `removeFirst`, NOT List.removeAt(0) (O(n) shift on
+  // the hot path). Allocation-light: no per-event wrapper churn beyond the small
+  // _ByteEvent/_ScrollEvent holders, and crucially NO byte copy/encode on the
+  // hot path.
+  final ListQueue<_ByteEvent> _bytes = ListQueue<_ByteEvent>();
   int _byteTotal = 0;
-  final List<_ScrollEvent> _scroll = <_ScrollEvent>[];
+  final ListQueue<_ScrollEvent> _scroll = ListQueue<_ScrollEvent>();
+  // #793: sent-SGR ring — ONLY the synthesized mouse/wheel SGR reports the app
+  // WRITES to the proxy (filtered by [isSentSgrMouseReport]). Reveals "swipe →
+  // wheel events emitted → tmux scrolled" in tmux mouse mode (where the local
+  // scroll never moves). NEVER carries keystrokes, so a typed password can never
+  // be recorded — the filter is the security boundary.
+  final ListQueue<_ByteEvent> _sentSgr = ListQueue<_ByteEvent>();
 
   int? _cols;
   int? _rows;
@@ -119,7 +158,26 @@ class SessionByteRecorder {
       // present. Age eviction may still drop it once it's stale.
       if (_bytes.length == 1 && _bytes.first.tMs >= ageFloor) break;
       _byteTotal -= _bytes.first.bytes.length;
-      _bytes.removeAt(0);
+      _bytes.removeFirst();
+    }
+  }
+
+  /// #793: append a chunk of bytes the app WROTE to the proxy, but ONLY if it is
+  /// a synthesized SGR-1006 mouse/wheel report ([isSentSgrMouseReport]). Any
+  /// other chunk (a typed keystroke, password, control char, Enter) is dropped
+  /// here — it never enters the ring, so typed secrets are never recorded
+  /// (rules/security.md). Hot path: a cheap byte-scan filter, then store the
+  /// reference + timestamp. No copy/encode here (cold path at snapshot).
+  void recordSentSgr(Uint8List chunk) {
+    if (!isSentSgrMouseReport(chunk)) return;
+    final t = _nowMs();
+    _sentSgr.add(_ByteEvent(t, chunk));
+    final ageFloor = t - maxAge.inMilliseconds;
+    while (_sentSgr.isNotEmpty &&
+        (_sentSgr.first.tMs < ageFloor ||
+            _sentSgr.length > maxSentSgrEvents)) {
+      if (_sentSgr.length == 1 && _sentSgr.first.tMs >= ageFloor) break;
+      _sentSgr.removeFirst();
     }
   }
 
@@ -131,7 +189,7 @@ class SessionByteRecorder {
     while (_scroll.isNotEmpty &&
         (_scroll.first.tMs < ageFloor || _scroll.length > maxScrollEvents)) {
       if (_scroll.length == 1 && _scroll.first.tMs >= ageFloor) break;
-      _scroll.removeAt(0);
+      _scroll.removeFirst();
     }
   }
 
@@ -160,6 +218,28 @@ class SessionByteRecorder {
     return out;
   }
 
+  /// #793: snapshot the sent-SGR ring as a list of `{tMs, b64}`, oldest first.
+  /// Scrubs each chunk (defense in depth — mouse reports carry no credentials,
+  /// but the ring uses the same cold-path scrub as the output ring). Encode +
+  /// scrub happen here, not on the hot path.
+  List<Map<String, Object?>> snapshotSentSgrTrace() {
+    final out = <Map<String, Object?>>[];
+    for (final ev in _sentSgr) {
+      final text = utf8.decode(ev.bytes, allowMalformed: true);
+      final scrubbed = scrubSecrets(text);
+      final bytes = identical(scrubbed, text) || scrubbed == text
+          ? ev.bytes
+          : Uint8List.fromList(utf8.encode(scrubbed));
+      out.add(<String, Object?>{'tMs': ev.tMs, 'b64': base64Encode(bytes)});
+    }
+    return out;
+  }
+
+  /// #793 (test-only): the live total of bytes retained in the byte ring, so the
+  /// O(1)-eviction tests can assert `_byteTotal` stays consistent with the
+  /// surviving chunks after `ListQueue` eviction.
+  int get debugByteTotal => _byteTotal;
+
   /// Snapshot the scroll ring as a list of `{tMs, offset}`, oldest first.
   List<Map<String, Object?>> snapshotScrollTrace() {
     return _scroll
@@ -178,6 +258,7 @@ class SessionByteRecorder {
     _bytes.clear();
     _byteTotal = 0;
     _scroll.clear();
+    _sentSgr.clear();
     _cols = null;
     _rows = null;
   }
@@ -229,6 +310,11 @@ List<Map<String, Object?>> activeByteTraceSnapshot() =>
 /// Scroll trace of the active session, or empty when none is active.
 List<Map<String, Object?>> activeScrollTraceSnapshot() =>
     _active?.snapshotScrollTrace() ?? const <Map<String, Object?>>[];
+
+/// #793: sent-SGR trace (synthesized mouse/wheel reports the app sent) of the
+/// active session, or empty when none is active.
+List<Map<String, Object?>> activeSentSgrTraceSnapshot() =>
+    _active?.snapshotSentSgrTrace() ?? const <Map<String, Object?>>[];
 
 /// Grid `{cols, rows}` of the active session, or null when none is active.
 Map<String, Object?>? activeGridSnapshot() => _active?.grid();

--- a/native/lib/ui/feedback_overlay.dart
+++ b/native/lib/ui/feedback_overlay.dart
@@ -75,6 +75,7 @@ Map<String, Object?> buildFeedbackPayload({
   List<String> lifecycleLog = const <String>[],
   List<Map<String, Object?>> byteTrace = const <Map<String, Object?>>[],
   List<Map<String, Object?>> scrollTrace = const <Map<String, Object?>>[],
+  List<Map<String, Object?>> sentSgrTrace = const <Map<String, Object?>>[],
   Map<String, Object?>? grid,
 }) {
   final fullComment = comment;
@@ -146,6 +147,13 @@ Map<String, Object?> buildFeedbackPayload({
     // active (no empty-array / null noise).
     if (byteTrace.isNotEmpty) 'byteTrace': byteTrace,
     if (scrollTrace.isNotEmpty) 'scrollTrace': scrollTrace,
+    // #793: the synthesized mouse/wheel SGR reports the app SENT
+    // (sentSgrTrace: [{tMs,b64}]). In tmux mouse mode the scroll is wheel-SGR
+    // sent TO tmux (local scroll never moves), so this reveals
+    // "swipe → wheel events emitted → tmux scrolled" — the missing half of #789.
+    // Filtered at the send seam to SGR-mouse reports ONLY, so a typed password
+    // is NEVER recorded. Omitted entirely when no session is active.
+    if (sentSgrTrace.isNotEmpty) 'sentSgrTrace': sentSgrTrace,
     'grid': ?grid,
   };
 }
@@ -356,6 +364,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       // reproduced during the burst.
       byteTrace: activeByteTraceSnapshot(),
       scrollTrace: activeScrollTraceSnapshot(),
+      sentSgrTrace: activeSentSgrTraceSnapshot(),
       grid: activeGridSnapshot(),
     );
   }
@@ -381,6 +390,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     // current (buggy) frame the owner is reporting.
     final byteTrace = activeByteTraceSnapshot();
     final scrollTrace = activeScrollTraceSnapshot();
+    final sentSgrTrace = activeSentSgrTraceSnapshot();
     final grid = activeGridSnapshot();
     final dpr = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0;
     final bytes = await widget.screenshotCapturer(_captureKey, dpr);
@@ -398,6 +408,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       lifecycleLog: lifecycleLog,
       byteTrace: byteTrace,
       scrollTrace: scrollTrace,
+      sentSgrTrace: sentSgrTrace,
       grid: grid,
     );
   }
@@ -411,6 +422,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     List<String> frameDataUrls = const <String>[],
     List<Map<String, Object?>> byteTrace = const <Map<String, Object?>>[],
     List<Map<String, Object?>> scrollTrace = const <Map<String, Object?>>[],
+    List<Map<String, Object?>> sentSgrTrace = const <Map<String, Object?>>[],
     Map<String, Object?>? grid,
   }) async {
     // Show the sheet from the Navigator's OVERLAY context — NOT this overlay's
@@ -439,6 +451,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       lifecycleLog: lifecycleLog,
       byteTrace: byteTrace,
       scrollTrace: scrollTrace,
+      sentSgrTrace: sentSgrTrace,
       grid: grid,
     );
     final ok = await widget.submitter.submit(payload);

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -1865,7 +1865,14 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // shell.
       controller.onOutput = (bytes) {
         if (proxy.data.state != SshSessionState.connected) return;
-        proxy.sendInput(_applyArmedCtrlToKeystroke(bytes));
+        final sent = _applyArmedCtrlToKeystroke(bytes);
+        // #793: record this only if it's a synthesized mouse/wheel SGR report —
+        // the recorder FILTERS to SGR-mouse bytes, so a typed keystroke (incl. a
+        // password at a prompt) is dropped here and NEVER recorded. In tmux mouse
+        // mode the local scroll is wheel-SGR that flterm emits through onOutput,
+        // so this is the seam that reveals "swipe → wheel events → tmux scrolled".
+        _byteRecorder.recordSentSgr(sent);
+        proxy.sendInput(sent);
       };
       // Grid resize -> PTY resize. flterm reports (cols, rows); the proxy's
       // pixel sizes default to 0 (the task isolate only needs cols/rows). Also
@@ -2866,7 +2873,12 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
               final proxy = _resolveProxy();
               if (proxy == null) return;
               if (proxy.data.state != SshSessionState.connected) return;
-              proxy.sendInput(Uint8List.fromList(report.codeUnits));
+              final bytes = Uint8List.fromList(report.codeUnits);
+              // #793: capture the synthesized window-switch wheel / tap-click /
+              // selection SGR report the app sends (the recorder filters to
+              // SGR-mouse bytes — never keystrokes).
+              _byteRecorder.recordSentSgr(bytes);
+              proxy.sendInput(bytes);
             },
             // #705: long-press-drag drives flterm's LOCAL selection (persists
             // after release → Copy reads it), not a tmux SGR drag.

--- a/native/test/diagnostics/gesture_trace_test.dart
+++ b/native/test/diagnostics/gesture_trace_test.dart
@@ -128,6 +128,47 @@ void main() {
       expect(snap.last, contains('line-${gestureLogCapacity + 24}'));
     });
 
+    test('a flood of non-gesture events does NOT evict recent swipe gestures '
+        '(#793)', () {
+      // The real #790 capture: ~68 ghostty-resync/resume/refit/focus lines
+      // pushed the actual swipe-vertical gestures out of the bounded ring. The
+      // swipe/scroll gesture lines must survive a resume burst.
+      gtrace('swipe-vertical pos=(10.0,200.0) early');
+      gtrace('scroll-local offset=120 early');
+      // Now flood with far more non-gesture events than the capacity.
+      for (var i = 0; i < gestureLogCapacity * 2; i++) {
+        gtrace('ghostty-resync cols=55 rows=28 i=$i');
+      }
+      final snap = gestureLogSnapshot();
+      // The early swipe + scroll gestures are still present despite the flood.
+      expect(
+        snap.any((l) => l.contains('swipe-vertical') && l.contains('early')),
+        isTrue,
+        reason: 'swipe gesture must survive a non-gesture flood',
+      );
+      expect(
+        snap.any((l) => l.contains('scroll-local') && l.contains('early')),
+        isTrue,
+        reason: 'scroll gesture must survive a non-gesture flood',
+      );
+    });
+
+    test('priority (gesture) retention is itself bounded — newest swipes win '
+        '(#793)', () {
+      for (var i = 0; i < gestureLogGestureRetention + 10; i++) {
+        gtrace('swipe-vertical i=$i');
+      }
+      final snap = gestureLogSnapshot();
+      final swipes = snap.where((l) => l.contains('swipe-vertical')).toList();
+      // Retained swipes are capped, and the NEWEST ones survive.
+      expect(swipes.length, lessThanOrEqualTo(gestureLogGestureRetention));
+      expect(swipes.last, contains('i=${gestureLogGestureRetention + 9}'));
+      expect(
+        swipes.any((l) => l.contains('i=0 ') || l.endsWith('i=0')),
+        isFalse,
+      );
+    });
+
     test('clearGestureLog empties the ring and resets collapse state', () {
       gtrace('z');
       gtrace('z');

--- a/native/test/diagnostics/session_byte_recorder_test.dart
+++ b/native/test/diagnostics/session_byte_recorder_test.dart
@@ -106,6 +106,150 @@ void main() {
     });
   });
 
+  group('sent-SGR ring', () {
+    test('records a synthesized mouse/wheel SGR report', () {
+      final rec = SessionByteRecorder();
+      // A window-switch wheel-down report: CSI<65;1;28M
+      rec.recordSentSgr(Uint8List.fromList(utf8.encode('\x1b[<65;1;28M')));
+      final snap = rec.snapshotSentSgrTrace();
+      expect(snap, hasLength(1));
+      final decoded = utf8.decode(base64Decode(snap.single['b64'] as String));
+      expect(decoded, '\x1b[<65;1;28M');
+      expect(snap.single['tMs'], isA<int>());
+    });
+
+    test('does NOT record a typed keystroke / password line', () {
+      final rec = SessionByteRecorder();
+      // A typed password at a prompt flows through the SAME send seam. The
+      // filter must drop it entirely — it is NOT an SGR-mouse report, so it
+      // never enters the ring. rules/security.md: typed secrets never recorded.
+      rec.recordSentSgr(Uint8List.fromList(utf8.encode('hunter2\r')));
+      rec.recordSentSgr(Uint8List.fromList(utf8.encode('ls -la\n')));
+      // Plain Enter / control keys are not mouse reports either.
+      rec.recordSentSgr(Uint8List.fromList([0x03])); // Ctrl-C
+      expect(rec.snapshotSentSgrTrace(), isEmpty);
+    });
+
+    test('records ONLY the SGR-mouse part is irrelevant — whole chunk in, but '
+        'keystroke chunks dropped; mouse chunks kept', () {
+      final rec = SessionByteRecorder();
+      rec.recordSentSgr(Uint8List.fromList(utf8.encode('password123'))); // drop
+      rec.recordSentSgr(Uint8List.fromList(utf8.encode('\x1b[<0;5;10M'))); // keep (press)
+      rec.recordSentSgr(Uint8List.fromList(utf8.encode('\x1b[<0;5;10m'))); // keep (release)
+      final snap = rec.snapshotSentSgrTrace();
+      expect(snap, hasLength(2));
+      final texts = snap
+          .map((e) => utf8.decode(base64Decode(e['b64'] as String)))
+          .toList();
+      expect(texts, ['\x1b[<0;5;10M', '\x1b[<0;5;10m']);
+    });
+
+    test('evicts oldest sent-SGR events past the count cap', () {
+      final rec = SessionByteRecorder(maxSentSgrEvents: 3);
+      for (var i = 0; i < 6; i++) {
+        rec.recordSentSgr(Uint8List.fromList(utf8.encode('\x1b[<65;$i;1M')));
+      }
+      final snap = rec.snapshotSentSgrTrace();
+      expect(snap, hasLength(3));
+      final texts = snap
+          .map((e) => utf8.decode(base64Decode(e['b64'] as String)))
+          .toList();
+      // Newest three survive.
+      expect(texts, [
+        '\x1b[<65;3;1M',
+        '\x1b[<65;4;1M',
+        '\x1b[<65;5;1M',
+      ]);
+    });
+
+    test('snapshot scrubs the sent-SGR stream (defense in depth)', () {
+      final rec = SessionByteRecorder();
+      // Mouse reports never carry credentials, but the snapshot scrubs as
+      // defense in depth like the output ring. A report is kept; a scrub that
+      // changes nothing preserves the exact bytes.
+      rec.recordSentSgr(Uint8List.fromList(utf8.encode('\x1b[<32;7;3M')));
+      final snap = rec.snapshotSentSgrTrace();
+      expect(
+        utf8.decode(base64Decode(snap.single['b64'] as String)),
+        '\x1b[<32;7;3M',
+      );
+    });
+
+    test('active registry routes the sent-SGR snapshot to the active session', () {
+      final a = registerByteRecorder('s-a');
+      final b = registerByteRecorder('s-b');
+      a.recordSentSgr(Uint8List.fromList(utf8.encode('\x1b[<64;1;1M')));
+      b.recordSentSgr(Uint8List.fromList(utf8.encode('\x1b[<65;1;1M')));
+
+      setActiveByteRecorder('s-a');
+      expect(
+        utf8.decode(
+          base64Decode(activeSentSgrTraceSnapshot().single['b64'] as String),
+        ),
+        '\x1b[<64;1;1M',
+      );
+      setActiveByteRecorder('s-b');
+      expect(
+        utf8.decode(
+          base64Decode(activeSentSgrTraceSnapshot().single['b64'] as String),
+        ),
+        '\x1b[<65;1;1M',
+      );
+    });
+
+    test('sent-SGR snapshot is empty (not null) when no session is active', () {
+      setActiveByteRecorder(null);
+      expect(activeSentSgrTraceSnapshot(), isEmpty);
+    });
+  });
+
+  group('O(1) Queue eviction', () {
+    test('byte ring preserves FIFO order across eviction', () {
+      final rec = SessionByteRecorder(maxBytes: 100, maxEvents: 1000);
+      // 8 chunks of 25 bytes; cap 100 keeps the newest ~4.
+      for (var i = 0; i < 8; i++) {
+        rec.recordBytes(Uint8List(25)..fillRange(0, 25, i));
+      }
+      final snap = rec.snapshotByteTrace();
+      // The surviving chunks are a contiguous newest-first suffix, in order.
+      final firstBytes = snap
+          .map((e) => base64Decode(e['b64'] as String).first)
+          .toList();
+      for (var i = 1; i < firstBytes.length; i++) {
+        expect(firstBytes[i], greaterThan(firstBytes[i - 1]));
+      }
+      // Last is the newest chunk (filled with 7).
+      expect(firstBytes.last, 7);
+    });
+
+    test('byteTotal accounting stays consistent after Queue eviction', () {
+      final rec = SessionByteRecorder(maxBytes: 100, maxEvents: 1000);
+      for (var i = 0; i < 10; i++) {
+        rec.recordBytes(Uint8List(30)..fillRange(0, 30, i));
+      }
+      final snap = rec.snapshotByteTrace();
+      var total = 0;
+      for (final ev in snap) {
+        total += base64Decode(ev['b64'] as String).length;
+      }
+      expect(total, lessThanOrEqualTo(100));
+      // Reported byteTotal matches the sum of surviving chunk lengths.
+      expect(rec.debugByteTotal, total);
+    });
+
+    test('scroll ring preserves FIFO order across Queue eviction', () {
+      final rec = SessionByteRecorder(maxScrollEvents: 4);
+      for (var i = 0; i < 9; i++) {
+        rec.recordScroll(i * 10);
+      }
+      final offsets = rec
+          .snapshotScrollTrace()
+          .map((e) => e['offset'] as int)
+          .toList();
+      expect(offsets, [50, 60, 70, 80]);
+    });
+  });
+
   group('scroll ring', () {
     test('appends scroll offsets as {tMs, offset}', () {
       var clock = 0;

--- a/server/index.js
+++ b/server/index.js
@@ -900,7 +900,7 @@ const server = http.createServer((req, res) => {
     req.on('end', () => {
       try {
         const data = JSON.parse(body);
-        const { screenshot, frames, logs, title, comment, userAgent, url, version, connectLog, gestureLog, byteTrace, scrollTrace, grid } = data;
+        const { screenshot, frames, logs, title, comment, userAgent, url, version, connectLog, gestureLog, byteTrace, scrollTrace, sentSgrTrace, grid } = data;
         const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
         const reportDir = path.join(__dirname, '..', 'test-results', 'uploads');
         fs.mkdirSync(reportDir, { recursive: true });
@@ -1008,6 +1008,30 @@ const server = http.createServer((req, res) => {
           console.log(`[bug-report] byte trace: ${byteTraceFile} (${byteTraceEventCount} byte events, ${scrollTraceEventCount} scroll events)`);
         }
 
+        // #793: the sent-SGR trace — the synthesized mouse/wheel SGR reports the
+        // app SENT to the remote (sentSgrTrace: [{tMs,b64}]). In tmux mouse mode
+        // the scroll is wheel-SGR sent TO tmux (local scroll never moves), so
+        // this is the half of #789 the OUTPUT byteTrace can't show. Filtered at
+        // the client send seam to SGR-mouse reports ONLY (never keystrokes), so
+        // no typed secret is ever present. Mirrors the byteTrace branch; capped.
+        let sentSgrTraceFile = '';
+        let sentSgrTraceEventCount = 0;
+        const hasSentSgrTrace = Array.isArray(sentSgrTrace) && sentSgrTrace.length > 0;
+        if (hasSentSgrTrace) {
+          const MAX_SENT_SGR_EVENTS = 8192;
+          const cappedSentSgr = sentSgrTrace.slice(-MAX_SENT_SGR_EVENTS);
+          sentSgrTraceEventCount = cappedSentSgr.length;
+          sentSgrTraceFile = `${ts}-bug-report.sent-sgr-trace.json`;
+          fs.writeFileSync(
+            path.join(reportDir, sentSgrTraceFile),
+            JSON.stringify({
+              grid: (grid && typeof grid === 'object') ? grid : null,
+              sentSgrTrace: cappedSentSgr,
+            }, null, 2),
+          );
+          console.log(`[bug-report] sent-SGR trace: ${sentSgrTraceFile} (${sentSgrTraceEventCount} events)`);
+        }
+
         // Save metadata
         const meta = {
           title: title || `Bug report ${ts}`,
@@ -1030,6 +1054,9 @@ const server = http.createServer((req, res) => {
           byteTraceFile,
           byteTraceEventCount,
           scrollTraceEventCount,
+          // #793: sent-SGR (synthesized mouse/wheel reports the app sent) sidecar.
+          sentSgrTraceFile,
+          sentSgrTraceEventCount,
           grid: (grid && typeof grid === 'object') ? grid : null,
         };
         fs.writeFileSync(path.join(reportDir, `${ts}-bug-report.json`), JSON.stringify(meta, null, 2));


### PR DESCRIPTION
## Summary
Recorder v2 — closes the 3 gaps a real #790 capture exposed so the next capture can diagnose tmux-mouse-mode scroll unresponsiveness (#789) definitively, and hardens the hot path.

- **Sent-SGR ring** — `SessionByteRecorder.recordSentSgr` captures ONLY synthesized mouse/wheel SGR reports (`ESC[<...M`/`m`, digits+`;` body) via a byte-shape filter (`isSentSgrMouseReport`). Keystrokes never enter the ring, so a typed password is structurally impossible to record — **the filter is the security boundary**. Tapped at both send sinks in `ghostty_terminal_view.dart` (`controller.onOutput` + `onMouseReport` → `proxy.sendInput`). Reveals "swipe → wheel events emitted → tmux scrolled" — the half of #789 the OUTPUT byteTrace can't show.
- **Gesture retention** — `gesture_trace.dart` cap now evicts the oldest NON-gesture line first, guaranteeing the newest `gestureLogGestureRetention` (32) swipe/scroll lines survive a resync/resume burst. The real capture lost its swipes to ~68 `ghostty-resync`/resume/refit lines.
- **O(1) eviction** — byte/scroll/sent rings use `dart:collection` `ListQueue` (`removeFirst`, O(1)) instead of `List.removeAt(0)` (O(n) shift). `_byteTotal` accounting preserved. The recorder is now provably non-perturbing.

Wired `sentSgrTrace` through `buildFeedbackPayload` + saved a `sent-sgr-trace.json` sidecar in `server/index.js` `/api/bug-report` (mirrors the `byteTrace` branch; `node --check` clean).

## TDD Analysis
- Type: feature + refactor (O(1))
- Behavior change: yes (new sent-SGR ring + gesture retention); O(1) is behavior-preserving
- TDD approach: full (unit tests written first, red baseline confirmed, then green)

## Test coverage
- **Existing tests updated**: none broken — all prior recorder/gesture tests stay green.
- **New tests added (fail→pass)**:
  - sent-SGR ring records a synthesized mouse/wheel report but DROPS a seeded keystroke/password line (security boundary)
  - sent-SGR ring keeps mouse chunks, drops keystroke chunks; count-cap eviction; scrub; active-registry routing
  - gesture: a flood of non-gesture events does NOT evict recent swipe/scroll gestures; protected segment itself bounded (newest swipes win)
  - O(1) Queue eviction: byte ring FIFO order + `byteTotal` accounting; scroll ring FIFO order
- **Smoketest**: the send seam is wired (`recordSentSgr` called at both `proxy.sendInput` sinks); `activeSentSgrTraceSnapshot()` routes through the active-session registry.

## Test results
- flutter analyze: PASS (No issues found!)
- flutter test (fast gate): PASS (926 tests)
- node --check server/index.js: PASS

## Diff stats
- Files changed: 7 (4 lib + server + 2 test)
- Lines: +395 / -14 (production +224/-14; rest tests)

## Security
The sent-SGR ring captures mouse/wheel SGR reports ONLY (byte-shape filter) — typed keystrokes/passwords never enter it, so the secret-capture risk is sidestepped entirely. Snapshot still scrubs (defense in depth). Output ring unchanged.

Closes #793

## Cycles used
1/3