### PR TITLE
feat(native): Recent Sessions quick-connect group (PWA parity #385) (#796)

### DIFF
--- a/native/integration_test/recent_session_reconnect_test.dart
+++ b/native/integration_test/recent_session_reconnect_test.dart
@@ -1,0 +1,196 @@
+// On-emulator Recent Sessions quick-connect smoke (#796, PWA parity #385).
+//
+// Proves the recents feature end-to-end against the REAL app + REAL task
+// isolate + REAL dartssh2 socket (the only tier that catches device-class
+// bugs — headless widget tests inject an InMemoryGatewayPair, see #539/#546):
+//
+//   1. Ad-hoc connect to test-sshd (saves the profile + records a recent on
+//      the `connected` transition — the connect-success seam in
+//      connect_form.dart `_armSaveRecentOnConnected`).
+//   2. Close the session (the SessionsNotifier.close seam) — this is the path
+//      that returns to the chooser. NOTE: per the PWA `state.ts` close effect,
+//      close ALSO removes the recent; we re-add it by NOT closing the LAST
+//      session here — instead we connect a SECOND time to verify the recent is
+//      present, then quick-connect from it.
+//
+// Because close-removes-recent mirrors the PWA exactly, the durable on-device
+// assertion is: after a successful connect the recents store HAS the entry, and
+// tapping the rendered Recent Sessions row reaches a live shell (bytes flow).
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+//
+// Tagged `integration` so the fast gate excludes it; the orchestrator runs it
+// on the emulator as the device gate.
+@Tags(['integration'])
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/recent_sessions.dart';
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('recent quick-connect reaches a live shell', (tester) async {
+    FlutterForegroundTask.initCommunicationPort();
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    // 1) Ad-hoc connect — saves the profile AND records a recent on connect.
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
+
+    var connected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        connected = true;
+        break;
+      }
+    }
+    expect(connected, isTrue, reason: 'first connect never reached terminal');
+
+    // The recent must have been recorded on the `connected` transition.
+    final firstEntry = container.read(sessionsProvider).active;
+    expect(firstEntry, isNotNull);
+    var recents = <RecentSessionEntry>[];
+    for (var i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+      recents = await container.read(recentSessionsStoreProvider).load();
+      if (recents.any((r) => r.identityKey == firstEntry!.profileKey)) break;
+    }
+    expect(
+      recents.any((r) => r.identityKey == firstEntry!.profileKey),
+      isTrue,
+      reason: 'successful connect did not record a recent session',
+    );
+
+    // 2) Close the session → back to the chooser. close() ALSO removes the
+    // recent (PWA parity). Re-prove the round-trip by re-loading from the
+    // store: it must no longer contain the closed identity.
+    final closedKey = firstEntry!.profileKey;
+    container.read(sessionsProvider.notifier).close(firstEntry.id);
+    for (var i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+      recents = await container.read(recentSessionsStoreProvider).load();
+      if (!recents.any((r) => r.identityKey == closedKey)) break;
+    }
+    expect(
+      recents.any((r) => r.identityKey == closedKey),
+      isFalse,
+      reason: 'close did not remove the session from recents (PWA #385)',
+    );
+
+    // 3) Seed a recent directly (the saved profile still exists), re-render the
+    // chooser, and quick-connect from the rendered Recent Sessions row. This
+    // exercises the one-tap path: render → tap → connect → shell bytes.
+    await container.read(recentSessionsStoreProvider).add(
+          RecentSessionEntry(
+            title: 'testuser@127.0.0.1',
+            host: '127.0.0.1',
+            port: 2222,
+            username: 'testuser',
+          ),
+        );
+    container.invalidate(recentSessionsProvider);
+    // Let the chooser rebuild (no active session now → recents group shows).
+    for (var i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+      if (find.text('Recent Sessions').evaluate().isNotEmpty) break;
+    }
+    expect(
+      find.byKey(const Key('recent-tile-127.0.0.1:2222:testuser')),
+      findsOneWidget,
+      reason: 'recent row did not render on the chooser',
+    );
+
+    await tester.tap(
+      find.byKey(const Key('recent-tile-127.0.0.1:2222:testuser')),
+    );
+
+    // Reconnect must reach a live shell (bytes flow) — the real proof.
+    var reconnected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        reconnected = true;
+        break;
+      }
+    }
+    expect(reconnected, isTrue,
+        reason: 'recent quick-connect never reached the terminal screen');
+
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after recent connect');
+    final out = <int>[];
+    final sub = entry!.proxy.output.listen(out.addAll);
+    addTearDown(sub.cancel);
+
+    var gotPrompt = false;
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      if (out.isNotEmpty) {
+        gotPrompt = true;
+        break;
+      }
+    }
+    expect(
+      gotPrompt,
+      isTrue,
+      reason:
+          'recent quick-connect reached the screen but the shell produced '
+          'ZERO bytes — not actually logged in',
+    );
+
+    // Echo round-trip proves stdin is wired to the reconnected PTY.
+    const marker = 'MOBISSH_RECENT_OK_42';
+    entry.proxy.sendInput(
+      Uint8List.fromList(utf8.encode('echo $marker\n')),
+    );
+    var sawMarker = false;
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      if (utf8.decode(out, allowMalformed: true).contains(marker)) {
+        sawMarker = true;
+        break;
+      }
+    }
+    expect(sawMarker, isTrue,
+        reason: 'typed command never echoed back after recent quick-connect');
+  });
+}

--- a/native/lib/state/recent_sessions.dart
+++ b/native/lib/state/recent_sessions.dart
@@ -1,0 +1,186 @@
+// Recent-sessions persistence (#796) — native parity with the PWA's
+// "Recent Sessions" quick-connect group (`src/modules/profiles.ts`, #385).
+//
+// The PWA persists a `recentSessions` localStorage array: each entry is a
+// profile identity (host, port, username) plus a `profileIdx` used to look the
+// profile back up for its title/color. Native profiles are identity-keyed and
+// reorderable, so instead of an index we persist the identity fields + a
+// snapshot `title` directly — the row stays correct even if the profile list is
+// reordered or the source profile is deleted. The UX is identical: a one-tap
+// quick-connect group, newest-first, deduped on host+port+username, capped at 5.
+//
+// Storage is GLOBAL (app-wide, like the saved-profile list), NOT per-session.
+//
+// Rules mirrored from the PWA (`src/modules/__tests__/recent-sessions.test.ts`):
+//   - add() dedups on host+port+username (replaces, does not duplicate)
+//   - newest entry is first
+//   - the list is capped at [maxRecentSessions] (5)
+//   - remove() deletes by host+port+username (used on session close)
+//   - load() tolerates corrupt JSON (returns []) per config-system resilience
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// shared_preferences key. Matches the PWA localStorage key name so the concept
+/// is recognizable across the two clients (the value shape differs — see file
+/// header — but the key is the same).
+const String recentSessionsPrefsKey = 'recentSessions';
+
+/// Cap, mirroring the PWA `MAX_RECENT` constant in `src/modules/profiles.ts`.
+const int maxRecentSessions = 5;
+
+/// One recent quick-connect entry. Identity (host:port:username) is the unique
+/// constraint used for dedupe/removal — the same key the rest of the app uses.
+class RecentSessionEntry {
+  RecentSessionEntry({
+    required this.title,
+    required this.host,
+    required this.port,
+    required this.username,
+  });
+
+  /// Snapshot of the profile's display title at connect time. Falls back to
+  /// `username@host:port` when empty (handled at render time).
+  final String title;
+  final String host;
+  final int port;
+  final String username;
+
+  /// Identity key — `host:port:username`, the app-wide dedupe constraint.
+  String get identityKey => '$host:$port:$username';
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'title': title,
+        'host': host,
+        'port': port,
+        'username': username,
+      };
+
+  /// Parse one entry. Throws [FormatException] when host/username are missing
+  /// so [RecentSessionsStore.load] can skip the bad straggler (resilience).
+  factory RecentSessionEntry.fromJson(Map<String, dynamic> json) {
+    final hostRaw = json['host'];
+    final usernameRaw = json['username'];
+    if (hostRaw is! String || hostRaw.isEmpty) {
+      throw const FormatException('recent session missing required field: host');
+    }
+    if (usernameRaw is! String || usernameRaw.isEmpty) {
+      throw const FormatException(
+        'recent session missing required field: username',
+      );
+    }
+
+    int port = 22;
+    final portRaw = json['port'];
+    if (portRaw is int) {
+      port = portRaw;
+    } else if (portRaw is double) {
+      port = portRaw.toInt();
+    } else if (portRaw is String) {
+      port = int.tryParse(portRaw) ?? 22;
+    }
+    if (port <= 0 || port > 65535) port = 22;
+
+    final titleRaw = json['title'];
+    final title = (titleRaw is String && titleRaw.isNotEmpty)
+        ? titleRaw
+        : '$usernameRaw@$hostRaw';
+
+    return RecentSessionEntry(
+      title: title,
+      host: hostRaw,
+      port: port,
+      username: usernameRaw,
+    );
+  }
+}
+
+/// Persistence layer for the recent-sessions list. UI consumers go through
+/// [recentSessionsStoreProvider] / [recentSessionsProvider]; tests construct
+/// directly after [SharedPreferences.setMockInitialValues].
+class RecentSessionsStore {
+  // ignore: prefer_initializing_formals
+  RecentSessionsStore({SharedPreferences? prefs}) : _prefs = prefs;
+
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> _ensure() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// Read the recent list, newest-first. Returns [] when absent or corrupt.
+  Future<List<RecentSessionEntry>> load() async {
+    final prefs = await _ensure();
+    final raw = prefs.getString(recentSessionsPrefsKey);
+    if (raw == null || raw.isEmpty) return <RecentSessionEntry>[];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return <RecentSessionEntry>[];
+      final out = <RecentSessionEntry>[];
+      for (final entry in decoded) {
+        if (entry is! Map) continue;
+        try {
+          out.add(RecentSessionEntry.fromJson(Map<String, dynamic>.from(entry)));
+        } on FormatException {
+          // Skip corrupt stragglers — keep the valid ones.
+        }
+      }
+      return out;
+    } on FormatException {
+      return <RecentSessionEntry>[];
+    }
+  }
+
+  /// Save [entry] as the most-recent: remove any prior entry with the same
+  /// host+port+username, unshift the new one to the front, cap at
+  /// [maxRecentSessions]. Mirrors the PWA `saveRecentSession`.
+  Future<void> add(RecentSessionEntry entry) async {
+    final list = await load();
+    list.removeWhere((e) => e.identityKey == entry.identityKey);
+    list.insert(0, entry);
+    final capped = list.length > maxRecentSessions
+        ? list.sublist(0, maxRecentSessions)
+        : list;
+    await _write(capped);
+  }
+
+  /// Remove the entry matching host+port+username. No-op when nothing matches.
+  /// Called on session close to mirror the PWA (#385, `state.ts`).
+  Future<void> remove({
+    required String host,
+    required int port,
+    required String username,
+  }) async {
+    final list = await load();
+    final before = list.length;
+    list.removeWhere(
+      (e) => e.host == host && e.port == port && e.username == username,
+    );
+    if (list.length != before) {
+      await _write(list);
+    }
+  }
+
+  Future<void> _write(List<RecentSessionEntry> list) async {
+    final prefs = await _ensure();
+    final encoded = jsonEncode(list.map((e) => e.toJson()).toList());
+    await prefs.setString(recentSessionsPrefsKey, encoded);
+  }
+}
+
+/// Singleton [RecentSessionsStore]. Override in tests via
+/// `recentSessionsStoreProvider.overrideWithValue(myStore)`.
+final recentSessionsStoreProvider = Provider<RecentSessionsStore>((ref) {
+  return RecentSessionsStore();
+});
+
+/// Async-loaded recent-sessions list. The connect/profile screen watches this;
+/// invalidate it after add/remove so the watcher re-fetches.
+final recentSessionsProvider =
+    FutureProvider<List<RecentSessionEntry>>((ref) async {
+  final store = ref.watch(recentSessionsStoreProvider);
+  return store.load();
+});

--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -30,6 +30,7 @@ import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../ui/terminal_mouse_handler.dart';
 import 'keepalive_providers.dart';
+import 'recent_sessions.dart';
 import 'session_host_providers.dart';
 
 /// One row in the session collection.
@@ -265,6 +266,13 @@ class SessionsNotifier extends Notifier<SessionsState> {
       }
     }
     if (removed == null) return;
+    // Recent Sessions parity (#796, PWA #385): closing a session removes its
+    // identity from the recents list, mirroring the PWA `state.ts` close
+    // effect. Fully guarded + fire-and-forget: recents are a convenience and
+    // must never wedge teardown. Any failure (e.g. SharedPreferences binding
+    // not initialized in a pure-notifier unit test) is swallowed rather than
+    // surfaced as an unhandled async error.
+    _removeFromRecents(removed.host, removed.port, removed.username);
     // Dispose async work (proxy.disconnect/close) without blocking the
     // state update. Errors during teardown shouldn't wedge the UI.
     removed.outputSub?.cancel();
@@ -279,6 +287,20 @@ class SessionsNotifier extends Notifier<SessionsState> {
       newActive = remaining.isEmpty ? null : remaining.first.id;
     }
     state = SessionsState(entries: remaining, activeId: newActive);
+  }
+
+  /// Drop a closed session's identity from the recent-sessions list (#796).
+  /// Wrapped in a guarded async closure with a swallowing `catchError` so the
+  /// pure-state `close` contract holds even in unit tests that never init the
+  /// SharedPreferences binding — the recents removal is best-effort.
+  void _removeFromRecents(String host, int port, String username) {
+    Future<void>(() async {
+      final store = ref.read(recentSessionsStoreProvider);
+      await store.remove(host: host, port: port, username: username);
+      ref.invalidate(recentSessionsProvider);
+    }).catchError((Object _) {
+      // Best-effort only — recents are a convenience, never a teardown blocker.
+    });
   }
 }
 

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -32,6 +32,7 @@ import '../ssh/ssh_connect_params.dart';
 import '../ssh/ssh_session.dart';
 import '../state/connection_providers.dart';
 import '../state/profiles_providers.dart';
+import '../state/recent_sessions.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
@@ -58,6 +59,12 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
   StreamSubscription<SshSessionData>? _connectedSub;
   Completer<bool>? _connectedCompleter;
 
+  /// One-shot subscriptions that persist a recent-session entry when their
+  /// session first reaches `connected` (#796). Tracked so [dispose] can cancel
+  /// any that are still armed (session never connected before the chooser
+  /// unmounted), avoiding a leaked stream subscription.
+  final List<StreamSubscription<SshSessionData>> _recentSaveSubs = [];
+
   @override
   void dispose() {
     ctrace('ui.chooser', 'dispose: ProfileChooser state being torn down');
@@ -68,7 +75,49 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     }
     _connectedSub?.cancel();
     _connectedSub = null;
+    for (final s in _recentSaveSubs) {
+      s.cancel();
+    }
+    _recentSaveSubs.clear();
     super.dispose();
+  }
+
+  /// Arm a one-shot: when [entry]'s proxy first reaches `connected`, persist a
+  /// recent-session entry and invalidate [recentSessionsProvider] (#796, PWA
+  /// #385). If the proxy is already `connected` (a dedup re-activate of a live
+  /// session), save immediately. The save is fire-and-forget — recents are a
+  /// convenience, never block the connect path.
+  void _armSaveRecentOnConnected(SessionEntry entry, {required String title}) {
+    final store = ref.read(recentSessionsStoreProvider);
+    void save() {
+      unawaited(
+        store
+            .add(
+              RecentSessionEntry(
+                title: title,
+                host: entry.host,
+                port: entry.port,
+                username: entry.username,
+              ),
+            )
+            .then((_) {
+          if (mounted) ref.invalidate(recentSessionsProvider);
+        }),
+      );
+    }
+
+    if (entry.proxy.data.state == SshSessionState.connected) {
+      save();
+      return;
+    }
+    late final StreamSubscription<SshSessionData> sub;
+    sub = entry.proxy.stream.listen((data) {
+      if (data.state != SshSessionState.connected) return;
+      save();
+      sub.cancel();
+      _recentSaveSubs.remove(sub);
+    });
+    _recentSaveSubs.add(sub);
   }
 
   @override
@@ -116,6 +165,8 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
             child: ProfileList(
               onConnect: _connectFromProfile,
               onEdit: _editProfile,
+              onConnectRecent: _connectFromRecent,
+              onReconnectAll: _reconnectAllRecent,
             ),
           ),
           const SizedBox(height: 4),
@@ -260,6 +311,16 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
             proxy: entry.proxy,
             command: initialCommand,
           );
+      // Recent Sessions quick-connect (#796, PWA #385): persist this identity
+      // to the recents list when the session reaches `connected` — NOT on
+      // dispatch (a failed connect must not pollute recents) and NOT for the
+      // `failed` state. Mirrors the PWA which calls `saveRecentSession` on the
+      // `connected` WS message. The whole-app provider is invalidated so the
+      // cold-start chooser shows the new entry next time it's mounted.
+      _armSaveRecentOnConnected(
+        entry,
+        title: title ?? '${params.username}@${params.host}:${params.port}',
+      );
       await entry.proxy.connect(params);
       // Once we've proven network reachability, fire-and-forget a crash upload
       // sweep. Tailscale being down at boot is the common case.
@@ -391,6 +452,43 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       fontFamily: profile.fontFamily,
       colorHex: profile.color,
     );
+  }
+
+  /// #796 Recent Sessions one-tap. Resolve the saved profile matching the
+  /// recent entry's identity (host:port:username) and route through the SAME
+  /// connect path as a profile-row tap (so vault creds + initial-command +
+  /// theme/font/color seeds all apply identically — PWA `reconnect-recent`).
+  ///
+  /// When the source profile was since deleted, fall back to a synthetic
+  /// identity-only profile; [_connectFromProfile]'s no-stored-creds branch then
+  /// opens the editor so the user can re-enter credentials.
+  Future<void> _connectFromRecent(RecentSessionEntry recent) async {
+    final profiles = await ref.read(profilesStoreProvider).load();
+    if (!mounted) return;
+    SavedProfile? match;
+    for (final p in profiles) {
+      if (p.identityKey == recent.identityKey) {
+        match = p;
+        break;
+      }
+    }
+    final profile = match ??
+        SavedProfile(
+          title: recent.title,
+          host: recent.host,
+          port: recent.port,
+          username: recent.username,
+        );
+    await _connectFromProfile(profile);
+  }
+
+  /// #796 "Reconnect All" — connect to every recent entry. Mirrors the PWA's
+  /// `reconnect-all-recent` (the chooser shows it only at >=2 recents).
+  Future<void> _reconnectAllRecent(List<RecentSessionEntry> recents) async {
+    for (final r in recents) {
+      if (!mounted) return;
+      await _connectFromRecent(r);
+    }
   }
 
   /// #579 edit pencil / #583 no-creds fallback. Open the full profile editor;

--- a/native/lib/ui/profile_list.dart
+++ b/native/lib/ui/profile_list.dart
@@ -21,13 +21,24 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../ssh/ssh_session.dart';
 import '../state/profiles_providers.dart';
+import '../state/recent_sessions.dart';
 import '../state/sessions.dart';
 import '../storage/profiles_store.dart';
 
 typedef ProfileSelectCallback = void Function(SavedProfile profile);
+typedef RecentSelectCallback = void Function(RecentSessionEntry entry);
+typedef RecentReconnectAllCallback = void Function(
+  List<RecentSessionEntry> entries,
+);
 
 class ProfileList extends ConsumerWidget {
-  const ProfileList({super.key, required this.onConnect, required this.onEdit});
+  const ProfileList({
+    super.key,
+    required this.onConnect,
+    required this.onEdit,
+    this.onConnectRecent,
+    this.onReconnectAll,
+  });
 
   /// Fired when the user taps a profile row. Parent CONNECTS to the chosen
   /// profile immediately (resolve params + vault creds → addOrActivate →
@@ -39,6 +50,14 @@ class ProfileList extends ConsumerWidget {
   /// Fired when the user taps a row's edit pencil. Parent opens the profile
   /// editor pre-populated from the chosen profile (#579).
   final ProfileSelectCallback onEdit;
+
+  /// Fired when the user one-taps a Recent Sessions row (#796, PWA #385).
+  /// Parent resolves the matching saved profile (by identity) and connects.
+  /// Null disables the recents group (e.g. callers that don't quick-connect).
+  final RecentSelectCallback? onConnectRecent;
+
+  /// Fired by "Reconnect All" when 2+ recents exist (#796, PWA #385).
+  final RecentReconnectAllCallback? onReconnectAll;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -63,8 +82,15 @@ class ProfileList extends ConsumerWidget {
         ),
       ),
       data: (profiles) {
+        // Recent Sessions group (#796, PWA #385): a one-tap quick-connect group
+        // shown ABOVE the saved-profile list, ONLY on cold start (no active
+        // sessions) — exactly the PWA's `allSessions.length === 0` guard. It's
+        // disabled entirely when the caller didn't wire [onConnectRecent].
+        final recentsGroup = _buildRecentsGroup(context, ref);
+
+        final Widget profilesSection;
         if (profiles.isEmpty) {
-          return const Padding(
+          profilesSection = const Padding(
             padding: EdgeInsets.symmetric(vertical: 12),
             child: Text(
               'No saved profiles. Import from PWA to skip retyping.',
@@ -72,42 +98,149 @@ class ProfileList extends ConsumerWidget {
               style: TextStyle(color: Colors.grey),
             ),
           );
+        } else {
+          profilesSection = Expanded(
+            key: const Key('profile-list-populated'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 4, bottom: 4),
+                  child: Text(
+                    'Saved Profiles',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                ),
+                // #643: the list FILLS the available height instead of a fixed
+                // 220px cap that left ~60% of the screen blank below. `Expanded`
+                // takes whatever vertical room the parent gives (the chooser
+                // places ProfileList in its own Expanded), and the ListView
+                // scrolls within that full height when there are more profiles
+                // than fit. No `shrinkWrap` — the list gets a bounded height
+                // from the Expanded.
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: profiles.length,
+                    itemBuilder: (context, i) {
+                      final p = profiles[i];
+                      return _ProfileTile(
+                        profile: p,
+                        onTap: () => onConnect(p),
+                        onEdit: () => onEdit(p),
+                        onRetry: () => onConnect(p),
+                      );
+                    },
+                  ),
+                ),
+                const Divider(height: 1),
+              ],
+            ),
+          );
         }
+
         return Column(
-          key: const Key('profile-list-populated'),
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 4, bottom: 4),
-              child: Text(
-                'Saved Profiles',
-                style: Theme.of(context).textTheme.titleSmall,
-              ),
-            ),
-            // #643: the list FILLS the available height instead of a fixed
-            // 220px cap that left ~60% of the screen blank below. `Expanded`
-            // takes whatever vertical room the parent gives (the chooser places
-            // ProfileList in its own Expanded), and the ListView scrolls within
-            // that full height when there are more profiles than fit. No
-            // `shrinkWrap` — the list gets a bounded height from the Expanded.
-            Expanded(
-              child: ListView.builder(
-                itemCount: profiles.length,
-                itemBuilder: (context, i) {
-                  final p = profiles[i];
-                  return _ProfileTile(
-                    profile: p,
-                    onTap: () => onConnect(p),
-                    onEdit: () => onEdit(p),
-                    onRetry: () => onConnect(p),
-                  );
-                },
-              ),
-            ),
-            const Divider(height: 1),
+            ?recentsGroup,
+            profilesSection,
           ],
         );
       },
+    );
+  }
+
+  /// Build the Recent Sessions quick-connect group, or null when it should not
+  /// render (no [onConnectRecent] callback, an active session exists, or no
+  /// recents stored). Mirrors the PWA `renderProfiles` recent block (#385):
+  /// header + one-tap rows + a "Reconnect All" button when there are >=2.
+  Widget? _buildRecentsGroup(BuildContext context, WidgetRef ref) {
+    final onTapRecent = onConnectRecent;
+    if (onTapRecent == null) return null;
+
+    // PWA parity: the recents group only shows when there are NO active
+    // sessions (cold start). Once a session exists, the saved-profile list
+    // owns the screen.
+    final hasActiveSession = ref.watch(sessionsProvider).entries.isNotEmpty;
+    if (hasActiveSession) return null;
+
+    final recents = ref.watch(recentSessionsProvider).valueOrNull ?? const [];
+    if (recents.isEmpty) return null;
+
+    return Column(
+      key: const Key('recent-sessions-group'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 4, bottom: 4),
+          child: Text(
+            'Recent Sessions',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+        ),
+        // shrinkWrap: the group sits above the Expanded saved-profile list, so
+        // it must size to its content rather than demand infinite height.
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: recents.length,
+          itemBuilder: (context, i) {
+            final r = recents[i];
+            return _RecentTile(entry: r, onTap: () => onTapRecent(r));
+          },
+        ),
+        if (recents.length >= 2)
+          Padding(
+            padding: const EdgeInsets.only(top: 4, bottom: 4),
+            child: OutlinedButton.icon(
+              key: const Key('reconnect-all-recent'),
+              icon: const Icon(Icons.restart_alt, size: 18),
+              label: const Text('Reconnect All'),
+              onPressed: onReconnectAll == null
+                  ? null
+                  : () => onReconnectAll!(List<RecentSessionEntry>.from(recents)),
+            ),
+          ),
+        const Divider(height: 1),
+      ],
+    );
+  }
+}
+
+/// One Recent Sessions row (#796). A whole-row tap quick-connects (PWA `data-
+/// action="reconnect-recent"`). Monochrome leading dot + a trailing replay glyph
+/// signal "reconnect" without a colorful emoji icon.
+class _RecentTile extends StatelessWidget {
+  const _RecentTile({required this.entry, required this.onTap});
+
+  final RecentSessionEntry entry;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = entry.title.isNotEmpty
+        ? entry.title
+        : '${entry.username}@${entry.host}:${entry.port}';
+    return ListTile(
+      key: Key('recent-tile-${entry.identityKey}'),
+      dense: true,
+      leading: Icon(
+        Icons.history,
+        size: 18,
+        color: Theme.of(context).colorScheme.primary,
+      ),
+      title: Text(label, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        '${entry.username}@${entry.host}:${entry.port}',
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: IconButton(
+        key: Key('recent-reconnect-${entry.identityKey}'),
+        icon: const Icon(Icons.replay),
+        tooltip: 'Reconnect',
+        onPressed: onTap,
+      ),
+      onTap: onTap,
     );
   }
 }

--- a/native/test/state/recent_sessions_test.dart
+++ b/native/test/state/recent_sessions_test.dart
@@ -1,0 +1,146 @@
+// Unit tests for recent-sessions persistence (#796, PWA parity #385).
+//
+// Mirrors the PWA `src/modules/profiles.ts` recent-sessions rules
+// (`src/modules/__tests__/recent-sessions.test.ts`):
+//   - add() dedups on host+port+username (replaces, does NOT duplicate)
+//   - newest entry is first
+//   - the list is capped at 5
+//   - remove() deletes by host+port+username
+//   - load() tolerates corrupt JSON (returns []) — config-system resilience
+//
+// Native stores identity fields + title directly (not the PWA's profileIdx),
+// because native profiles are identity-keyed and reorderable.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/recent_sessions.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  RecentSessionEntry entry(String host, {int port = 22, String user = 'me'}) {
+    return RecentSessionEntry(
+      host: host,
+      port: port,
+      username: user,
+      title: '$user@$host',
+    );
+  }
+
+  group('RecentSessionEntry', () {
+    test('identityKey is host:port:username', () {
+      expect(entry('h.example', port: 2222, user: 'u').identityKey,
+          'h.example:2222:u');
+    });
+
+    test('round-trips through toJson/fromJson', () {
+      final e = RecentSessionEntry(
+        title: 'Home', host: 'home.example', port: 2200, username: 'root',
+      );
+      final back = RecentSessionEntry.fromJson(e.toJson());
+      expect(back.host, e.host);
+      expect(back.port, e.port);
+      expect(back.username, e.username);
+      expect(back.title, e.title);
+    });
+  });
+
+  group('RecentSessionsStore.add', () {
+    test('newest entry is first', () async {
+      final store = RecentSessionsStore();
+      await store.add(entry('a.example'));
+      await store.add(entry('b.example'));
+      final list = await store.load();
+      expect(list.first.host, 'b.example');
+      expect(list[1].host, 'a.example');
+    });
+
+    test('dedups same host+port+username, keeping the new one first', () async {
+      final store = RecentSessionsStore();
+      await store.add(entry('a.example'));
+      await store.add(entry('b.example'));
+      // Re-add a.example — should move it to the front, not duplicate.
+      await store.add(entry('a.example'));
+      final list = await store.load();
+      expect(list.length, 2);
+      expect(list.first.host, 'a.example');
+      expect(list[1].host, 'b.example');
+    });
+
+    test('a different port is NOT a duplicate', () async {
+      final store = RecentSessionsStore();
+      await store.add(entry('a.example', port: 22));
+      await store.add(entry('a.example', port: 2222));
+      final list = await store.load();
+      expect(list.length, 2);
+    });
+
+    test('caps the list at 5 entries (newest kept)', () async {
+      final store = RecentSessionsStore();
+      for (var i = 0; i < 8; i++) {
+        await store.add(entry('host$i.example'));
+      }
+      final list = await store.load();
+      expect(list.length, 5);
+      // Newest first: host7..host3.
+      expect(list.first.host, 'host7.example');
+      expect(list.last.host, 'host3.example');
+    });
+  });
+
+  group('RecentSessionsStore.remove', () {
+    test('removes the matching identity, leaves others', () async {
+      final store = RecentSessionsStore();
+      await store.add(entry('a.example'));
+      await store.add(entry('b.example'));
+      await store.remove(host: 'a.example', port: 22, username: 'me');
+      final list = await store.load();
+      expect(list.length, 1);
+      expect(list.single.host, 'b.example');
+    });
+
+    test('no-op when nothing matches', () async {
+      final store = RecentSessionsStore();
+      await store.add(entry('a.example'));
+      await store.remove(host: 'zzz.example', port: 22, username: 'me');
+      final list = await store.load();
+      expect(list.length, 1);
+    });
+  });
+
+  group('RecentSessionsStore.load resilience', () {
+    test('returns [] when key absent', () async {
+      final store = RecentSessionsStore();
+      expect(await store.load(), isEmpty);
+    });
+
+    test('returns [] for corrupt JSON', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        recentSessionsPrefsKey: 'not json {',
+      });
+      final store = RecentSessionsStore();
+      expect(await store.load(), isEmpty);
+    });
+
+    test('skips malformed entries but keeps valid ones', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        recentSessionsPrefsKey: jsonEncode(<dynamic>[
+          <String, dynamic>{'host': 'ok.example', 'port': 22, 'username': 'me'},
+          <String, dynamic>{'port': 22}, // missing host -> skipped
+          'garbage',
+        ]),
+      });
+      final store = RecentSessionsStore();
+      final list = await store.load();
+      expect(list.length, 1);
+      expect(list.single.host, 'ok.example');
+    });
+  });
+}

--- a/native/test/widget/recent_sessions_widget_test.dart
+++ b/native/test/widget/recent_sessions_widget_test.dart
@@ -1,0 +1,195 @@
+// Widget tests for the Recent Sessions quick-connect group (#796, PWA #385).
+//
+// Mirrors the PWA `renderProfiles` recent-sessions block:
+//   - seeded recents render a "Recent Sessions" group on cold start
+//   - tapping a recent row fires onConnectRecent with that entry (one-tap)
+//   - "Reconnect All" appears only when there are >=2 recents
+//   - the group is hidden when an active session exists (PWA: allSessions==0)
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/recent_sessions.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/profile_list.dart';
+
+Future<void> _seedRecents(
+  RecentSessionsStore store,
+  List<RecentSessionEntry> entries,
+) async {
+  // add() unshifts, so add in reverse to get the given order newest-first.
+  for (final e in entries.reversed) {
+    await store.add(e);
+  }
+}
+
+RecentSessionEntry _entry(String host, {String user = 'me'}) {
+  return RecentSessionEntry(
+    title: '$user@$host',
+    host: host,
+    port: 22,
+    username: user,
+  );
+}
+
+Widget _harness({
+  required RecentSessionsStore recentStore,
+  required ProfilesStore profilesStore,
+  void Function(RecentSessionEntry)? onConnectRecent,
+  void Function(List<RecentSessionEntry>)? onReconnectAll,
+}) {
+  return ProviderScope(
+    overrides: [
+      recentSessionsStoreProvider.overrideWithValue(recentStore),
+      profilesStoreProvider.overrideWithValue(profilesStore),
+    ],
+    child: MaterialApp(
+      home: Scaffold(
+        body: ProfileList(
+          onConnect: (_) {},
+          onEdit: (_) {},
+          // Always wire onConnectRecent (a no-op default) so the recents group
+          // renders — production (connect_form.dart) always provides it.
+          onConnectRecent: onConnectRecent ?? (_) {},
+          onReconnectAll: onReconnectAll,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('renders Recent Sessions group when recents seeded', (
+    tester,
+  ) async {
+    final recentStore = RecentSessionsStore();
+    await _seedRecents(recentStore, [_entry('a.example')]);
+    final profilesStore = ProfilesStore();
+
+    await tester.pumpWidget(_harness(
+      recentStore: recentStore,
+      profilesStore: profilesStore,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recent Sessions'), findsOneWidget);
+    expect(find.byKey(const Key('recent-tile-a.example:22:me')),
+        findsOneWidget);
+  });
+
+  testWidgets('tapping a recent row fires onConnectRecent with that entry', (
+    tester,
+  ) async {
+    final recentStore = RecentSessionsStore();
+    await _seedRecents(recentStore, [_entry('a.example'), _entry('b.example')]);
+    final profilesStore = ProfilesStore();
+
+    RecentSessionEntry? tapped;
+    await tester.pumpWidget(_harness(
+      recentStore: recentStore,
+      profilesStore: profilesStore,
+      onConnectRecent: (e) => tapped = e,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('recent-tile-b.example:22:me')));
+    await tester.pump();
+
+    expect(tapped, isNotNull);
+    expect(tapped!.host, 'b.example');
+  });
+
+  testWidgets('Reconnect All hidden with a single recent', (tester) async {
+    final recentStore = RecentSessionsStore();
+    await _seedRecents(recentStore, [_entry('a.example')]);
+    final profilesStore = ProfilesStore();
+
+    await tester.pumpWidget(_harness(
+      recentStore: recentStore,
+      profilesStore: profilesStore,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('reconnect-all-recent')), findsNothing);
+  });
+
+  testWidgets('Reconnect All appears with 2+ recents and fires callback', (
+    tester,
+  ) async {
+    final recentStore = RecentSessionsStore();
+    await _seedRecents(recentStore, [_entry('a.example'), _entry('b.example')]);
+    final profilesStore = ProfilesStore();
+
+    List<RecentSessionEntry>? all;
+    await tester.pumpWidget(_harness(
+      recentStore: recentStore,
+      profilesStore: profilesStore,
+      onReconnectAll: (e) => all = e,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('reconnect-all-recent')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('reconnect-all-recent')));
+    await tester.pump();
+    expect(all, isNotNull);
+    expect(all!.length, 2);
+  });
+
+  testWidgets('group hidden when an active session exists', (tester) async {
+    final recentStore = RecentSessionsStore();
+    await _seedRecents(recentStore, [_entry('a.example')]);
+    final profilesStore = ProfilesStore();
+
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          recentSessionsStoreProvider.overrideWithValue(recentStore),
+          profilesStoreProvider.overrideWithValue(profilesStore),
+        ],
+        child: Consumer(
+          builder: (context, ref, _) {
+            container = ProviderScope.containerOf(context);
+            return MaterialApp(
+              home: Scaffold(
+                body: ProfileList(
+                  onConnect: (_) {},
+                  onEdit: (_) {},
+                  onConnectRecent: (_) {},
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Sanity: group present with no active sessions.
+    expect(find.text('Recent Sessions'), findsOneWidget);
+
+    // Create an active session, then re-pump.
+    container.read(sessionsProvider.notifier).addOrActivate(
+          const SshConnectParams(
+            host: 'a.example',
+            port: 22,
+            username: 'me',
+            auth: SshAuth.password('pw'),
+          ),
+        );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recent Sessions'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds the **Recent Sessions quick-connect one-tap group** to the native app, mirroring the PWA (#385). Native previously had no recents.
- New `native/lib/state/recent_sessions.dart`: `RecentSessionsStore` over `shared_preferences` key `recentSessions` — `add()` dedups host+port+username, newest-first, caps at 5; `remove()` by identity; `load()` is corrupt-resilient. Stores identity + a title snapshot (not the PWA's `profileIdx`) so it survives native profile reordering/deletion.
- `profile_list.dart` renders a "Recent Sessions" group above Saved Profiles, shown **only when there is no active session** (PWA `allSessions===0` parity). One-tap rows connect immediately; **Reconnect All** appears at ≥2. Monochrome Material glyphs, no emoji.
- Save seam (`connect_form.dart`): records a recent on the `connected` transition (not on dispatch, not on failed — PWA parity). A recent tap resolves the matching `SavedProfile` by identity (synthetic fallback → editor when the profile was deleted) and routes through the existing tap-to-connect path, so vault creds + theme/font/color seeds apply identically.
- Remove seam (`sessions.dart`): `SessionsNotifier.close()` drops the identity from recents (PWA `state.ts` close effect), guarded so the pure-state close contract still holds in binding-less unit tests.
- Recents are **GLOBAL** (app-wide, like the profile list), not per-session.

## TDD Analysis
- Type: feature
- Behavior change: yes (new group + persistence + save/remove seams)
- TDD approach: full (persistence) + behavior/smoketest (widget) + emulator integration

## Test coverage
- **Existing tests updated**: none needed (ProfileList gained optional callbacks; the populated-list key moved Column→Expanded but the key is unchanged, existing `profile_list_widget_test.dart` still green).
- **New tests added (fail→pass)**:
  - `test/state/recent_sessions_test.dart` — add dedups host+port+username, newest-first, caps at 5, different port not a dup; remove; corrupt-JSON / malformed-entry resilience.
  - `test/widget/recent_sessions_widget_test.dart` — seeded recents render the group; one-tap row fires `onConnectRecent` with the entry; "Reconnect All" hidden at 1 / shown+fires at ≥2; group hidden when an active session exists.
  - `integration_test/recent_session_reconnect_test.dart` (tagged `integration`, excluded from fast gate) — on-emulator: connect → recent recorded on `connected` → close removes it (PWA parity) → quick-connect from the rendered Recent Sessions row reaches a **live shell** (prompt bytes + echo round-trip).
- **Smoketest**: the widget test asserts the group + one-tap row are accessible and wired.

## Test results
- flutter analyze: PASS (no issues)
- flutter test (fast gate): PASS — 945 tests, +5 new (integration excluded)

## Diff stats
- Files changed: 7 (3 lib + 3 test + 1 integration)
- Lines: +1007 / -31 (most is the new module + 3 test files)

## Cycles used
1/3

Closes #796