### PR TITLE
feat(native): IME compose history ring + recall (PWA parity) (#797)

### DIFF
--- a/native/lib/state/compose_history_providers.dart
+++ b/native/lib/state/compose_history_providers.dart
@@ -1,0 +1,53 @@
+// Per-session compose history ring (#797) — PWA parity with src/modules/ime.ts
+// `_commitHistory`.
+//
+// WHY A PROVIDER (not widget State): the compose bar CLOSES after every
+// commit/submit (#614), which destroys its `State`. The owner's need — "I write
+// a lot and then it gets lost sometimes" — is precisely that sent commands must
+// survive that open/close cycle so they can be recalled later. So the history
+// LIST lives here, keyed by session id, OUTSIDE the widget. The browse CURSOR
+// (index + stash) stays ephemeral in the compose bar's State, mirroring the
+// PWA's module-level `_historyIndex`/`_historyStash` which reset per browse.
+//
+// PER-SESSION ISOLATION (memory feedback_feature_scoping_and_isolation_tests):
+// each session id owns its own ring. Pushing to one session never changes
+// another. A session not yet in the map is treated as empty; the first push
+// materializes its entry.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Max entries retained per session — mirrors the PWA `HISTORY_MAX` (20). The
+/// oldest entry is evicted once the ring is full.
+const int kComposeHistoryMax = 20;
+
+/// Per-session ring of sent compose-bar commands. The map is keyed by session
+/// id; each value is the ordered history (oldest first, newest last).
+class ComposeHistoryNotifier extends Notifier<Map<String, List<String>>> {
+  @override
+  Map<String, List<String>> build() => const {};
+
+  /// The history for [sessionId], oldest first. Empty for an unknown session.
+  List<String> historyOf(String sessionId) => state[sessionId] ?? const [];
+
+  /// Record [text] as the newest entry for [sessionId]. Mirrors the PWA
+  /// `_recordHistory`: ignores empty text, de-duplicates a consecutive
+  /// identical entry, and caps the ring at [kComposeHistoryMax] (evicting the
+  /// oldest). Touches ONLY this session's entry — sibling sessions are
+  /// untouched (per-session isolation, #797).
+  void push(String sessionId, String text) {
+    if (text.isEmpty) return;
+    final current = state[sessionId] ?? const <String>[];
+    // Deduplicate consecutive identical entries.
+    if (current.isNotEmpty && current.last == text) return;
+    final next = [...current, text];
+    if (next.length > kComposeHistoryMax) {
+      next.removeRange(0, next.length - kComposeHistoryMax);
+    }
+    state = {...state, sessionId: next};
+  }
+}
+
+final composeHistoryProvider =
+    NotifierProvider<ComposeHistoryNotifier, Map<String, List<String>>>(
+      ComposeHistoryNotifier.new,
+    );

--- a/native/lib/ui/compose_bar.dart
+++ b/native/lib/ui/compose_bar.dart
@@ -17,9 +17,13 @@
 // soft keyboard. Drag the grip to move it; double-tap the grip to snap between
 // the bottom and top thirds.
 //
-// MVP slice. PWA-parity extras (preview mode + auto-commit ring, history ring,
-// sticky-Ctrl, password direct-mode, autocorrect diff) are backlogged on #599.
-// Icons are monochrome theme-tinted Material icons — never emoji (memory:
+// #797: per-session compose history ring + ▲/▼ recall (PWA parity with
+// src/modules/ime.ts `_commitHistory`) — sent commands are pushed to a
+// per-session ring ([composeHistoryProvider]) so they survive the bar's
+// close-on-send (#614), and ▲/▼ in the rail recall them into the buffer
+// WITHOUT sending. Remaining PWA-parity extras (preview mode + auto-commit
+// ring, sticky-Ctrl, password direct-mode, autocorrect diff) are backlogged on
+// #599. Icons are monochrome theme-tinted Material icons — never emoji (memory:
 // feedback_monochrome_icons_no_emoji).
 
 import 'package:flutter/material.dart';
@@ -27,6 +31,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
 
+import '../state/compose_history_providers.dart';
 import '../state/lifecycle_providers.dart';
 import '../util/terminal_copy_fixup.dart';
 
@@ -50,6 +55,7 @@ class ComposeBar extends ConsumerStatefulWidget {
   const ComposeBar({
     super.key,
     required this.terminal,
+    required this.sessionId,
     required this.onClose,
     this.bottomReserve = 0,
   });
@@ -57,6 +63,11 @@ class ComposeBar extends ConsumerStatefulWidget {
   /// The active session's terminal. Committed text is sent via
   /// `terminal.textInput` (onOutput → proxy.sendInput → PTY), like the keybar.
   final Terminal terminal;
+
+  /// The active session's id (#797). Keys the per-session compose history ring
+  /// ([composeHistoryProvider]) so sent commands survive the bar's close-on-send
+  /// (#614) and can be recalled with ▲/▼ — and never leak between sessions.
+  final String sessionId;
 
   /// Hides the compose bar (clears `composeBarVisibleProvider`).
   final VoidCallback onClose;
@@ -85,6 +96,15 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
   /// (lock screen, app switcher) doesn't lose the keyboard mid-compose. If the
   /// field wasn't focused at pause, resume leaves focus alone.
   bool _hadFocusAtPause = false;
+
+  /// History browse cursor (#797) — ephemeral, mirrors the PWA's module-level
+  /// `_historyIndex`/`_historyStash`. `-1` means "not browsing". `_historyStash`
+  /// saves the live (unsent) compose text when browsing begins so ▼ past the
+  /// newest entry can restore it instead of clobbering the draft. The durable
+  /// list lives in [composeHistoryProvider] (per-session), keyed by
+  /// `widget.sessionId`.
+  int _historyIndex = -1;
+  String _historyStash = '';
 
   @override
   void initState() {
@@ -144,17 +164,77 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
           ? '$_bracketedPasteStart$text$_bracketedPasteEnd'
           : text;
       widget.terminal.textInput(payload);
+      // #797: record the sent command in the per-session history ring so it
+      // can be recalled with ▲/▼ even after the panel closes. The notifier
+      // dedups consecutive identical entries and caps the ring.
+      ref
+          .read(composeHistoryProvider.notifier)
+          .push(widget.sessionId, text);
     }
     if (trailing.isNotEmpty) {
       widget.terminal.textInput(trailing);
     }
     _controller.clear();
+    _resetHistoryCursor();
     // #614: hide the panel after sending (both commit and submit).
     widget.onClose();
   }
 
+  /// #797: clear the browse cursor — called after a send or an explicit clear,
+  /// so the next ▲ starts a fresh browse from the newest entry (mirrors the
+  /// PWA resetting `_historyIndex` to -1 on record).
+  void _resetHistoryCursor() {
+    _historyIndex = -1;
+    _historyStash = '';
+  }
+
+  /// #797: recall an entry from the per-session history ring into the compose
+  /// buffer WITHOUT sending. Direction -1 (▲) walks toward older entries; +1
+  /// (▼) toward newer, and past the newest restores the stashed draft. Mirrors
+  /// the PWA `_navigateHistory` cycle exactly (src/modules/ime.ts):
+  ///   - empty history → no-op
+  ///   - not browsing (-1 index): ▲ stashes the live draft and lands on the
+  ///     newest; ▼ is a no-op (already at the newest)
+  ///   - past the newest → restore stash, leave browsing
+  ///   - clamp at the oldest
+  void _recall(int direction) {
+    final history =
+        ref.read(composeHistoryProvider.notifier).historyOf(widget.sessionId);
+    if (history.isEmpty) return;
+    String? next;
+    if (_historyIndex == -1) {
+      if (direction < 0) {
+        _historyStash = _controller.text;
+        _historyIndex = history.length - 1;
+        next = history[_historyIndex];
+      } else {
+        return; // already at the newest — nothing newer to show
+      }
+    } else {
+      _historyIndex += direction;
+      if (_historyIndex >= history.length) {
+        // Past the newest → restore the stashed draft, stop browsing.
+        _historyIndex = -1;
+        next = _historyStash;
+      } else if (_historyIndex < 0) {
+        // Clamp at the oldest.
+        _historyIndex = 0;
+        next = history[0];
+      } else {
+        next = history[_historyIndex];
+      }
+    }
+    _controller.value = TextEditingValue(
+      text: next,
+      selection: TextSelection.collapsed(offset: next.length),
+    );
+    _focusNode.requestFocus();
+    setState(() {});
+  }
+
   void _clear() {
     _controller.clear();
+    _resetHistoryCursor();
     _focusNode.requestFocus();
   }
 
@@ -218,10 +298,11 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
     // Panel width: most of the screen, capped so it reads as a panel.
     final panelWidth = size.width - 24;
     // Tall enough for the top drag bar + the inline pill row (Fix/Copy/Paste,
-    // #638) + the 4-button vertical action rail (close/clear/commit/submit)
-    // WITHOUT overflow — an overflowing Column under Clip.antiAlias clips the
-    // bottom buttons so their taps don't land.
-    const panelHeight = 272.0;
+    // #638) + the 6-button vertical action rail (#797: ▲/▼ history recall, then
+    // close/clear/commit/submit) WITHOUT overflow — an overflowing Column under
+    // Clip.antiAlias clips the bottom buttons so their taps don't land. Bumped
+    // from 272 to 352 to seat the two extra history buttons.
+    const panelHeight = 352.0;
     const margin = 12.0;
     final left = (size.width - panelWidth) / 2;
 
@@ -340,13 +421,19 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
                         ),
                       ),
                     ),
-                    // Vertical action rail (#604/#638): WHOLE-VIEW actions
-                    // only — close / clear / commit / submit. Text actions
-                    // (copy/paste/fix) moved to the inline pill row above.
+                    // Vertical action rail (#604/#638/#797): WHOLE-VIEW actions
+                    // only — ▲/▼ history recall, close, clear, commit, submit.
+                    // Text actions (copy/paste/fix) live in the inline pill row.
                     _ActionRail(
                       hasText: _controller.text.isNotEmpty,
+                      hasHistory: ref
+                          .watch(composeHistoryProvider.select(
+                            (m) => (m[widget.sessionId] ?? const []).isNotEmpty,
+                          )),
                       onClose: widget.onClose,
                       onClear: _clear,
+                      onHistoryUp: () => _recall(-1),
+                      onHistoryDown: () => _recall(1),
                       onCommit: () => _send(trailing: ''),
                       onSubmit: () => _send(trailing: '\r'),
                     ),
@@ -460,22 +547,33 @@ class _Pill extends StatelessWidget {
   }
 }
 
-/// Slim vertical button rail for the compose panel (#604/#638). WHOLE-VIEW
-/// actions only — close / clear / commit / submit. Text actions live in the
-/// pill row. Stacking keeps the editable wide for long composition. Monochrome
-/// theme-tinted icons.
+/// Slim vertical button rail for the compose panel (#604/#638/#797). WHOLE-VIEW
+/// actions only — history-up / history-down / close / clear / commit / submit.
+/// Text actions live in the pill row. Stacking keeps the editable wide for long
+/// composition. Monochrome theme-tinted icons (no emoji — memory:
+/// feedback_monochrome_icons_no_emoji).
 class _ActionRail extends StatelessWidget {
   const _ActionRail({
     required this.hasText,
+    required this.hasHistory,
     required this.onClose,
     required this.onClear,
+    required this.onHistoryUp,
+    required this.onHistoryDown,
     required this.onCommit,
     required this.onSubmit,
   });
 
   final bool hasText;
+
+  /// #797: whether the active session has any recallable sent commands. Both
+  /// ▲ and ▼ are disabled (dimmed) when false — PWA parity with the action
+  /// bar's `disabled` toggle keyed on `_commitHistory.length > 0`.
+  final bool hasHistory;
   final VoidCallback onClose;
   final VoidCallback onClear;
+  final VoidCallback onHistoryUp;
+  final VoidCallback onHistoryDown;
   final VoidCallback onCommit;
   final VoidCallback onSubmit;
 
@@ -488,6 +586,24 @@ class _ActionRail extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
+          // #797: recall older (▲) / newer (▼) sent commands into the compose
+          // buffer without sending. Disabled when the session has no history.
+          IconButton(
+            key: const Key('compose-bar-history-up'),
+            tooltip: 'Recall older sent command',
+            visualDensity: VisualDensity.compact,
+            iconSize: 20,
+            icon: const Icon(Icons.keyboard_arrow_up),
+            onPressed: hasHistory ? onHistoryUp : null,
+          ),
+          IconButton(
+            key: const Key('compose-bar-history-down'),
+            tooltip: 'Recall newer sent command',
+            visualDensity: VisualDensity.compact,
+            iconSize: 20,
+            icon: const Icon(Icons.keyboard_arrow_down),
+            onPressed: hasHistory ? onHistoryDown : null,
+          ),
           IconButton(
             key: const Key('compose-bar-close'),
             tooltip: 'Hide compose bar',

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -205,6 +205,9 @@ class TerminalScreen extends ConsumerWidget {
               ComposeBar(
                 key: ValueKey('compose-bar-${activeEntry.id}'),
                 terminal: activeEntry.terminal,
+                // #797: keys the per-session compose history ring so recalled
+                // commands stay isolated to this session.
+                sessionId: activeEntry.id,
                 // Reserve the bottom chrome so a bottom-docked panel never hides
                 // the session bar (#610). Heights are centralized constants
                 // (#615): kSessionBarReserve (session bar) + kKeybarReserve

--- a/native/test/state/compose_history_providers_test.dart
+++ b/native/test/state/compose_history_providers_test.dart
@@ -1,0 +1,80 @@
+// Per-session compose history ring (#797) — PWA parity with src/modules/ime.ts
+// `_commitHistory`.
+//
+// These tests assert the ring SEMANTICS (dedup, cap, empty-skip) and ISOLATION
+// (memory: feedback_feature_scoping_and_isolation_tests): pushing to one session
+// never changes another. The browse cursor is the compose bar's job (covered in
+// the widget test); here we only verify the durable list.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/compose_history_providers.dart';
+
+void main() {
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('compose history ring', () {
+    test('push records text, historyOf returns it oldest-first', () {
+      final c = makeContainer();
+      final notifier = c.read(composeHistoryProvider.notifier);
+      notifier.push('s1', 'a');
+      notifier.push('s1', 'b');
+      notifier.push('s1', 'c');
+      expect(notifier.historyOf('s1'), ['a', 'b', 'c']);
+    });
+
+    test('empty text is not recorded (PWA: _recordHistory skips falsy)', () {
+      final c = makeContainer();
+      final notifier = c.read(composeHistoryProvider.notifier);
+      notifier.push('s1', '');
+      expect(notifier.historyOf('s1'), isEmpty);
+    });
+
+    test('consecutive identical entries are de-duplicated', () {
+      final c = makeContainer();
+      final notifier = c.read(composeHistoryProvider.notifier);
+      notifier.push('s1', 'ls');
+      notifier.push('s1', 'ls');
+      expect(notifier.historyOf('s1'), ['ls']);
+      // Non-consecutive duplicate is kept (matches PWA — only consecutive dedup).
+      notifier.push('s1', 'pwd');
+      notifier.push('s1', 'ls');
+      expect(notifier.historyOf('s1'), ['ls', 'pwd', 'ls']);
+    });
+
+    test('ring caps at kComposeHistoryMax, evicting the oldest', () {
+      final c = makeContainer();
+      final notifier = c.read(composeHistoryProvider.notifier);
+      for (var i = 0; i < kComposeHistoryMax + 5; i++) {
+        notifier.push('s1', 'cmd$i');
+      }
+      final h = notifier.historyOf('s1');
+      expect(h.length, kComposeHistoryMax);
+      // Oldest 5 evicted; newest retained.
+      expect(h.first, 'cmd5');
+      expect(h.last, 'cmd${kComposeHistoryMax + 4}');
+    });
+
+    test('unknown session has empty history', () {
+      final c = makeContainer();
+      expect(
+        c.read(composeHistoryProvider.notifier).historyOf('nope'),
+        isEmpty,
+      );
+    });
+
+    test('per-session isolation: pushing s1 does not leak into s2', () {
+      final c = makeContainer();
+      final notifier = c.read(composeHistoryProvider.notifier);
+      notifier.push('s1', 'one');
+      notifier.push('s1', 'two');
+      notifier.push('s2', 'alpha');
+      expect(notifier.historyOf('s1'), ['one', 'two']);
+      expect(notifier.historyOf('s2'), ['alpha']);
+    });
+  });
+}

--- a/native/test/widget/compose_bar_test.dart
+++ b/native/test/widget/compose_bar_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/compose_history_providers.dart';
 import 'package:mobissh/state/lifecycle_providers.dart';
 import 'package:mobissh/ui/compose_bar.dart';
 import 'package:xterm/xterm.dart';
@@ -33,21 +34,27 @@ void main() {
     WidgetTester tester,
     List<String> sink, {
     VoidCallback? onClose,
+    String sessionId = 'sess',
+    ProviderContainer? container,
   }) async {
     final terminal = Terminal();
     terminal.onOutput = sink.add;
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+    final c = container ?? ProviderContainer();
+    if (container == null) addTearDown(c.dispose);
     await tester.pumpWidget(
       UncontrolledProviderScope(
-        container: container,
+        container: c,
         child: MaterialApp(
           home: Scaffold(
             // ComposeBar is a floating panel (returns a Positioned), so it must
             // live inside a Stack (#604).
             body: Stack(
               children: [
-                ComposeBar(terminal: terminal, onClose: onClose ?? () {}),
+                ComposeBar(
+                  terminal: terminal,
+                  sessionId: sessionId,
+                  onClose: onClose ?? () {},
+                ),
               ],
             ),
           ),
@@ -55,7 +62,7 @@ void main() {
       ),
     );
     await tester.pump();
-    return container;
+    return c;
   }
 
   group('byte contract', () {
@@ -429,5 +436,138 @@ void main() {
         reason: 'no re-focus when it was not focused at pause (#633)',
       );
     });
+  });
+
+  group('#797 — IME compose history ring + ▲/▼ recall (PWA parity)', () {
+    // Reads the live controller text out of the compose field.
+    String controllerText(WidgetTester tester) => tester
+        .widget<TextField>(find.byKey(const Key('compose-bar-input')))
+        .controller!
+        .text;
+
+    testWidgets('▲/▼ recall buttons exist in the rail', (tester) async {
+      await pumpBar(tester, <String>[]);
+      expect(find.byKey(const Key('compose-bar-history-up')), findsOneWidget);
+      expect(find.byKey(const Key('compose-bar-history-down')), findsOneWidget);
+    });
+
+    testWidgets('▲/▼ are disabled when history is empty', (tester) async {
+      await pumpBar(tester, <String>[]);
+      final up = tester.widget<IconButton>(
+        find.byKey(const Key('compose-bar-history-up')),
+      );
+      final down = tester.widget<IconButton>(
+        find.byKey(const Key('compose-bar-history-down')),
+      );
+      expect(up.onPressed, isNull, reason: '▲ disabled with no history');
+      expect(down.onPressed, isNull, reason: '▼ disabled with no history');
+    });
+
+    testWidgets(
+      'committing a command pushes it to the per-session history',
+      (tester) async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        await pumpBar(tester, <String>[], container: container);
+
+        await tester.enterText(
+          find.byKey(const Key('compose-bar-input')),
+          'ls -la',
+        );
+        await tester.pump();
+        await tester.tap(find.byKey(const Key('compose-bar-commit')));
+        await tester.pump();
+
+        expect(
+          container.read(composeHistoryProvider.notifier).historyOf('sess'),
+          ['ls -la'],
+        );
+      },
+    );
+
+    testWidgets(
+      'send A,B,C → ▲ recalls C, ▲ again B, ▼ returns to C (PWA cycle)',
+      (tester) async {
+        // A single shared container so history survives the bar across sends
+        // (the bar would normally close+reopen; here onClose is a no-op so the
+        // same State persists, but the durable list lives in the provider).
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        await pumpBar(tester, <String>[], container: container);
+
+        for (final cmd in ['A', 'B', 'C']) {
+          await tester.enterText(
+            find.byKey(const Key('compose-bar-input')),
+            cmd,
+          );
+          await tester.pump();
+          await tester.tap(find.byKey(const Key('compose-bar-commit')));
+          await tester.pump();
+        }
+        // After commits the field is cleared.
+        expect(controllerText(tester), '');
+
+        // ▲ recalls the newest (C).
+        await tester.tap(find.byKey(const Key('compose-bar-history-up')));
+        await tester.pump();
+        expect(controllerText(tester), 'C');
+
+        // ▲ again → older (B).
+        await tester.tap(find.byKey(const Key('compose-bar-history-up')));
+        await tester.pump();
+        expect(controllerText(tester), 'B');
+
+        // ▼ → back toward newer (C).
+        await tester.tap(find.byKey(const Key('compose-bar-history-down')));
+        await tester.pump();
+        expect(controllerText(tester), 'C');
+      },
+    );
+
+    testWidgets('recall populates the buffer WITHOUT sending', (tester) async {
+      final sink = <String>[];
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpBar(tester, sink, container: container);
+
+      // Seed history directly (a prior session/compose), then clear the sink so
+      // we measure only what recall sends.
+      container.read(composeHistoryProvider.notifier).push('sess', 'echo hi');
+      await tester.pump();
+      sink.clear();
+
+      await tester.tap(find.byKey(const Key('compose-bar-history-up')));
+      await tester.pump();
+
+      expect(controllerText(tester), 'echo hi');
+      expect(sink, isEmpty, reason: 'recall must NOT send to the terminal');
+    });
+
+    testWidgets(
+      '▼ past the newest restores the stashed unsent input (PWA stash)',
+      (tester) async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        await pumpBar(tester, <String>[], container: container);
+
+        container.read(composeHistoryProvider.notifier).push('sess', 'old');
+        await tester.pump();
+
+        // Type unsent text, then browse up into history (stashes the draft).
+        await tester.enterText(
+          find.byKey(const Key('compose-bar-input')),
+          'draft',
+        );
+        await tester.pump();
+        await tester.tap(find.byKey(const Key('compose-bar-history-up')));
+        await tester.pump();
+        expect(controllerText(tester), 'old');
+
+        // ▼ past the newest → the stashed draft comes back (not clobbered).
+        await tester.tap(find.byKey(const Key('compose-bar-history-down')));
+        await tester.pump();
+        expect(controllerText(tester), 'draft');
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Brings the PWA's IME sent-command history (`src/modules/ime.ts` `_commitHistory`) to the native compose bar so composed/sent text isn't lost (owner: "I write a lot and then it gets lost").
- New per-session `composeHistoryProvider` holds the durable ring (dedup consecutive, cap 20). It must live outside the widget because the compose bar **closes after every send** (#614), which would otherwise destroy in-State history.
- ▲/▼ rail buttons recall older/newer sent commands into the compose buffer **without sending**; ▼ past the newest restores the stashed unsent draft; disabled when the session has no history. 1:1 port of the PWA `_navigateHistory` cycle.

## TDD Analysis
- Type: feature
- Behavior change: yes (new recall affordance)
- TDD approach: full (deterministic ring + cursor semantics)

## Test coverage
- **New tests added (fail→pass)**:
  - `native/test/state/compose_history_providers_test.dart` — ring semantics: push/historyOf oldest-first, empty-skip, consecutive dedup, cap-20 eviction, unknown-session empty, **per-session isolation** (s1 push doesn't leak into s2).
  - `native/test/widget/compose_bar_test.dart` (#797 group) — ▲/▼ exist; disabled when empty; commit pushes to per-session history; **send A,B,C → ▲ recalls C, ▲ again B, ▼ returns to C**; recall populates buffer **without sending**; ▼ past newest restores stashed draft.
- **Existing tests updated**: `compose_bar_test.dart` `pumpBar` helper gains `sessionId` + optional shared container (ComposeBar now requires `sessionId`).
- **Smoketest**: ▲/▼ buttons present in the rail.

## Test results
- flutter analyze: PASS
- native fast gate: PASS (941 tests, 5 pre-existing skips)

## Scope / design notes
- Per-session isolation (memory `feedback_feature_scoping_and_isolation_tests`): each session id owns its own ring; mutating one never touches another.
- Monochrome Material icons (`keyboard_arrow_up`/`keyboard_arrow_down`), no emoji (memory `feedback_monochrome_icons_no_emoji`).
- Panel height bumped 272→352 to seat the two extra rail buttons without clipping.
- The slim history **rail** visual was deferred (issue marked it optional/secondary) — ▲/▼ recall is the owner's actual need.

## Diff stats
- Files changed: 5
- Lines: +411 / -19 (production change ~150 lines; rest is tests)

Closes #797

## Cycles used
1/3