### PR TITLE
perf(native): gate + dirty-check background snapshot push (#806)

### DIFF
--- a/native/integration_test/background_snapshot_gate_test.dart
+++ b/native/integration_test/background_snapshot_gate_test.dart
@@ -1,0 +1,178 @@
+// On-emulator background snapshot gate (#806).
+//
+// Battery bug: the kept-alive task isolate pushes an SshSnapshotEvent per
+// session every 2s UNCONDITIONALLY — even backgrounded, where the UI is
+// `unbind()`-ed and discards it. Each push includes a ~4KB scrollback UTF-8
+// decode shipped cross-isolate. It is the largest AVOIDABLE background-battery
+// drain (the lock+keepalive floor #738 is separate).
+//
+// The fix sends a `paused`/`resumed` control (SshSetActiveCommand) over the
+// existing gateway on AppLifecycleState transitions. Backgrounded, the host
+// STOPS its periodic snapshot timer; foregrounded, it RESTORES the 2s timer and
+// emits ONE fresh full snapshot immediately so the UI repaints. The SSH session
+// is untouched throughout — snapshots are UI telemetry only.
+//
+// SEAM / coverage boundary (per #589):
+//   - The host-side gate + dirty-check + scrollback-off-periodic logic is
+//     covered DETERMINISTICALLY in test/services/snapshot_gate_test.dart
+//     (InMemoryGatewayPair: pause stops the timer, resume re-emits, periodic
+//     payload omits scrollback, idle session emits nothing).
+//   - THIS emulator test proves the END-TO-END lifecycle path against a LIVE
+//     sshd: a real connect + shell, then a simulated background→foreground
+//     cycle. While paused NO periodic snapshots cross the gateway; on resume a
+//     fresh snapshot arrives; and the session STAYS connected across the cycle
+//     (the gate never touched the SSH state machine).
+
+@Tags(['integration'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'background stops periodic snapshots; resume re-emits one; session stays '
+    'connected (#806)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Observe snapshot events as they cross the gateway (task → UI). This is
+      // the exact wire the periodic push travels on, so counting `snapshot`
+      // kinds here directly measures whether the timer is firing.
+      final gateway = container.read(taskSshGatewayProvider);
+      var snapshotCount = 0;
+      String? lastScrollback;
+      final gwSub = gateway.incoming.listen((p) {
+        if (p['kind'] == SshTaskEventKind.snapshot.name) {
+          snapshotCount += 1;
+          lastScrollback = p['scrollbackTail'] as String?;
+        }
+      });
+      addTearDown(gwSub.cancel);
+
+      // Connect to the emulator-local sshd and reach a live shell.
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(_slice);
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find
+            .byKey(const Key('session-menu-button'))
+            .evaluate()
+            .isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'initial connect did not reach a shell');
+
+      // Let a few periodic ticks run while foregrounded so we know the timer is
+      // alive before we background.
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(_slice);
+      }
+      expect(
+        snapshotCount,
+        greaterThan(0),
+        reason: 'foregrounded: the 2s snapshot timer must be running',
+      );
+
+      // ---- Background ----
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump(const Duration(milliseconds: 300));
+      final pausedBaseline = snapshotCount;
+
+      // Many ticks worth of wall time pass with the UI backgrounded. The host's
+      // periodic timer is stopped, so NO new snapshots cross the gateway.
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(_slice);
+      }
+      expect(
+        snapshotCount,
+        pausedBaseline,
+        reason:
+            'backgrounded: periodic snapshots must STOP (the largest avoidable '
+            'background-battery drain, #806)',
+      );
+
+      // ---- Foreground ----
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      // The resume path emits one fresh full snapshot immediately for repaint.
+      for (var i = 0; i < 6; i++) {
+        await tester.pump(_slice);
+      }
+      expect(
+        snapshotCount,
+        greaterThan(pausedBaseline),
+        reason:
+            'resume must re-emit a fresh snapshot so the terminal/audit '
+            'repaints (#806 A)',
+      );
+      expect(
+        lastScrollback,
+        isNotNull,
+        reason: 'resume snapshot must carry the scrollback tail for repaint',
+      );
+
+      // The session stayed connected across the whole background→foreground
+      // cycle — the gate is UI telemetry only and never touches SSH (#806).
+      final stateAfter = container
+          .read(sessionsProvider)
+          .active!
+          .proxy
+          .data
+          .state;
+      expect(
+        stateAfter == SshSessionState.connected ||
+            stateAfter == SshSessionState.reconnecting,
+        isTrue,
+        reason:
+            'the snapshot gate must NOT disturb the live session — state was '
+            '$stateAfter (#806)',
+      );
+    },
+    // SKIPPED (skip: true) for the same reason as resume_liveness_test.dart: a
+    // LIVE ghostty terminal view + the foreground-task isolate keep the
+    // integration binding from ever idling, so tester.pump never settles after
+    // connect. The gate logic is covered deterministically by
+    // test/services/snapshot_gate_test.dart. The orchestrator runs the full
+    // integration suite on the emulator (native-integration-suite.sh) as the
+    // device gate; on-device battery validation is owner device-validation.
+    skip: true,
+  );
+}

--- a/native/integration_test/initial_command_smoke_test.dart
+++ b/native/integration_test/initial_command_smoke_test.dart
@@ -25,6 +25,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
 
 import 'support/connect_helpers.dart';
@@ -92,10 +94,19 @@ void main() {
     // once in the echoed command line (`echo MARKER`) and once in its stdout
     // (`MARKER`); a single occurrence would just be the command line with the
     // run-on-connect dropped.
+    //
+    // #806 C moved the scrollback decode OFF the periodic snapshot (battery):
+    // periodic `SshSnapshotEvent`s now carry `scrollbackTail: ''`, and only the
+    // ON-DEMAND `SshRequestSnapshotCommand` path (audit live view / resume
+    // rebind) includes the tail. So drive that path each poll — send a snapshot
+    // request, pump to let it round-trip, then read the freshly-hydrated cached
+    // snapshot. This is exactly how the audit screen reads the live scrollback.
+    final gateway = container.read(taskSshGatewayProvider);
     var ran = false;
     for (var i = 0; i < 60; i++) {
+      gateway.send(SshRequestSnapshotCommand(sessionId: entry!.id).toJson());
       await tester.pump(const Duration(milliseconds: 500));
-      final text = entry!.proxy.snapshot.scrollbackTail;
+      final text = entry.proxy.snapshot.scrollbackTail;
       if (marker.allMatches(text).length >= 2) {
         ran = true;
         break;

--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -147,7 +147,13 @@ class _RootRouterState extends ConsumerState<RootRouter> {
         // doesn't accumulate state events while the foreground service keeps
         // SSH alive. Rebind on resume re-emits the cached snapshot so the
         // first paint is instant.
-        for (final e in ref.read(sessionsProvider).entries) {
+        final entries = ref.read(sessionsProvider).entries;
+        // #806: tell the task we're backgrounded so it STOPS the 2s snapshot
+        // push (the UI is about to unbind and discard snapshots — the push,
+        // incl. a ~4KB scrollback decode, is wasted battery). Task-global, so
+        // one send suffices. Does NOT touch the SSH socket / keepalive / locks.
+        if (entries.isNotEmpty) entries.first.proxy.setActive(false);
+        for (final e in entries) {
           e.proxy.unbind();
         }
       }
@@ -158,7 +164,13 @@ class _RootRouterState extends ConsumerState<RootRouter> {
         // (#524 500ms rebind budget) and requests a fresh task-side
         // snapshot. The setState forces the router to re-resolve route
         // selection from the now-current session data.
-        for (final e in ref.read(sessionsProvider).entries) {
+        final entries = ref.read(sessionsProvider).entries;
+        // #806: tell the task we're foregrounded again so it RESTORES the 2s
+        // snapshot timer and emits one fresh full snapshot per session
+        // immediately (instant repaint). Task-global → one send. The per-proxy
+        // rebind below still runs the cached-frame repaint + SshRequestSnapshot.
+        if (entries.isNotEmpty) entries.first.proxy.setActive(true);
+        for (final e in entries) {
           e.proxy.rebind();
         }
         setState(() {});

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -134,6 +134,14 @@ class SessionHost {
   Timer? _snapshotTimer;
   bool _disposed = false;
 
+  /// Whether the UI is foregrounded (#806). The UI sends `SshSetActiveCommand`
+  /// on `AppLifecycleState` transitions. While `false` the UI is `unbind()`-ed
+  /// and discards snapshots, so the periodic timer is stopped — the on-demand
+  /// `SshRequestSnapshotCommand` path still answers (audit live view / resume
+  /// rebind). Starts `true`: the host is built when a session connects, which
+  /// only happens with the UI foregrounded, and resume re-asserts it anyway.
+  bool _active = true;
+
   /// The exact lifecycle-forwarder closure this host installed into the global
   /// [lifecycleForwarder] (#766). Held so dispose detaches OUR closure only —
   /// it won't clobber a forwarder a different host installed afterward (matters
@@ -191,7 +199,12 @@ class SessionHost {
         }
       case SshRequestSnapshotCommand():
         final s = _sessions[cmd.sessionId];
-        if (s != null) _emitSnapshot(cmd.sessionId, s);
+        // On-demand (audit live view / resume rebind): always answer, and
+        // include the scrollback tail — this is the path that hydrates the
+        // terminal/audit, so it carries the full payload (#806 C).
+        if (s != null) _emitSnapshot(cmd.sessionId, s, includeScrollback: true);
+      case SshSetActiveCommand():
+        _handleSetActive(cmd.active);
       case SshHostKeyDecisionCommand():
         _handleHostKeyDecision(cmd);
       case SshUiHelloCommand():
@@ -778,14 +791,58 @@ class SessionHost {
     );
   }
 
-  void _pushSnapshots() {
+  /// Handle a UI foreground/background transition (#806). On background
+  /// (`active: false`) stop the periodic snapshot timer — the UI is unbound and
+  /// discards snapshots, so the 2s push is wasted battery (incl. the ~4KB
+  /// scrollback decode). On foreground (`active: true`) restore the 2s timer AND
+  /// emit one fresh FULL snapshot per session immediately so the UI repaints
+  /// from current state without waiting for the next tick. Idempotent: a repeat
+  /// of the current state is a no-op so duplicate lifecycle events don't churn
+  /// the timer. Does NOT touch the SSH session, keepalive, or locks.
+  void _handleSetActive(bool active) {
     if (_disposed) return;
-    for (final entry in _sessions.entries) {
-      _emitSnapshot(entry.key, entry.value);
+    if (_active == active) return;
+    _active = active;
+    if (active) {
+      _snapshotTimer?.cancel();
+      _snapshotTimer = Timer.periodic(snapshotInterval, (_) => _pushSnapshots());
+      // Resume repaint: one fresh full snapshot now (the UI just rebound and
+      // its cached frame may be stale). Dirty-check is bypassed — resume must
+      // always re-emit (#806 A).
+      for (final entry in _sessions.entries) {
+        _emitSnapshot(entry.key, entry.value, includeScrollback: true);
+      }
+    } else {
+      _snapshotTimer?.cancel();
+      _snapshotTimer = null;
     }
   }
 
-  void _emitSnapshot(String sessionId, _HostedSession hosted) {
+  void _pushSnapshots() {
+    if (_disposed) return;
+    for (final entry in _sessions.entries) {
+      // Dirty-check (#806 B): only ship a periodic snapshot when something the
+      // UI renders actually changed since the last periodic push. An idle
+      // session emits nothing — no event, no scrollback decode, no IPC copy.
+      final hosted = entry.value;
+      final sig = hosted.snapshotSignature();
+      if (sig == hosted.lastPushedSignature) continue;
+      hosted.lastPushedSignature = sig;
+      // Periodic payload omits the ~4KB scrollback decode (#806 C): the on-demand
+      // SshRequestSnapshotCommand path (resume / audit-open) carries it.
+      _emitSnapshot(entry.key, hosted, includeScrollback: false);
+    }
+  }
+
+  void _emitSnapshot(
+    String sessionId,
+    _HostedSession hosted, {
+    required bool includeScrollback,
+  }) {
+    // Keep dirty-check honest for any later periodic push: an on-demand emit
+    // re-baselines the signature so the next periodic tick doesn't re-send the
+    // same state it just shipped on demand.
+    hosted.lastPushedSignature = hosted.snapshotSignature();
     _gateway.send(
       SshSnapshotEvent(
         sessionId: sessionId,
@@ -795,7 +852,7 @@ class SessionHost {
         lastKeepaliveRttMs: hosted.metrics.lastKeepaliveRttMs,
         reconnectCount: hosted.metrics.reconnectCount,
         lastReconnectAtMs: hosted.metrics.lastReconnectAtMs,
-        scrollbackTail: hosted.scrollbackTailString(),
+        scrollbackTail: includeScrollback ? hosted.scrollbackTailString() : '',
       ).toJson(),
     );
   }
@@ -969,11 +1026,31 @@ class _HostedSession {
   String? challengedFingerprint;
   final BytesBuilder _scrollback = BytesBuilder(copy: false);
 
+  /// The signature value at the last PERIODIC snapshot push (#806 B). The
+  /// dirty-check compares the current [snapshotSignature] against this and skips
+  /// the push when nothing the UI renders changed. Re-baselined on every emit
+  /// (periodic OR on-demand) so the next periodic tick measures the delta from
+  /// what the UI actually last received. Null until the first push.
+  String? lastPushedSignature;
+
   /// Append raw bytes to the scrollback cache and cap the buffer at ~4KB
   /// (the cap is enforced by [scrollbackTailString], not here, so the latest
   /// bytes always win).
   void appendScrollback(Uint8List bytes) {
     _scrollback.add(bytes);
+  }
+
+  /// A cheap fingerprint of the snapshot-relevant fields (#806 B). When this is
+  /// unchanged since the last periodic push, the periodic snapshot is skipped —
+  /// an idle connected session produces no IPC traffic. Uses the scrollback
+  /// BYTE LENGTH (not a decode) so the dirty-check itself stays allocation-light:
+  /// scrollback only grows via [appendScrollback], so a length change is a
+  /// faithful "new bytes arrived" signal without the ~4KB UTF-8 decode.
+  String snapshotSignature() {
+    final m = metrics;
+    return '${controller.data.state.name}|${m.bytesIn}|${m.bytesOut}|'
+        '${m.lastKeepaliveRttMs}|${m.reconnectCount}|${m.lastReconnectAtMs}|'
+        '${_scrollback.length}';
   }
 
   /// Return the last [maxBytes] of scrollback decoded as UTF-8 (malformed

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -38,6 +38,15 @@ enum SshTaskCommandKind {
   /// instead of being trusted and left frozen.
   resumeProbe,
 
+  /// UI → task: the UI's foreground/background state changed (#806). Carries an
+  /// `active` flag — `false` when the UI is backgrounded (`AppLifecycleState.
+  /// paused`, proxies unbound), `true` on resume. The task-side host gates its
+  /// periodic snapshot timer on this: backgrounded, the UI discards snapshots,
+  /// so the 2s push (incl. a ~4KB scrollback decode shipped cross-isolate) is
+  /// pure battery waste. Task-global (empty sentinel sessionId) — one app-wide
+  /// state, not per-session.
+  setActive,
+
   // --- SFTP (#559) ---
   /// List a remote directory over the session's SftpClient.
   sftpList,
@@ -199,6 +208,8 @@ sealed class SshTaskCommand {
         return const SshUiHelloCommand();
       case SshTaskCommandKind.resumeProbe:
         return SshResumeProbeCommand(sessionId: sessionId);
+      case SshTaskCommandKind.setActive:
+        return SshSetActiveCommand(active: json['active'] as bool);
       case SshTaskCommandKind.sftpList:
         return SftpListCommand(
           sessionId: sessionId,
@@ -436,6 +447,33 @@ class SshResumeProbeCommand extends SshTaskCommand {
 
   @override
   Map<String, dynamic> toJson() => {'kind': kind.name, 'sessionId': sessionId};
+}
+
+/// UI → task: the UI moved to the foreground ([active] = true) or background
+/// ([active] = false) (#806). The task-side `SessionHost` gates its periodic
+/// snapshot timer on this: backgrounded, the UI is `unbind()`-ed and discards
+/// every snapshot, so the unconditional 2s push (a per-session `SshSnapshotEvent`
+/// including a ~4KB scrollback UTF-8 decode shipped cross-isolate) is wasted
+/// battery. On `active: false` the host stops the timer; on `active: true` it
+/// restores the 2s timer AND emits one fresh full snapshot immediately so the
+/// UI repaints from current state. Task-global, so [sessionId] is the empty
+/// sentinel (mirrors [SshUiHelloCommand]).
+class SshSetActiveCommand extends SshTaskCommand {
+  const SshSetActiveCommand({required this.active}) : super('');
+
+  /// True = UI foregrounded (resume periodic snapshots); false = backgrounded
+  /// (stop the periodic timer until the next resume).
+  final bool active;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.setActive;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'active': active,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -141,6 +141,19 @@ class SshSessionProxy {
     gateway.send(SshResumeProbeCommand(sessionId: sessionId).toJson());
   }
 
+  /// Tell the task side whether the UI is foregrounded (#806). Sent on
+  /// `AppLifecycleState` transitions (paused → false, resumed → true) so the
+  /// task can gate its periodic snapshot timer — backgrounded, the UI is
+  /// unbound and discards snapshots, so the 2s push (incl. a ~4KB scrollback
+  /// decode) is wasted battery. Task-global: the command carries the empty
+  /// sentinel sessionId, so calling it on ONE proxy suffices (all proxies share
+  /// the gateway). On resume the task re-emits a fresh snapshot itself; the
+  /// proxy's own [rebind] still runs for the cached-frame repaint.
+  void setActive(bool active) {
+    if (_disposed) return;
+    gateway.send(SshSetActiveCommand(active: active).toJson());
+  }
+
   /// Send a connect command across the gateway. The task-side host turns
   /// this into `SshSessionController.connect(...)`.
   ///

--- a/native/test/services/snapshot_gate_test.dart
+++ b/native/test/services/snapshot_gate_test.dart
@@ -1,0 +1,243 @@
+// SessionHost background snapshot gate + dirty-check + scrollback off the
+// periodic payload (#806).
+//
+// The kept-alive task isolate emits an SshSnapshotEvent per session every 2s.
+// Backgrounded, the UI is unbound and discards it, but the timer keeps firing
+// — incl. a ~4KB scrollback decode shipped cross-isolate. This is the largest
+// avoidable background-battery drain. The host now:
+//   A. Stops the periodic timer on SshSetActiveCommand(active: false); restores
+//      it + emits one fresh full snapshot on active: true.
+//   B. Dirty-checks the periodic push: an unchanged session emits nothing.
+//   C. Omits the scrollback tail from the PERIODIC payload; the on-demand
+//      SshRequestSnapshotCommand response still carries it.
+//
+// Headless via InMemoryGatewayPair + a controller whose connect() is inert so
+// the test owns the `connected` transition — no real socket.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// Controller whose real connect() is a no-op so the test owns the `connected`
+/// transition without a socket/auth race.
+class _NoConnectController extends SshSessionController {
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+/// Collects SshSnapshotEvent payloads the host sends to the UI side.
+class _SnapshotCollector {
+  _SnapshotCollector(TaskSshGateway uiSide) {
+    _sub = uiSide.incoming.listen((p) {
+      if (p['kind'] == SshTaskEventKind.snapshot.name) {
+        events.add(SshTaskEvent.fromJson(p) as SshSnapshotEvent);
+      }
+    });
+  }
+
+  final List<SshSnapshotEvent> events = [];
+  late final StreamSubscription<Map<String, dynamic>> _sub;
+
+  Future<void> cancel() => _sub.cancel();
+}
+
+/// Stand up a host with one connected session. Returns the pair, host,
+/// controller, and a snapshot collector. Uses a short snapshot interval so
+/// periodic ticks are observable in real time.
+Future<({InMemoryGatewayPair pair, SessionHost host, _SnapshotCollector col})>
+_setup({Duration interval = const Duration(milliseconds: 20)}) async {
+  const sid = 'h:22:u:1';
+  late SshSessionController controller;
+  final pair = InMemoryGatewayPair();
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: () {
+      controller = _NoConnectController();
+      return controller;
+    },
+    snapshotInterval: interval,
+  );
+  pair.uiSide.send(
+    const SshConnectCommand(
+      sessionId: sid,
+      host: 'h',
+      port: 22,
+      username: 'u',
+      authJson: {'type': 'password', 'password': 'p'},
+    ).toJson(),
+  );
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  controller.debugSetConnectedForTest(_params);
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  // Seed scrollback so a tail exists to (not) ship.
+  host.ingestOutputForTest(
+    'h:22:u:1',
+    Uint8List.fromList('hello world\n'.codeUnits),
+  );
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  final col = _SnapshotCollector(pair.uiSide);
+  return (pair: pair, host: host, col: col);
+}
+
+void main() {
+  test(
+    'B: periodic push is dirty-checked — an idle session emits nothing (#806)',
+    () async {
+      final s = await _setup();
+      addTearDown(() async {
+        await s.col.cancel();
+        await s.host.dispose();
+        await s.pair.dispose();
+      });
+
+      // Let several periodic ticks pass with NO change after the first.
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+      // At most one snapshot: the first periodic tick after connect ships the
+      // initial state; subsequent unchanged ticks are skipped.
+      expect(
+        s.col.events.length,
+        lessThanOrEqualTo(1),
+        reason: 'unchanged session must not re-emit every tick',
+      );
+    },
+  );
+
+  test('B: a change re-arms the periodic push (#806)', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.col.cancel();
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    final before = s.col.events.length;
+    // New remote bytes → metrics + scrollback change → next tick emits.
+    s.host.ingestOutputForTest(
+      'h:22:u:1',
+      Uint8List.fromList('more output\n'.codeUnits),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    expect(
+      s.col.events.length,
+      greaterThan(before),
+      reason: 'a state/byte/scrollback change must produce a fresh snapshot',
+    );
+  });
+
+  test(
+    'C: PERIODIC payload omits scrollback; on-demand includes it (#806)',
+    () async {
+      final s = await _setup();
+      addTearDown(() async {
+        await s.col.cancel();
+        await s.host.dispose();
+        await s.pair.dispose();
+      });
+
+      // Force a change so a periodic snapshot ships, then read it.
+      s.host.ingestOutputForTest(
+        'h:22:u:1',
+        Uint8List.fromList('tick\n'.codeUnits),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      final periodic = s.col.events.last;
+      expect(
+        periodic.scrollbackTail,
+        isEmpty,
+        reason: 'periodic snapshot must NOT carry the ~4KB scrollback decode',
+      );
+
+      // On-demand request (audit live view / resume rebind) → full payload.
+      s.pair.uiSide.send(
+        const SshRequestSnapshotCommand(sessionId: 'h:22:u:1').toJson(),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final onDemand = s.col.events.last;
+      expect(
+        onDemand.scrollbackTail,
+        contains('hello world'),
+        reason: 'on-demand snapshot must carry the scrollback tail',
+      );
+    },
+  );
+
+  test(
+    'A: setActive(false) stops the periodic timer; (true) restores + emits one '
+    'fresh snapshot immediately (#806)',
+    () async {
+      final s = await _setup();
+      addTearDown(() async {
+        await s.col.cancel();
+        await s.host.dispose();
+        await s.pair.dispose();
+      });
+
+      // Background: stop the timer.
+      s.pair.uiSide.send(const SshSetActiveCommand(active: false).toJson());
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      // Even a change while backgrounded must NOT produce a periodic snapshot.
+      s.host.ingestOutputForTest(
+        'h:22:u:1',
+        Uint8List.fromList('bg output\n'.codeUnits),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+      final whilePaused = s.col.events.length;
+
+      // Foreground: restore the timer AND emit one fresh full snapshot now.
+      s.pair.uiSide.send(const SshSetActiveCommand(active: true).toJson());
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(
+        s.col.events.length,
+        greaterThan(whilePaused),
+        reason: 'resume must re-emit a fresh snapshot for instant repaint',
+      );
+      // The resume snapshot carries the scrollback (full payload for repaint).
+      expect(s.col.events.last.scrollbackTail, contains('bg output'));
+
+      // And the session stayed connected throughout (snapshots are UI-only):
+      // the resume snapshot reports `connected`, proving the gate never touched
+      // the SSH lifecycle.
+      expect(s.col.events.last.state, SshSessionState.connected.name);
+    },
+  );
+
+  test('A: no periodic snapshots accumulate while paused (#806)', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.col.cancel();
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+
+    s.pair.uiSide.send(const SshSetActiveCommand(active: false).toJson());
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    final baseline = s.col.events.length;
+    // Drive many ticks worth of wall time + a change each — none should ship.
+    for (var i = 0; i < 5; i++) {
+      s.host.ingestOutputForTest(
+        'h:22:u:1',
+        Uint8List.fromList('paused $i\n'.codeUnits),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+    }
+    expect(
+      s.col.events.length,
+      baseline,
+      reason: 'paused: the periodic timer is stopped, no snapshots emitted',
+    );
+  });
+}

--- a/native/test/services/task_ipc_test.dart
+++ b/native/test/services/task_ipc_test.dart
@@ -80,6 +80,19 @@ void main() {
       expect(restored.sessionId, 'host:22:user:1');
     });
 
+    test('SshSetActiveCommand round-trips active flag (#806)', () {
+      for (final active in [true, false]) {
+        final cmd = SshSetActiveCommand(active: active);
+        final restored = SshTaskCommand.fromJson(cmd.toJson());
+        expect(restored, isA<SshSetActiveCommand>());
+        restored as SshSetActiveCommand;
+        expect(restored.kind, SshTaskCommandKind.setActive);
+        expect(restored.active, active);
+        // Task-global: empty sentinel sessionId (mirrors SshUiHelloCommand).
+        expect(restored.sessionId, '');
+      }
+    });
+
     test('unknown kind throws FormatException', () {
       expect(
         () => SshTaskCommand.fromJson({'kind': 'bogus', 'sessionId': 'sid'}),


### PR DESCRIPTION
## Summary
- **A. Background-gate the snapshot timer.** New task-global `SshSetActiveCommand(active)` sent over the existing UI→task gateway on `AppLifecycleState` pause/resume (`main.dart`). On pause the host cancels `_snapshotTimer`; on resume it restores the 2s timer **and** emits one fresh full snapshot per session immediately so the terminal/audit repaints instantly.
- **B. Dirty-check `_pushSnapshots`.** A periodic snapshot ships per session only when a cheap signature (`state | bytesIn | bytesOut | rtt | reconnectCount | lastReconnectAtMs | scrollback byte-length`) changed since the last push. An idle connected session produces zero IPC traffic. The on-demand `SshRequestSnapshotCommand` path always answers (audit live view / resume rebind).
- **C. Scrollback off the periodic payload.** `_emitSnapshot` gained a required `includeScrollback` flag: periodic = `false` (no ~4KB UTF-8 decode), on-demand = `true`. The dirty-check signature uses scrollback **byte length** (`BytesBuilder.length`), so the gate itself never decodes.

Does **not** touch wake lock / Wi-Fi lock / SSH keepalive / reconnect (the #738 survive-sleep floor). Snapshots are UI telemetry only — the session stays alive exactly as before while backgrounded.

## TDD Analysis
- Type: perf / protocol (new task-global control message)
- Behavior change: yes — background snapshot frequency + periodic payload shape
- TDD approach: full (unit) + smoketest-only on-emulator integration (orchestrator-run)

## Test coverage
- **Existing tests updated**: `task_ipc_test.dart` — added `SshSetActiveCommand` round-trip (the single-codebase wire sync check).
- **New tests (fail→pass)**: `test/services/snapshot_gate_test.dart` —
  - B: idle session emits nothing across many periodic ticks;
  - B: a state/byte/scrollback change re-arms the push;
  - C: periodic payload omits scrollback, on-demand includes it;
  - A: `setActive(false)` stops the timer; `setActive(true)` restores it + emits one fresh snapshot, session reports `connected` throughout;
  - A: no periodic snapshots accumulate while paused (even with changes).
- **Integration (tagged `integration`, excluded from fast gate; orchestrator-run on emulator)**: `integration_test/background_snapshot_gate_test.dart` — real connect to test-sshd, simulated background→foreground; asserts periodic snapshots stop while paused, resume re-emits a fresh snapshot (with scrollback), and the session stays connected across the cycle. Marked `skip: true` for the same live-ghostty integration-binding hang as `resume_liveness_test.dart`; the gate logic is covered deterministically by the unit suite.

## Test results
- flutter analyze: PASS
- flutter test (`--exclude-tags integration`): PASS (973 passed, 5 integration skipped)

## Diff stats
- Files changed: 7 (5 source/test + 2 new tests)
- Lines: +580 / -6

Closes #806

## Cycles used
1/3