### PR TITLE
feat(native): Active Sessions UI — state dot + Reconnect for dropped sessions (#817)

### DIFF
--- a/native/integration_test/active_session_reconnect_test.dart
+++ b/native/integration_test/active_session_reconnect_test.dart
@@ -1,0 +1,157 @@
+// On-emulator Active Sessions UI: a dropped session is visible + reconnectable
+// (#817, #811 Slice 2). Orchestrator-run (tag `integration`).
+//
+// The owner's pain: "zombie sessions require me to ✕ them, no reconnect option."
+// After Slice 2 a non-connected session row must surface a Reconnect affordance
+// (not a ✕-only tile), and tapping it must re-enter the connect path from the
+// task-held params (no auth re-supply) and reach a LIVE shell again.
+//
+// This runs the full device path: connect to test-sshd → drop the session
+// (proxy.disconnect → `disconnected`) → open the session menu → assert the row
+// shows a Reconnect button → tap it → prove the shell streams bytes again.
+//
+// PASS = the Reconnect button appears on the dropped row AND tapping it revives
+// the session to a live shell.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+Future<bool> _proveShellBytes(
+  WidgetTester tester,
+  dynamic entry,
+) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  var gotBytes = false;
+  for (var i = 0; i < 40; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+    if (out.isNotEmpty) {
+      gotBytes = true;
+      break;
+    }
+  }
+  await sub.cancel();
+  return gotBytes;
+}
+
+Future<bool> _connect(WidgetTester tester) async {
+  await adhocPasswordConnect(
+    tester,
+    host: '127.0.0.1',
+    port: '2222',
+    user: 'testuser',
+    pass: 'testpass',
+  );
+  for (var i = 0; i < 60; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+    final accept = find.text('Trust + connect');
+    if (accept.evaluate().isNotEmpty) {
+      await tester.tap(accept.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'a dropped session shows a Reconnect button that revives a live shell',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(await _connect(tester), isTrue, reason: 'initial connect failed');
+
+      final entry = container.read(sessionsProvider).active!;
+      final sid = entry.id;
+
+      // Prove the first shell is live before dropping it.
+      expect(
+        await _proveShellBytes(tester, entry),
+        isTrue,
+        reason: 'first connect did not stream shell bytes',
+      );
+
+      // Drop the session WITHOUT removing the entry: disconnect drives the task
+      // controller to `disconnected` while the entry (and its proxy) survives —
+      // the zombie-tile condition the owner hit.
+      entry.proxy.disconnect();
+      var dropped = false;
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        final state = entry.proxy.data.state;
+        if (state == SshSessionState.disconnected ||
+            state == SshSessionState.failed ||
+            state == SshSessionState.softDisconnected) {
+          dropped = true;
+          break;
+        }
+      }
+      expect(dropped, isTrue, reason: 'session never reached a drop state');
+      // The entry must still exist (a drop is not a forget).
+      expect(
+        container.read(sessionsProvider).entries.any((e) => e.id == sid),
+        isTrue,
+      );
+
+      // Open the session menu and assert the dropped row surfaces a Reconnect
+      // affordance — not a ✕-only tile.
+      await tester.tap(find.byKey(const Key('session-bar-open-menu')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
+
+      final reconnectBtn = find.byKey(Key('session-menu-reconnect-$sid'));
+      expect(
+        reconnectBtn,
+        findsOneWidget,
+        reason: 'a dropped session row must offer Reconnect (#817)',
+      );
+
+      // Tap Reconnect → re-enter the connect path from held params.
+      await tester.tap(reconnectBtn);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // The session must reach `connected` and stream bytes again.
+      var reconnected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (entry.proxy.data.state == SshSessionState.connected) {
+          reconnected = true;
+          break;
+        }
+      }
+      expect(
+        reconnected,
+        isTrue,
+        reason: 'Reconnect did not drive the session back to connected',
+      );
+      expect(
+        await _proveShellBytes(tester, entry),
+        isTrue,
+        reason: 'Reconnect reached connected but no live shell bytes flowed',
+      );
+    },
+  );
+}

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -363,9 +363,26 @@ class SessionHost {
   }
 
   void _handleConnect(SshConnectCommand cmd) {
-    if (_sessions.containsKey(cmd.sessionId)) {
-      // Already hosted — emit the current state so the UI can sync.
-      _emitState(cmd.sessionId, _sessions[cmd.sessionId]!.controller);
+    final existing = _sessions[cmd.sessionId];
+    if (existing != null) {
+      // Already hosted. If the session is in a manually-reconnectable DROP state
+      // (#817), a re-issued connect IS a Reconnect: force-revive it in place from
+      // the controller's held params (no need to rebuild the controller — its
+      // creds + state machine are intact). Otherwise just emit the current state
+      // so the UI can sync (the original dedup-connect contract). This keeps the
+      // UI's Reconnect path uniform: it always re-issues a connect, and the host
+      // routes it to reconnectNow() for a live-but-dropped session or to a fresh
+      // connect when the session was lost (e.g. the foreground isolate was torn
+      // down on the last-session drop and rebuilt empty).
+      if (_isReconnectableDrop(existing.controller.data.state)) {
+        ctrace(
+          'task.host',
+          'connect sid=${cmd.sessionId} on dropped session → reconnectNow()',
+        );
+        existing.controller.reconnectNow();
+      } else {
+        _emitState(cmd.sessionId, existing.controller);
+      }
       return;
     }
     final controller = _factory();
@@ -426,6 +443,16 @@ class SessionHost {
       'connect sid=${cmd.sessionId} → controller.connect(${cmd.host}:${cmd.port})',
     );
     unawaited(controller.connect(params));
+  }
+
+  /// A drop state the user can manually reconnect from (#817) — mirrors the UI's
+  /// `_canReconnect`. A re-issued connect for a session in one of these states is
+  /// treated as a force-reconnect rather than a no-op state sync.
+  static bool _isReconnectableDrop(SshSessionState state) {
+    return state == SshSessionState.softDisconnected ||
+        state == SshSessionState.reconnecting ||
+        state == SshSessionState.failed ||
+        state == SshSessionState.disconnected;
   }
 
   void _handleDisconnect(SshDisconnectCommand cmd) {

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -221,6 +221,11 @@ class SessionHost {
         // end-to-end nudge check (#759) for the transport-alive-but-shell-frozen
         // case a ping cannot catch.
         _handleResumeProbe(cmd.sessionId);
+      case SshReconnectCommand():
+        // #817: user tapped Reconnect on a dropped session row. Force re-enter
+        // the reconnect path from held params (no auth re-supply). No-op when
+        // the session isn't hosted (already forgotten) or isn't in a drop state.
+        _sessions[cmd.sessionId]?.controller.reconnectNow();
       case SftpListCommand():
         _handleSftpList(cmd);
       case SftpDownloadCommand():

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -38,6 +38,14 @@ enum SshTaskCommandKind {
   /// instead of being trusted and left frozen.
   resumeProbe,
 
+  /// UI -> task: user tapped Reconnect on a dropped session (#817, Active
+  /// Sessions UI). Maps task-side to `SshSessionController.reconnectNow()`,
+  /// which FORCE re-enters the reconnect path from held params (no auth
+  /// re-supply) for a `failed` / `disconnected` / `softDisconnected` /
+  /// `reconnecting` session — ignoring the resume staleness threshold and
+  /// overriding a prior user disconnect (an explicit "revive" intent).
+  reconnect,
+
   /// UI → task: the UI's foreground/background state changed (#806). Carries an
   /// `active` flag — `false` when the UI is backgrounded (`AppLifecycleState.
   /// paused`, proxies unbound), `true` on resume. The task-side host gates its
@@ -208,6 +216,8 @@ sealed class SshTaskCommand {
         return const SshUiHelloCommand();
       case SshTaskCommandKind.resumeProbe:
         return SshResumeProbeCommand(sessionId: sessionId);
+      case SshTaskCommandKind.reconnect:
+        return SshReconnectCommand(sessionId: sessionId);
       case SshTaskCommandKind.setActive:
         return SshSetActiveCommand(active: json['active'] as bool);
       case SshTaskCommandKind.sftpList:
@@ -444,6 +454,20 @@ class SshResumeProbeCommand extends SshTaskCommand {
 
   @override
   SshTaskCommandKind get kind => SshTaskCommandKind.resumeProbe;
+
+  @override
+  Map<String, dynamic> toJson() => {'kind': kind.name, 'sessionId': sessionId};
+}
+
+/// UI → task: user tapped Reconnect on a dropped session (#817). Maps task-side
+/// to `SshSessionController.reconnectNow()` — a FORCE reconnect from held params
+/// (no auth re-supply) that ignores the resume staleness threshold and overrides
+/// a prior user disconnect. Per-session, so [sessionId] identifies which session.
+class SshReconnectCommand extends SshTaskCommand {
+  const SshReconnectCommand({required String sessionId}) : super(sessionId);
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.reconnect;
 
   @override
   Map<String, dynamic> toJson() => {'kind': kind.name, 'sessionId': sessionId};

--- a/native/lib/ssh/ssh_session.dart
+++ b/native/lib/ssh/ssh_session.dart
@@ -622,6 +622,45 @@ class SshSessionController {
     _scheduleReconnect(null);
   }
 
+  /// User-initiated FORCE reconnect (#817, Active Sessions UI Reconnect button).
+  ///
+  /// Unlike [resumeReconnectIfStale] (the app-resume re-arm), this:
+  ///  - ignores the staleness threshold — the user tapped Reconnect, so retry
+  ///    NOW rather than waiting for a drop to age past 8s,
+  ///  - clears the user-suppressed bit — tapping Reconnect IS an explicit
+  ///    "revive this session" intent, so it overrides a prior user ✕/Disconnect
+  ///    (`disconnected` by user). The ✕ remains the "forget" action; Reconnect
+  ///    is the "bring it back" action,
+  ///  - and for a session already mid-reconnect (`softDisconnected` /
+  ///    `reconnecting`) it cancels the pending backoff timer and retries
+  ///    immediately ("force now").
+  ///
+  /// Re-enters the existing reconnect path from the controller's held
+  /// [_lastParams] — so NO auth is re-supplied UI-side (creds live task-side).
+  /// No-op for a healthy/connecting session (nothing to reconnect) or when there
+  /// are no params to reconnect with (never reached `connected`).
+  void reconnectNow() {
+    final state = _data.state;
+    final canReconnect =
+        state == SshSessionState.failed ||
+        state == SshSessionState.disconnected ||
+        state == SshSessionState.softDisconnected ||
+        state == SshSessionState.reconnecting;
+    if (!canReconnect) return;
+    if (_lastParams == null) return;
+    // Explicit revive: overrides a prior user disconnect. Keep the bit and the
+    // state-derived suppress predicate consistent — the `reconnecting` emit in
+    // [_scheduleReconnect] moves state off `disconnected`/`failed` (#813).
+    _userDisconnected = false;
+    // Force-now: drop any pending backoff timer and restart with a full budget.
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    _reconnectAttempts = 0;
+    _lastErrorUnreachable = false;
+    clifecycle('task.ssh', 'reconnectNow: user-forced ${state.name} → reconnect');
+    _scheduleReconnect(null);
+  }
+
   Future<void> _defaultLivenessProbe() async {
     final client = _client;
     if (client == null) {

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -180,6 +180,17 @@ class SshSessionProxy {
     gateway.send(SshDisconnectCommand(sessionId: sessionId).toJson());
   }
 
+  /// Force-reconnect a dropped session (#817, Active Sessions UI). The task-side
+  /// host maps this to `SshSessionController.reconnectNow()`, which re-enters the
+  /// reconnect path from its held params — so NO auth is re-supplied here (creds
+  /// live task-side). State updates (`reconnecting` → `connected` / `failed`)
+  /// arrive asynchronously through [stream]. No-op for a healthy session
+  /// (handled controller-side).
+  void reconnect() {
+    if (_disposed) return;
+    gateway.send(SshReconnectCommand(sessionId: sessionId).toJson());
+  }
+
   /// Accept a pending host-key prompt (#536). Sends a decision command to the
   /// task side (which trusts the key + resolves the controller's verify
   /// callback) and clears the local `pendingHostKey` so the dialog dismisses.

--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -29,7 +29,9 @@ import '../ssh/ssh_connect_params.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../ui/terminal_mouse_handler.dart';
+import '../storage/profiles_store.dart';
 import 'keepalive_providers.dart';
+import 'profiles_providers.dart';
 import 'recent_sessions.dart';
 import 'session_host_providers.dart';
 
@@ -250,6 +252,108 @@ class SessionsNotifier extends Notifier<SessionsState> {
         state = state.copyWith(activeId: id);
         return;
       }
+    }
+  }
+
+  /// User-initiated FORCE reconnect of a dropped session (#817, Active Sessions
+  /// UI Reconnect button). No-op when [id] is unknown.
+  ///
+  /// Two things must happen for a dropped session to genuinely revive on device:
+  ///
+  /// 1. RESTART the foreground task isolate. Disconnecting the LAST live session
+  ///    drives the keepalive connected-count to 0, which STOPS the foreground
+  ///    service — tearing down the task isolate (and its `SessionHost`, with the
+  ///    controller's held params + creds). The UI↔task gateway goes not-ready, so
+  ///    a bare command would BUFFER against a dead isolate forever (the device
+  ///    bug the emulator gate caught). `ensureStarted()` respawns the isolate;
+  ///    the gateway re-handshakes to ready and flushes buffered commands. It is
+  ///    idempotent, so when the service is still up this is a harmless no-op.
+  ///
+  /// 2. Re-establish the SSH session. When the isolate was torn down, the fresh
+  ///    `SessionHost` has NO record of the session — `SshReconnectCommand` would
+  ///    no-op (`_sessions[id]` is null) because the held params died with it. So
+  ///    we re-resolve credentials from the matching saved profile's vault entry
+  ///    (silent — no user prompt, mirroring the PWA `reconnect-recent` path) and
+  ///    re-issue a full `connect` on the SAME proxy/session id. The task-side
+  ///    `_handleConnect` rehosts + connects when the session is gone, or routes
+  ///    the connect to `reconnectNow()` when the session survived but dropped.
+  ///    Falls back to the bare `proxy.reconnect()` (held-params fast path) for an
+  ///    ad-hoc session with no resolvable saved creds.
+  void reconnect(String id) {
+    SessionEntry? entry;
+    for (final e in state.entries) {
+      if (e.id == id) {
+        entry = e;
+        break;
+      }
+    }
+    final e = entry;
+    if (e == null) return;
+    unawaited(ref.read(keepaliveServiceStarterProvider)());
+    unawaited(_reviveFromProfile(e));
+  }
+
+  /// Re-resolve [entry]'s credentials from its saved profile and re-issue a full
+  /// connect, so a session whose task-side host was torn down (last-session drop
+  /// stopped the foreground service) can be rebuilt without prompting the user
+  /// (#817). Falls back to the held-params `proxy.reconnect()` when no matching
+  /// profile / stored credentials exist. Guarded + fire-and-forget: any failure
+  /// degrades to the bare reconnect rather than wedging the UI.
+  Future<void> _reviveFromProfile(SessionEntry entry) async {
+    try {
+      final profiles = await ref.read(profilesStoreProvider).load();
+      SavedProfile? match;
+      for (final p in profiles) {
+        if (p.identityKey == entry.profileKey) {
+          match = p;
+          break;
+        }
+      }
+      if (match == null) {
+        entry.proxy.reconnect();
+        return;
+      }
+      final secrets = ref.read(secretsStoreProvider);
+      final creds = await loadProfileCredentials(secrets, match);
+      final wantsKey =
+          match.authType == 'key' ||
+          (match.authType == null &&
+              (creds.privateKey != null && creds.privateKey!.isNotEmpty));
+      final SshAuth? auth;
+      if (wantsKey &&
+          creds.privateKey != null &&
+          creds.privateKey!.isNotEmpty) {
+        auth = SshAuth.key(
+          Uint8List.fromList(utf8.encode(creds.privateKey!)),
+          passphrase: (creds.passphrase == null || creds.passphrase!.isEmpty)
+              ? null
+              : creds.passphrase,
+        );
+      } else if (!wantsKey &&
+          creds.password != null &&
+          creds.password!.isNotEmpty) {
+        auth = SshAuth.password(creds.password!);
+      } else {
+        auth = null;
+      }
+      if (auth == null) {
+        // No stored secret to re-supply — fall back to held-params reconnect
+        // (works when the task-side session survived the drop).
+        entry.proxy.reconnect();
+        return;
+      }
+      entry.proxy.connect(
+        SshConnectParams(
+          host: entry.host,
+          port: entry.port,
+          username: entry.username,
+          auth: auth,
+        ),
+        title: entry.title,
+      );
+    } catch (_) {
+      // Best-effort: degrade to the bare held-params reconnect.
+      entry.proxy.reconnect();
     }
   }
 

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -761,8 +761,13 @@ class _SessionRow extends ConsumerWidget {
               // Monochrome replay glyph (mirrors the recents reconnect icon).
               icon: const Icon(Icons.replay),
               // Re-enter the connect path for THIS entry from held params
-              // (#817). The ✕ remains "forget"; this is "bring it back".
-              onPressed: () => entry.proxy.reconnect(),
+              // (#817). Routed through the notifier so the foreground task
+              // isolate is (re)started before the reconnect command is sent —
+              // disconnecting the last session stops the service, and a bare
+              // proxy.reconnect() would buffer against a dead isolate forever.
+              // The ✕ remains "forget"; this is "bring it back".
+              onPressed: () =>
+                  ref.read(sessionsProvider.notifier).reconnect(entry.id),
             ),
           IconButton(
             key: Key('session-menu-close-${entry.id}'),
@@ -961,16 +966,16 @@ class _StatusDotState extends State<_StatusDot>
 /// dropped session (held params, no auth re-supply). It watches every entry's
 /// proxy state so it appears/disappears reactively as sessions drop/recover —
 /// mirroring the PWA `activeSessionList` reconnect-all.
-class _ReconnectAllRow extends StatefulWidget {
+class _ReconnectAllRow extends ConsumerStatefulWidget {
   const _ReconnectAllRow({required this.entries});
 
   final List<SessionEntry> entries;
 
   @override
-  State<_ReconnectAllRow> createState() => _ReconnectAllRowState();
+  ConsumerState<_ReconnectAllRow> createState() => _ReconnectAllRowState();
 }
 
-class _ReconnectAllRowState extends State<_ReconnectAllRow> {
+class _ReconnectAllRowState extends ConsumerState<_ReconnectAllRow> {
   final List<StreamSubscription<SshSessionData>> _subs = [];
 
   @override
@@ -1034,8 +1039,12 @@ class _ReconnectAllRowState extends State<_ReconnectAllRow> {
           dropped.length == 1 ? 'Reconnect' : 'Reconnect all (${dropped.length})',
         ),
         onPressed: () {
+          // Route through the notifier so the foreground task isolate is
+          // (re)started before each reconnect command — see
+          // SessionsNotifier.reconnect (#817).
+          final notifier = ref.read(sessionsProvider.notifier);
           for (final e in dropped) {
-            e.proxy.reconnect();
+            notifier.reconnect(e.id);
           }
         },
       ),

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -25,6 +25,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../main.dart' show openConnectHome;
+import '../ssh/ssh_session.dart';
 import '../state/profiles_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
@@ -310,13 +311,19 @@ class SessionMenu extends ConsumerWidget {
               padding: EdgeInsets.all(16),
               child: Text('No sessions yet.'),
             )
-          else
+          else ...[
             for (final e in sessions.entries)
               _SessionRow(
                 entry: e,
                 isActive: e.id == sessions.activeId,
                 onClose: onClose,
               ),
+            // #817: a "Reconnect all" affordance shown whenever ANY session is
+            // non-connected (dropped/failed/disconnected/connecting). Mirrors the
+            // PWA's `activeSessionList` reconnect-all. It watches every entry's
+            // proxy state so it appears/disappears reactively.
+            _ReconnectAllRow(entries: sessions.entries),
+          ],
           // #721: open the FULL home (Profiles / Settings / Diagnostics) OVER
           // the live terminal — the SAME unified view as first-run, not a
           // reduced connect form. Reaches every setting + profiles without
@@ -654,32 +661,53 @@ class _SessionRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
     // #739: profile color swatch for THIS row's session. The per-session color
     // is seeded from the profile on connect (#653) and read via
-    // `sessionColorProvider`. Unlike the session bar — which falls back to the
-    // theme accent (`session-bar-swatch`) — a colorless session here shows a
-    // NEUTRAL muted dot (`outlineVariant`), never a fake real-looking color
-    // (issue #739). The SAME color identifies the SAME profile everywhere
-    // (PWA `session-dot`).
+    // `sessionColorProvider`. The SAME color identifies the SAME profile
+    // everywhere (PWA `session-dot`).
     final profileColor = ref.watch(sessionColorProvider(entry.id));
-    final swatchColor = profileColor ?? theme.colorScheme.outlineVariant;
+    // #817: the row now reads the session's lifecycle STATE directly (not a
+    // boolean) and surfaces a state-driven status dot + per-state action.
+    // StreamBuilder on the proxy state stream keeps the row reactive as the
+    // session moves connected → softDisconnected/reconnecting → failed without
+    // re-opening the menu — exactly the PWA `activeSessionList` behaviour.
+    return StreamBuilder<SshSessionData>(
+      stream: entry.proxy.stream,
+      initialData: entry.proxy.data,
+      builder: (context, snapshot) {
+        final data = snapshot.data ?? entry.proxy.data;
+        return _buildRow(context, ref, data.state, data.error, profileColor);
+      },
+    );
+  }
+
+  Widget _buildRow(
+    BuildContext context,
+    WidgetRef ref,
+    SshSessionState state,
+    String? error,
+    Color? profileColor,
+  ) {
+    final theme = Theme.of(context);
+    final subtitle = _subtitleFor(theme, state, error);
     return ListTile(
       key: Key('session-menu-row-${entry.id}'),
-      // [swatch][terminal] — the small filled circle (profile color, else a
-      // neutral dot) sits immediately left of the existing terminal glyph so the
-      // row reads as `● ⌨ label`, mirroring the profile list / session bar.
+      // [status dot][terminal] — the dot's COLOR + animation reflect the
+      // session state (#817): solid profile/accent when connected, pulsing
+      // while connecting, amber while reconnecting, red on failure, grey when
+      // user-disconnected. Monochrome theme glyphs only — no emoji
+      // (feedback_monochrome_icons_no_emoji). The profile color is preserved as
+      // the "connected" tint so the SAME color still identifies the profile.
       leading: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            key: Key('session-menu-swatch-${entry.id}'),
-            width: 10,
-            height: 10,
-            decoration: BoxDecoration(
-              color: swatchColor,
-              shape: BoxShape.circle,
-            ),
+          _StatusDot(
+            key: Key('session-menu-status-dot-${entry.id}'),
+            // The swatch key is retained (#739 tests + device screenshots
+            // address it) and now lives on the same dot.
+            swatchKey: Key('session-menu-swatch-${entry.id}'),
+            state: state,
+            profileColor: profileColor,
           ),
           const SizedBox(width: 8),
           Icon(
@@ -688,10 +716,6 @@ class _SessionRow extends ConsumerWidget {
           ),
         ],
       ),
-      // #567: the label alone identifies the session (mirrors the PWA's slim
-      // session list, which shows the label + a connection dot, no verbose
-      // user@host:port subtitle). Dropping the subtitle halves each row's
-      // height and tightens the menu.
       dense: true,
       title: Text(
         entry.label,
@@ -700,11 +724,17 @@ class _SessionRow extends ConsumerWidget {
           fontWeight: isActive ? FontWeight.w600 : FontWeight.normal,
         ),
       ),
-      // [file icon][X] — the file icon opens the browser for THIS row's
-      // session (#649); the X disconnects/closes THIS row's session. Both are
-      // per-row so a multi-session menu addresses each session independently.
-      // The file glyph is monochrome (Material `folder_outlined`, currentColor)
-      // — no emoji (feedback_monochrome_icons_no_emoji).
+      // A short status line under the label for non-connected states (#817) so
+      // a dropped session is never an invisible/✕-only tile: "Connecting…",
+      // "Reconnecting…", or the failure reason. Connected rows stay subtitle-
+      // less (the slim #567 direction).
+      subtitle: subtitle,
+      // Trailing action set (#817): a Reconnect button is ADDED for drop states
+      // (softDisconnected/reconnecting/failed/disconnected) — it's omitted while
+      // connected/connecting (nothing to manually reconnect). Files stays a
+      // per-row affordance in EVERY state (#649 contract — the browser handles a
+      // non-live link itself). The ✕ is ALWAYS present and means "forget this
+      // session" (explicit close).
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -714,8 +744,8 @@ class _SessionRow extends ConsumerWidget {
             visualDensity: VisualDensity.compact,
             icon: const Icon(Icons.folder_outlined),
             // Open the file browser for THIS row's session id (its live SSH
-            // connection drives SFTP), not just the active session. Close the
-            // menu first so the browser route isn't covered by the overlay.
+            // connection drives SFTP). Close the menu first so the browser
+            // route isn't covered by the overlay.
             onPressed: () {
               final sessionId = entry.id;
               final navigator = Navigator.of(context);
@@ -723,6 +753,17 @@ class _SessionRow extends ConsumerWidget {
               openFileBrowser(navigator.context, sessionId);
             },
           ),
+          if (_canReconnect(state))
+            IconButton(
+              key: Key('session-menu-reconnect-${entry.id}'),
+              tooltip: 'Reconnect',
+              visualDensity: VisualDensity.compact,
+              // Monochrome replay glyph (mirrors the recents reconnect icon).
+              icon: const Icon(Icons.replay),
+              // Re-enter the connect path for THIS entry from held params
+              // (#817). The ✕ remains "forget"; this is "bring it back".
+              onPressed: () => entry.proxy.reconnect(),
+            ),
           IconButton(
             key: Key('session-menu-close-${entry.id}'),
             tooltip: 'Close session',
@@ -737,37 +778,266 @@ class _SessionRow extends ConsumerWidget {
         ref.read(sessionsProvider.notifier).setActive(entry.id);
         onClose();
       },
-      onLongPress: () => _showRowActions(context, ref),
     );
   }
 
-  void _showRowActions(BuildContext context, WidgetRef ref) {
-    showModalBottomSheet<void>(
-      context: context,
-      builder: (ctx) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              key: const Key('session-menu-action-disconnect'),
-              leading: const Icon(Icons.link_off),
-              title: const Text('Disconnect'),
-              onTap: () {
-                entry.proxy.disconnect();
-                Navigator.of(ctx).pop();
-              },
-            ),
-            ListTile(
-              key: const Key('session-menu-action-close'),
-              leading: const Icon(Icons.close),
-              title: const Text('Close session'),
-              onTap: () {
-                ref.read(sessionsProvider.notifier).close(entry.id);
-                Navigator.of(ctx).pop();
-              },
-            ),
-          ],
+  /// True when the session is in a drop state the user can manually reconnect
+  /// from (#817). A live/connecting session is excluded — it's already healthy
+  /// or trying. Reads STATE, never a boolean.
+  static bool _canReconnect(SshSessionState state) {
+    return state == SshSessionState.softDisconnected ||
+        state == SshSessionState.reconnecting ||
+        state == SshSessionState.failed ||
+        state == SshSessionState.disconnected;
+  }
+
+  /// The per-state status line under the row label, or null for `connected`
+  /// (slim — no subtitle) and `idle` (pre-connect, nothing to say yet).
+  Widget? _subtitleFor(
+    ThemeData theme,
+    SshSessionState state,
+    String? error,
+  ) {
+    switch (state) {
+      case SshSessionState.idle:
+      case SshSessionState.connected:
+        return null;
+      case SshSessionState.connecting:
+      case SshSessionState.authenticating:
+      case SshSessionState.awaitingHostKey:
+        return Text(
+          key: Key('session-menu-status-text-${entry.id}'),
+          'Connecting…',
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall,
+        );
+      case SshSessionState.softDisconnected:
+      case SshSessionState.reconnecting:
+        return Text(
+          key: Key('session-menu-status-text-${entry.id}'),
+          'Reconnecting…',
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: Colors.orange.shade700,
+          ),
+        );
+      case SshSessionState.failed:
+        final reason = (error != null && error.trim().isNotEmpty)
+            ? error.trim()
+            : 'Disconnected';
+        return Text(
+          key: Key('session-menu-status-text-${entry.id}'),
+          reason,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.error,
+          ),
+        );
+      case SshSessionState.disconnected:
+        return Text(
+          key: Key('session-menu-status-text-${entry.id}'),
+          'Disconnected',
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        );
+    }
+  }
+}
+
+/// State-driven status dot for a session row (#817). The COLOR encodes the
+/// lifecycle state; `connecting`/`reconnecting` pulse to signal "in flight".
+/// Monochrome / theme-derived colors only — no emoji
+/// (feedback_monochrome_icons_no_emoji):
+///   connected → solid profile color (else theme accent)
+///   connecting/authenticating/awaitingHostKey → pulsing accent
+///   softDisconnected/reconnecting → amber
+///   failed → red (theme error)
+///   disconnected (user) / idle → grey (outlineVariant)
+class _StatusDot extends StatefulWidget {
+  const _StatusDot({
+    super.key,
+    required this.swatchKey,
+    required this.state,
+    required this.profileColor,
+  });
+
+  final Key swatchKey;
+  final SshSessionState state;
+  final Color? profileColor;
+
+  @override
+  State<_StatusDot> createState() => _StatusDotState();
+}
+
+class _StatusDotState extends State<_StatusDot>
+    with SingleTickerProviderStateMixin {
+  // Constructed eagerly in initState (NOT `late final`): a lazy field would be
+  // built inside dispose() if it was never animated, and constructing an
+  // AnimationController during unmount does a TickerMode ancestor lookup on a
+  // deactivated widget (crash). Eager construction makes dispose() always safe.
+  late final AnimationController _pulse;
+
+  bool get _pulsing =>
+      widget.state == SshSessionState.connecting ||
+      widget.state == SshSessionState.authenticating ||
+      widget.state == SshSessionState.awaitingHostKey ||
+      widget.state == SshSessionState.softDisconnected ||
+      widget.state == SshSessionState.reconnecting;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulse = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+      value: 1.0,
+    );
+    if (_pulsing) _pulse.repeat(reverse: true);
+  }
+
+  @override
+  void didUpdateWidget(_StatusDot oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_pulsing && !_pulse.isAnimating) {
+      _pulse.repeat(reverse: true);
+    } else if (!_pulsing && _pulse.isAnimating) {
+      _pulse
+        ..stop()
+        ..value = 1.0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  Color _color(ThemeData theme) {
+    switch (widget.state) {
+      // connected (and idle, pre-connect) keep the PROFILE color so the SAME
+      // color still identifies the SAME profile across the app (#739, PWA
+      // `session-dot`). A colorless session shows the neutral fallback — never a
+      // fake real-looking color (#739).
+      case SshSessionState.idle:
+      case SshSessionState.connected:
+        return widget.profileColor ?? theme.colorScheme.outlineVariant;
+      case SshSessionState.connecting:
+      case SshSessionState.authenticating:
+      case SshSessionState.awaitingHostKey:
+        return theme.colorScheme.primary;
+      case SshSessionState.softDisconnected:
+      case SshSessionState.reconnecting:
+        return Colors.orange.shade700;
+      case SshSessionState.failed:
+        return theme.colorScheme.error;
+      case SshSessionState.disconnected:
+        return theme.colorScheme.outlineVariant;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color(Theme.of(context));
+    final dot = Container(
+      key: widget.swatchKey,
+      width: 10,
+      height: 10,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+    if (!_pulsing) return dot;
+    return FadeTransition(
+      opacity: Tween<double>(begin: 0.35, end: 1.0).animate(_pulse),
+      child: dot,
+    );
+  }
+}
+
+/// "Reconnect all" affordance (#817), shown only when at least one session is
+/// in a manually-reconnectable drop state. Each tap force-reconnects every
+/// dropped session (held params, no auth re-supply). It watches every entry's
+/// proxy state so it appears/disappears reactively as sessions drop/recover —
+/// mirroring the PWA `activeSessionList` reconnect-all.
+class _ReconnectAllRow extends StatefulWidget {
+  const _ReconnectAllRow({required this.entries});
+
+  final List<SessionEntry> entries;
+
+  @override
+  State<_ReconnectAllRow> createState() => _ReconnectAllRowState();
+}
+
+class _ReconnectAllRowState extends State<_ReconnectAllRow> {
+  final List<StreamSubscription<SshSessionData>> _subs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateWidget(_ReconnectAllRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Re-subscribe when the entry set changes (a session added/removed).
+    _resubscribe();
+  }
+
+  void _subscribe() {
+    for (final e in widget.entries) {
+      _subs.add(
+        e.proxy.stream.listen((_) {
+          if (mounted) setState(() {});
+        }),
+      );
+    }
+  }
+
+  void _resubscribe() {
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _subs.clear();
+    _subscribe();
+  }
+
+  @override
+  void dispose() {
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _subs.clear();
+    super.dispose();
+  }
+
+  bool _isDropped(SshSessionState state) {
+    return state == SshSessionState.softDisconnected ||
+        state == SshSessionState.reconnecting ||
+        state == SshSessionState.failed ||
+        state == SshSessionState.disconnected;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dropped =
+        widget.entries.where((e) => _isDropped(e.proxy.data.state)).toList();
+    if (dropped.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: OutlinedButton.icon(
+        key: const Key('session-menu-reconnect-all'),
+        icon: const Icon(Icons.restart_alt, size: 18),
+        label: Text(
+          dropped.length == 1 ? 'Reconnect' : 'Reconnect all (${dropped.length})',
         ),
+        onPressed: () {
+          for (final e in dropped) {
+            e.proxy.reconnect();
+          }
+        },
       ),
     );
   }

--- a/native/test/services/reconnect_command_host_test.dart
+++ b/native/test/services/reconnect_command_host_test.dart
@@ -1,0 +1,125 @@
+// SessionHost reconnect-command routing (#817, Active Sessions UI).
+//
+// When the user taps Reconnect on a dropped session row, the UI sends an
+// `SshReconnectCommand` for that session. The task-side `SessionHost` must route
+// it to the hosted controller's `reconnectNow()`, which force re-enters the
+// reconnect path from held params (no auth re-supply). A command for a session
+// that is no longer hosted (already forgotten via ✕) is a safe no-op.
+//
+// Headless via InMemoryGatewayPair + a controller whose connect() is inert so
+// the test owns the lifecycle transitions — no real socket.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+class _NoConnectController extends SshSessionController {
+  _NoConnectController({super.reconnectDelay, super.reconnectAttemptOverride});
+
+  @override
+  Future<void> connect(SshConnectParams params) async {
+    // Inert — the test drives lifecycle via debugSetConnectedForTest +
+    // handleTransportClosed; reconnectNow uses the held params from connect,
+    // which debugSetConnectedForTest seeds.
+  }
+}
+
+void main() {
+  test(
+    'reconnect command routes to reconnectNow — a FAILED session reconnects',
+    () async {
+      const sid = 'h:22:u:1';
+      var reconnectCalled = false;
+      late SshSessionController controller;
+      SshSessionController factory() {
+        controller = _NoConnectController(
+          reconnectDelay: Duration.zero,
+          reconnectAttemptOverride: (_) async {
+            reconnectCalled = true;
+            return true;
+          },
+        );
+        return controller;
+      }
+
+      final pair = InMemoryGatewayPair();
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: factory,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(() async {
+        await host.dispose();
+        await pair.dispose();
+      });
+
+      pair.uiSide.send(
+        const SshConnectCommand(
+          sessionId: sid,
+          host: 'h',
+          port: 22,
+          username: 'u',
+          authJson: {'type': 'password', 'password': 'p'},
+        ).toJson(),
+      );
+      await Future<void>.delayed(Duration.zero);
+      // Seed connected (held params), then fail it.
+      controller.debugSetConnectedForTest(_params);
+      controller
+        ..reconnectNow() // no-op while connected — sanity
+        ..debugSetConnectedForTest(_params);
+      // Drive to failed via a non-transient close path: simulate exhausted
+      // reconnect by forcing the state with a clean close from non-connected.
+      // Simplest deterministic route: disconnect (user) then reconnect command
+      // must STILL revive (explicit intent) — see the controller unit test. Here
+      // we assert the host wires the command at all: send it after a failure.
+      controller.handleTransportClosed(null); // connected → softDisconnected
+      await Future<void>.delayed(Duration.zero);
+
+      pair.uiSide.send(const SshReconnectCommand(sessionId: sid).toJson());
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(Duration.zero);
+        if (reconnectCalled) break;
+      }
+
+      expect(
+        reconnectCalled,
+        isTrue,
+        reason: 'reconnect command must route to controller.reconnectNow()',
+      );
+    },
+  );
+
+  test('reconnect command for an unhosted session is a safe no-op', () async {
+    final pair = InMemoryGatewayPair();
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: () => _NoConnectController(),
+      snapshotInterval: const Duration(hours: 1),
+    );
+    addTearDown(() async {
+      await host.dispose();
+      await pair.dispose();
+    });
+
+    // No session hosted for this id (already forgotten).
+    pair.uiSide.send(
+      const SshReconnectCommand(sessionId: 'gone:22:u:1').toJson(),
+    );
+    // Just draining without throwing is the assertion.
+    for (var i = 0; i < 5; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    expect(true, isTrue);
+  });
+}

--- a/native/test/services/task_ipc_test.dart
+++ b/native/test/services/task_ipc_test.dart
@@ -80,6 +80,14 @@ void main() {
       expect(restored.sessionId, 'host:22:user:1');
     });
 
+    test('SshReconnectCommand round-trips (#817)', () {
+      const cmd = SshReconnectCommand(sessionId: 'host:22:user:1');
+      final restored = SshTaskCommand.fromJson(cmd.toJson());
+      expect(restored, isA<SshReconnectCommand>());
+      expect(restored.kind, SshTaskCommandKind.reconnect);
+      expect(restored.sessionId, 'host:22:user:1');
+    });
+
     test('SshSetActiveCommand round-trips active flag (#806)', () {
       for (final active in [true, false]) {
         final cmd = SshSetActiveCommand(active: active);

--- a/native/test/ssh/reconnect_now_test.dart
+++ b/native/test/ssh/reconnect_now_test.dart
@@ -1,0 +1,157 @@
+// User-initiated FORCE reconnect tests (#817, Active Sessions UI Reconnect).
+//
+// `reconnectNow()` backs the Reconnect button on a dropped session row. Unlike
+// the app-resume re-arm (`resumeReconnectIfStale`), it:
+//  - fires immediately (no staleness threshold),
+//  - OVERRIDES a prior user disconnect (tapping Reconnect is an explicit revive
+//    intent — distinct from the resume re-arm, which must never auto-revive a
+//    user ✕),
+//  - cancels any pending backoff and retries now from a `softDisconnected` /
+//    `reconnecting` session,
+//  - is a no-op for a healthy/connecting session and when there are no held
+//    params.
+//
+// We assert externally-observable transitions (states emitted) and whether the
+// reconnect attempt ran — never a private flag (rules/state-management.md).
+
+import 'dart:io';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'example',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+Future<void> _settle(SshSessionController c, SshSessionState target) async {
+  for (var i = 0; i < 30; i++) {
+    await Future<void>.delayed(Duration.zero);
+    if (c.data.state == target) return;
+  }
+}
+
+void main() {
+  test('reconnectNow on a `failed` session re-arms to reconnecting → connected',
+      () async {
+    var attempts = 0;
+    final controller = SshSessionController(
+      reconnectDelay: Duration.zero,
+      maxReconnectAttempts: 1,
+      reconnectAttemptOverride: (_) async {
+        attempts += 1;
+        return attempts > 1; // exhaust to failed, then succeed on the re-arm
+      },
+    );
+    controller.debugSetConnectedForTest(_params);
+
+    controller.handleTransportClosed(
+      SSHSocketError(
+        const SocketException('broken', osError: OSError('broken', 32)),
+      ),
+    );
+    await _settle(controller, SshSessionState.failed);
+    expect(controller.data.state, SshSessionState.failed);
+
+    final states = <SshSessionState>[];
+    final sub = controller.stream.listen((d) => states.add(d.state));
+
+    controller.reconnectNow();
+    await _settle(controller, SshSessionState.connected);
+
+    expect(states, contains(SshSessionState.reconnecting));
+    expect(controller.data.state, SshSessionState.connected);
+    await sub.cancel();
+    await controller.dispose();
+  });
+
+  test(
+    'reconnectNow OVERRIDES a user disconnect (explicit revive intent)',
+    () async {
+      var reconnectCalled = false;
+      final controller = SshSessionController(
+        reconnectDelay: Duration.zero,
+        reconnectAttemptOverride: (_) async {
+          reconnectCalled = true;
+          return true;
+        },
+      );
+      controller.debugSetConnectedForTest(_params);
+      await controller.disconnect();
+      expect(controller.data.state, SshSessionState.disconnected);
+
+      // The resume re-arm must NOT revive this (regression guard for #813)...
+      await controller.resumeReconnectIfStale(staleThreshold: Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      expect(reconnectCalled, isFalse);
+      expect(controller.data.state, SshSessionState.disconnected);
+
+      // ...but an explicit Reconnect tap MUST.
+      controller.reconnectNow();
+      await _settle(controller, SshSessionState.connected);
+      expect(reconnectCalled, isTrue);
+      expect(controller.data.state, SshSessionState.connected);
+      await controller.dispose();
+    },
+  );
+
+  test(
+    'reconnectNow on a `reconnecting` session re-arms with a fresh budget',
+    () async {
+      var attempts = 0;
+      final controller = SshSessionController(
+        reconnectDelay: Duration.zero,
+        maxReconnectAttempts: 5,
+        reconnectAttemptOverride: (_) async {
+          attempts += 1;
+          return true;
+        },
+      );
+      controller.debugSetConnectedForTest(_params);
+
+      // Clean server close → softDisconnected → schedules a reconnect.
+      controller.handleTransportClosed(null);
+      // Force-now from a mid-reconnect state: re-enters the reconnect path and
+      // settles connected (the override succeeds). The force is a no-op-safe
+      // re-arm even while a schedule is already pending.
+      controller.reconnectNow();
+      await _settle(controller, SshSessionState.connected);
+      expect(controller.data.state, SshSessionState.connected);
+      expect(attempts, greaterThanOrEqualTo(1));
+      await controller.dispose();
+    },
+  );
+
+  test('reconnectNow is a no-op on a connected session', () async {
+    var reconnectCalled = false;
+    final controller = SshSessionController(
+      reconnectDelay: Duration.zero,
+      reconnectAttemptOverride: (_) async {
+        reconnectCalled = true;
+        return true;
+      },
+    );
+    controller.debugSetConnectedForTest(_params);
+
+    controller.reconnectNow();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.data.state, SshSessionState.connected);
+    expect(reconnectCalled, isFalse);
+    await controller.dispose();
+  });
+
+  test('reconnectNow is a no-op when there are no held params (never connected)',
+      () async {
+    final controller = SshSessionController(reconnectDelay: Duration.zero);
+    // idle, no _lastParams.
+    controller.reconnectNow();
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.data.state, SshSessionState.idle);
+    await controller.dispose();
+  });
+}

--- a/native/test/state/session_collection_test.dart
+++ b/native/test/state/session_collection_test.dart
@@ -13,21 +13,47 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
 import 'package:mobissh/services/task_ssh_gateway.dart';
 import 'package:mobissh/ssh/ssh_connect_params.dart';
 import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/state/keepalive_providers.dart';
+import 'package:mobissh/state/profiles_providers.dart';
 import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-ProviderContainer _makeContainer() {
+ProviderContainer _makeContainer({void Function()? onStart}) {
+  return _makeContainerWithPair(onStart: onStart).$1;
+}
+
+/// Like [_makeContainer] but also returns the in-memory gateway pair so a test
+/// can observe UI→task commands on `pair.taskSide.incoming` (#817).
+///
+/// When [profiles] / [secrets] are supplied they back the profiles + secrets
+/// providers so the #817 Reconnect revive path can re-resolve credentials
+/// deterministically (no platform channels).
+(ProviderContainer, InMemoryGatewayPair) _makeContainerWithPair({
+  void Function()? onStart,
+  ProfilesStore? profiles,
+  SecretsStore? secrets,
+}) {
   final pair = InMemoryGatewayPair();
   final container = ProviderContainer(overrides: [
     taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+    if (onStart != null)
+      keepaliveServiceStarterProvider.overrideWithValue(() async {
+        onStart();
+      }),
+    if (profiles != null) profilesStoreProvider.overrideWithValue(profiles),
+    if (secrets != null) secretsStoreProvider.overrideWithValue(secrets),
   ]);
   addTearDown(() async {
     await pair.dispose();
   });
-  return container;
+  return (container, pair);
 }
 
 SshConnectParams _params({
@@ -157,6 +183,135 @@ void main() {
       final miss =
           notifier.findByProfile(host: 'a', port: 2222, username: 'u');
       expect(miss, isNull);
+    });
+
+    // #817 regression: tapping Reconnect on a dropped session must (re)START the
+    // foreground task isolate AND re-establish the session. Disconnecting the
+    // last session stops the service, tearing down the task isolate + its host
+    // session (held params + creds). A bare proxy.reconnect() then (a) buffers
+    // against a dead isolate and (b) reaches a FRESH host with no record of the
+    // session — a double no-op, so the session never revives (the device-only
+    // bug the emulator gate caught). The fix routes Reconnect through the
+    // notifier, which restarts the service (idempotent starter) and re-resolves
+    // credentials from the saved profile to re-issue a FULL connect — the
+    // task-side host rehosts + connects (or routes to reconnectNow when the
+    // session survived).
+    test('reconnect(id) restarts the service and re-issues a credentialed '
+        'connect from the saved profile', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final profilesStore = ProfilesStore(prefs: prefs);
+      final secretsStore =
+          SecretsStore(backend: InMemorySecretsBackend());
+      // Seed a saved profile matching the session identity + its vault secret.
+      await profilesStore.save([
+        SavedProfile(
+          title: 'host',
+          host: 'h',
+          port: 22,
+          username: 'u',
+          authType: 'password',
+          vaultId: 'vault-1',
+        ),
+      ]);
+      await secretsStore.write('vault-1', {'password': 'sekret'});
+
+      var starts = 0;
+      final (c, pair) = _makeContainerWithPair(
+        onStart: () => starts++,
+        profiles: profilesStore,
+        secrets: secretsStore,
+      );
+      addTearDown(c.dispose);
+
+      // Capture commands the task isolate receives over the gateway.
+      final taskSeen = <Map<String, dynamic>>[];
+      final taskSub = pair.taskSide.incoming.listen(taskSeen.add);
+      addTearDown(taskSub.cancel);
+
+      final entry = c.read(sessionsProvider.notifier).addOrActivate(_params());
+      await Future<void>.delayed(Duration.zero);
+      final startsAfterConnect = starts;
+      expect(startsAfterConnect, greaterThanOrEqualTo(1),
+          reason: 'addOrActivate already starts the service once');
+      taskSeen.clear();
+
+      c.read(sessionsProvider.notifier).reconnect(entry.id);
+      // Settle the starter future + the async profile/secret resolution.
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(starts, greaterThan(startsAfterConnect),
+          reason: 'reconnect must (re)start the keepalive service');
+      final connect = taskSeen.firstWhere(
+        (m) =>
+            m['sessionId'] == entry.id &&
+            m['kind'] == SshTaskCommandKind.connect.name,
+        orElse: () => <String, dynamic>{},
+      );
+      expect(connect, isNotEmpty,
+          reason: 'a credentialed connect must reach the task side on revive');
+      // The re-issued connect must carry the re-resolved auth (no user prompt).
+      expect(connect['auth'], isNotNull,
+          reason: 'revive connect must re-supply auth from the vault');
+    });
+
+    // Fallback: an ad-hoc session with no matching saved profile still revives
+    // via the held-params reconnect command (no creds to re-resolve).
+    test('reconnect(id) with no saved profile falls back to a reconnect '
+        'command', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      var starts = 0;
+      final (c, pair) = _makeContainerWithPair(
+        onStart: () => starts++,
+        profiles: ProfilesStore(prefs: prefs), // empty store
+        secrets: SecretsStore(backend: InMemorySecretsBackend()),
+      );
+      addTearDown(c.dispose);
+      final taskSeen = <Map<String, dynamic>>[];
+      final taskSub = pair.taskSide.incoming.listen(taskSeen.add);
+      addTearDown(taskSub.cancel);
+
+      final entry = c.read(sessionsProvider.notifier).addOrActivate(_params());
+      await Future<void>.delayed(Duration.zero);
+      taskSeen.clear();
+
+      c.read(sessionsProvider.notifier).reconnect(entry.id);
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(
+        taskSeen.any((m) =>
+            m['sessionId'] == entry.id &&
+            m['kind'] == SshTaskCommandKind.reconnect.name),
+        isTrue,
+        reason: 'no saved creds → held-params reconnect command',
+      );
+    });
+
+    test('reconnect(id) on an unknown id is a no-op', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      var starts = 0;
+      final (c, pair) = _makeContainerWithPair(
+        onStart: () => starts++,
+        profiles: ProfilesStore(prefs: prefs),
+        secrets: SecretsStore(backend: InMemorySecretsBackend()),
+      );
+      addTearDown(c.dispose);
+      final taskSeen = <Map<String, dynamic>>[];
+      final taskSub = pair.taskSide.incoming.listen(taskSeen.add);
+      addTearDown(taskSub.cancel);
+
+      c.read(sessionsProvider.notifier).reconnect('does-not-exist');
+      await Future<void>.delayed(Duration.zero);
+      expect(starts, 0,
+          reason: 'unknown id must not start the service');
+      expect(taskSeen, isEmpty,
+          reason: 'unknown id must not send anything');
     });
   });
 }

--- a/native/test/widget/session_menu_active_state_test.dart
+++ b/native/test/widget/session_menu_active_state_test.dart
@@ -1,0 +1,389 @@
+// Widget tests: Active Sessions UI — state-driven session-menu rows (#817).
+//
+// Slice 2 of the session-lifecycle fix (#811). A dropped/zombie session must
+// never be an invisible or ✕-only tile: each row reads `entry.proxy.data.state`
+// (NOT a boolean) and surfaces a status dot + a per-state action:
+//   connected → solid dot, [Files][✕]
+//   connecting/authenticating/awaitingHostKey → pulsing dot, "Connecting…", [✕]
+//   softDisconnected/reconnecting → amber dot, "Reconnecting…", [Reconnect][✕]
+//   failed → red dot + reason, [Reconnect][✕]
+//   disconnected (user) → grey dot, "Disconnected", [Reconnect][✕]
+//
+// State is driven exactly as the real task isolate would: push SshStateEvent /
+// SshErrorEvent from the task side through the in-memory gateway pair keyed by
+// the session id. Reconnect dispatch is asserted by reading the SshReconnect
+// command off the task side of the gateway.
+//
+// Isolation (feedback_feature_scoping_and_isolation_tests): N sessions, drop
+// ONE → the others' rows are unchanged; Reconnect/✕ on one never touches
+// another.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/session_menu.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _host({required ProviderContainer container}) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(
+              key: const Key('open-menu'),
+              onPressed: () => showSessionMenu(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 8}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+SessionEntry _add(ProviderContainer c, String host) {
+  return c.read(sessionsProvider.notifier).addOrActivate(
+        SshConnectParams(
+          host: host,
+          port: 22,
+          username: 'u',
+          auth: const SshAuth.password('p'),
+        ),
+      );
+}
+
+/// Push a state event for [entry] from the task side of [pair], as the real
+/// `SessionHost` would. `error` carries the failure reason for `failed`.
+void _drive(
+  InMemoryGatewayPair pair,
+  SessionEntry entry,
+  SshSessionState state, {
+  String? error,
+}) {
+  pair.taskSide.send(
+    SshStateEvent(
+      sessionId: entry.id,
+      state: state.name,
+      error: error,
+      host: entry.host,
+      port: entry.port,
+      username: entry.username,
+    ).toJson(),
+  );
+}
+
+/// The fill color of the row's status dot (the swatch container).
+Color _dotColor(WidgetTester tester, SessionEntry entry) {
+  final container = tester.widget<Container>(
+    find.byKey(Key('session-menu-swatch-${entry.id}')),
+  );
+  final decoration = container.decoration as BoxDecoration;
+  return decoration.color!;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  ({ProviderContainer container, InMemoryGatewayPair pair}) make() {
+    final pair = InMemoryGatewayPair();
+    final container = ProviderContainer(
+      overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+    );
+    addTearDown(() async {
+      await pair.dispose();
+    });
+    addTearDown(container.dispose);
+    return (container: container, pair: pair);
+  }
+
+  group('Active Sessions UI — state-driven rows (#817)', () {
+    testWidgets(
+      'failed session → red dot + reason + Reconnect (Files + ✕ still present)',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        _drive(w.pair, a, SshSessionState.failed,
+            error: 'No SSH response in 25s');
+        await _pumpFrames(tester);
+
+        // Status surfaced: dot color = theme error (red), reason text, Reconnect.
+        expect(
+          find.byKey(Key('session-menu-status-dot-${a.id}')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(Key('session-menu-reconnect-${a.id}')),
+          findsOneWidget,
+          reason: 'a failed session must offer Reconnect',
+        );
+        expect(
+          find.text('No SSH response in 25s'),
+          findsOneWidget,
+          reason: 'the failure reason is shown on the row',
+        );
+        // The ✕ (forget) and the per-row Files affordance both stay (#649).
+        expect(find.byKey(Key('session-menu-close-${a.id}')), findsOneWidget);
+        expect(find.byKey(Key('session-menu-files-${a.id}')), findsOneWidget);
+        expect(
+          _dotColor(tester, a),
+          Theme.of(tester.element(find.byKey(Key('session-menu-row-${a.id}'))))
+              .colorScheme
+              .error,
+        );
+      },
+    );
+
+    testWidgets(
+      'reconnecting session → amber dot + "Reconnecting…" + Reconnect',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        _drive(w.pair, a, SshSessionState.reconnecting);
+        await _pumpFrames(tester);
+
+        expect(find.text('Reconnecting…'), findsOneWidget);
+        expect(
+          find.byKey(Key('session-menu-reconnect-${a.id}')),
+          findsOneWidget,
+        );
+        expect(_dotColor(tester, a), Colors.orange.shade700);
+      },
+    );
+
+    testWidgets(
+      'user-disconnected session → grey dot + Reconnect (not invisible)',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        _drive(w.pair, a, SshSessionState.disconnected);
+        await _pumpFrames(tester);
+
+        expect(find.text('Disconnected'), findsOneWidget);
+        expect(
+          find.byKey(Key('session-menu-reconnect-${a.id}')),
+          findsOneWidget,
+          reason: 'a dropped session is reconnectable, not ✕-only',
+        );
+      },
+    );
+
+    testWidgets(
+      'connecting session → "Connecting…", NO Reconnect (already trying)',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        _drive(w.pair, a, SshSessionState.connecting);
+        await _pumpFrames(tester);
+
+        expect(find.text('Connecting…'), findsOneWidget);
+        expect(
+          find.byKey(Key('session-menu-reconnect-${a.id}')),
+          findsNothing,
+          reason: 'a session already connecting has nothing to reconnect',
+        );
+      },
+    );
+
+    testWidgets(
+      'connected session → Files + ✕, no Reconnect, no status subtitle',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        _drive(w.pair, a, SshSessionState.connected);
+        await _pumpFrames(tester);
+
+        expect(find.byKey(Key('session-menu-files-${a.id}')), findsOneWidget);
+        expect(find.byKey(Key('session-menu-close-${a.id}')), findsOneWidget);
+        expect(
+          find.byKey(Key('session-menu-reconnect-${a.id}')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(Key('session-menu-status-text-${a.id}')),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('tapping Reconnect sends a reconnect command for THAT session', (
+      tester,
+    ) async {
+      final w = make();
+      final a = _add(w.container, 'host-a');
+
+      // Capture commands arriving on the task side.
+      final commands = <Map<String, dynamic>>[];
+      final sub = w.pair.taskSide.incoming.listen(commands.add);
+      addTearDown(sub.cancel);
+
+      await tester.pumpWidget(_host(container: w.container));
+      await tester.tap(find.byKey(const Key('open-menu')));
+      await _pumpFrames(tester);
+
+      _drive(w.pair, a, SshSessionState.failed, error: 'boom');
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(Key('session-menu-reconnect-${a.id}')));
+      await _pumpFrames(tester);
+
+      final reconnects = commands
+          .where((c) => c['kind'] == SshTaskCommandKind.reconnect.name)
+          .toList();
+      expect(reconnects.length, 1);
+      expect(reconnects.single['sessionId'], a.id);
+    });
+
+    testWidgets(
+      'isolation: dropping ONE session leaves the others unchanged',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+        final b = _add(w.container, 'host-b');
+        final c = _add(w.container, 'host-c');
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        // All start connected.
+        _drive(w.pair, a, SshSessionState.connected);
+        _drive(w.pair, b, SshSessionState.connected);
+        _drive(w.pair, c, SshSessionState.connected);
+        await _pumpFrames(tester);
+
+        // Drop only b.
+        _drive(w.pair, b, SshSessionState.failed, error: 'just b');
+        await _pumpFrames(tester);
+
+        // b shows Reconnect; a and c do NOT (no leakage).
+        expect(
+          find.byKey(Key('session-menu-reconnect-${b.id}')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(Key('session-menu-reconnect-${a.id}')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(Key('session-menu-reconnect-${c.id}')),
+          findsNothing,
+        );
+        // a and c keep their Files affordance (still connected).
+        expect(find.byKey(Key('session-menu-files-${a.id}')), findsOneWidget);
+        expect(find.byKey(Key('session-menu-files-${c.id}')), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'isolation: ✕ on one dropped session does not affect a sibling',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+        final b = _add(w.container, 'host-b');
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        _drive(w.pair, a, SshSessionState.failed, error: 'a down');
+        _drive(w.pair, b, SshSessionState.failed, error: 'b down');
+        await _pumpFrames(tester);
+
+        // Forget a.
+        await tester.tap(find.byKey(Key('session-menu-close-${a.id}')));
+        await _pumpFrames(tester);
+
+        final entries = w.container.read(sessionsProvider).entries;
+        expect(entries.length, 1);
+        expect(entries.single.id, b.id);
+      },
+    );
+
+    testWidgets(
+      'Reconnect all appears when any session is dropped, reconnects each',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+        final b = _add(w.container, 'host-b');
+
+        final commands = <Map<String, dynamic>>[];
+        final sub = w.pair.taskSide.incoming.listen(commands.add);
+        addTearDown(sub.cancel);
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        // Both connected → no Reconnect-all.
+        _drive(w.pair, a, SshSessionState.connected);
+        _drive(w.pair, b, SshSessionState.connected);
+        await _pumpFrames(tester);
+        expect(
+          find.byKey(const Key('session-menu-reconnect-all')),
+          findsNothing,
+        );
+
+        // Drop both → Reconnect-all appears.
+        _drive(w.pair, a, SshSessionState.failed, error: 'x');
+        _drive(w.pair, b, SshSessionState.disconnected);
+        await _pumpFrames(tester);
+        expect(
+          find.byKey(const Key('session-menu-reconnect-all')),
+          findsOneWidget,
+        );
+
+        await tester.tap(find.byKey(const Key('session-menu-reconnect-all')));
+        await _pumpFrames(tester);
+
+        final reconnects = commands
+            .where((c) => c['kind'] == SshTaskCommandKind.reconnect.name)
+            .map((c) => c['sessionId'] as String)
+            .toSet();
+        expect(reconnects, {a.id, b.id});
+      },
+    );
+  });
+}

--- a/native/test/widget/session_menu_test.dart
+++ b/native/test/widget/session_menu_test.dart
@@ -2,9 +2,15 @@
 //
 // Covers the contract the PWA's session menu exposes:
 //   - tap-to-switch sets activeSessionId and dismisses the menu
-//   - long-press opens the contextual actions sheet
 //   - the keybar toggle flips ONLY the active session's keybar (#573)
 //   - the close affordance on each row removes the entry
+//
+// #817: the long-press contextual actions sheet was removed — the row's
+// Disconnect/Close are now always-visible per-row affordances (the ✕ button,
+// plus a Reconnect button for dropped sessions). A dropped session must be
+// directly actionable, not hidden behind a long-press. The Active-Sessions UI
+// state surface (status dot + per-state action) is covered by
+// `session_menu_active_state_test.dart`.
 //
 // Tests pump bounded frames rather than `pumpAndSettle` — the modal bottom
 // sheet's slide animation can leave the harness waiting forever for a
@@ -106,7 +112,7 @@ void main() {
       expect(find.byKey(const Key('session-menu')), findsNothing);
     });
 
-    testWidgets('long-press opens the contextual actions sheet', (
+    testWidgets('each row exposes an always-visible close (✕) affordance (#817)', (
       tester,
     ) async {
       final container = _makeContainer();
@@ -127,16 +133,17 @@ void main() {
       await tester.tap(find.byKey(const Key('open-menu')));
       await _pumpFrames(tester);
 
-      await tester.longPress(find.byKey(Key('session-menu-row-${entry.id}')));
-      await _pumpFrames(tester);
-
+      // The close (✕) action is directly on the row — no long-press needed.
       expect(
-        find.byKey(const Key('session-menu-action-disconnect')),
+        find.byKey(Key('session-menu-close-${entry.id}')),
         findsOneWidget,
       );
+      // The old long-press contextual sheet is gone (#817).
+      await tester.longPress(find.byKey(Key('session-menu-row-${entry.id}')));
+      await _pumpFrames(tester);
       expect(
-        find.byKey(const Key('session-menu-action-close')),
-        findsOneWidget,
+        find.byKey(const Key('session-menu-action-disconnect')),
+        findsNothing,
       );
     });
 


### PR DESCRIPTION
## Summary
- Session-menu rows are now **state-driven** (#811 Slice 2): each `_SessionRow` watches `entry.proxy.stream` and renders a status dot + per-state subtitle + a **Reconnect** button for drop states. A dropped/zombie session is never an invisible or ✕-only tile.
- Per-state surface (reads `state`, never booleans): connected → solid dot + Files/✕; connecting/auth/awaitingHostKey → pulsing dot + "Connecting…"; softDisconnected/reconnecting → amber dot + "Reconnecting…" + Reconnect; failed → red dot + reason + Reconnect; disconnected (user) → grey dot + Reconnect. Plus a **"Reconnect all"** affordance when any session is non-connected.
- **Reconnect re-enters the connect path from task-held params** (no auth re-supply): new `SshSessionController.reconnectNow()` (force, ignores the resume staleness threshold, overrides the user-disconnect suppress bit — an explicit revive), a `reconnect` command kind + `SshReconnectCommand`, `SshSessionProxy.reconnect()`, and `SessionHost` routing.

## Scope
- Files stays a per-row affordance in **every** state (#649 contract — the browser handles a non-live link itself); Reconnect is purely ADDED for drop states.
- Removed the long-press contextual sheet (Disconnect/Close) — superseded by the always-visible per-row ✕ + Reconnect (the point of #817: dropped sessions must be directly actionable).
- Does **NOT** touch recents-suppression (`profile_list.dart` `hasActiveSession`) — that's Slice 3 (#809).

## TDD Analysis
- Type: feature
- Behavior change: yes (state-driven row surface + Reconnect path)
- TDD approach: full for the controller/protocol; widget smoketests + isolation for the UI; emulator integration for the device path.

## Test coverage
- **New (fail→pass)**:
  - `test/ssh/reconnect_now_test.dart` — `reconnectNow()` from failed/disconnected/reconnecting, OVERRIDES a user disconnect, no-op on connected / no params.
  - `test/services/reconnect_command_host_test.dart` — `SshReconnectCommand` routes to `controller.reconnectNow()`; unhosted session is a safe no-op.
  - `test/services/task_ipc_test.dart` — `SshReconnectCommand` round-trip.
  - `test/widget/session_menu_active_state_test.dart` — each state → correct dot color + action; Reconnect dispatches a command for THAT session; per-session isolation (drop one, others unchanged; ✕/Reconnect doesn't leak); Reconnect-all.
  - `integration_test/active_session_reconnect_test.dart` — on-emulator: connect → drop → Reconnect button appears → tap → live shell again (tag `integration`, orchestrator-run).
- **Updated**: `test/widget/session_menu_test.dart` — long-press sheet replaced by always-visible per-row ✕.

## Test results
- flutter analyze: PASS (no issues)
- native fast gate (`native-fast-gate.sh`): PASS — 1009 tests
- integration: authored, orchestrator runs on emulator

## Diff stats
- Files changed: 11
- Lines: +1257 / -65 (lib ≈ +110 net; rest tests)

Closes #817

## Cycles used
1/3