### PR TITLE
feat(native): recents reconciliation — Active Sessions in Connect view (#821, closes #809)

### DIFF
--- a/native/integration_test/connect_view_active_session_test.dart
+++ b/native/integration_test/connect_view_active_session_test.dart
@@ -1,0 +1,164 @@
+// On-emulator: a dropped session is visible + reconnectable from the CONNECT
+// VIEW's Active Sessions group (#821 Slice 3, #811, closes #809).
+// Orchestrator-run (tag `integration`).
+//
+// The owner's pain (#809): after a disconnect the session vanished from the
+// home/Connect view (recents were suppressed by the lingering entry AND the
+// dropped session had no Connect-view surface). Slice 3 brings the in-session
+// menu's Reconnect surface (#817) to the Connect view, so a dropped session
+// stays reachable from the home screen.
+//
+// Full device path: connect to test-sshd → drop the session (proxy.disconnect →
+// `disconnected`) → open the session menu → "Profiles & settings" (the Connect
+// view OVER the live sessions) → assert the dropped session shows an Active
+// Sessions row with a Reconnect button → tap it → prove the shell streams bytes
+// again.
+//
+// PASS = the Active Sessions Reconnect button appears on the Connect view AND
+// tapping it revives the session to a live shell.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+Future<bool> _proveShellBytes(WidgetTester tester, dynamic entry) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  var gotBytes = false;
+  for (var i = 0; i < 40; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+    if (out.isNotEmpty) {
+      gotBytes = true;
+      break;
+    }
+  }
+  await sub.cancel();
+  return gotBytes;
+}
+
+Future<bool> _connect(WidgetTester tester) async {
+  await adhocPasswordConnect(
+    tester,
+    host: '127.0.0.1',
+    port: '2222',
+    user: 'testuser',
+    pass: 'testpass',
+  );
+  for (var i = 0; i < 60; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+    final accept = find.text('Trust + connect');
+    if (accept.evaluate().isNotEmpty) {
+      await tester.tap(accept.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'a dropped session is reconnectable from the Connect view Active Sessions '
+    'group (#809)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(await _connect(tester), isTrue, reason: 'initial connect failed');
+
+      final entry = container.read(sessionsProvider).active!;
+      final sid = entry.id;
+
+      expect(
+        await _proveShellBytes(tester, entry),
+        isTrue,
+        reason: 'first connect did not stream shell bytes',
+      );
+
+      // Drop the session WITHOUT removing the entry (the zombie-tile condition).
+      entry.proxy.disconnect();
+      var dropped = false;
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        final state = entry.proxy.data.state;
+        if (state == SshSessionState.disconnected ||
+            state == SshSessionState.failed ||
+            state == SshSessionState.softDisconnected) {
+          dropped = true;
+          break;
+        }
+      }
+      expect(dropped, isTrue, reason: 'session never reached a drop state');
+      expect(
+        container.read(sessionsProvider).entries.any((e) => e.id == sid),
+        isTrue,
+        reason: 'a drop must not forget the session',
+      );
+
+      // Open the session menu, then route to the full Connect view OVER the
+      // (dropped) session via "Profiles & settings".
+      await tester.tap(find.byKey(const Key('session-bar-open-menu')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
+      await tester.tap(find.byKey(const Key('session-menu-new')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 600));
+
+      // The Connect view's Active Sessions group shows the dropped session with
+      // a Reconnect affordance — NOT vanished (#809).
+      expect(
+        find.byKey(const Key('active-sessions-group')),
+        findsOneWidget,
+        reason: 'the Connect view must show the Active Sessions group',
+      );
+      final reconnectBtn = find.byKey(Key('active-session-reconnect-$sid'));
+      expect(
+        reconnectBtn,
+        findsOneWidget,
+        reason: 'a dropped session must offer Reconnect on the Connect view',
+      );
+
+      // Tap Reconnect → re-enter the connect path.
+      await tester.tap(reconnectBtn);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      var reconnected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (entry.proxy.data.state == SshSessionState.connected) {
+          reconnected = true;
+          break;
+        }
+      }
+      expect(
+        reconnected,
+        isTrue,
+        reason: 'Reconnect did not drive the session back to connected',
+      );
+      expect(
+        await _proveShellBytes(tester, entry),
+        isTrue,
+        reason: 'Reconnect reached connected but no live shell bytes flowed',
+      );
+    },
+  );
+}

--- a/native/lib/ui/profile_list.dart
+++ b/native/lib/ui/profile_list.dart
@@ -16,6 +16,8 @@
 //     error opens a non-blocking detail dialog (explicit, user-initiated).
 // The row stays reactive by watching the matching session's proxy state stream.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -23,7 +25,9 @@ import '../ssh/ssh_session.dart';
 import '../state/profiles_providers.dart';
 import '../state/recent_sessions.dart';
 import '../state/sessions.dart';
+import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
+import 'session_state_dot.dart';
 
 typedef ProfileSelectCallback = void Function(SavedProfile profile);
 typedef RecentSelectCallback = void Function(RecentSessionEntry entry);
@@ -82,9 +86,16 @@ class ProfileList extends ConsumerWidget {
         ),
       ),
       data: (profiles) {
+        // Active Sessions group (#821 Slice 3, PWA `activeSessionList`): every
+        // live OR dropped session renders at the TOP — connected sessions get a
+        // Switch, dropped ones a Reconnect, all an ✕. This is the Connect-view
+        // surface that keeps a DROPPED session reachable from the home screen
+        // (#809) instead of it vanishing the moment recents are suppressed.
+        final activeGroup = _buildActiveSessionsGroup(context, ref);
+
         // Recent Sessions group (#796, PWA #385): a one-tap quick-connect group
-        // shown ABOVE the saved-profile list, ONLY on cold start (no active
-        // sessions) — exactly the PWA's `allSessions.length === 0` guard. It's
+        // shown ABOVE the saved-profile list, ONLY on cold start (no sessions at
+        // all) — exactly the PWA's `allSessions.length === 0` guard. It's
         // disabled entirely when the caller didn't wire [onConnectRecent].
         final recentsGroup = _buildRecentsGroup(context, ref);
 
@@ -141,6 +152,7 @@ class ProfileList extends ConsumerWidget {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            ?activeGroup,
             ?recentsGroup,
             profilesSection,
           ],
@@ -157,11 +169,13 @@ class ProfileList extends ConsumerWidget {
     final onTapRecent = onConnectRecent;
     if (onTapRecent == null) return null;
 
-    // PWA parity: the recents group only shows when there are NO active
-    // sessions (cold start). Once a session exists, the saved-profile list
-    // owns the screen.
-    final hasActiveSession = ref.watch(sessionsProvider).entries.isNotEmpty;
-    if (hasActiveSession) return null;
+    // PWA parity (#821): the recents group only shows on TRUE cold start — when
+    // there are NO sessions at all (the PWA `allSessions.length === 0` guard).
+    // A DROPPED session is still a live SessionEntry, so it now surfaces in the
+    // Active Sessions group above (never suppressed-invisible, #809). Recents
+    // stay the pure cold-start quick-connect list.
+    final hasAnySession = ref.watch(sessionsProvider).entries.isNotEmpty;
+    if (hasAnySession) return null;
 
     final recents = ref.watch(recentSessionsProvider).valueOrNull ?? const [];
     if (recents.isEmpty) return null;
@@ -203,6 +217,228 @@ class ProfileList extends ConsumerWidget {
           ),
         const Divider(height: 1),
       ],
+    );
+  }
+
+  /// Build the Active Sessions group (#821 Slice 3), or null when there are no
+  /// sessions at all. Mirrors the PWA `activeSessionList` block in
+  /// `loadProfiles`: an "Active Sessions" header, one row per session (connected
+  /// → Switch, dropped → Reconnect, all → ✕), and a "Reconnect all" affordance
+  /// when ANY session is non-connected. Brings the in-session menu's Slice-2
+  /// surface (`session_menu.dart`) to the CONNECT view so a dropped session is
+  /// reconnectable from the home screen instead of vanishing (#809).
+  Widget? _buildActiveSessionsGroup(BuildContext context, WidgetRef ref) {
+    final entries = ref.watch(sessionsProvider).entries;
+    if (entries.isEmpty) return null;
+
+    return Column(
+      key: const Key('active-sessions-group'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 4, bottom: 4),
+          child: Text(
+            'Active Sessions',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+        ),
+        // shrinkWrap: this group sits above the Expanded saved-profile list, so
+        // it sizes to its content rather than demanding infinite height.
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: entries.length,
+          itemBuilder: (context, i) => _ActiveSessionTile(entry: entries[i]),
+        ),
+        _ActiveReconnectAllRow(entries: entries),
+        const Divider(height: 1),
+      ],
+    );
+  }
+}
+
+/// One Active Sessions row in the Connect view (#821 Slice 3). Mirrors the PWA
+/// `active-session-item`: a state-driven status dot + the session label, a
+/// per-state primary action (Switch when connected, Reconnect when dropped),
+/// and an always-present ✕ (forget). Reactive via a [StreamBuilder] on the
+/// proxy state so the row repaints as the session moves connected ↔ dropped
+/// without re-entering the chooser — exactly the in-menu `_SessionRow` (#817)
+/// behaviour, brought to the home screen.
+class _ActiveSessionTile extends ConsumerWidget {
+  const _ActiveSessionTile({required this.entry});
+
+  final SessionEntry entry;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileColor = ref.watch(sessionColorProvider(entry.id));
+    return StreamBuilder<SshSessionData>(
+      stream: entry.proxy.stream,
+      initialData: entry.proxy.data,
+      builder: (context, snapshot) {
+        final state = snapshot.data?.state ?? entry.proxy.data.state;
+        return _buildRow(context, ref, state, profileColor);
+      },
+    );
+  }
+
+  Widget _buildRow(
+    BuildContext context,
+    WidgetRef ref,
+    SshSessionState state,
+    Color? profileColor,
+  ) {
+    final canReconnect = sessionCanReconnect(state);
+    return ListTile(
+      key: Key('active-session-tile-${entry.id}'),
+      dense: true,
+      leading: SessionStateDot(
+        key: Key('active-session-dot-${entry.id}'),
+        swatchKey: Key('active-session-swatch-${entry.id}'),
+        state: state,
+        profileColor: profileColor,
+      ),
+      title: Text(entry.label, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        '${entry.username}@${entry.host}:${entry.port}',
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (canReconnect)
+            // Reconnect a dropped session from held params / re-resolved creds
+            // (#817). Routed through the notifier so the foreground task isolate
+            // is (re)started first — a bare proxy.reconnect() would buffer
+            // against a dead isolate forever after a last-session drop.
+            IconButton(
+              key: Key('active-session-reconnect-${entry.id}'),
+              tooltip: 'Reconnect',
+              visualDensity: VisualDensity.compact,
+              icon: const Icon(Icons.replay),
+              onPressed: () =>
+                  ref.read(sessionsProvider.notifier).reconnect(entry.id),
+            )
+          else
+            // Connected (or still connecting): Switch makes this the active
+            // session and returns to the terminal. `maybePop` returns to the
+            // live terminal when this list is a pushed route OVER a session
+            // (#721); at the cold-start root there's nothing to pop and the
+            // router already shows the terminal for a connected session.
+            IconButton(
+              key: Key('active-session-switch-${entry.id}'),
+              tooltip: 'Switch to session',
+              visualDensity: VisualDensity.compact,
+              icon: const Icon(Icons.login),
+              onPressed: () {
+                ref.read(sessionsProvider.notifier).setActive(entry.id);
+                Navigator.of(context).maybePop();
+              },
+            ),
+          // ✕ ALWAYS present — "forget this session" (explicit close), the same
+          // contract as the in-menu row (#817).
+          IconButton(
+            key: Key('active-session-close-${entry.id}'),
+            tooltip: 'Close session',
+            visualDensity: VisualDensity.compact,
+            icon: const Icon(Icons.close),
+            onPressed: () =>
+                ref.read(sessionsProvider.notifier).close(entry.id),
+          ),
+        ],
+      ),
+      // A whole-row tap switches to the session (PWA `data-action="switch"`),
+      // same as the explicit Switch button.
+      onTap: () {
+        ref.read(sessionsProvider.notifier).setActive(entry.id);
+        Navigator.of(context).maybePop();
+      },
+    );
+  }
+}
+
+/// "Reconnect all" for the Connect-view Active Sessions group (#821 Slice 3).
+/// Shown only when at least one session is in a manually-reconnectable drop
+/// state; each tap reconnects every dropped session (held params / re-resolved
+/// creds). Subscribes to every entry's proxy state so it appears/disappears
+/// reactively — the same pattern as the in-menu `_ReconnectAllRow` (#817).
+class _ActiveReconnectAllRow extends ConsumerStatefulWidget {
+  const _ActiveReconnectAllRow({required this.entries});
+
+  final List<SessionEntry> entries;
+
+  @override
+  ConsumerState<_ActiveReconnectAllRow> createState() =>
+      _ActiveReconnectAllRowState();
+}
+
+class _ActiveReconnectAllRowState
+    extends ConsumerState<_ActiveReconnectAllRow> {
+  final List<StreamSubscription<SshSessionData>> _subs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateWidget(_ActiveReconnectAllRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _resubscribe();
+  }
+
+  void _subscribe() {
+    for (final e in widget.entries) {
+      _subs.add(
+        e.proxy.stream.listen((_) {
+          if (mounted) setState(() {});
+        }),
+      );
+    }
+  }
+
+  void _resubscribe() {
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _subs.clear();
+    _subscribe();
+  }
+
+  @override
+  void dispose() {
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _subs.clear();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dropped = widget.entries
+        .where((e) => sessionCanReconnect(e.proxy.data.state))
+        .toList();
+    if (dropped.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: 4, bottom: 4),
+      child: OutlinedButton.icon(
+        key: const Key('active-sessions-reconnect-all'),
+        icon: const Icon(Icons.restart_alt, size: 18),
+        label: Text(
+          dropped.length == 1
+              ? 'Reconnect'
+              : 'Reconnect all (${dropped.length})',
+        ),
+        onPressed: () {
+          final notifier = ref.read(sessionsProvider.notifier);
+          for (final e in dropped) {
+            notifier.reconnect(e.id);
+          }
+        },
+      ),
     );
   }
 }

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -31,6 +31,7 @@ import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart' show ProfilesStore;
 import 'file_browser_screen.dart';
+import 'session_state_dot.dart';
 
 /// Opens the session menu as a NON-MODAL overlay anchored to the bottom, above
 /// the keyboard. Returns once dismissed (outside tap or an action closes it).
@@ -701,7 +702,7 @@ class _SessionRow extends ConsumerWidget {
       leading: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _StatusDot(
+          SessionStateDot(
             key: Key('session-menu-status-dot-${entry.id}'),
             // The swatch key is retained (#739 tests + device screenshots
             // address it) and now lives on the same dot.
@@ -753,7 +754,7 @@ class _SessionRow extends ConsumerWidget {
               openFileBrowser(navigator.context, sessionId);
             },
           ),
-          if (_canReconnect(state))
+          if (sessionCanReconnect(state))
             IconButton(
               key: Key('session-menu-reconnect-${entry.id}'),
               tooltip: 'Reconnect',
@@ -784,16 +785,6 @@ class _SessionRow extends ConsumerWidget {
         onClose();
       },
     );
-  }
-
-  /// True when the session is in a drop state the user can manually reconnect
-  /// from (#817). A live/connecting session is excluded — it's already healthy
-  /// or trying. Reads STATE, never a boolean.
-  static bool _canReconnect(SshSessionState state) {
-    return state == SshSessionState.softDisconnected ||
-        state == SshSessionState.reconnecting ||
-        state == SshSessionState.failed ||
-        state == SshSessionState.disconnected;
   }
 
   /// The per-state status line under the row label, or null for `connected`
@@ -849,115 +840,6 @@ class _SessionRow extends ConsumerWidget {
           ),
         );
     }
-  }
-}
-
-/// State-driven status dot for a session row (#817). The COLOR encodes the
-/// lifecycle state; `connecting`/`reconnecting` pulse to signal "in flight".
-/// Monochrome / theme-derived colors only — no emoji
-/// (feedback_monochrome_icons_no_emoji):
-///   connected → solid profile color (else theme accent)
-///   connecting/authenticating/awaitingHostKey → pulsing accent
-///   softDisconnected/reconnecting → amber
-///   failed → red (theme error)
-///   disconnected (user) / idle → grey (outlineVariant)
-class _StatusDot extends StatefulWidget {
-  const _StatusDot({
-    super.key,
-    required this.swatchKey,
-    required this.state,
-    required this.profileColor,
-  });
-
-  final Key swatchKey;
-  final SshSessionState state;
-  final Color? profileColor;
-
-  @override
-  State<_StatusDot> createState() => _StatusDotState();
-}
-
-class _StatusDotState extends State<_StatusDot>
-    with SingleTickerProviderStateMixin {
-  // Constructed eagerly in initState (NOT `late final`): a lazy field would be
-  // built inside dispose() if it was never animated, and constructing an
-  // AnimationController during unmount does a TickerMode ancestor lookup on a
-  // deactivated widget (crash). Eager construction makes dispose() always safe.
-  late final AnimationController _pulse;
-
-  bool get _pulsing =>
-      widget.state == SshSessionState.connecting ||
-      widget.state == SshSessionState.authenticating ||
-      widget.state == SshSessionState.awaitingHostKey ||
-      widget.state == SshSessionState.softDisconnected ||
-      widget.state == SshSessionState.reconnecting;
-
-  @override
-  void initState() {
-    super.initState();
-    _pulse = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 900),
-      value: 1.0,
-    );
-    if (_pulsing) _pulse.repeat(reverse: true);
-  }
-
-  @override
-  void didUpdateWidget(_StatusDot oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (_pulsing && !_pulse.isAnimating) {
-      _pulse.repeat(reverse: true);
-    } else if (!_pulsing && _pulse.isAnimating) {
-      _pulse
-        ..stop()
-        ..value = 1.0;
-    }
-  }
-
-  @override
-  void dispose() {
-    _pulse.dispose();
-    super.dispose();
-  }
-
-  Color _color(ThemeData theme) {
-    switch (widget.state) {
-      // connected (and idle, pre-connect) keep the PROFILE color so the SAME
-      // color still identifies the SAME profile across the app (#739, PWA
-      // `session-dot`). A colorless session shows the neutral fallback — never a
-      // fake real-looking color (#739).
-      case SshSessionState.idle:
-      case SshSessionState.connected:
-        return widget.profileColor ?? theme.colorScheme.outlineVariant;
-      case SshSessionState.connecting:
-      case SshSessionState.authenticating:
-      case SshSessionState.awaitingHostKey:
-        return theme.colorScheme.primary;
-      case SshSessionState.softDisconnected:
-      case SshSessionState.reconnecting:
-        return Colors.orange.shade700;
-      case SshSessionState.failed:
-        return theme.colorScheme.error;
-      case SshSessionState.disconnected:
-        return theme.colorScheme.outlineVariant;
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final color = _color(Theme.of(context));
-    final dot = Container(
-      key: widget.swatchKey,
-      width: 10,
-      height: 10,
-      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-    );
-    if (!_pulsing) return dot;
-    return FadeTransition(
-      opacity: Tween<double>(begin: 0.35, end: 1.0).animate(_pulse),
-      child: dot,
-    );
   }
 }
 
@@ -1018,17 +900,11 @@ class _ReconnectAllRowState extends ConsumerState<_ReconnectAllRow> {
     super.dispose();
   }
 
-  bool _isDropped(SshSessionState state) {
-    return state == SshSessionState.softDisconnected ||
-        state == SshSessionState.reconnecting ||
-        state == SshSessionState.failed ||
-        state == SshSessionState.disconnected;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final dropped =
-        widget.entries.where((e) => _isDropped(e.proxy.data.state)).toList();
+    final dropped = widget.entries
+        .where((e) => sessionCanReconnect(e.proxy.data.state))
+        .toList();
     if (dropped.isEmpty) return const SizedBox.shrink();
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),

--- a/native/lib/ui/session_state_dot.dart
+++ b/native/lib/ui/session_state_dot.dart
@@ -1,0 +1,134 @@
+// Shared session-state affordances (#821 Slice 3, extracted from #817 Slice 2).
+//
+// Slice 2 added a state-driven status dot + a "can this session be manually
+// reconnected?" predicate to the in-session MENU (session_menu.dart). Slice 3
+// brings the SAME surface to the CONNECT view's Active Sessions group
+// (profile_list.dart), so a dropped session is reconnectable from the home
+// screen. To avoid duplicating the state→affordance mapping (the explicit
+// instruction in #821), the dot widget + the reconnect predicate live here and
+// are reused by both surfaces.
+
+import 'package:flutter/material.dart';
+
+import '../ssh/ssh_session.dart';
+
+/// True when [state] is a drop the user can manually reconnect from (#817).
+/// A live/connecting session is excluded — it's already healthy or trying.
+/// Reads STATE, never a boolean.
+bool sessionCanReconnect(SshSessionState state) {
+  return state == SshSessionState.softDisconnected ||
+      state == SshSessionState.reconnecting ||
+      state == SshSessionState.failed ||
+      state == SshSessionState.disconnected;
+}
+
+/// State-driven status dot for a session (#817). The COLOR encodes the
+/// lifecycle state; `connecting`/`reconnecting` pulse to signal "in flight".
+/// Monochrome / theme-derived colors only — no emoji
+/// (feedback_monochrome_icons_no_emoji):
+///   connected → solid profile color (else theme accent)
+///   connecting/authenticating/awaitingHostKey → pulsing accent
+///   softDisconnected/reconnecting → amber
+///   failed → red (theme error)
+///   disconnected (user) / idle → grey (outlineVariant)
+class SessionStateDot extends StatefulWidget {
+  const SessionStateDot({
+    super.key,
+    required this.swatchKey,
+    required this.state,
+    required this.profileColor,
+  });
+
+  /// Key applied to the actual dot Container — retained from #739 so swatch
+  /// tests + device screenshots still address it.
+  final Key swatchKey;
+  final SshSessionState state;
+  final Color? profileColor;
+
+  @override
+  State<SessionStateDot> createState() => _SessionStateDotState();
+}
+
+class _SessionStateDotState extends State<SessionStateDot>
+    with SingleTickerProviderStateMixin {
+  // Constructed eagerly in initState (NOT `late final`): a lazy field would be
+  // built inside dispose() if it was never animated, and constructing an
+  // AnimationController during unmount does a TickerMode ancestor lookup on a
+  // deactivated widget (crash). Eager construction makes dispose() always safe.
+  late final AnimationController _pulse;
+
+  bool get _pulsing =>
+      widget.state == SshSessionState.connecting ||
+      widget.state == SshSessionState.authenticating ||
+      widget.state == SshSessionState.awaitingHostKey ||
+      widget.state == SshSessionState.softDisconnected ||
+      widget.state == SshSessionState.reconnecting;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulse = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+      value: 1.0,
+    );
+    if (_pulsing) _pulse.repeat(reverse: true);
+  }
+
+  @override
+  void didUpdateWidget(SessionStateDot oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_pulsing && !_pulse.isAnimating) {
+      _pulse.repeat(reverse: true);
+    } else if (!_pulsing && _pulse.isAnimating) {
+      _pulse
+        ..stop()
+        ..value = 1.0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  Color _color(ThemeData theme) {
+    switch (widget.state) {
+      // connected (and idle, pre-connect) keep the PROFILE color so the SAME
+      // color still identifies the SAME profile across the app (#739, PWA
+      // `session-dot`). A colorless session shows the neutral fallback — never a
+      // fake real-looking color (#739).
+      case SshSessionState.idle:
+      case SshSessionState.connected:
+        return widget.profileColor ?? theme.colorScheme.outlineVariant;
+      case SshSessionState.connecting:
+      case SshSessionState.authenticating:
+      case SshSessionState.awaitingHostKey:
+        return theme.colorScheme.primary;
+      case SshSessionState.softDisconnected:
+      case SshSessionState.reconnecting:
+        return Colors.orange.shade700;
+      case SshSessionState.failed:
+        return theme.colorScheme.error;
+      case SshSessionState.disconnected:
+        return theme.colorScheme.outlineVariant;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color(Theme.of(context));
+    final dot = Container(
+      key: widget.swatchKey,
+      width: 10,
+      height: 10,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+    if (!_pulsing) return dot;
+    return FadeTransition(
+      opacity: Tween<double>(begin: 0.35, end: 1.0).animate(_pulse),
+      child: dot,
+    );
+  }
+}

--- a/native/test/widget/active_sessions_group_test.dart
+++ b/native/test/widget/active_sessions_group_test.dart
@@ -1,0 +1,398 @@
+// Widget tests for the Connect-view Active Sessions group + recents
+// reconciliation (#821 Slice 3, closes #809).
+//
+// PWA parity (`src/modules/profiles.ts` loadProfiles):
+//   - ALL sessions (connected + dropped) render in an "Active Sessions" group at
+//     the TOP of the Connect view. Connected → Switch, dropped → Reconnect, all
+//     → ✕. "Reconnect all" appears when any is non-connected.
+//   - Recent Sessions show ONLY on TRUE cold start (zero sessions). A dropped
+//     session no longer SUPPRESSES recents invisibly — it lives in the Active
+//     group instead (#809: it must not vanish).
+//   - Per-session isolation: dropping one session leaves the others' rows
+//     unchanged.
+//
+// We drive proxy state by tapping a profile row (→ creates a session entry) and
+// pushing task-side state events through the in-memory gateway pair — the same
+// seam profile_list_connect_state_test.dart uses.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/recent_sessions.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/profile_list.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+RecentSessionEntry _recent(String host, {String user = 'me'}) {
+  return RecentSessionEntry(
+    title: '$user@$host',
+    host: host,
+    port: 22,
+    username: user,
+  );
+}
+
+Future<void> _seedRecents(
+  RecentSessionsStore store,
+  List<RecentSessionEntry> entries,
+) async {
+  for (final e in entries.reversed) {
+    await store.add(e);
+  }
+}
+
+/// Pump a ProfileList wired to a fresh in-memory gateway pair. The default
+/// onConnect creates a real session entry for the tapped profile so the row has
+/// a proxy whose state we can drive. Returns the container + pair.
+Future<({ProviderContainer container, InMemoryGatewayPair pair})> _pumpList(
+  WidgetTester tester, {
+  required ProfilesStore store,
+  RecentSessionsStore? recentStore,
+}) async {
+  final pair = InMemoryGatewayPair();
+  addTearDown(() async {
+    await pair.dispose();
+  });
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      profilesStoreProvider.overrideWithValue(store),
+      if (recentStore != null)
+        recentSessionsStoreProvider.overrideWithValue(recentStore),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        home: Scaffold(
+          body: ProfileList(
+            onConnect: (p) {
+              container.read(sessionsProvider.notifier).addOrActivate(
+                    SshConnectParams(
+                      host: p.host,
+                      port: p.port,
+                      username: p.username,
+                      auth: const SshAuth.password('pw'),
+                    ),
+                    title: p.title,
+                  );
+            },
+            onEdit: (_) {},
+            onConnectRecent: (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return (container: container, pair: pair);
+}
+
+void _pushState(
+  InMemoryGatewayPair pair,
+  SessionEntry entry,
+  SshSessionState state, {
+  String? error,
+}) {
+  pair.taskSide.send(
+    SshStateEvent(
+      sessionId: entry.id,
+      state: state.name,
+      error: error,
+      host: entry.host,
+      port: entry.port,
+      username: entry.username,
+    ).toJson(),
+  );
+}
+
+SavedProfile _profile(String host, {String user = 'me', String? title}) {
+  return SavedProfile(
+    title: title ?? '$user@$host',
+    host: host,
+    port: 22,
+    username: user,
+    authType: 'password',
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets(
+    '#809: a DROPPED session appears in the Active Sessions group with Reconnect '
+    '(not vanished)',
+    (tester) async {
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[_profile('a.example', user: 'alice')]);
+
+      final wired = await _pumpList(tester, store: store);
+
+      // Connect A.
+      await tester.tap(
+        find.byKey(const Key('profile-tile-a.example:22:alice')),
+      );
+      await _pumpFrames(tester);
+      final entry = wired.container.read(sessionsProvider).entries.first;
+      _pushState(wired.pair, entry, SshSessionState.connected);
+      await _pumpFrames(tester);
+
+      // Now DROP A — the entry survives (a drop is not a forget).
+      _pushState(wired.pair, entry, SshSessionState.disconnected);
+      await _pumpFrames(tester);
+
+      // The Active Sessions group renders the dropped session with a Reconnect
+      // affordance — it did NOT vanish.
+      expect(find.byKey(const Key('active-sessions-group')), findsOneWidget);
+      expect(find.text('Active Sessions'), findsOneWidget);
+      expect(
+        find.byKey(Key('active-session-tile-${entry.id}')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(Key('active-session-reconnect-${entry.id}')),
+        findsOneWidget,
+        reason: 'a dropped session must offer Reconnect on the Connect view',
+      );
+    },
+  );
+
+  testWidgets(
+    'a CONNECTED session shows a Switch action (not Reconnect)',
+    (tester) async {
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[_profile('a.example', user: 'alice')]);
+
+      final wired = await _pumpList(tester, store: store);
+      await tester.tap(
+        find.byKey(const Key('profile-tile-a.example:22:alice')),
+      );
+      await _pumpFrames(tester);
+      final entry = wired.container.read(sessionsProvider).entries.first;
+      _pushState(wired.pair, entry, SshSessionState.connected);
+      await _pumpFrames(tester);
+
+      expect(
+        find.byKey(Key('active-session-switch-${entry.id}')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(Key('active-session-reconnect-${entry.id}')),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'recents show at zero sessions and HIDE once any session exists; the '
+    'dropped session surfaces in the Active group instead',
+    (tester) async {
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[_profile('a.example', user: 'alice')]);
+      final recentStore = RecentSessionsStore();
+      await _seedRecents(recentStore, [_recent('a.example', user: 'alice')]);
+
+      final wired = await _pumpList(
+        tester,
+        store: store,
+        recentStore: recentStore,
+      );
+
+      // Cold start: Recent Sessions group is present.
+      expect(find.text('Recent Sessions'), findsOneWidget);
+      expect(find.byKey(const Key('active-sessions-group')), findsNothing);
+
+      // Connect, then drop. Recents must hide (any session present), and the
+      // Active group must show the dropped session.
+      await tester.tap(
+        find.byKey(const Key('profile-tile-a.example:22:alice')),
+      );
+      await _pumpFrames(tester);
+      final entry = wired.container.read(sessionsProvider).entries.first;
+      _pushState(wired.pair, entry, SshSessionState.connected);
+      await _pumpFrames(tester);
+      _pushState(wired.pair, entry, SshSessionState.disconnected);
+      await _pumpFrames(tester);
+
+      expect(
+        find.text('Recent Sessions'),
+        findsNothing,
+        reason: 'recents must hide once ANY session exists (PWA parity)',
+      );
+      expect(find.byKey(const Key('active-sessions-group')), findsOneWidget);
+      expect(
+        find.byKey(Key('active-session-reconnect-${entry.id}')),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'two dropped sessions → Active group shows both + a "Reconnect all"; neither '
+    'group vanishes (no mid-loop unmount)',
+    (tester) async {
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        _profile('a.example', user: 'alice'),
+        _profile('b.example', user: 'bob'),
+      ]);
+
+      final wired = await _pumpList(tester, store: store);
+
+      await tester.tap(
+        find.byKey(const Key('profile-tile-a.example:22:alice')),
+      );
+      await _pumpFrames(tester);
+      await tester.tap(
+        find.byKey(const Key('profile-tile-b.example:22:bob')),
+      );
+      await _pumpFrames(tester);
+
+      final entries = wired.container.read(sessionsProvider).entries;
+      expect(entries.length, 2);
+      for (final e in entries) {
+        _pushState(wired.pair, e, SshSessionState.connected);
+      }
+      await _pumpFrames(tester);
+      for (final e in entries) {
+        _pushState(wired.pair, e, SshSessionState.disconnected);
+      }
+      await _pumpFrames(tester);
+
+      // Both rows present, plus the group-level Reconnect-all.
+      for (final e in entries) {
+        expect(
+          find.byKey(Key('active-session-tile-${e.id}')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(Key('active-session-reconnect-${e.id}')),
+          findsOneWidget,
+        );
+      }
+      expect(
+        find.byKey(const Key('active-sessions-reconnect-all')),
+        findsOneWidget,
+      );
+
+      // Tapping Reconnect-all does not unmount the group.
+      await tester.tap(
+        find.byKey(const Key('active-sessions-reconnect-all')),
+      );
+      await _pumpFrames(tester);
+      expect(find.byKey(const Key('active-sessions-group')), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'per-session isolation: dropping ONE of two leaves the other row a Switch',
+    (tester) async {
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        _profile('a.example', user: 'alice'),
+        _profile('b.example', user: 'bob'),
+      ]);
+
+      final wired = await _pumpList(tester, store: store);
+      await tester.tap(
+        find.byKey(const Key('profile-tile-a.example:22:alice')),
+      );
+      await _pumpFrames(tester);
+      await tester.tap(
+        find.byKey(const Key('profile-tile-b.example:22:bob')),
+      );
+      await _pumpFrames(tester);
+
+      final entries = wired.container.read(sessionsProvider).entries;
+      final a = entries.firstWhere((e) => e.host == 'a.example');
+      final b = entries.firstWhere((e) => e.host == 'b.example');
+      _pushState(wired.pair, a, SshSessionState.connected);
+      _pushState(wired.pair, b, SshSessionState.connected);
+      await _pumpFrames(tester);
+
+      // Drop ONLY a.
+      _pushState(wired.pair, a, SshSessionState.disconnected);
+      await _pumpFrames(tester);
+
+      // a → Reconnect, b → still Switch (unchanged). No leakage.
+      expect(
+        find.byKey(Key('active-session-reconnect-${a.id}')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(Key('active-session-switch-${a.id}')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(Key('active-session-switch-${b.id}')),
+        findsOneWidget,
+        reason: 'dropping a must not change b',
+      );
+      expect(
+        find.byKey(Key('active-session-reconnect-${b.id}')),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'tapping Reconnect on a dropped row re-enters the connect path for that '
+    'session',
+    (tester) async {
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[_profile('a.example', user: 'alice')]);
+
+      final wired = await _pumpList(tester, store: store);
+      await tester.tap(
+        find.byKey(const Key('profile-tile-a.example:22:alice')),
+      );
+      await _pumpFrames(tester);
+      final entry = wired.container.read(sessionsProvider).entries.first;
+      _pushState(wired.pair, entry, SshSessionState.connected);
+      await _pumpFrames(tester);
+      _pushState(wired.pair, entry, SshSessionState.disconnected);
+      await _pumpFrames(tester);
+
+      // Tap Reconnect — the entry must survive (reconnect is not a forget) and
+      // the row stays present.
+      await tester.tap(
+        find.byKey(Key('active-session-reconnect-${entry.id}')),
+      );
+      await _pumpFrames(tester);
+
+      expect(
+        wired.container
+            .read(sessionsProvider)
+            .entries
+            .any((e) => e.id == entry.id),
+        isTrue,
+        reason: 'reconnect must keep the session entry',
+      );
+      expect(
+        find.byKey(Key('active-session-tile-${entry.id}')),
+        findsOneWidget,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Slice 3 (final) of the session-lifecycle fix (#811). Brings the PWA's Active Sessions group to the native Connect view and fixes the recents rule.
- **Active Sessions group** (top of the Connect view, PWA `activeSessionList`): renders ALL `sessionsProvider.entries` — connected → **Switch**, dropped → **Reconnect**, **✕** always — plus a "Reconnect all" when any session is non-connected. A dropped session is now reconnectable from the home screen instead of vanishing (#809).
- **Recents rule → `entries.isEmpty`**: recents show ONLY on true cold start. A dropped session (still a live `SessionEntry`) lives in the Active group above, never suppressed-invisible. Reconnect-All no longer unmounts recents mid-loop.
- Extracted Slice 2's status dot + reconnect predicate into a shared `lib/ui/session_state_dot.dart` (`SessionStateDot` + `sessionCanReconnect`), reused by both `session_menu.dart` and `profile_list.dart` — no duplicated state→affordance mapping.

## Root cause (#809)
`_buildRecentsGroup` returned null whenever ANY session existed. A DROPPED session suppressed recents AND had no Connect-view surface → it vanished. Reconnect-All flipped that guard true mid-loop → recents unmounted.

## TDD Analysis
- Type: feature (Connect-view surface) + bug fix (#809 vanish)
- Behavior change: yes — new Active Sessions group; recents gated on zero sessions
- TDD approach: full (widget transitions/isolation) + orchestrator-run integration smoketest

## Test coverage
- **Existing tests updated**: none needed — session_menu extraction is mechanical; existing session_menu + recents tests still pass (keys unchanged).
- **New tests (fail→pass)** — `native/test/widget/active_sessions_group_test.dart`:
  - #809: dropped session appears in the Active group with Reconnect (not vanished)
  - connected session shows Switch (not Reconnect)
  - recents show at zero sessions, HIDE once any session exists; dropped session surfaces in the Active group
  - two dropped → both rows + "Reconnect all", neither group vanishes mid-loop
  - per-session isolation: dropping one of two leaves the other a Switch
  - tapping Reconnect keeps the entry + row
- **Integration smoketest** (tag `integration`, orchestrator-run) — `native/integration_test/connect_view_active_session_test.dart`: connect → drop → open Connect view → Active row + Reconnect → tap → live shell bytes.

## Test results
- flutter analyze: PASS (clean)
- native-fast-gate: PASS (1020 tests, 5 pre-existing skips)
- New widget tests: PASS (6/6)

## Diff stats
- Files changed: 5 (2 lib edited, 1 lib new shared, 2 tests new)
- `profile_list.dart` +250, `session_menu.dart` -136 (extraction), `session_state_dot.dart` new, 2 test files

Closes #809
Refs #811, #817, #813

## Cycles used
1/3