### PR TITLE
feat(native): bigger, solid keybar arrow/nav keys (#823)

### DIFF
--- a/native/lib/ui/keybar.dart
+++ b/native/lib/ui/keybar.dart
@@ -53,6 +53,16 @@ const double kKeybarButtonMinWidth = 44;
 const double kKeybarButtonMinHeight = 32; // #752: was 44 (collapsed dead space)
 const double kKeybarIconSize = 18;
 
+/// #823: the arrow / navigation glyphs render LARGER than the standard
+/// [kKeybarIconSize] so they read at a glance — the owner found the thin
+/// chevrons hard to differentiate on-device. The size is deliberately capped at
+/// the (unchanged) [kKeybarButtonMinHeight] so the bigger GLYPH never grows the
+/// bar's height (#615/#752 trimmed it on purpose) — only the glyph inside the
+/// existing key gets bigger and solid. Standard icons (Tab/Enter/Paste) stay at
+/// [kKeybarIconSize]; only the arrow/nav keys opt into this larger size via
+/// [KeybarKey.iconSize].
+const double kKeybarNavIconSize = 24;
+
 /// Single-character TEXT keys (`|`, `/`, `-` and any other 1-glyph label) are
 /// NARROWER than multi-char keys so they don't waste width (#703 owner device
 /// feedback). Multi-char text keys (Esc, Tab label, Home, PgUp…) keep the full
@@ -102,6 +112,7 @@ class KeybarKey {
     required this.label,
     required this.sequence,
     this.icon,
+    this.iconSize = kKeybarIconSize,
     this.isModifier = false,
   });
 
@@ -112,6 +123,11 @@ class KeybarKey {
   /// When non-null, the button shows this monochrome icon instead of [label]
   /// text (e.g. Paste). [label] is still used as the accessibility tooltip.
   final IconData? icon;
+
+  /// Size of [icon] when shown. Defaults to the standard [kKeybarIconSize]; the
+  /// arrow / navigation keys opt into the larger [kKeybarNavIconSize] (#823) so
+  /// their solid glyphs read at a glance without growing the bar height.
+  final double iconSize;
 
   /// A sticky modifier key (the Ctrl key, #694) — tapping it ARMS the modifier
   /// rather than emitting [sequence]. Modifier keys carry no literal byte; the
@@ -195,34 +211,70 @@ const List<KeybarKey> kDefaultKeybarKeys = [
   KeybarKey(id: 'keySlash', label: '/', sequence: '/'),
   KeybarKey(id: 'keyDash', label: '-', sequence: '-'),
   KeybarKey(id: 'keyPipe', label: '|', sequence: '|'),
+  // #823: the four arrows use SOLID/FILLED directional glyphs (Icons.arrow_*)
+  // rather than the thin `keyboard_arrow_*` chevrons the owner found hard to
+  // read and differentiate on-device. They render at the larger
+  // [kKeybarNavIconSize] so they read at a glance without growing the bar.
   KeybarKey(
     id: 'keyLeft',
     label: 'Left',
     sequence: '\x1b[D',
-    icon: Icons.keyboard_arrow_left,
+    icon: Icons.arrow_back,
+    iconSize: kKeybarNavIconSize,
   ),
   KeybarKey(
     id: 'keyUp',
     label: 'Up',
     sequence: '\x1b[A',
-    icon: Icons.keyboard_arrow_up,
+    icon: Icons.arrow_upward,
+    iconSize: kKeybarNavIconSize,
   ),
   KeybarKey(
     id: 'keyDown',
     label: 'Down',
     sequence: '\x1b[B',
-    icon: Icons.keyboard_arrow_down,
+    icon: Icons.arrow_downward,
+    iconSize: kKeybarNavIconSize,
   ),
   KeybarKey(
     id: 'keyRight',
     label: 'Right',
     sequence: '\x1b[C',
-    icon: Icons.keyboard_arrow_right,
+    icon: Icons.arrow_forward,
+    iconSize: kKeybarNavIconSize,
   ),
-  KeybarKey(id: 'keyHome', label: 'Home', sequence: '\x1b[H'),
-  KeybarKey(id: 'keyEnd', label: 'End', sequence: '\x1b[F'),
-  KeybarKey(id: 'keyPgUp', label: 'PgUp', sequence: '\x1b[5~'),
-  KeybarKey(id: 'keyPgDn', label: 'PgDn', sequence: '\x1b[6~'),
+  // #823: the page-navigation keys also become SOLID, mutually-distinct glyphs
+  // (single bar-anchored first/last_page for Home/End, double-chevron for the
+  // Page keys) at the larger nav size — they were ambiguous text labels before.
+  // The `label` is still the accessibility tooltip; routing uses `sequence`.
+  KeybarKey(
+    id: 'keyHome',
+    label: 'Home',
+    sequence: '\x1b[H',
+    icon: Icons.first_page,
+    iconSize: kKeybarNavIconSize,
+  ),
+  KeybarKey(
+    id: 'keyEnd',
+    label: 'End',
+    sequence: '\x1b[F',
+    icon: Icons.last_page,
+    iconSize: kKeybarNavIconSize,
+  ),
+  KeybarKey(
+    id: 'keyPgUp',
+    label: 'PgUp',
+    sequence: '\x1b[5~',
+    icon: Icons.keyboard_double_arrow_up,
+    iconSize: kKeybarNavIconSize,
+  ),
+  KeybarKey(
+    id: 'keyPgDn',
+    label: 'PgDn',
+    sequence: '\x1b[6~',
+    icon: Icons.keyboard_double_arrow_down,
+    iconSize: kKeybarNavIconSize,
+  ),
   // #650: was `label: '↵'` (U+21B5), which renders as tofu in the bundled
   // font — the SAME issue the arrows had. Use the monochrome Material icon
   // path (Icons.keyboard_return) so it's clearly an Enter/Return key. The tap
@@ -522,7 +574,10 @@ class _KeybarButtonState extends State<_KeybarButton> {
     final Widget child = keyData.icon != null
         ? Icon(
             keyData.icon,
-            size: kKeybarIconSize,
+            // #823: arrow/nav keys opt into the larger nav size; other icons
+            // keep the standard size. Capped at the bar height so the bigger
+            // glyph never grows the bar.
+            size: keyData.iconSize,
             color: fg,
             semanticLabel: keyData.label,
           )

--- a/native/test/widget/keybar_arrow_glyphs_test.dart
+++ b/native/test/widget/keybar_arrow_glyphs_test.dart
@@ -1,0 +1,245 @@
+// Tests for bigger, solid, differentiated keybar arrow/nav glyphs (#823).
+//
+// Owner device feedback: the arrow/navigation keys were hard to read — thin
+// chevrons (Icons.keyboard_arrow_*) that look alike. #823 makes them:
+//   - SOLID/FILLED (Icons.arrow_back/upward/downward/forward, not chevrons),
+//   - LARGER (a dedicated nav icon size, bigger than the standard icon), and
+//   - clearly DIFFERENTIATED (Home/End/PgUp/PgDn get distinct filled glyphs).
+//
+// Constraints pinned here (do not regress):
+//   - The bar HEIGHT must NOT grow: the larger nav icon must still fit within
+//     the (unchanged) button min-height, and the height/font constants are
+//     untouched (#615/#752/#703).
+//   - Byte sequences + #732 auto-repeat eligibility are UNCHANGED (routing is
+//     identical — only the glyph rendering changes).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/keybar.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 8}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+KeybarKey _key(String id) =>
+    kDefaultKeybarKeys.firstWhere((k) => k.id == id);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('#823 arrow keys are SOLID/FILLED, not thin chevrons', () {
+    test('the four arrows use the filled arrow_* glyphs (not keyboard_arrow_*)', () {
+      expect(_key('keyLeft').icon, equals(Icons.arrow_back));
+      expect(_key('keyUp').icon, equals(Icons.arrow_upward));
+      expect(_key('keyDown').icon, equals(Icons.arrow_downward));
+      expect(_key('keyRight').icon, equals(Icons.arrow_forward));
+      // The old thin chevrons must be gone.
+      for (final id in ['keyLeft', 'keyUp', 'keyDown', 'keyRight']) {
+        expect(
+          _key(id).icon,
+          isNot(
+            anyOf(
+              Icons.keyboard_arrow_left,
+              Icons.keyboard_arrow_up,
+              Icons.keyboard_arrow_down,
+              Icons.keyboard_arrow_right,
+            ),
+          ),
+          reason: '$id must use a solid/filled arrow, not a thin chevron',
+        );
+      }
+    });
+
+    test('the four arrows are mutually distinct glyphs', () {
+      final icons = ['keyLeft', 'keyUp', 'keyDown', 'keyRight']
+          .map((id) => _key(id).icon)
+          .toSet();
+      expect(icons.length, 4, reason: 'each direction must be a distinct glyph');
+    });
+  });
+
+  group('#823 Home/End/PgUp/PgDn become solid, differentiated icons', () {
+    test('each nav key now carries a (filled) icon, not a text label', () {
+      for (final id in ['keyHome', 'keyEnd', 'keyPgUp', 'keyPgDn']) {
+        expect(
+          _key(id).icon,
+          isNotNull,
+          reason: '$id must render a solid, differentiated icon (#823)',
+        );
+      }
+    });
+
+    test('the nav icons are mutually distinct, and distinct from the arrows', () {
+      final ids = [
+        'keyLeft',
+        'keyUp',
+        'keyDown',
+        'keyRight',
+        'keyHome',
+        'keyEnd',
+        'keyPgUp',
+        'keyPgDn',
+      ];
+      final icons = ids.map((id) => _key(id).icon).toSet();
+      expect(
+        icons.length,
+        ids.length,
+        reason: 'all arrow + nav glyphs must be visually distinct shapes',
+      );
+    });
+  });
+
+  group('#823 nav/arrow glyphs are LARGER (without growing the bar)', () {
+    test('a dedicated nav icon size is bigger than the standard icon size', () {
+      expect(
+        kKeybarNavIconSize,
+        greaterThan(kKeybarIconSize),
+        reason: 'arrow/nav glyphs must read as MORE prominent than other icons',
+      );
+    });
+
+    test('the larger nav icon still fits inside the (unchanged) bar height', () {
+      // The bigger glyph must NOT grow the bar — it must fit within the
+      // existing tap-target min height (#615/#752 deliberately trimmed it).
+      expect(
+        kKeybarNavIconSize,
+        lessThanOrEqualTo(kKeybarButtonMinHeight),
+        reason: 'a taller glyph than the bar would grow the bar — forbidden',
+      );
+    });
+
+    test('the bar height + text/standard-icon constants are UNCHANGED', () {
+      expect(kKeybarButtonMinHeight, equals(32));
+      expect(kKeybarLabelFontSize, equals(14));
+      expect(kKeybarIconSize, equals(18));
+      expect(kKeybarReserve, equals(40));
+    });
+
+    test('arrow/nav keys carry the larger nav icon size; others stay standard', () {
+      for (final id in [
+        'keyLeft',
+        'keyUp',
+        'keyDown',
+        'keyRight',
+        'keyHome',
+        'keyEnd',
+        'keyPgUp',
+        'keyPgDn',
+      ]) {
+        expect(
+          _key(id).iconSize,
+          equals(kKeybarNavIconSize),
+          reason: '$id must render at the larger nav icon size',
+        );
+      }
+      // Non-nav icon keys keep the standard size.
+      for (final id in ['keyTab', 'keyEnter', 'keyPaste']) {
+        expect(
+          _key(id).iconSize,
+          equals(kKeybarIconSize),
+          reason: '$id is not a nav key — it must keep the standard icon size',
+        );
+      }
+    });
+  });
+
+  group('#823 routing + auto-repeat UNCHANGED (glyph-only change)', () {
+    test('arrow/nav byte sequences are unchanged', () {
+      expect(_key('keyLeft').sequence, equals('\x1b[D'));
+      expect(_key('keyUp').sequence, equals('\x1b[A'));
+      expect(_key('keyDown').sequence, equals('\x1b[B'));
+      expect(_key('keyRight').sequence, equals('\x1b[C'));
+      expect(_key('keyHome').sequence, equals('\x1b[H'));
+      expect(_key('keyEnd').sequence, equals('\x1b[F'));
+      expect(_key('keyPgUp').sequence, equals('\x1b[5~'));
+      expect(_key('keyPgDn').sequence, equals('\x1b[6~'));
+    });
+
+    test('#732 auto-repeat eligibility is unchanged', () {
+      for (final id in [
+        'keyLeft',
+        'keyUp',
+        'keyDown',
+        'keyRight',
+        'keyHome',
+        'keyEnd',
+        'keyPgUp',
+        'keyPgDn',
+      ]) {
+        expect(isRepeatEligibleKeyId(id), isTrue);
+      }
+      for (final id in ['keyEsc', 'keyCtrl', 'keyTab', 'keyCtrlC']) {
+        expect(isRepeatEligibleKeyId(id), isFalse);
+      }
+    });
+  });
+
+  group('#823 widget renders the larger nav glyphs at the right size', () {
+    testWidgets('each arrow/nav Icon paints at kKeybarNavIconSize', (
+      tester,
+    ) async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async {
+        await pair.dispose();
+      });
+      final container = ProviderContainer(
+        overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+      );
+      addTearDown(container.dispose);
+
+      final entry = container
+          .read(sessionsProvider.notifier)
+          .addOrActivate(
+            const SshConnectParams(
+              host: 'h',
+              port: 22,
+              username: 'u',
+              auth: SshAuth.password('p'),
+            ),
+          );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(home: Scaffold(body: Keybar(activeEntry: entry))),
+        ),
+      );
+      await _pumpFrames(tester);
+
+      for (final id in [
+        'keyLeft',
+        'keyUp',
+        'keyDown',
+        'keyRight',
+        'keyHome',
+        'keyEnd',
+        'keyPgUp',
+        'keyPgDn',
+      ]) {
+        final icon = tester.widget<Icon>(
+          find.descendant(
+            of: find.byKey(Key('keybar-btn-$id')),
+            matching: find.byType(Icon),
+          ),
+        );
+        expect(
+          icon.size,
+          equals(kKeybarNavIconSize),
+          reason: '$id must paint its glyph at the larger nav size',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- The four arrow keys now use SOLID/FILLED directional glyphs (`Icons.arrow_back` / `arrow_upward` / `arrow_downward` / `arrow_forward`) instead of the thin `keyboard_arrow_*` chevrons the owner found hard to read and differentiate on-device.
- Home/End/PgUp/PgDn are promoted from ambiguous text labels to distinct, filled, mutually-differentiated icons: `first_page` / `last_page` / `keyboard_double_arrow_up` / `keyboard_double_arrow_down`.
- All eight arrow/nav glyphs render at a new, larger `kKeybarNavIconSize` (24, vs the standard 18) so they read at a glance — capped at the unchanged button min-height (32) so the bar height does NOT grow (#615/#752 trimmed it deliberately).
- A new per-key `KeybarKey.iconSize` (default `kKeybarIconSize`) lets only the nav keys opt into the larger size; Tab/Enter/Paste and all text/symbol/^keys are untouched.

## TDD Analysis
- Type: feature (UX visual polish)
- Behavior change: no — byte sequences, key routing, and #732 auto-repeat eligibility are all unchanged; only the glyph rendering changes
- TDD approach: full (red→green on a new contract test)

## Test coverage
- **Existing tests updated**: none needed — all keybar suites (`keybar_test`, `keybar_height_test`, `keybar_autorepeat_test`, `keybar_ctrl_modifier_test`, `keybar_per_session_test`) stay green unchanged.
- **New tests added (fail→pass)**: `native/test/widget/keybar_arrow_glyphs_test.dart` — asserts the four arrows are the solid `arrow_*` glyphs (not chevrons) and mutually distinct; Home/End/PgUp/PgDn carry distinct filled icons; `kKeybarNavIconSize > kKeybarIconSize` AND `<= kKeybarButtonMinHeight` (no bar growth); bar-height/font/standard-icon constants UNCHANGED; sequences + #732 repeat-eligibility unchanged; widget paints each nav `Icon` at the larger size.
- **Smoketest**: the widget test mounts the keybar and verifies every arrow/nav button renders its `Icon` at `kKeybarNavIconSize`.

## Test results
- flutter analyze: PASS
- native fast gate: PASS (1031 tests)
- new test: PASS (11 tests, all new)

## Diff stats
- Files changed: 2 (1 source + 1 new test)
- Lines: +64 / -9 (source)

Closes #823

## Cycles used
1/3

## Device validation
Glyph legibility / differentiation is the owner's to confirm on real hardware.