### PR TITLE
fix(native): no URL/path detection on the alt-screen (vim) (#824)

### DIFF
--- a/native/test/fixtures/replay/vim_altscreen_66x34.byte-trace.json
+++ b/native/test/fixtures/replay/vim_altscreen_66x34.byte-trace.json
@@ -1,0 +1,190 @@
+{
+  "grid": {
+    "cols": 66,
+    "rows": 34
+  },
+  "byteTrace": [
+    {
+      "tMs": 3779672,
+      "b64": "Yw=="
+    },
+    {
+      "tMs": 3779873,
+      "b64": "CGNk"
+    },
+    {
+      "tMs": 3780062,
+      "b64": "IA=="
+    },
+    {
+      "tMs": 3781446,
+      "b64": "CA=="
+    },
+    {
+      "tMs": 3781514,
+      "b64": "CAhjIAg="
+    },
+    {
+      "tMs": 3781545,
+      "b64": "CCAI"
+    },
+    {
+      "tMs": 3786207,
+      "b64": "cw=="
+    },
+    {
+      "tMs": 3786370,
+      "b64": "CHNz"
+    },
+    {
+      "tMs": 3786955,
+      "b64": "aA=="
+    },
+    {
+      "tMs": 3788456,
+      "b64": "CCAI"
+    },
+    {
+      "tMs": 3788526,
+      "b64": "CAhzIAg="
+    },
+    {
+      "tMs": 3788555,
+      "b64": "CCAI"
+    },
+    {
+      "tMs": 3789162,
+      "b64": "bA=="
+    },
+    {
+      "tMs": 3789507,
+      "b64": "CGxz"
+    },
+    {
+      "tMs": 3789719,
+      "b64": "IA=="
+    },
+    {
+      "tMs": 3791741,
+      "b64": "fg=="
+    },
+    {
+      "tMs": 3792289,
+      "b64": "Lw=="
+    },
+    {
+      "tMs": 3793172,
+      "b64": "Lg=="
+    },
+    {
+      "tMs": 3793708,
+      "b64": "cw=="
+    },
+    {
+      "tMs": 3793814,
+      "b64": "cw=="
+    },
+    {
+      "tMs": 3794328,
+      "b64": "aA=="
+    },
+    {
+      "tMs": 3794988,
+      "b64": "Lw=="
+    },
+    {
+      "tMs": 3795579,
+      "b64": "Yw=="
+    },
+    {
+      "tMs": 3795858,
+      "b64": "bw=="
+    },
+    {
+      "tMs": 3796749,
+      "b64": "bmZpZxtbMW0gGyhCG1tt"
+    },
+    {
+      "tMs": 3797344,
+      "b64": "G1sxOzMzchtbMzM7MUgKG1szMjs0M0ggDQobW0sbWzE7MzRyG1szMzsxSA=="
+    },
+    {
+      "tMs": 3797362,
+      "b64": "G1sxOzMzchtbMzM7MUgKG1tBL1VzZXJzL21mLy5zc2gvY29uZmlnDQobW0sbWzE7MzRyG1szMzsxSA=="
+    },
+    {
+      "tMs": 3797363,
+      "b64": "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgG1szMzsxSA=="
+    },
+    {
+      "tMs": 3797363,
+      "b64": "G1sxOzMzchtbMzM7MUgbW0ttZkBNYXR0cy1NYWNCb29rLUFpciBudiAlIBtbSxtbMTszNHIbWzMzOzI3SA=="
+    },
+    {
+      "tMs": 3798642,
+      "b64": "bHMgfi8uc3NoL2NvbmZpZw=="
+    },
+    {
+      "tMs": 3799862,
+      "b64": "G1sxNkQ="
+    },
+    {
+      "tMs": 3803845,
+      "b64": "G1tD"
+    },
+    {
+      "tMs": 3804033,
+      "b64": "G1tD"
+    },
+    {
+      "tMs": 3804675,
+      "b64": "CAhsG1sxUBtbMTRDIBtbMTVE"
+    },
+    {
+      "tMs": 3804857,
+      "b64": "CBtbMVAbWzE0QyAbWzE1RA=="
+    },
+    {
+      "tMs": 3806152,
+      "b64": "diB+Ly5zc2gvY29uZmlnG1sxNEQ="
+    },
+    {
+      "tMs": 3806509,
+      "b64": "CHZpIH4vLnNzaC9jb25maWcbWzE0RA=="
+    },
+    {
+      "tMs": 3806852,
+      "b64": "bSB+Ly5zc2gvY29uZmlnG1sxNEQ="
+    },
+    {
+      "tMs": 3807201,
+      "b64": "G1sxOzMzchtbMzM7MUgKG1tLG1sxOzM0chtbMzM7MUg="
+    },
+    {
+      "tMs": 3807281,
+      "b64": "G1s/MjVsG1tIG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSxtbPzEybBtbPzI1aA=="
+    },
+    {
+      "tMs": 3807282,
+      "b64": "G1sxOzMzchtbMTsxSBtbMjszM3IbWzMyUxtbMTsxSBtbSxtbMzNkIn4vLnNzaC9jb25maWciG1sxOzM0chtbMzM7MTZIG1s/MjVs"
+    },
+    {
+      "tMs": 3807282,
+      "b64": "IDQ5TCwgMTI5OEI="
+    },
+    {
+      "tMs": 3807282,
+      "b64": "G1tISW5jbHVkZSAiL1VzZXJzL21mL0xpYnJhcnkvQXBwbGljYXRpb24gU3VwcG9ydC9OVklESUEvU3luYy9jb25maWcvc3NoX2NvbmZpZyIbWzQ7MUhIb3N0IHJhYy5sYW4NCiAgSG9zdE5hbWUgcmFjLmxhbg0KICBVc2VyIHJldHVyG1s4OzFISG9zdCBudmlkaWEtbWFmcmF6aWVyDQogIEhvc3ROYW1lIGRjMi1jb250YWluZXIteHRlcm0tMDEzLnByZC5pdC5udmlkaWEuY29tDQogIFBvcnQgNDE2Nw0KICBVc2VyIG1hZnJhemllchtbMTM7MUhIb3N0IHJhc2VydmVyDQogIEhvc3ROYW1lIHJhc2VydmVyDQogIFVzZXIgcmENCiAgRHluYW1pY0ZvcndhcmQgMTgwODANCiAgTG9jYWxGb3J3YXJkIDkwOTAgMTI3LjAuMC4xOjgwODAbWzE5OzFISG9zdCByYXNlcnZlci1yZW1vdGUNCiAgSG9zdE5hbWUgcmFob21lDQogIFBvcnQgMjExMDYNCiAgVXNlciByYQ0KICBMb2NhbEZvcndhcmQgOTA5MCBsb2NhbGhvc3Q6ODA4MA0KICBMb2NhbEZvcndhcmQgODAwNiAxOTIuMTY4Ljg2LjQ3OjgwMDYNCiAgTG9jYWxGb3J3YXJkIDk5OTkgMTkyLjE2OC44Ni41MDo5OTk5DQogIExvY2FsRm9yd2FyZCA5NDQzIDE5Mi4xNjguODYuNTA6OTQ0Mw0KICBMb2NhbEZvcndhcmQgMzc1NjUgMTkyLjE2OC44Ni41MDozNzU2NQ0KICBMb2NhbEZvcndhcmQgODEyMyAxOTIuMTY4Ljg2LjUwOjgxMjMNCiAgTG9jYWxGb3J3YXJkIDM3MDQ3IHJhbmFzLmxhbjozNzA0NxtbMzE7MUhIb3N0IGZkLWRldg0KICBIb3N0TmFtZSAxMDAuNzUuMTM1LjUxG1tIG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3808451,
+      "b64": "G1s/MjVsG1szODsyOzc0OzE1ODs5Mm0bWzQ4OzI7MjY7MzY7MzJtG1szNGQgMCAbWzM4OzI7ODA7MjUwOzEyM20bWzFtIDE6dmltIBsoQhtbbRtbMzg7MjsxMjI7MTU4OzEyMm0bWzQ4OzI7MjY7MzY7MzJtICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAbWzM4OzI7NzQ7OTY7ODBtIDIyOjI2ICBKdW4gMDggGyhCG1ttG1s/MTJsG1s/MjVoG1sxOzFI"
+    }
+  ],
+  "scrollTrace": [
+    {
+      "tMs": 3686570,
+      "offset": 0
+    }
+  ]
+}

--- a/native/test/terminal/replay_altscreen_no_detection_test.dart
+++ b/native/test/terminal/replay_altscreen_no_detection_test.dart
@@ -1,0 +1,240 @@
+@Tags(['ffi'])
+library;
+
+// REPLAY-based acceptance for #824: suppress URL/PATH detection on the ALTERNATE
+// screen (vim / less / htop / full-screen TUIs).
+//
+// The real bug report (0.1.10+40, "erroneously detecting paths in vim") captured
+// the device's PTY byte stream while editing `~/.ssh/config` in vim. The #778 path
+// decorator underlined `~/.ssh/config`, `/Users/mf/.ssh/config`, etc. — but in a
+// full-screen editor those paths aren't navigable and the highlight is pure noise.
+//
+// THE FIX: HEURISTIC structured-text detection (the regex url/path patterns) is
+// for SHELL OUTPUT. Full-screen apps use the alternate screen buffer (DEC
+// `?1049h`/`?1047h`). flterm tracks this via `controller.activeScreen`; the
+// controller now scans only OSC-8 (app-declared hyperlink) patterns on the
+// alt-screen and suppresses the regex url/path patterns — so vim's incidental
+// `~/.ssh/config` no longer underlines, while a TUI's explicit OSC-8 link (the
+// owner's #810 tap-to-copy case) stays detectable/copyable.
+//
+// FIXTURE NOTE (important): the #790/#793 recorder's byteTrace is a BOUNDED ring
+// buffer — it kept only the last 44 chunks (1694 bytes) of a long-running vim
+// session, so the original `?1049h` alt-screen-enter had already scrolled OUT of
+// the captured window (verified: no 1049/1047 sequence in the captured bytes).
+// Replaying those bytes ALONE into a fresh terminal would leave it on the PRIMARY
+// screen and the paths would (wrongly) detect. To reproduce the EXACT device
+// condition — vim already on the alt-screen when these redraw bytes arrived — the
+// test primes the controller into the alternate screen (`?1049h`) before replaying
+// the captured vim redraw. That is the honest device state, not a synthetic one.
+//
+// RED (pre-fix): paths detected on the alt-screen → anchors non-empty.
+// GREEN (post-fix): activeScreen == alternate AND anchors is EMPTY.
+//
+// A complementary case proves NO over-suppression: leaving the alt-screen
+// (`?1049l`) back to a shell grid with a real path resumes detection.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'replay_trace_harness.dart';
+
+const _vimFixture =
+    'test/fixtures/replay/vim_altscreen_66x34.byte-trace.json';
+
+/// DEC private mode 1049: enter the alternate screen buffer (what vim/less emit).
+final _enterAltScreen = Uint8List.fromList(utf8.encode('\x1b[?1049h'));
+
+/// DEC private mode 1049 reset: leave the alternate screen, back to primary.
+final _leaveAltScreen = Uint8List.fromList(utf8.encode('\x1b[?1049l'));
+
+Uint8List _ascii(String s) => Uint8List.fromList(utf8.encode(s));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('REPLAY #824 — no URL/path detection on the alternate screen (vim)', () {
+    test(
+      'replaying the real vim alt-screen trace yields NO anchors '
+      '(activeScreen == alternate, anchors EMPTY)',
+      () async {
+        final trace = loadByteTrace(_vimFixture);
+        // The real captured grid: vim editing ~/.ssh/config at 66x34.
+        expect(trace.cols, 66);
+        expect(trace.rows, 34);
+        expect(trace.byteTrace, hasLength(44));
+
+        final controller = TerminalController(
+          config: TerminalConfig(cols: trace.cols, rows: trace.rows),
+        );
+        addTearDown(controller.dispose);
+        // Register BOTH patterns the live view registers — the bug is the path
+        // pattern, but URL must be suppressed on the alt-screen too.
+        controller.registerTextPattern(TextPattern.path());
+        controller.registerTextPattern(TextPattern.url());
+
+        // Reproduce the device condition: vim was ALREADY on the alt-screen when
+        // these redraw bytes arrived (the `?1049h` scrolled out of the recorder's
+        // bounded ring). Prime the alt-screen, THEN replay the captured vim grid.
+        controller.write(_enterAltScreen);
+        await replayTrace(controller, trace);
+
+        expect(
+          controller.activeScreen,
+          TerminalScreen.alternate,
+          reason: 'the primed + replayed trace must sit on the alternate screen '
+              '(vim) — the precondition for suppression',
+        );
+        expect(
+          controller.anchors,
+          isEmpty,
+          reason: 'on the alternate screen (vim) NO URL/path anchors must be '
+              'detected — the paths in ~/.ssh/config are not navigable and the '
+              'underline is noise (#824)',
+        );
+        expect(
+          controller.highlights,
+          isEmpty,
+          reason: 'no detection highlights are painted on the alt-screen',
+        );
+      },
+    );
+
+    test(
+      'leaving the alt-screen back to a shell grid RESUMES detection '
+      '(no over-suppression)',
+      () async {
+        final controller = TerminalController(
+          config: const TerminalConfig(cols: 66, rows: 34),
+        );
+        addTearDown(controller.dispose);
+        controller.registerTextPattern(TextPattern.path());
+
+        // Enter vim (alt-screen) and draw a path — must NOT detect.
+        controller.write(_enterAltScreen);
+        controller.write(_ascii('  edit /etc/ssh/sshd_config in vim\r\n'));
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+        expect(
+          controller.activeScreen,
+          TerminalScreen.alternate,
+          reason: 'precondition: on the alt-screen',
+        );
+        expect(
+          controller.anchors,
+          isEmpty,
+          reason: 'no detection while on the alt-screen',
+        );
+
+        // Leave vim back to the shell and echo a path — detection must RESUME.
+        controller.write(_leaveAltScreen);
+        controller.write(_ascii('cat /etc/ssh/sshd_config\r\n'));
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        expect(
+          controller.activeScreen,
+          TerminalScreen.primary,
+          reason: 'back on the primary/shell screen',
+        );
+        final pathPayloads = controller.anchors
+            .where((a) => a.patternId == 'path')
+            .map((a) => '${a.payload}')
+            .toList();
+        expect(
+          pathPayloads,
+          contains('/etc/ssh/sshd_config'),
+          reason: 'detection resumes on returning to the shell (alt-screen exit '
+              'must NOT permanently disable detection — #824)',
+        );
+      },
+    );
+
+    test(
+      'an APP-DECLARED OSC-8 hyperlink on the alt-screen is STILL detected '
+      '(the #810 tap-to-copy case is NOT over-suppressed)',
+      () async {
+        // The #824 gate suppresses only the HEURISTIC regex patterns (url/path)
+        // on the alt-screen. An OSC-8 hyperlink is an EXPLICIT, app-emitted
+        // clickable link — an alt-screen TUI that marks a URL clickable (the
+        // owner's #810 tap-to-copy report) deliberately declared it, so it must
+        // remain detectable/copyable even on the alt-screen.
+        final controller = TerminalController(
+          config: const TerminalConfig(cols: 66, rows: 34),
+        );
+        addTearDown(controller.dispose);
+        // The app registers osc8 + url + path (same order as the live view).
+        controller.registerTextPattern(TextPattern.osc8());
+        controller.registerTextPattern(TextPattern.url());
+        controller.registerTextPattern(TextPattern.path());
+
+        const link = 'https://example.com/p/alt-screen-link';
+        // Enter the alt-screen, then emit an OSC-8 hyperlink (`ESC]8;;<uri>ESC\`
+        // ... `ESC]8;;ESC\`) plus a heuristic path that must NOT detect.
+        controller.write(_enterAltScreen);
+        controller.write(_ascii('\x1b]8;;$link\x1b\\clickme\x1b]8;;\x1b\\'));
+        controller.write(_ascii('  and /etc/ssh/sshd_config here\r\n'));
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        expect(
+          controller.activeScreen,
+          TerminalScreen.alternate,
+          reason: 'precondition: on the alt-screen',
+        );
+        final osc8Payloads = controller.anchors
+            .where((a) => a.patternId == 'osc8')
+            .map((a) => '${a.payload}')
+            .toList();
+        expect(
+          osc8Payloads,
+          contains(link),
+          reason: 'an app-declared OSC-8 hyperlink survives alt-screen '
+              'suppression — it is explicit app intent, not heuristic noise',
+        );
+        final pathPayloads = controller.anchors
+            .where((a) => a.patternId == 'path')
+            .toList();
+        expect(
+          pathPayloads,
+          isEmpty,
+          reason: 'the HEURISTIC path is still suppressed on the alt-screen — '
+              'only the explicit OSC-8 link survives',
+        );
+      },
+    );
+
+    test(
+      'a PRIMARY-screen shell grid still detects paths normally '
+      '(the Claude-CLI / repainting-TUI case is unaffected)',
+      () async {
+        // A repainting TUI (Claude CLI #803) repaints the PRIMARY screen — no
+        // `?1049h` — so detection must run. Model that here: a shell path on the
+        // primary screen, no alt-screen ever entered.
+        final controller = TerminalController(
+          config: const TerminalConfig(cols: 66, rows: 34),
+        );
+        addTearDown(controller.dispose);
+        controller.registerTextPattern(TextPattern.path());
+
+        controller.write(_ascii('see /home/dev/workspace/mobissh/README.md\r\n'));
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        expect(
+          controller.activeScreen,
+          TerminalScreen.primary,
+          reason: 'no alt-screen entered — a primary-screen repaint',
+        );
+        final pathPayloads = controller.anchors
+            .where((a) => a.patternId == 'path')
+            .map((a) => '${a.payload}')
+            .toList();
+        expect(
+          pathPayloads,
+          contains('/home/dev/workspace/mobissh/README.md'),
+          reason: 'primary-screen shell/TUI detection is NOT suppressed (#824 '
+              'gates only the alternate screen)',
+        );
+      },
+    );
+  });
+}

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -429,6 +429,30 @@ class TerminalControllerImpl extends TerminalController
       _detectionMatches = const [];
       return;
     }
+    // #824: HEURISTIC structured-text detection (the regex `url`/`path` patterns)
+    // is for SHELL OUTPUT, not full-screen alt-screen apps (vim/less/htop use DEC
+    // `?1049h`/`?1047h`). On the alternate screen a `~/.ssh/config` the user is
+    // EDITING in vim isn't navigable and the underline is pure noise, so the
+    // regex patterns are suppressed there. APP-DECLARED OSC-8 hyperlinks
+    // (`isOsc8Source`) are NOT suppressed: an alt-screen TUI that emits a real
+    // OSC-8 link (the owner's tap-to-copy case, #810) deliberately marked it
+    // clickable, so it stays detectable/copyable. The Claude-CLI / repainting-TUI
+    // URL case repaints the PRIMARY screen (#803) and is unaffected on either
+    // count. Detection of the regex patterns resumes on returning to the primary
+    // screen — `_onTerminalChanged` re-scans on the alternate->primary transition.
+    final scanPatterns = _activeScreen == .alternate
+        ? [for (final p in _textPatterns.values) if (p.isOsc8Source) p]
+        : _textPatterns.values.toList(growable: false);
+    if (scanPatterns.isEmpty) {
+      // On the alt-screen with no OSC-8 source registered there is nothing to
+      // detect; drop any anchors carried over from the primary screen so the
+      // underlines vanish the instant vim opens, and wake the decorator.
+      if (_detectionMatches.isEmpty) return;
+      _detectionMatches = const [];
+      highlights = const [];
+      _decorationNotifier.notify();
+      return;
+    }
     List<StructuredMatch> matches;
     try {
       _renderState.update(terminal);
@@ -463,10 +487,7 @@ class TerminalControllerImpl extends TerminalController
           startAbsRow: startAbs,
           endAbsRow: endAbs,
         );
-        matches = _detectionScanner.scan(
-          reader,
-          _textPatterns.values.toList(growable: false),
-        );
+        matches = _detectionScanner.scan(reader, scanPatterns);
       }
     } catch (_) {
       matches = const [];
@@ -1211,7 +1232,10 @@ class TerminalControllerImpl extends TerminalController
     }
 
     final newActiveScreen = terminal.activeScreen;
+    var leftAlternateScreen = false;
     if (newActiveScreen != _activeScreen) {
+      leftAlternateScreen =
+          _activeScreen == .alternate && newActiveScreen == .primary;
       _activeScreen = newActiveScreen;
       if (newActiveScreen == .primary) _applyModes();
       changed = true;
@@ -1235,6 +1259,10 @@ class TerminalControllerImpl extends TerminalController
     // viewport scrolled; re-scan registered structured-text patterns on a
     // debounce so the highlights track new content. No-op when none registered.
     _scheduleDetectionRescan();
+    // #824: returning to the shell (alternate->primary) must resume detection
+    // immediately, not on the next stray notify — re-scan synchronously so the
+    // shell's URLs/paths re-anchor the moment vim exits.
+    if (leftAlternateScreen) _rescanDetections();
     if (changed) notifyListeners();
   }
 


### PR DESCRIPTION
## Summary
- On the **alternate screen** (vim/less/htop — DEC `?1049h`/`?1047h`) the #778 path decorator underlined incidental paths the user was *editing* (`~/.ssh/config`) — not navigable, pure noise. Structured-text detection is for shell output.
- Gate `_rescanDetections` in the flterm fork on the active screen: on the alt-screen, scan **only OSC-8** (app-declared hyperlink) patterns and drop the heuristic regex `url`/`path` patterns. On returning to the primary screen, re-scan synchronously so shell links re-anchor immediately.
- **OSC-8 hyperlinks survive the alt-screen** — an explicit app-declared link (the owner's #810 alt-screen tap-to-copy case) is intent, not noise, so it stays detectable/copyable. The Claude-CLI repainting-TUI case repaints the **primary** screen (#803) and is unaffected on both counts.

## Why scoped to OSC-8, not a blanket `!isAltScreen`
The issue proposed a blanket suppression. That broke the #810 `url_copy_empty` regression fixture, which is a REAL alt-screen app (`?1049h`, no matching `?1049l`) carrying an OSC-8 hyperlink the owner taps to copy. Scoping suppression to **heuristic regex** detection (`isOsc8Source == false`) satisfies both #824 (vim noise gone) and #810 (alt-screen OSC-8 link still copyable). This is the correct boundary: explicit OSC-8 = app intent; regex url/path = incidental content.

## Fixture note
The #790/#793 recorder's byteTrace is a bounded ring buffer — the vim fixture's original `?1049h` alt-screen-enter had scrolled out before capture (verified: no 1049/1047 in the 1694 captured bytes). The replay test primes the alt-screen (`?1049h`) before replaying the captured vim redraw, reproducing the exact device state (vim was already on the alt-screen when these bytes arrived).

## TDD Analysis
- Type: bug fix
- Behavior change: yes — heuristic detection suppressed on the alternate screen
- TDD approach: full (RED confirmed by stashing the fix — the vim trace detected 3 path anchors on the alt-screen; GREEN after)

## Test coverage
- **Existing tests updated**: none needed — all stay green.
- **New tests added (fail→pass)** — `native/test/terminal/replay_altscreen_no_detection_test.dart`:
  - replays the real vim alt-screen byte-trace (66x34, 44 events) → `activeScreen == alternate` AND `anchors` EMPTY
  - leaving the alt-screen back to a shell grid RESUMES path detection (no permanent disable)
  - an app-declared OSC-8 hyperlink on the alt-screen is STILL detected while a heuristic path is suppressed (the #810 boundary)
  - a primary-screen shell grid still detects paths normally (Claude-CLI / repainting-TUI unaffected)
- **Fixture**: `native/test/fixtures/replay/vim_altscreen_66x34.byte-trace.json` (the real #824 report)
- **No over-suppression** — existing #778 (paths), #787 (url scroll-window), #803 (markup dance), #810 (url-copy-empty, alt-screen OSC-8), #812 (hide-on-scroll) replay fixtures all stay green.

## Test results
- flutter analyze: PASS
- native fast gate: PASS (1024 tests)
- flterm fork suite: PASS (708 tests)
- targeted replay suite (incl. #810/#803/#812/#778/#787 + new #824): PASS (17 tests)

## Diff stats
- Files changed: 3 (1 source, 1 test, 1 fixture)
- Source: +32 / -4 in `terminal_controller_impl.dart`

Closes #824

## Cycles used
1/3