### PR TITLE
fix(native): stop fit659 offstage spam flooding the connect-log; keep disconnect events visible (#836)

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -406,6 +406,18 @@ class SessionHost {
       // a stall shows WHERE it stopped instead of a blank cursor.
       if (data.state != prevState) {
         _emitConnectStatus(cmd.sessionId, data);
+        // #836: record the transition in the DURABLE lifecycle ring (and forward
+        // it UI-side) so a session drop is observable in the connect-log bundle.
+        // Previously a transition was only echoed to the TERMINAL bytes via
+        // `_emitConnectStatus` — never to the ctrace/lifecycle ring — so a silent
+        // mid-session drop left NO trace event, and even a logged one was evicted
+        // by the per-frame fit659 offstage flood. `clifecycle` lands in the
+        // dedicated ring that survives connect-ring churn and is never collapsed.
+        clifecycle(
+          'task.host',
+          'state: ${prevState.name} → ${data.state.name}'
+              '${data.error != null ? ' (${data.error})' : ''}',
+        );
         prevState = data.state;
       }
       // Drop the prior shell the instant the transport leaves `connected`

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -86,6 +86,18 @@ int debugExplicitFitAppliedCount = 0;
 @visibleForTesting
 int debugForcedPtyResyncCount = 0;
 
+/// Test-only counter: incremented each time an explicit fit (#659) is SKIPPED
+/// because the body is OFFSTAGE (no mounted `TerminalViewState`, e.g. an
+/// IndexedStack child for an inactive session) — #836. The fit does no useful
+/// work offstage and its per-frame `[ui.fit659] no TerminalViewState yet`
+/// ctrace line flooded the 200-event connect ring (~100×/sec), evicting the
+/// real disconnect/state-transition events. We now skip the work every frame
+/// but emit the ctrace line only ONCE per offstage period (see
+/// `_offstageFitLogged`). This counter rises every skipped frame; the connect
+/// log must NOT. Reset it in test `setUp`.
+@visibleForTesting
+int debugOffstageFitSkipCount = 0;
+
 /// #570 — test hook. Set to the URL a long-press hit-test resolved (or null when
 /// a long-press landed on no URL). Lets the on-emulator integration test assert
 /// the tap→cell→URL path end to end without UI scraping. Reset in test `setUp`.
@@ -525,6 +537,17 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
   /// bundled asset font is in effect). Null until the first fit attempt.
   Size? _lastLoggedCellSize;
 
+  /// #836: latch so the offstage-skip ctrace line is emitted at most ONCE per
+  /// offstage period. The fit path is driven per-frame (post-frame callbacks,
+  /// `didChangeMetrics`, font changes, the connect burst); while the body is an
+  /// inactive IndexedStack child there is no mounted `TerminalViewState`, so
+  /// every one of those used to log `no TerminalViewState yet (offstage?)`
+  /// (~100×/sec), flooding the 200-event connect ring and burying the real
+  /// disconnect/state events. We still SKIP the fit each frame, but only log
+  /// the skip once; the latch is cleared the moment a view IS found so a later
+  /// offstage→onstage→offstage cycle is logged again.
+  bool _offstageFitLogged = false;
+
   @override
   void initState() {
     super.initState();
@@ -606,9 +629,23 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
     // state by descending our own element subtree instead.
     final state = _findTerminalViewState();
     if (state == null) {
-      ctrace('ui.fit659', '$trigger: no TerminalViewState yet (offstage?)');
+      // #836: offstage (inactive IndexedStack child) — there is no mounted
+      // TerminalViewState to measure, so the fit is pure churn. Always skip the
+      // work, but emit the ctrace line ONLY ONCE per offstage period: the fit
+      // path fires per-frame, so logging every skip floods the 200-event
+      // connect ring (~100×/sec) and evicts the real disconnect/state events
+      // (the symptom this issue reports). The latch is cleared as soon as a
+      // view is found again (below), so a later offstage cycle re-logs.
+      debugOffstageFitSkipCount += 1;
+      if (!_offstageFitLogged) {
+        _offstageFitLogged = true;
+        ctrace('ui.fit659', '$trigger: no TerminalViewState yet (offstage?)');
+      }
       return;
     }
+    // A mounted view exists — re-arm the offstage latch so a future offstage
+    // period is logged once more.
+    _offstageFitLogged = false;
     // `RenderTerminal` is not exported from package:xterm, so the type is left
     // inferred. The getter throws if the viewport hasn't laid out yet (null
     // currentContext) and a detached box would also reject reads — either way a

--- a/native/test/services/session_state_trace_test.dart
+++ b/native/test/services/session_state_trace_test.dart
@@ -1,0 +1,131 @@
+// SessionHost state-transition telemetry (#836).
+//
+// Problem 1 of #836: a "disconnected with no indication" report shipped a
+// connect-log that was almost entirely the per-frame `[ui.fit659] no
+// TerminalViewState yet (offstage?)` spam — it flooded the 200-event connect
+// ring and BURIED the disconnect. Worse, the only place a state transition was
+// recorded was the TERMINAL bytes (`_emitConnectStatus`), NOT the ctrace ring,
+// so a silent mid-session drop left NO trace event to find.
+//
+// The fix routes every state transition through `clifecycle`, which lands in
+// the dedicated lifecycle ring (capacity 80, NEVER evicted by connect-ring
+// churn) AND forwards UI-side. These tests assert a `connected → softDisconnected`
+// drop writes a transition line that SURVIVES a connect-ring flood — exactly the
+// flood the offstage-fit spam used to cause.
+//
+// Headless via InMemoryGatewayPair + a no-connect controller driven through the
+// `connected` → `softDisconnected` transition with no real socket.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// A controller whose real `connect()` is inert so the test owns the
+/// `connected` transition and the drop (via `handleTransportClosed`). The
+/// reconnect attempt is forced to fail-fast so the session settles instead of
+/// looping while the test inspects the trace.
+class _NoConnectController extends SshSessionController {
+  _NoConnectController({super.reconnectDelay, super.reconnectAttemptOverride});
+
+  @override
+  Future<void> connect(SshConnectParams params) async {
+    // Inert — no socket, no auth. The test drives the state machine directly.
+  }
+}
+
+void main() {
+  setUp(clearConnectLog);
+  tearDown(() {
+    lifecycleForwarder = null;
+    clearConnectLog();
+  });
+
+  test(
+    'a connected → softDisconnected drop writes a transition line to the '
+    'lifecycle ring that SURVIVES connect-ring churn (#836)',
+    () async {
+      const sid = 'h:22:u:1';
+      late SshSessionController controller;
+      SshSessionController factory() {
+        controller = _NoConnectController(
+          reconnectDelay: Duration.zero,
+          // Fail-fast so the drop settles (no reconnect loop spamming state).
+          reconnectAttemptOverride: (_) async => false,
+        );
+        return controller;
+      }
+
+      final pair = InMemoryGatewayPair();
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: factory,
+        snapshotInterval: const Duration(hours: 1),
+      );
+      addTearDown(() async {
+        await host.dispose();
+        await pair.dispose();
+      });
+
+      // Host + connect the session, then drive it to connected.
+      pair.uiSide.send(
+        const SshConnectCommand(
+          sessionId: sid,
+          host: 'h',
+          port: 22,
+          username: 'u',
+          authJson: {'type': 'password', 'password': 'p'},
+        ).toJson(),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      controller.debugSetConnectedForTest(_params);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(controller.data.state, SshSessionState.connected);
+
+      // Drop the transport — the device's mid-session disconnect. This drives
+      // connected → softDisconnected through the controller's state stream,
+      // which the host's listener observes and traces. (The session then
+      // continues toward reconnecting/failed; we only care that the DROP edge
+      // was recorded.)
+      controller.handleTransportClosed(null);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // The drop must have been recorded in the DURABLE lifecycle ring.
+      final lifecycle = lifecycleLogSnapshot().join('\n');
+      expect(
+        lifecycle,
+        contains('state: connected → softDisconnected'),
+        reason:
+            'a mid-session drop must write a state-transition line to the '
+            'lifecycle ring so it is observable in the connect-log bundle '
+            '(#836). Lifecycle ring: $lifecycle',
+      );
+
+      // Now flood the connect ring past its cap — the exact thing the per-frame
+      // fit659 offstage spam used to do. The dedicated lifecycle ring must STILL
+      // retain the drop event.
+      for (var i = 0; i < connectLogCapacity + 50; i++) {
+        ctrace('ui.fit659', 'no TerminalViewState yet (offstage?) $i');
+      }
+
+      expect(
+        lifecycleLogSnapshot().join('\n'),
+        contains('state: connected → softDisconnected'),
+        reason:
+            'the drop transition must outlive a connect-ring flood — the whole '
+            'point of #836 telemetry hygiene. The fit659 spam must never be '
+            'able to bury a disconnect again.',
+      );
+    },
+  );
+}

--- a/native/test/widget/terminal_remeasure_test.dart
+++ b/native/test/widget/terminal_remeasure_test.dart
@@ -178,6 +178,7 @@ void main() {
     debugConnectRemeasureArmCount = 0;
     debugExplicitFitAppliedCount = 0;
     debugForcedPtyResyncCount = 0;
+    debugOffstageFitSkipCount = 0;
     clearConnectLog();
   });
 
@@ -528,6 +529,155 @@ void main() {
         await _fireFontsChange(tester);
         await tester.pump(const Duration(milliseconds: 50));
         expect(s.entry.terminal.viewHeight, before);
+        expect(tester.takeException(), isNull);
+      },
+    );
+  });
+
+  group('offstage fit hygiene (#836)', () {
+    // The device "disconnected with no indication" report shipped a connect-log
+    // that was ~entirely the per-frame `[ui.fit659] no TerminalViewState yet
+    // (offstage?)` line — the fit path fires per-frame (post-frame callbacks,
+    // didChangeMetrics, font changes, the connect burst), and while the body is
+    // offstage (no mounted TerminalViewState) every one logged, flooding the
+    // 200-event ring and burying the actual disconnect. The fix SKIPS the fit
+    // offstage and logs the skip AT MOST ONCE per offstage period.
+
+    testWidgets(
+      'repeated metrics/font events with NO mounted TerminalViewState skip the '
+      'fit and log the offstage line ONLY ONCE — the connect ring does not '
+      'flood (#836)',
+      (tester) async {
+        // Use the DEFAULT (ghostty) backend: TerminalScreen renders the flterm
+        // body, NOT the xterm TerminalView, so `_findTerminalViewState()`
+        // returns null on every fit attempt — the exact "no TerminalViewState
+        // (offstage?)" condition. The metrics/font listeners + the mount/connect
+        // fit all still route through `_explicitFit`, so this faithfully drives
+        // the offstage branch the device hit (the fit659 spam fired while there
+        // was no xterm view to measure).
+        final pair = InMemoryGatewayPair();
+        addTearDown(() async => pair.dispose());
+        final container = ProviderContainer(
+          overrides: [
+            taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+          ],
+        );
+        addTearDown(container.dispose);
+        container
+            .read(sessionsProvider.notifier)
+            .addOrActivate(
+              const SshConnectParams(
+                host: 'h',
+                port: 22,
+                username: 'u',
+                auth: SshAuth.password('p'),
+              ),
+            );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: TerminalScreen()),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 50));
+
+        clearConnectLog();
+        final skipsBefore = debugOffstageFitSkipCount;
+
+        // Fire many metrics/font events — each routes through _explicitFit.
+        for (var i = 0; i < 20; i++) {
+          tester.binding.handleMetricsChanged();
+          await _fireFontsChange(tester);
+          await tester.pump(const Duration(milliseconds: 20));
+        }
+
+        // The fit was SKIPPED on each attempt (work avoided)...
+        expect(
+          debugOffstageFitSkipCount,
+          greaterThan(skipsBefore),
+          reason:
+              'fits with no mounted TerminalViewState must be skipped (counted) '
+              '— the fit does no useful work (#836)',
+        );
+
+        // ...but the offstage ctrace line was emitted AT MOST ONCE, so the ring
+        // did not flood. (Before the fix this was one line PER attempt — the
+        // ~100×/sec spam that buried the disconnect.)
+        final offstageLines = connectLogSnapshot()
+            .where((l) => l.contains('offstage?'))
+            .toList();
+        expect(
+          offstageLines.length,
+          lessThanOrEqualTo(1),
+          reason:
+              'the offstage-skip line must be logged at most once per offstage '
+              'period — it must NOT flood the 200-event connect ring and bury '
+              'disconnect events (#836). Got: $offstageLines',
+        );
+
+        // No real fit ran, so neither the explicit-fit nor the forced
+        // PTY-resync counters advanced — pure churn was eliminated.
+        expect(debugExplicitFitAppliedCount, 0);
+        expect(debugForcedPtyResyncCount, 0);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'a HIGH-signal lifecycle event survives a flood of offstage-fit lines '
+      '— state transitions are not evicted (#836)',
+      (tester) async {
+        // Even if some offstage spam slips through, a lifecycle event (the kind
+        // a session drop records via clifecycle) lands in the dedicated ring
+        // that outlives connect-ring churn. This is the survivability guarantee.
+        clifecycle('task.host', 'state: connected → softDisconnected');
+
+        // Flood the connect ring with offstage-style fit lines past its cap.
+        for (var i = 0; i < connectLogCapacity + 50; i++) {
+          ctrace('ui.fit659', 'metrics $i: no TerminalViewState yet (offstage?)');
+        }
+
+        expect(
+          lifecycleLogSnapshot().join('\n'),
+          contains('state: connected → softDisconnected'),
+          reason:
+              'the drop transition must outlive an offstage-fit flood — the '
+              'core #836 telemetry-hygiene guarantee',
+        );
+      },
+    );
+
+    testWidgets(
+      'when the view IS mounted the fit still runs — first-connect fill is not '
+      'regressed (#659/#666)',
+      (tester) async {
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        // Onstage + shell-ready: the connect burst must still arm and the fit
+        // must still drive the PTY resize (the #659/#666 first-connect fill).
+        final s = await _setupConnected(tester, transport);
+        for (var i = 0; i < 30; i++) {
+          await tester.pump(const Duration(milliseconds: 50));
+        }
+
+        expect(
+          debugConnectRemeasureArmCount,
+          greaterThanOrEqualTo(1),
+          reason: 'onstage connect must still arm the fit burst (no regression)',
+        );
+        expect(
+          debugForcedPtyResyncCount,
+          greaterThanOrEqualTo(1),
+          reason: 'onstage connect must still force-resync the PTY (#666)',
+        );
+        expect(s.entry.terminal.viewHeight, greaterThan(24));
+        // The onstage path must NOT have logged any offstage-skip line.
+        expect(
+          connectLogSnapshot().where((l) => l.contains('offstage?')),
+          isEmpty,
+          reason: 'a mounted view must never log the offstage-skip line',
+        );
         expect(tester.takeException(), isNull);
       },
     );


### PR DESCRIPTION
## Summary
Problem 1 of #836 ONLY — telemetry hygiene so a disconnect is observable. Does NOT touch the deeper mid-session-liveness fix (Problem 2 / #766), which needs a re-capture with working telemetry first.

- `terminal_screen.dart`: when there is NO mounted `TerminalViewState` (offstage / the default ghostty body), `_explicitFit` SKIPS the fit pass AND emits the `no TerminalViewState yet (offstage?)` ctrace line at most ONCE per offstage period (a `_offstageFitLogged` latch, reset when a view is found). Stops the ~100×/sec per-frame churn that flooded the 200-event connect ring and buried the actual disconnect. `ctrace` only collapses *consecutive* identical lines; the offstage line's `$trigger` varies (mount/metrics/font/burst-Nms), so the run broke and the ring flooded — the latch fixes that.
- `session_host.dart`: every session state transition (`data.state != prevState`) now also writes `clifecycle('task.host', 'state: prev → next [(error)]')`. Previously a transition was only echoed to the TERMINAL bytes (`_emitConnectStatus`), never to the ctrace/lifecycle ring — so a silent mid-session drop left NO trace event at all. `clifecycle` lands in the dedicated lifecycle ring (cap 80, never evicted by connect-ring churn) and forwards UI-side, so a re-captured "no indication" drop now shows `state: connected → softDisconnected` regardless of any remaining spam.

## TDD Analysis
- Type: bug fix (telemetry hygiene)
- Behavior change: no user-facing behavior — diagnostics only
- TDD approach: full (red baseline confirmed, then green)

## Test coverage
- **New `test/services/session_state_trace_test.dart`**: a `connected → softDisconnected` drop writes a `state:` transition line to the lifecycle ring that SURVIVES a connect-ring flood. (Red first: failed only on a transient intermediate-state assertion, confirming the transition IS recorded.)
- **`test/widget/terminal_remeasure_test.dart` (offstage group, #836)**:
  - repeated metrics/font events with NO mounted TerminalViewState → fit SKIPPED (counter rises), offstage ctrace line logged at most ONCE (ring does not flood), no explicit-fit/PTY-resync churn.
  - a high-signal lifecycle event survives a flood of offstage-fit lines.
  - **regression guard**: when the view IS mounted, the connect burst still arms + force-resyncs the PTY and the terminal fills (no #659/#666 regression); the onstage path never logs an offstage line.
- **Existing**: all `connect_trace` + `terminal_remeasure` tests still pass; added `debugOffstageFitSkipCount` reset to `setUp`.

## Test results
- flutter analyze: PASS (No issues found)
- flutter test (fast gate, excludes integration): PASS (1053 tests)
- NATIVE FAST GATE: PASSED

## Diff stats
- Files changed: 4 (2 source, 2 test)
- Lines: ~+200 / -1

## Device note
Per Article 6: this is a telemetry/diagnostics change with no layout/keyboard/gesture surface, validated headless. The PAYOFF is on-device — the owner should re-capture a "no indication" drop; the connect-log will now show whether it's a silent drop (no `state:` line) or a UI-update miss, which informs the #766 Problem-2 fix.

Closes #836

## Cycles used
1/3