### PR TITLE
feat(native): disconnect-case instrumentation (cause/end-time/latency/heartbeat) (#838)

### DIFF
--- a/native/integration_test/disconnect_telemetry_test.dart
+++ b/native/integration_test/disconnect_telemetry_test.dart
@@ -1,0 +1,133 @@
+// On-emulator disconnect-telemetry test (#838).
+//
+// Proves the disconnect-case instrumentation against a LIVE sshd end-to-end:
+// after a real connect + shell, a user Disconnect must write ONE structured
+// `disconnect:` line into the DURABLE lifecycle ring carrying the cause label,
+// the end-time→detection latency, and a single edge# ("cut once"). This is the
+// on-device gate for the telemetry the eventual #766 mid-session-liveness fix
+// will be built + validated from.
+//
+// SEAM / coverage boundary (per #589):
+//   - The CAUSE classification, LATENCY computation, single-edge "cut once"
+//     guard, and the liveness HEARTBEAT are covered DETERMINISTICALLY in
+//     test/services/disconnect_telemetry_test.dart and
+//     test/services/liveness_heartbeat_test.dart (injected clock + inert
+//     controller — every cause, exact latency, growing silent-drop age).
+//   - THIS emulator test proves the END-TO-END path against a real sshd: a real
+//     connect → shell → user Disconnect lands a `disconnect:` line in the ring
+//     the feedback bundle reads. Inducing transport socket-error / Doze
+//     half-open drops needs OS-level Doze the emulator can't reproduce, so the
+//     headless seams stand in for those causes; this guards that the real
+//     wiring emits the line at all.
+//
+// SKIPPED (skip: true), matching resume_liveness_test.dart: a LIVE ghostty
+// terminal view + the foreground-task isolate keep the integration binding from
+// ever idling, so pump never settles. Orchestrator runs it on a booted emulator
+// as the device gate; CI/fast-gate excludes integration_test.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'a real connect + user Disconnect writes a single disconnect line with '
+    'cause + latency to the durable lifecycle ring (#838)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      clearConnectLog();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Connect to the emulator-local sshd and prove a live shell.
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find
+            .byKey(const Key('session-menu-button'))
+            .evaluate()
+            .isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'initial connect did not reach a shell');
+
+      // Prove the first shell streams bytes (so tLastActivity is a real byte).
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull);
+      final out = <int>[];
+      final sub = entry!.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      var gotBytes = false;
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (out.isNotEmpty) {
+          gotBytes = true;
+          break;
+        }
+      }
+      expect(gotBytes, isTrue, reason: 'no pre-disconnect shell bytes');
+
+      // User Disconnect: open the session menu, tap Disconnect (#607).
+      await tester.tap(find.byKey(const Key('session-bar-open-menu')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      await tester.tap(find.byKey(const Key('terminal-disconnect-button')));
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(const Key('new-connection')).evaluate().isNotEmpty) {
+          break;
+        }
+      }
+
+      // The disconnect must have landed a structured line in the durable ring
+      // (forwarded task→UI via SshLifecycleEvent). Exactly one drop edge.
+      final drops = lifecycleLogSnapshot()
+          .where((l) => l.contains('disconnect:'))
+          .toList();
+      expect(
+        drops.length,
+        1,
+        reason:
+            'exactly ONE disconnect line per user Disconnect (cut once). '
+            'Ring: ${lifecycleLogSnapshot().join('\n')}',
+      );
+      final line = drops.single;
+      expect(line, contains('cause=user-disconnect'));
+      expect(line, contains('intent=user'));
+      expect(line, contains('latencyMs='));
+      expect(line, contains('edge=1'));
+    },
+    skip: true,
+  );
+}

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -148,6 +148,12 @@ class SessionHost {
   /// for the desktop / in-process path where hosts share one isolate).
   void Function(String line)? _lifecycleForward;
 
+  /// Minimum spacing between liveness-heartbeat lines per session (#838).
+  /// The heartbeat piggybacks the 2s snapshot tick but only emits this often so
+  /// the durable lifecycle ring isn't churned by alive-pings — yet a silent drop
+  /// is still caught within ~10s by the growing lastActivityAge.
+  static const int _heartbeatIntervalMs = 10000;
+
   final Map<String, _HostedSession> _sessions = {};
 
   /// Sessions visible to tests + the future audit screen wiring.
@@ -418,6 +424,12 @@ class SessionHost {
           'state: ${prevState.name} → ${data.state.name}'
               '${data.error != null ? ' (${data.error})' : ''}',
         );
+        // #838: when this edge is a DROP (left/never-reached `connected` into a
+        // disconnect state), emit ONE structured disconnect line carrying the
+        // CAUSE, end-time→detection LATENCY, transport/keepalive/attempt/intent
+        // context, and a monotonic edge# so a capture reveals double-fires
+        // ("cut once"). Telemetry only — drives no behaviour.
+        _maybeRecordDisconnect(cmd.sessionId, hosted, prevState, data);
         prevState = data.state;
       }
       // Drop the prior shell the instant the transport leaves `connected`
@@ -439,6 +451,9 @@ class SessionHost {
       // disabled by the #533 task-isolate migration and the task-side shell
       // was never wired until now.
       if (data.state == SshSessionState.connected) {
+        // #838: stamp connect time as a latency fallback for a drop that
+        // happens before the remote ever produced a byte.
+        hosted.connectedAtMs = _nowMs();
         unawaited(_ensureShell(cmd.sessionId, hosted));
       }
     });
@@ -660,6 +675,134 @@ class SessionHost {
     );
   }
 
+  /// The disconnect / dropped-into states (#838). Entering one of these from a
+  /// non-drop state is a single DROP edge — the unit the disconnect telemetry
+  /// records once. `reconnecting`/`softDisconnected` are included because they
+  /// are the FIRST observable edge of an involuntary drop (the user sees the
+  /// session leave `connected`); a later `failed` after reconnect-exhaustion is
+  /// a SEPARATE edge and is logged as such, so a capture shows the full chain.
+  static const Set<SshSessionState> _dropStates = {
+    SshSessionState.softDisconnected,
+    SshSessionState.reconnecting,
+    SshSessionState.failed,
+    SshSessionState.disconnected,
+  };
+
+  /// Classify a drop edge's CAUSE from the (prev→new) transition + controller
+  /// context (#838). Pure string label for telemetry; no behaviour depends on
+  /// it. Cause taxonomy mirrors the Phase-0 disconnect-path map.
+  static String _classifyDropCause(
+    SshSessionState prev,
+    SshSessionData data,
+    SshSessionController controller,
+  ) {
+    final next = data.state;
+    if (controller.userInitiatedDisconnect &&
+        next == SshSessionState.disconnected) {
+      return 'user-disconnect';
+    }
+    if (next == SshSessionState.failed) {
+      final err = data.error ?? '';
+      if (err.contains('reconnect exhausted')) return 'reconnect-exhausted';
+      if (err.contains('No SSH response')) return 'handshake-timeout';
+      if (err.contains('Authentication failed')) return 'auth-failed';
+      if (err.contains('Host key rejected')) return 'hostkey-rejected';
+      if (err.contains('TCP connect failed')) return 'tcp-connect-failed';
+      if (err.contains('Could not load private key') ||
+          err.contains('Private key contained no usable identity')) {
+        return 'key-load-failed';
+      }
+      if (err.contains('Transport error')) {
+        return controller.lastErrorUnreachable
+            ? 'transport-unreachable'
+            : 'transport-error';
+      }
+      return 'failed';
+    }
+    if (prev == SshSessionState.connected) {
+      // Left a working session. softDisconnected = clean server close or a
+      // probe/nudge-declared stale link; reconnecting = transient socket error.
+      if (next == SshSessionState.softDisconnected) return 'server-or-stale';
+      if (next == SshSessionState.reconnecting) {
+        return controller.lastErrorUnreachable
+            ? 'socket-unreachable'
+            : 'socket-transient';
+      }
+    }
+    return 'clean-close';
+  }
+
+  /// Emit ONE structured disconnect-cause line per DROP edge (#838).
+  ///
+  /// Fires only on the FIRST edge into a drop state from a non-drop state — so a
+  /// `connected → softDisconnected → reconnecting → failed` chain logs each
+  /// distinct edge once (visible as increasing `edge=`), but a repeated emit of
+  /// the SAME drop state (e.g. a banner update while `failed`) does NOT re-fire.
+  /// This is the "cut once" guard: a true double-fire would show two disconnect
+  /// lines with the SAME prev→new at the same instant.
+  ///
+  /// LATENCY = tDetected − tLastActivity: how long the link was effectively dead
+  /// before we noticed. tLastActivity is the last fresh remote byte (the honest
+  /// "remote is producing output" signal, #759); when the session never produced
+  /// a byte we fall back to the connect time so the number is bounded, flagged
+  /// `latencyFrom=connect`. Allocation-light: one formatted string per drop edge.
+  void _maybeRecordDisconnect(
+    String sessionId,
+    _HostedSession hosted,
+    SshSessionState prev,
+    SshSessionData data,
+  ) {
+    final next = data.state;
+    final isDropEdge = _dropStates.contains(next) && !_dropStates.contains(prev);
+    if (!isDropEdge) return;
+
+    hosted.dropEdges += 1;
+    final now = _nowMs();
+    final lastActivity = hosted.lastRemoteByteAtMs ?? hosted.connectedAtMs;
+    final latencyMs = lastActivity == null ? -1 : (now - lastActivity);
+    final latencyFrom = hosted.lastRemoteByteAtMs != null
+        ? 'lastByte'
+        : (hosted.connectedAtMs != null ? 'connect' : 'none');
+    final controller = hosted.controller;
+    final cause = _classifyDropCause(prev, data, controller);
+
+    clifecycle(
+      'task.host',
+      'disconnect: cause=$cause ${prev.name}→${next.name} '
+          'latencyMs=$latencyMs from=$latencyFrom '
+          'transport=${controller.client != null ? 'open' : 'closed'} '
+          'attempt=${controller.reconnectAttempts} '
+          'intent=${controller.userInitiatedDisconnect ? 'user' : 'auto'} '
+          'edge=${hosted.dropEdges}',
+    );
+  }
+
+  /// Emit a periodic liveness HEARTBEAT for each `connected` session (#838).
+  ///
+  /// Piggybacks the existing snapshot tick — NO new wakeful timer (battery /
+  /// #806). Throttled to [_heartbeatIntervalMs] so it stays allocation-light
+  /// even at the 2s snapshot cadence. The line records perceived-alive + the
+  /// AGE of the last fresh remote byte: a SILENT drop (no transition fires)
+  /// shows up as "heartbeat says alive but lastActivityAgeMs keeps growing" —
+  /// exactly the undetected-drop window #766 will close. Skipped while the UI is
+  /// backgrounded (the snapshot timer is stopped then anyway).
+  void _maybeEmitHeartbeats() {
+    final now = _nowMs();
+    for (final entry in _sessions.entries) {
+      final hosted = entry.value;
+      if (hosted.controller.data.state != SshSessionState.connected) continue;
+      if (now - hosted.lastHeartbeatAtMs < _heartbeatIntervalMs) continue;
+      hosted.lastHeartbeatAtMs = now;
+      final lastActivity = hosted.lastRemoteByteAtMs ?? hosted.connectedAtMs;
+      final ageMs = lastActivity == null ? -1 : (now - lastActivity);
+      clifecycle(
+        'task.host',
+        'heartbeat: alive state=connected lastActivityAgeMs=$ageMs '
+            'edge=${hosted.dropEdges}',
+      );
+    }
+  }
+
   /// One concise terminal line per connect phase so a stall is visible.
   void _emitConnectStatus(String sessionId, SshSessionData data) {
     final String? line;
@@ -864,6 +1007,9 @@ class SessionHost {
 
   void _pushSnapshots() {
     if (_disposed) return;
+    // #838: piggyback the existing snapshot tick to emit liveness heartbeats —
+    // no extra wakeful timer (battery / #806). Throttled inside.
+    _maybeEmitHeartbeats();
     for (final entry in _sessions.entries) {
       // Dirty-check (#806 B): only ship a periodic snapshot when something the
       // UI renders actually changed since the last periodic push. An idle
@@ -1058,6 +1204,23 @@ class _HostedSession {
   /// session that produced fresh bytes recently is NOT escalated to the nudge
   /// check on resume (conservative — don't churn a healthy idle session).
   int? lastRemoteByteAtMs;
+
+  /// Wall-clock (ms since epoch) the session most recently reached `connected`
+  /// (#838). Used as the tLastActivity fallback when a drop happens before the
+  /// remote ever produced a byte, so the disconnect latency is bounded rather
+  /// than -1.
+  int? connectedAtMs;
+
+  /// Monotonic count of DROP edges observed for this session (#838). Stamped on
+  /// each `disconnect:` line as `edge=N` so a capture reveals double-fires
+  /// (a true "cut once" violation = two lines with the same prev→new at once)
+  /// and lets the heartbeat correlate to the most recent drop.
+  int dropEdges = 0;
+
+  /// Wall-clock (ms since epoch) of the last liveness-heartbeat line (#838).
+  /// Throttles the heartbeat to one per [SessionHost._heartbeatIntervalMs]
+  /// even though it piggybacks the faster snapshot tick.
+  int lastHeartbeatAtMs = 0;
 
   /// Monotonic token bumped each time the shell is dropped (#590). An in-flight
   /// [SessionHost._ensureShell] open captures this before awaiting and discards

--- a/native/lib/ssh/ssh_session.dart
+++ b/native/lib/ssh/ssh_session.dart
@@ -248,6 +248,12 @@ class SshSessionController {
   /// [_assertSuppressConsistent]).
   bool get _autoReconnectSuppressed => _userDisconnected;
 
+  /// Read-only view of the user-intent bit (#838). The disconnect-cause
+  /// classifier reads this to label a drop as user-initiated (✕/Disconnect) vs.
+  /// involuntary, since the `disconnected` state alone is ambiguous between the
+  /// two. Pure telemetry — no behaviour depends on this getter.
+  bool get userInitiatedDisconnect => _userDisconnected;
+
   /// Debug-only invariant: when the user-intent bit is set, the session MUST be
   /// in the `disconnected` terminal state. (The converse does NOT hold —
   /// `disconnected` is also reached by an involuntary clean close.) Guards

--- a/native/test/services/disconnect_telemetry_test.dart
+++ b/native/test/services/disconnect_telemetry_test.dart
@@ -1,0 +1,221 @@
+// Disconnect-case instrumentation (#838).
+//
+// Builds on #836's state-transition logging. For each disconnect CAUSE this
+// asserts the host writes ONE structured `disconnect:` line to the durable
+// lifecycle ring carrying: cause label, prev→new edge, end-time→detection
+// LATENCY, transport/keepalive/attempt/intent context, and a monotonic edge#.
+// The edge# is the "cut once" guard — a flap shows as increasing edges, a true
+// double-fire would show two lines with the same prev→new at one instant.
+//
+// Headless via InMemoryGatewayPair + a no-connect controller the test drives
+// directly (no real socket), and an injectable clock so latency is deterministic.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// Inert controller: the test owns connected + the drop, the reconnect attempt
+/// fail-fasts so the session settles instead of looping.
+class _NoConnectController extends SshSessionController {
+  _NoConnectController({super.reconnectDelay, super.reconnectAttemptOverride});
+
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+class _Harness {
+  _Harness(this.host, this.pair, this.controllerOf, this.clock);
+  final SessionHost host;
+  final InMemoryGatewayPair pair;
+  final SshSessionController Function() controllerOf;
+  final List<int> clock;
+}
+
+Future<_Harness> _spawn({Duration reconnectDelay = Duration.zero}) async {
+  late SshSessionController controller;
+  final clock = <int>[1000]; // mutable "now"
+  SshSessionController factory() {
+    controller = _NoConnectController(
+      reconnectDelay: reconnectDelay,
+      reconnectAttemptOverride: (_) async => false,
+    );
+    return controller;
+  }
+
+  final pair = InMemoryGatewayPair();
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: factory,
+    snapshotInterval: const Duration(hours: 1),
+    nowMs: () => clock.first,
+  );
+  return _Harness(host, pair, () => controller, clock);
+}
+
+Future<void> _connect(_Harness h, String sid) async {
+  h.pair.uiSide.send(
+    SshConnectCommand(
+      sessionId: sid,
+      host: 'h',
+      port: 22,
+      username: 'u',
+      authJson: const {'type': 'password', 'password': 'p'},
+    ).toJson(),
+  );
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+}
+
+void main() {
+  setUp(clearConnectLog);
+  tearDown(() {
+    lifecycleForwarder = null;
+    clearConnectLog();
+  });
+
+  test(
+    'a clean server close (connected→softDisconnected) logs ONE disconnect line '
+    'with cause + latency + a single edge',
+    () async {
+      const sid = 'h:22:u:1';
+      final h = await _spawn();
+      addTearDown(() async {
+        await h.host.dispose();
+        await h.pair.dispose();
+      });
+      await _connect(h, sid);
+
+      // Reach connected at t=1000, last remote byte at t=2000.
+      h.clock[0] = 1000;
+      h.controllerOf().debugSetConnectedForTest(_params);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      h.clock[0] = 2000;
+      h.host.ingestOutputForTest(sid, Uint8List.fromList([1, 2, 3]));
+
+      // Detect the drop at t=5000 → latency = 5000 - 2000 = 3000ms.
+      h.clock[0] = 5000;
+      h.controllerOf().handleTransportClosed(null);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final lines = lifecycleLogSnapshot()
+          .where((l) => l.contains('disconnect:'))
+          .toList();
+      expect(
+        lines.length,
+        1,
+        reason: 'exactly ONE disconnect line per drop edge (cut once). '
+            'Got: $lines',
+      );
+      final line = lines.single;
+      expect(line, contains('cause=server-or-stale'));
+      expect(line, contains('connected→softDisconnected'));
+      expect(line, contains('latencyMs=3000'));
+      expect(line, contains('from=lastByte'));
+      expect(line, contains('edge=1'));
+    },
+  );
+
+  test(
+    'a user disconnect logs cause=user-disconnect intent=user',
+    () async {
+      const sid = 'h:22:u:2';
+      final h = await _spawn();
+      addTearDown(() async {
+        await h.host.dispose();
+        await h.pair.dispose();
+      });
+      await _connect(h, sid);
+      h.controllerOf().debugSetConnectedForTest(_params);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      await h.controllerOf().disconnect();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final lines = lifecycleLogSnapshot()
+          .where((l) => l.contains('disconnect:'))
+          .toList();
+      expect(lines.length, 1, reason: 'one drop edge. Got: $lines');
+      expect(lines.single, contains('cause=user-disconnect'));
+      expect(lines.single, contains('intent=user'));
+      expect(lines.single, contains('→disconnected'));
+    },
+  );
+
+  test(
+    'latency falls back to connect time (from=connect) when no remote byte '
+    'ever arrived',
+    () async {
+      const sid = 'h:22:u:3';
+      final h = await _spawn();
+      addTearDown(() async {
+        await h.host.dispose();
+        await h.pair.dispose();
+      });
+      await _connect(h, sid);
+      h.clock[0] = 1000;
+      h.controllerOf().debugSetConnectedForTest(_params);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      // No ingestOutputForTest → never produced a byte.
+      h.clock[0] = 4000;
+      h.controllerOf().handleTransportClosed(null);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final line = lifecycleLogSnapshot()
+          .firstWhere((l) => l.contains('disconnect:'));
+      expect(line, contains('from=connect'));
+      expect(line, contains('latencyMs=3000'));
+    },
+  );
+
+  test(
+    'a drop chain (softDisconnected → failed) logs each edge once with '
+    'increasing edge# (no double-fire)',
+    () async {
+      const sid = 'h:22:u:4';
+      // reconnect override returns false so the session exhausts and goes failed.
+      final h = await _spawn();
+      addTearDown(() async {
+        await h.host.dispose();
+        await h.pair.dispose();
+      });
+      await _connect(h, sid);
+      h.controllerOf().debugSetConnectedForTest(_params);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      h.controllerOf().handleTransportClosed(null);
+      // Drain reconnect microtasks until it settles on failed.
+      for (var i = 0; i < 40; i++) {
+        await Future<void>.delayed(Duration.zero);
+        if (h.controllerOf().data.state == SshSessionState.failed) break;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final lines = lifecycleLogSnapshot()
+          .where((l) => l.contains('disconnect:'))
+          .toList();
+      // First edge: connected→softDisconnected (edge=1). The chain may also
+      // produce a reconnecting and/or failed edge; each must be unique + once.
+      expect(lines.first, contains('edge=1'));
+      final edges = lines
+          .map((l) => RegExp(r'edge=(\d+)').firstMatch(l)!.group(1))
+          .toList();
+      expect(
+        edges.toSet().length,
+        edges.length,
+        reason: 'every disconnect edge# is unique — no double-fire. $lines',
+      );
+    },
+  );
+}

--- a/native/test/services/liveness_heartbeat_test.dart
+++ b/native/test/services/liveness_heartbeat_test.dart
@@ -1,0 +1,154 @@
+// Liveness-heartbeat instrumentation (#838).
+//
+// A SILENT mid-session drop fires NO transition — the session sits `connected`
+// over a dead link and #836's transition log shows nothing. The heartbeat
+// closes that observability gap: while `connected`, the host emits a periodic
+// `heartbeat: alive ... lastActivityAgeMs=N` line (piggybacked on the existing
+// snapshot tick, NO new timer). A silent drop is then visible as "heartbeat
+// keeps saying alive but lastActivityAgeMs keeps growing" — the undetected-drop
+// window #766 will close.
+//
+// Headless via InMemoryGatewayPair + an injectable clock so the age is
+// deterministic, and a short snapshot interval so the piggybacked tick fires.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+class _NoConnectController extends SshSessionController {
+  _NoConnectController() : super(reconnectDelay: Duration.zero);
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+void main() {
+  setUp(clearConnectLog);
+  tearDown(() {
+    lifecycleForwarder = null;
+    clearConnectLog();
+  });
+
+  test(
+    'a connected session emits heartbeats with a GROWING lastActivityAge while '
+    'NO transition fires (silent-drop visibility)',
+    () async {
+      const sid = 'h:22:u:1';
+      final clock = <int>[0];
+      late SshSessionController controller;
+      SshSessionController factory() => controller = _NoConnectController();
+
+      final pair = InMemoryGatewayPair();
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: factory,
+        // Short tick so the piggybacked heartbeat fires quickly in the test.
+        snapshotInterval: const Duration(milliseconds: 20),
+        nowMs: () => clock.first,
+      );
+      addTearDown(() async {
+        await host.dispose();
+        await pair.dispose();
+      });
+
+      pair.uiSide.send(
+        const SshConnectCommand(
+          sessionId: sid,
+          host: 'h',
+          port: 22,
+          username: 'u',
+          authJson: {'type': 'password', 'password': 'p'},
+        ).toJson(),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      // Connected at t=0 with a fresh byte at t=0.
+      clock[0] = 0;
+      controller.debugSetConnectedForTest(_params);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      host.ingestOutputForTest(sid, Uint8List.fromList([1]));
+
+      // Advance the clock past the heartbeat interval and let the snapshot tick
+      // fire twice — at t=10000 and t=25000. No byte ingested, no transition:
+      // the link is silently dead. Heartbeats must still fire, age growing.
+      clock[0] = 10000;
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      clock[0] = 25000;
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+
+      final beats = lifecycleLogSnapshot()
+          .where((l) => l.contains('heartbeat:'))
+          .toList();
+      expect(
+        beats.length,
+        greaterThanOrEqualTo(2),
+        reason: 'heartbeat must keep firing while connected. Got: $beats',
+      );
+      for (final b in beats) {
+        expect(b, contains('alive state=connected'));
+      }
+      // Age must be strictly growing across the two beats (silent drop signal).
+      int ageOf(String l) =>
+          int.parse(RegExp(r'lastActivityAgeMs=(\d+)').firstMatch(l)!.group(1)!);
+      final ages = beats.map(ageOf).toList();
+      expect(
+        ages.last,
+        greaterThan(ages.first),
+        reason: 'lastActivityAgeMs must grow under a silent drop. $ages',
+      );
+    },
+  );
+
+  test(
+    'no heartbeat fires for a session that is NOT connected',
+    () async {
+      const sid = 'h:22:u:2';
+      final clock = <int>[0];
+      SshSessionController factory() => _NoConnectController();
+
+      final pair = InMemoryGatewayPair();
+      final host = SessionHost(
+        gateway: pair.taskSide,
+        controllerFactory: factory,
+        snapshotInterval: const Duration(milliseconds: 20),
+        nowMs: () => clock.first,
+      );
+      addTearDown(() async {
+        await host.dispose();
+        await pair.dispose();
+      });
+
+      pair.uiSide.send(
+        const SshConnectCommand(
+          sessionId: sid,
+          host: 'h',
+          port: 22,
+          username: 'u',
+          authJson: {'type': 'password', 'password': 'p'},
+        ).toJson(),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      // Stays idle (no debugSetConnectedForTest). Advance time + tick.
+      clock[0] = 30000;
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(
+        lifecycleLogSnapshot().where((l) => l.contains('heartbeat:')),
+        isEmpty,
+        reason: 'only connected sessions get a heartbeat',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Instruments every disconnect path at the `SessionHost` transition listener — the one seam that observes all transitions AND holds `tLastActivity` (`lastRemoteByteAtMs`).
- Per DROP edge, emits ONE structured `disconnect:` line to the durable lifecycle ring: **cause**, prev→new, **latencyMs = tDetected − tLastActivity** (`from=lastByte|connect|none`), transport open/closed, reconnect attempt#, user-intent bit, monotonic **edge#**.
- Adds a periodic **liveness heartbeat** piggybacked on the existing 2s snapshot tick (no new wakeful timer; throttled to 10s) recording perceived-alive + `lastActivityAgeMs`. A SILENT drop shows as "heartbeat alive but age growing" — the undetected-drop window #766 will close.
- "cut once": `edge=N` per session; a drop fires exactly one edge (first entry into a drop state); a flap shows as increasing edges.

## Phase 0 — disconnect-path map (file:line)
| Cause label | Site | Edge |
|---|---|---|
| user-disconnect | ssh_session.dart:929 | →disconnected (intent=user) |
| server-or-stale | ssh_session.dart:695 / probe:547 / nudge:572 | connected→softDisconnected |
| socket-transient / socket-unreachable | ssh_session.dart:706 | connected→reconnecting |
| transport-error / transport-unreachable | ssh_session.dart:712 | →failed |
| handshake-timeout | ssh_session.dart:1041 | connecting/authenticating→failed |
| reconnect-exhausted | ssh_session.dart:814 | →failed |
| auth-failed / hostkey-rejected / tcp-connect-failed / key-load-failed | connect() paths | →failed |
| SILENT (no event) | — | exposed by heartbeat age-growth |

## TDD Analysis
- Type: feature (telemetry only)
- Behavior change: no (reconnect/keepalive/probe untouched)
- TDD approach: full (headless, injected clock + inert controller) + on-device gate

## Test coverage
- **New tests (fail→pass)**:
  - `test/services/disconnect_telemetry_test.dart` — clean server close (cause + latencyMs=3000 from=lastByte + edge=1), user disconnect (cause=user-disconnect intent=user), connect-time latency fallback (from=connect), drop chain logs each edge once with unique edge# (no double-fire).
  - `test/services/liveness_heartbeat_test.dart` — connected session emits heartbeats with a GROWING lastActivityAge while no transition fires (silent-drop visibility); non-connected session emits none.
- **Integration (orchestrator-runs, tag-skipped like resume_liveness_test)**: `integration_test/disconnect_telemetry_test.dart` — real connect + user Disconnect lands a single `disconnect:` line with cause + latency in the durable ring.
- **Existing tests**: unchanged; all still pass (the new line appears alongside existing `state:` lines, verified across the suite e.g. `cause=tcp-connect-failed`).

## Test results
- flutter analyze: PASS
- flutter test (native fast gate): PASS (1059 tests, ~5 pre-existing skips)

## Diff stats
- Files changed: 5 (2 source, 3 test)
- Lines: +677 (source +169; rest tests/integration)

## Out of scope
The actual mid-session-liveness DETECTION/FIX (#766) — to be built and validated FROM this telemetry, not blind-fixed.

Closes #838

## Cycles used
1/3