### PR TITLE
feat(#840): in-band attention-signal detector + telemetry (Slice 1)

### DIFF
--- a/native/integration_test/attention_signal_measurement_test.dart
+++ b/native/integration_test/attention_signal_measurement_test.dart
@@ -1,0 +1,273 @@
+// On-emulator ATTENTION-SIGNAL MEASUREMENT test (#840, Slice 1) — THE EXPERIMENT.
+//
+// Slice 1 ships a detector ONLY (no notification). The open empirical question
+// is: of the four in-band signal forms (bare BEL, OSC 9, OSC 777, the
+// notify-bell `# <message>` line), WHICH ones actually reach the MobiSSH PTY
+// stream, and does tmux forward/swallow them differently when the signal is
+// emitted in the ACTIVE vs a BACKGROUND tmux window?
+//
+// This test emits each form over a live session in THREE positions:
+//   (a) plain interactive shell (no tmux)
+//   (b) inside `tmux`, signal emitted in the ACTIVE window
+//   (c) inside `tmux`, signal emitted in a BACKGROUND window (we create a 2nd
+//       window, emit there, and STAY focused on window 0)
+// then reads back the task-isolate `clifecycle` ring (forwarded to the UI ring,
+// #766) to see whether the AttentionSignalScanner fired, and prints a findings
+// table.
+//
+// A "background-window bell/text NOT received" result is a VALID, expected
+// finding — tmux's bell-action / window isolation may legitimately swallow it.
+// This test does NOT assert every cell is detected; it RECORDS what was, and
+// only hard-fails if NOTHING is detected even in the plain-shell baseline (which
+// would mean the detector or its wiring is dead).
+//
+// tmux may be ABSENT on the Alpine test-sshd target. We try to install it over
+// the live session (`apk add tmux`). If that fails, the tmux cases are reported
+// as "tmux-unavailable" (NOT silently skipped) and only the plain-shell cases
+// run.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+
+@Tags(['integration'])
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+
+import 'support/connect_helpers.dart';
+
+/// The four signal forms under test, with the shell command that emits each.
+/// `printf` is used over the live PTY so the bytes hit the stream verbatim.
+class _Form {
+  const _Form(this.label, this.emit, this.expectText);
+  final String label;
+
+  /// The shell snippet (no trailing newline) that emits the signal.
+  final String emit;
+
+  /// A substring expected in the parsed signal text, or null for the bare bell.
+  final String? expectText;
+}
+
+const _msg = 'Claude is waiting';
+
+const _forms = <_Form>[
+  _Form('bell', "printf '\\a'", null),
+  _Form('osc9', "printf '\\033]9;$_msg\\007'", _msg),
+  _Form('osc777', "printf '\\033]777;notify;MobiSSH;$_msg\\007'", _msg),
+  // The exact notify-bell.sh pattern: CR, clear-to-EOL, "# message", BEL.
+  _Form('hookLine', "printf '\\r\\033[K# $_msg\\a'", _msg),
+];
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('measure which attention-signal forms reach the scanner '
+      'across plain / tmux-active / tmux-background positions', (tester) async {
+    FlutterForegroundTask.initCommunicationPort();
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
+
+    // Reach the terminal screen, accepting the host-key prompt if shown.
+    var connected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        connected = true;
+        break;
+      }
+    }
+    expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after connect');
+    final proxy = entry!.proxy;
+
+    final out = <int>[];
+    final sub = proxy.output.listen(out.addAll);
+    addTearDown(sub.cancel);
+
+    Future<void> settle(int pumps) async {
+      for (var i = 0; i < pumps; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+    }
+
+    void send(String cmd) =>
+        proxy.sendInput(Uint8List.fromList(utf8.encode(cmd)));
+
+    // Wait for the shell prompt (proves the PTY is live).
+    for (var i = 0; i < 40 && out.isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+    expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+    // The dedup cooldown is 2s per scanner; we wait >2.5s between emissions so
+    // each form is counted independently and a prior emission can't swallow the
+    // next under the cooldown.
+    Future<void> cooldown() => settle(12); // 12 * 250ms = 3s
+
+    // Count `attention:` lines for [kind] currently in the lifecycle ring.
+    int countKind(String kind, int sinceLen) {
+      final ring = lifecycleLogSnapshot();
+      var n = 0;
+      for (var i = sinceLen; i < ring.length; i++) {
+        if (ring[i].contains('[attention]') && ring[i].contains(' $kind ')) {
+          n++;
+        }
+      }
+      return n;
+    }
+
+    // result[position][formLabel] = detected?
+    final results = <String, Map<String, bool>>{
+      'plain': {},
+      'tmux-active': {},
+      'tmux-bg': {},
+    };
+    var tmuxStatus = 'not-attempted';
+
+    Future<bool> emitAndDetect(String emitCmd, String kind) async {
+      await cooldown();
+      final before = lifecycleLogSnapshot().length;
+      send('$emitCmd\n');
+      // Give the byte round-trip + scanner time to log.
+      await settle(16); // 4s
+      final got = countKind(kind, before) > 0;
+      return got;
+    }
+
+    // ── (a) PLAIN SHELL ────────────────────────────────────────────────────
+    for (final f in _forms) {
+      results['plain']![f.label] = await emitAndDetect(f.emit, f.label);
+    }
+
+    // ── Provision tmux (best-effort) ────────────────────────────────────────
+    // Check for tmux; install via apk if missing. The test-sshd is Alpine.
+    send('command -v tmux >/dev/null 2>&1 && echo MOBISSH_TMUX_YES '
+        '|| echo MOBISSH_TMUX_NO\n');
+    await settle(12);
+    var tmuxPresent =
+        utf8.decode(out, allowMalformed: true).contains('MOBISSH_TMUX_YES');
+    if (!tmuxPresent) {
+      // Try to install. apk may need root; testuser may or may not have it.
+      send('apk add --no-cache tmux >/dev/null 2>&1 || '
+          'sudo apk add --no-cache tmux >/dev/null 2>&1; '
+          'command -v tmux >/dev/null 2>&1 && echo MOBISSH_TMUX_INSTALLED '
+          '|| echo MOBISSH_TMUX_FAIL\n');
+      // apk fetch can be slow; allow a generous window.
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final s = utf8.decode(out, allowMalformed: true);
+        if (s.contains('MOBISSH_TMUX_INSTALLED')) {
+          tmuxPresent = true;
+          break;
+        }
+        if (s.contains('MOBISSH_TMUX_FAIL')) break;
+      }
+    }
+    tmuxStatus = tmuxPresent ? 'available' : 'unavailable';
+
+    if (tmuxPresent) {
+      // Start a clean tmux session, mouse off (not needed). Window 0 is active.
+      send('tmux kill-server 2>/dev/null; tmux new -d -s m; tmux attach -t m\n');
+      await settle(20); // let tmux take the alternate buffer
+
+      // ── (b) tmux ACTIVE window ────────────────────────────────────────────
+      // We're attached to window 0; emit directly into its pane (the shell we
+      // are typing into is that pane).
+      for (final f in _forms) {
+        results['tmux-active']![f.label] =
+            await emitAndDetect(f.emit, f.label);
+      }
+
+      // ── (c) tmux BACKGROUND window ────────────────────────────────────────
+      // Create window 1, send the emit command to it via `tmux send-keys -t`,
+      // but STAY focused on window 0. Whether tmux forwards a background
+      // window's BEL/OSC to the attached client is exactly what we measure.
+      // First create the second window and immediately switch back to 0.
+      send('tmux neww -t m: \\; selectw -t m:0\n');
+      await settle(12);
+      for (final f in _forms) {
+        await cooldown();
+        final before = lifecycleLogSnapshot().length;
+        // send-keys to window 1 (background), literal command + Enter.
+        // Escape single quotes for the tmux send-keys argument layer.
+        final inner = f.emit.replaceAll("'", "'\\''");
+        send("tmux send-keys -t m:1 '$inner' Enter\n");
+        await settle(16);
+        results['tmux-bg']![f.label] =
+            countKind(f.label, before) > 0;
+      }
+
+      send('tmux kill-server 2>/dev/null\n');
+      await settle(8);
+    } else {
+      for (final f in _forms) {
+        results['tmux-active']![f.label] = false;
+        results['tmux-bg']![f.label] = false;
+      }
+    }
+
+    // ── FINDINGS TABLE ───────────────────────────────────────────────────────
+    final sb = StringBuffer();
+    sb.writeln('ATTENTION840 ===== MEASUREMENT FINDINGS (#840 Slice 1) =====');
+    sb.writeln('ATTENTION840 tmux: $tmuxStatus');
+    sb.writeln('ATTENTION840 form      | plain | tmux-active | tmux-bg');
+    for (final f in _forms) {
+      String cell(String pos) => (results[pos]![f.label] ?? false) ? 'YES' : 'no ';
+      sb.writeln('ATTENTION840 ${f.label.padRight(9)} |  ${cell('plain')}  '
+          '|     ${cell('tmux-active')}     |   ${cell('tmux-bg')}');
+    }
+    sb.writeln('ATTENTION840 (lifecycle ring tail follows)');
+    for (final line in lifecycleLogSnapshot()) {
+      if (line.contains('[attention]')) sb.writeln('ATTENTION840 $line');
+    }
+    debugPrint(sb.toString());
+
+    // ── ACCEPTANCE (minimal) ─────────────────────────────────────────────────
+    // The detector + wiring must be ALIVE: at least one form must be detected
+    // in the plain-shell baseline. (We do NOT require tmux cells — those are the
+    // empirical unknowns this test exists to measure.)
+    final anyPlain = _forms.any((f) => results['plain']![f.label] == true);
+    expect(
+      anyPlain,
+      isTrue,
+      reason:
+          'NO attention signal detected even in the plain shell — the scanner '
+          'or its session_host wiring is dead. Findings:\n$sb',
+    );
+  });
+}

--- a/native/lib/services/attention_signal_scanner.dart
+++ b/native/lib/services/attention_signal_scanner.dart
@@ -1,0 +1,334 @@
+// In-band agent-attention signal detector (#840, Slice 1).
+//
+// Claude Code (and other tools) signal "I want your attention" through the PTY
+// byte stream in several forms. The PWA handles these in-band via xterm.js
+// `onBell` + `registerOscHandler(9)` + `registerOscHandler(777)`
+// (src/modules/terminal.ts). The native app has no server subscription, so it
+// must detect the same signals by scanning the raw dartssh2 byte stream BEFORE
+// the bytes reach the terminal renderer.
+//
+// This scanner is OBSERVE-ONLY: it never alters the forwarded bytes. It runs in
+// the task isolate alongside [Da2HyperlinkResponder] so it sees output for ALL
+// sessions, including backgrounded ones.
+//
+// FORMS DETECTED
+// --------------
+//   * bare BEL          0x07
+//   * OSC 9             ESC ] 9 ; <text> (BEL | ST)            ST = ESC \
+//   * OSC 777 (notify)  ESC ] 777 ; notify ; <title> ; <body> (BEL | ST)
+//   * notify-bell line  CR ESC [ K "# <message>" BEL
+//     (the exact sequence `~/.claude/hooks/notify-bell.sh` writes:
+//      `\r\033[K# <message>\a`)
+//
+// CHUNK BOUNDARIES
+// ----------------
+// A BEL or OSC can straddle two `output.listen` chunks, so a small suffix that
+// could still be the start of a sequence is buffered until the next [feed].
+//
+// FRAMING ORDER (no double-fire)
+// ------------------------------
+// OSC sequences are stripped FIRST. An OSC terminated by BEL must NOT also fire
+// as a bare-BEL signal — so the OSC's terminating BEL is consumed as part of the
+// OSC match and never re-examined as a standalone bell.
+//
+// DEDUP
+// -----
+// A 2-second per-scanner cooldown (mirroring the host `notify-bell.sh` lockfile)
+// collapses a burst of signals into one. The clock is injectable so unit tests
+// can drive it deterministically with `fake_async`.
+
+import 'dart:convert';
+
+/// The kind of attention signal detected in the PTY stream.
+enum AttentionKind {
+  /// A bare `0x07` BEL not consumed by an OSC terminator.
+  bell,
+
+  /// `ESC ] 9 ; <text> (BEL|ST)` — carries a human-readable message.
+  osc9,
+
+  /// `ESC ] 777 ; notify ; <title> ; <body> (BEL|ST)`.
+  osc777,
+
+  /// The `\r\033[K# <message>\a` line written by `notify-bell.sh`.
+  hookLine,
+}
+
+/// A single detected attention signal: its [kind] and any parsed [text]
+/// (the message body, with framing stripped). [text] is null for a bare bell.
+class AttentionSignal {
+  const AttentionSignal(this.kind, this.text);
+
+  final AttentionKind kind;
+  final String? text;
+
+  @override
+  String toString() {
+    final t = text;
+    return t == null ? kind.name : '${kind.name} "$t"';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is AttentionSignal && other.kind == kind && other.text == text;
+
+  @override
+  int get hashCode => Object.hash(kind, text);
+}
+
+const int _bel = 0x07; // BEL \a
+const int _esc = 0x1b; // ESC
+const int _rbracket = 0x5d; // ]
+const int _backslash = 0x5c; // \  (ST = ESC \)
+const int _cr = 0x0d; // CR \r
+const int _lbracket = 0x5b; // [
+const int _k = 0x4b; // K
+const int _hash = 0x23; // #
+
+/// Per-session, stateful, chunk-boundary-safe attention-signal detector.
+///
+/// Feed each remote-output chunk into [feed]; it returns every NEW signal seen
+/// (after dedup). State (partial-sequence tail, last-signal time) persists
+/// across calls and is cleared by [reset] on a fresh shell attach.
+class AttentionSignalScanner {
+  AttentionSignalScanner({
+    int Function()? nowMs,
+    this.cooldownMs = 2000,
+  }) : _nowMs = nowMs ?? (() => DateTime.now().millisecondsSinceEpoch);
+
+  /// Injected clock (ms since epoch). Tests pass a `fake_async`-driven closure.
+  final int Function() _nowMs;
+
+  /// Per-scanner dedup window (ms). A signal within [cooldownMs] of the last
+  /// emitted one is collapsed away. Mirrors the host notify-bell lockfile.
+  final int cooldownMs;
+
+  /// Bytes held back because they form a proper prefix of some signal and the
+  /// rest may arrive in the next chunk.
+  final List<int> _pending = <int>[];
+
+  /// Wall-clock (ms) of the last EMITTED signal, or null if none yet.
+  int? _lastEmitMs;
+
+  /// Feed a chunk of remote bytes. Returns the (deduped) signals detected.
+  /// Never throws on malformed input — unmatched bytes are simply consumed.
+  List<AttentionSignal> feed(List<int> bytes) {
+    final buf = <int>[..._pending, ...bytes];
+    _pending.clear();
+
+    final raw = <AttentionSignal>[];
+    var i = 0;
+    while (i < buf.length) {
+      final b = buf[i];
+
+      // 1) OSC: ESC ] ... (BEL | ST). Strip framing FIRST so a terminating BEL
+      //    is consumed here and never re-fires as a bare bell.
+      if (b == _esc) {
+        final osc = _matchOsc(buf, i);
+        if (osc.kind == _MatchKind.full) {
+          final sig = _classifyOsc(osc.payload);
+          if (sig != null) raw.add(sig);
+          i += osc.length;
+          continue;
+        }
+        if (osc.kind == _MatchKind.partial) {
+          _pending.addAll(buf.sublist(i));
+          i = buf.length;
+          continue;
+        }
+        // Not an OSC (some other escape sequence). Skip the lone ESC; the bytes
+        // that follow are examined normally on subsequent iterations.
+        i++;
+        continue;
+      }
+
+      // 2) notify-bell line: CR ESC[K "# <message>" BEL. Detect from the CR so
+      //    the `# message` text + its terminating BEL are consumed as one unit
+      //    (the BEL must not also fire as a bare bell).
+      if (b == _cr) {
+        final hook = _matchHookLine(buf, i);
+        if (hook.kind == _MatchKind.full) {
+          raw.add(AttentionSignal(AttentionKind.hookLine, hook.payload));
+          i += hook.length;
+          continue;
+        }
+        if (hook.kind == _MatchKind.partial) {
+          _pending.addAll(buf.sublist(i));
+          i = buf.length;
+          continue;
+        }
+        // A CR that isn't the start of a hook line — ordinary byte.
+        i++;
+        continue;
+      }
+
+      // 3) bare BEL.
+      if (b == _bel) {
+        raw.add(const AttentionSignal(AttentionKind.bell, null));
+        i++;
+        continue;
+      }
+
+      // Ordinary byte.
+      i++;
+    }
+
+    return _dedup(raw);
+  }
+
+  /// Flush state for a fresh shell/attach (e.g. after reconnect).
+  void reset() {
+    _pending.clear();
+    _lastEmitMs = null;
+  }
+
+  /// Apply the per-scanner cooldown: collapse a burst into one signal. The
+  /// FIRST signal of a burst is emitted; subsequent ones within [cooldownMs]
+  /// are dropped. The cooldown clock advances to each emitted signal's time.
+  List<AttentionSignal> _dedup(List<AttentionSignal> signals) {
+    if (signals.isEmpty) return const <AttentionSignal>[];
+    final out = <AttentionSignal>[];
+    for (final s in signals) {
+      final now = _nowMs();
+      final last = _lastEmitMs;
+      if (last == null || (now - last) >= cooldownMs) {
+        out.add(s);
+        _lastEmitMs = now;
+      }
+    }
+    return out;
+  }
+
+  /// Match an OSC sequence starting at [start] (`buf[start]` is ESC).
+  ///
+  /// Shape: `ESC ] <params> (BEL | ESC \)`. [_OscMatch.payload] is the params
+  /// between `ESC ]` and the terminator. A bare `ESC` (no `]` yet, or `]`
+  /// without a terminator) at the end of the buffer is reported as partial so
+  /// the caller buffers it for the next chunk.
+  _OscMatch _matchOsc(List<int> buf, int start) {
+    var i = start;
+    // ESC
+    if (i >= buf.length) return const _OscMatch(_MatchKind.partial, 0, '');
+    if (buf[i] != _esc) return const _OscMatch(_MatchKind.none, 0, '');
+    i++;
+    // ]
+    if (i >= buf.length) return const _OscMatch(_MatchKind.partial, 0, '');
+    if (buf[i] != _rbracket) return const _OscMatch(_MatchKind.none, 0, '');
+    i++;
+    // params up to BEL or ST (ESC \). Cap the scan so an unterminated OSC can't
+    // buffer unboundedly — a real notify OSC is short.
+    final payloadStart = i;
+    const maxPayload = 4096;
+    while (i < buf.length) {
+      final c = buf[i];
+      if (c == _bel) {
+        final payload = _decode(buf.sublist(payloadStart, i));
+        return _OscMatch(_MatchKind.full, (i - start) + 1, payload);
+      }
+      if (c == _esc) {
+        // Possible ST (ESC \).
+        if (i + 1 >= buf.length) {
+          return const _OscMatch(_MatchKind.partial, 0, '');
+        }
+        if (buf[i + 1] == _backslash) {
+          final payload = _decode(buf.sublist(payloadStart, i));
+          return _OscMatch(_MatchKind.full, (i + 2 - start), payload);
+        }
+        // An embedded ESC that isn't ST — give up on this OSC; treat the
+        // leading ESC as a non-OSC byte so we don't swallow real output.
+        return const _OscMatch(_MatchKind.none, 0, '');
+      }
+      i++;
+      if (i - payloadStart > maxPayload) {
+        // Too long to be a notify OSC — abandon (treat ESC as ordinary).
+        return const _OscMatch(_MatchKind.none, 0, '');
+      }
+    }
+    // Ran out of bytes before a terminator — buffer for the next chunk.
+    return const _OscMatch(_MatchKind.partial, 0, '');
+  }
+
+  /// Classify an OSC payload (the text between `ESC ]` and the terminator) into
+  /// an OSC 9 / OSC 777 attention signal, or null if it's an unrelated OSC
+  /// (e.g. OSC 4/7/8/12 handled elsewhere).
+  AttentionSignal? _classifyOsc(String payload) {
+    // OSC 9 ; <text>
+    if (payload == '9' || payload.startsWith('9;')) {
+      final text = payload.length > 2 ? payload.substring(2) : '';
+      return AttentionSignal(AttentionKind.osc9, text);
+    }
+    // OSC 777 ; notify ; <title> ; <body>
+    if (payload.startsWith('777;')) {
+      final parts = payload.split(';');
+      // parts[0] = '777', parts[1] = 'notify', parts[2] = title, rest = body.
+      if (parts.length >= 2 && parts[1] == 'notify') {
+        final title = parts.length >= 3 ? parts[2] : '';
+        final body = parts.length >= 4 ? parts.sublist(3).join(';') : '';
+        final text = body.isEmpty
+            ? title
+            : (title.isEmpty ? body : '$title: $body');
+        return AttentionSignal(AttentionKind.osc777, text);
+      }
+    }
+    return null;
+  }
+
+  /// Match the notify-bell line `CR ESC[K "# <message>" BEL` starting at the CR.
+  /// Returns the message with the leading `# ` stripped.
+  _HookMatch _matchHookLine(List<int> buf, int start) {
+    var i = start;
+    // CR
+    if (i >= buf.length) return const _HookMatch(_MatchKind.partial, 0, '');
+    if (buf[i] != _cr) return const _HookMatch(_MatchKind.none, 0, '');
+    i++;
+    // ESC
+    if (i >= buf.length) return const _HookMatch(_MatchKind.partial, 0, '');
+    if (buf[i] != _esc) return const _HookMatch(_MatchKind.none, 0, '');
+    i++;
+    // [
+    if (i >= buf.length) return const _HookMatch(_MatchKind.partial, 0, '');
+    if (buf[i] != _lbracket) return const _HookMatch(_MatchKind.none, 0, '');
+    i++;
+    // K (clear-to-EOL). notify-bell writes `\033[K` (no leading param).
+    if (i >= buf.length) return const _HookMatch(_MatchKind.partial, 0, '');
+    if (buf[i] != _k) return const _HookMatch(_MatchKind.none, 0, '');
+    i++;
+    // '#'
+    if (i >= buf.length) return const _HookMatch(_MatchKind.partial, 0, '');
+    if (buf[i] != _hash) return const _HookMatch(_MatchKind.none, 0, '');
+    i++;
+    // Message bytes up to BEL.
+    final msgStart = i;
+    const maxMsg = 4096;
+    while (i < buf.length) {
+      if (buf[i] == _bel) {
+        final msg = _decode(buf.sublist(msgStart, i)).trimLeft();
+        return _HookMatch(_MatchKind.full, (i - start) + 1, msg);
+      }
+      i++;
+      if (i - msgStart > maxMsg) {
+        return const _HookMatch(_MatchKind.none, 0, '');
+      }
+    }
+    // No terminating BEL yet — buffer for the next chunk.
+    return const _HookMatch(_MatchKind.partial, 0, '');
+  }
+
+  String _decode(List<int> bytes) => utf8.decode(bytes, allowMalformed: true);
+}
+
+enum _MatchKind { none, partial, full }
+
+class _OscMatch {
+  const _OscMatch(this.kind, this.length, this.payload);
+  final _MatchKind kind;
+  final int length;
+  final String payload;
+}
+
+class _HookMatch {
+  const _HookMatch(this.kind, this.length, this.payload);
+  final _MatchKind kind;
+  final int length;
+  final String payload;
+}

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -28,6 +28,7 @@ import '../ssh/ssh_connect_params.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_shell.dart';
 import '../ssh/sftp_session.dart';
+import 'attention_signal_scanner.dart';
 import 'session_messages.dart';
 import 'task_ssh_gateway.dart';
 
@@ -598,6 +599,8 @@ class SessionHost {
       // Fresh attach => fresh DA2 handshake: clear any buffered partial query
       // from a prior shell so we answer THIS attach's `ESC[>c` cleanly (#osc8).
       hosted.da2Responder.reset();
+      // Fresh attach => fresh attention-signal dedup state (#840).
+      hosted.attentionScanner.reset();
       // Wire the output listener BEFORE announcing shell-ready (#619). The UI's
       // run-on-connect command fires on shell-ready, writes to stdin, and the
       // shell echoes + runs it immediately. If we announced ready first (the
@@ -629,6 +632,23 @@ class SessionHost {
           }
           final forward = scan.forward;
           if (forward.isEmpty) return;
+          // Observe (don't alter) the post-DA2-strip bytes for in-band
+          // agent-attention signals (#840). Slice 1: log each detection to the
+          // durable lifecycle ring so the first on-device awaiting-moment proves
+          // which form arrives. Defensive — a malformed sequence must never
+          // crash the session.
+          try {
+            final signals = hosted.attentionScanner.feed(forward);
+            for (final sig in signals) {
+              clifecycle(
+                'attention',
+                '${sig.kind.name} ${sig.text == null ? '(no text)' : '"${sig.text}"'} '
+                    '(session $sessionId)',
+              );
+            }
+          } catch (e) {
+            clifecycle('attention', 'scan-error: $e (session $sessionId)');
+          }
           hosted.appendScrollback(forward);
           _gateway.send(
             SshOutputEvent(sessionId: sessionId, bytes: forward).toJson(),
@@ -1190,6 +1210,14 @@ class _HostedSession {
   /// to this client. See [Da2HyperlinkResponder]. Reset per shell open so a
   /// reconnect re-answers the fresh attach's query.
   final Da2HyperlinkResponder da2Responder = Da2HyperlinkResponder();
+
+  /// Observes the remote byte stream for in-band agent-attention signals
+  /// (#840): bare BEL, OSC 9, OSC 777, and the `notify-bell.sh` `# <message>`
+  /// line. Slice 1 only LOGS detections to the `clifecycle` ring (no
+  /// notification yet) so the first on-device awaiting-moment reveals which form
+  /// actually arrives. Reset per shell open like [da2Responder]. Observe-only:
+  /// it never alters the forwarded bytes. See [AttentionSignalScanner].
+  final AttentionSignalScanner attentionScanner = AttentionSignalScanner();
 
   /// Monotonic count of remote-output CHUNKS actually received from the shell
   /// (#759). Bumped only by the live shell-output listener (and the test

--- a/native/test/services/attention_signal_scanner_test.dart
+++ b/native/test/services/attention_signal_scanner_test.dart
@@ -1,0 +1,167 @@
+// Unit tests for [AttentionSignalScanner] — the in-band agent-attention signal
+// detector (#840, Slice 1). See native/lib/services/attention_signal_scanner.dart.
+//
+// The scanner observes the raw PTY byte stream (after the DA2 strip) and detects
+// four signal forms: bare BEL, OSC 9, OSC 777, and the `notify-bell.sh`
+// `\r\033[K# <message>\a` line. It buffers partial sequences across chunk
+// boundaries, strips OSC framing first (so a sequence-terminating BEL doesn't
+// double-fire as a bare bell), and applies a 2s per-scanner dedup cooldown.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/attention_signal_scanner.dart';
+
+/// String -> raw byte list (codeUnits is fine — all test data is ASCII/UTF-8).
+List<int> _b(String s) => s.codeUnits;
+
+void main() {
+  group('AttentionSignalScanner — single forms', () {
+    test('bare BEL fires one bell signal', () {
+      final s = AttentionSignalScanner();
+      final sigs = s.feed(_b('output\x07more'));
+      expect(sigs, hasLength(1));
+      expect(sigs.single.kind, AttentionKind.bell);
+      expect(sigs.single.text, isNull);
+    });
+
+    test('OSC 9 (BEL-terminated) captures the message', () {
+      final s = AttentionSignalScanner();
+      final sigs = s.feed(_b('\x1b]9;Claude is waiting\x07'));
+      expect(sigs, hasLength(1));
+      expect(sigs.single.kind, AttentionKind.osc9);
+      expect(sigs.single.text, 'Claude is waiting');
+    });
+
+    test('OSC 9 (ST-terminated, ESC backslash) captures the message', () {
+      final s = AttentionSignalScanner();
+      final sigs = s.feed(_b('\x1b]9;Claude is waiting\x1b\\'));
+      expect(sigs, hasLength(1));
+      expect(sigs.single.kind, AttentionKind.osc9);
+      expect(sigs.single.text, 'Claude is waiting');
+    });
+
+    test('OSC 777 notify captures title + body', () {
+      final s = AttentionSignalScanner();
+      final sigs = s.feed(_b('\x1b]777;notify;MobiSSH;Claude is waiting\x07'));
+      expect(sigs, hasLength(1));
+      expect(sigs.single.kind, AttentionKind.osc777);
+      expect(sigs.single.text, 'MobiSSH: Claude is waiting');
+    });
+
+    test('notify-bell line captures the message (leading "# " stripped)', () {
+      final s = AttentionSignalScanner();
+      final sigs = s.feed(_b('\r\x1b[K# Claude is waiting\x07'));
+      expect(sigs, hasLength(1));
+      expect(sigs.single.kind, AttentionKind.hookLine);
+      expect(sigs.single.text, 'Claude is waiting');
+    });
+  });
+
+  group('AttentionSignalScanner — chunk straddle', () {
+    test('OSC 9 split across two feeds is detected exactly once', () {
+      final s = AttentionSignalScanner();
+      final first = s.feed(_b('\x1b]9;Claude is'));
+      expect(first, isEmpty, reason: 'incomplete OSC must buffer, not fire');
+      final second = s.feed(_b(' waiting\x07'));
+      expect(second, hasLength(1));
+      expect(second.single.kind, AttentionKind.osc9);
+      expect(second.single.text, 'Claude is waiting');
+    });
+
+    test('bare BEL split (ESC of ST lands at chunk end) detected once', () {
+      // OSC 9 terminated by ST where the ESC is the last byte of chunk 1.
+      final s = AttentionSignalScanner();
+      final first = s.feed(_b('\x1b]9;hi\x1b'));
+      expect(first, isEmpty, reason: 'pending ESC may be ST — must buffer');
+      final second = s.feed(_b('\\'));
+      expect(second, hasLength(1));
+      expect(second.single.kind, AttentionKind.osc9);
+      expect(second.single.text, 'hi');
+    });
+
+    test('notify-bell line split across feeds is detected once', () {
+      final s = AttentionSignalScanner();
+      final first = s.feed(_b('\r\x1b[K# Claude is'));
+      expect(first, isEmpty);
+      final second = s.feed(_b(' waiting\x07'));
+      expect(second, hasLength(1));
+      expect(second.single.kind, AttentionKind.hookLine);
+      expect(second.single.text, 'Claude is waiting');
+    });
+  });
+
+  group('AttentionSignalScanner — no double-fire', () {
+    test('OSC terminated by BEL does NOT also emit a bare bell', () {
+      final s = AttentionSignalScanner();
+      final sigs = s.feed(_b('\x1b]9;done\x07'));
+      expect(sigs, hasLength(1), reason: 'the terminating BEL is consumed by the OSC');
+      expect(sigs.single.kind, AttentionKind.osc9);
+    });
+
+    test('notify-bell terminating BEL does NOT also emit a bare bell', () {
+      final s = AttentionSignalScanner();
+      final sigs = s.feed(_b('\r\x1b[K# hi\x07'));
+      expect(sigs, hasLength(1));
+      expect(sigs.single.kind, AttentionKind.hookLine);
+    });
+  });
+
+  group('AttentionSignalScanner — dedup (fake_async clock)', () {
+    test('two BELs within the cooldown collapse to one; after cooldown, two', () {
+      fakeAsync((async) {
+        final s = AttentionSignalScanner(
+          nowMs: () => async.elapsed.inMilliseconds,
+          cooldownMs: 2000,
+        );
+
+        // First BEL fires.
+        expect(s.feed(_b('\x07')), hasLength(1));
+
+        // Second BEL 500ms later is within the 2s cooldown -> collapsed.
+        async.elapse(const Duration(milliseconds: 500));
+        expect(s.feed(_b('\x07')), isEmpty);
+
+        // After the cooldown fully elapses, the next BEL fires again.
+        async.elapse(const Duration(milliseconds: 2000));
+        expect(s.feed(_b('\x07')), hasLength(1));
+      });
+    });
+
+    test('a burst within one feed collapses to a single signal', () {
+      fakeAsync((async) {
+        final s = AttentionSignalScanner(
+          nowMs: () => async.elapsed.inMilliseconds,
+          cooldownMs: 2000,
+        );
+        // Three BELs in one chunk, same instant -> one signal.
+        final sigs = s.feed(_b('\x07\x07\x07'));
+        expect(sigs, hasLength(1));
+      });
+    });
+  });
+
+  group('AttentionSignalScanner — non-signal traffic', () {
+    test('plain shell output produces nothing', () {
+      final s = AttentionSignalScanner();
+      expect(s.feed(_b('user@host:~\$ ls -la\r\ntotal 4\r\n')), isEmpty);
+    });
+
+    test('SGR colors / cursor moves / primary-DA produce nothing', () {
+      final s = AttentionSignalScanner();
+      // SGR red, reset, cursor up, primary DA query — none is an attention form.
+      expect(s.feed(_b('\x1b[31mred\x1b[0m\x1b[2A\x1b[?1;2c')), isEmpty);
+    });
+
+    test('an unrelated OSC (OSC 8 hyperlink) produces nothing', () {
+      final s = AttentionSignalScanner();
+      // OSC 8 ; ; https://example.com  ST  -- a hyperlink, not an attention form.
+      expect(s.feed(_b('\x1b]8;;https://example.com\x1b\\')), isEmpty);
+    });
+
+    test('clear-to-EOL without "# " is not a hook line', () {
+      final s = AttentionSignalScanner();
+      // `\r\033[K` redraw with no `# message` — common prompt repaint.
+      expect(s.feed(_b('\r\x1b[Kuser@host\$ ')), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Slice 1 of #840 — in-band attention-signal detector + telemetry (no UI)

Detects agent-attention signals in the raw dartssh2 PTY byte stream **before**
they reach the terminal renderer, so the native app needs no server
subscription (the in-band-only path the owner chose). **Slice 1 logs only** —
no notification yet. Every detection lands in the durable `clifecycle` ring so
the first on-device awaiting-moment proves which form actually arrives.

### What's here
- **`native/lib/services/attention_signal_scanner.dart`** (new) — per-session,
  stateful, chunk-buffered scanner modeled on `Da2HyperlinkResponder`.
  - Detects: bare **BEL** `0x07`; **OSC 9** `ESC]9;text (BEL|ST)`; **OSC 777**
    `ESC]777;notify;title;body (BEL|ST)`; the **notify-bell line**
    `CR ESC[K "# message" BEL` (text stripped of leading `# `).
  - Strips OSC framing **first** so a sequence-terminating BEL never double-fires
    as a bare bell.
  - Buffers partial sequences across `output.listen` chunk boundaries.
  - 2s per-scanner dedup cooldown (injectable clock → `fake_async` in tests).
- **`native/lib/services/session_host.dart`** — one scanner per hosted session,
  fed each post-DA2-strip chunk in the task-isolate output path (alongside
  `da2Responder.scan`), reset on shell open. Observe-only (forwarded bytes
  unchanged); wrapped in try/catch so a malformed sequence can't crash the
  session. On detection → `clifecycle('attention', '<kind> "<text>" (session <id>)')`.
- **`native/test/services/attention_signal_scanner_test.dart`** — 16 unit tests:
  each form once, OSC9 BEL+ST, chunk-straddle, no-double-fire, fake_async dedup,
  non-signal traffic. Red→green.
- **`native/integration_test/attention_signal_measurement_test.dart`** — the
  measurement experiment: emits each form in **plain / tmux-active /
  tmux-background** positions, reads back the `clifecycle` ring, prints a
  `form × position → detected?` findings table. Installs tmux on the Alpine
  target if missing; reports a tmux gap rather than silently skipping.
  Asserts only that the plain-shell baseline detects something (the tmux cells
  are the empirical unknowns this test exists to measure — a swallowed
  background-window signal is a valid finding).

### Gate
`scripts/native-fast-gate.sh` green (1075 tests; analyze clean). Integration
suite runs on the emulator as the orchestrator's gate (#589) — the measurement
test is authored and compiles/analyzes clean.

### Out of scope (later slices)
- Slice 2: `flutter_local_notifications` HIGH channel.
- Slice 3: tap → `setActive(sessionId)` routing.

Refs #840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)