### PR TITLE
feat(native): attention notifications on agent-attention signals (#840 Slice 2)

### DIFF
--- a/native/android/app/build.gradle.kts
+++ b/native/android/app/build.gradle.kts
@@ -31,6 +31,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // Required by flutter_local_notifications (uses java.time on minSdk < 26).
+        isCoreLibraryDesugaringEnabled = true
     }
 
     defaultConfig {
@@ -71,4 +73,10 @@ kotlin {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Backports java.time etc. so flutter_local_notifications builds on
+    // minSdk < 26 (coreLibraryDesugaringEnabled above).
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/native/integration_test/attention_notification_post_test.dart
+++ b/native/integration_test/attention_notification_post_test.dart
@@ -1,0 +1,135 @@
+// On-emulator ATTENTION-NOTIFICATION POST test (#840, Slice 2).
+//
+// Slice 1 proved the scanner detects an OSC 9 over a live session. Slice 2 adds
+// the NOTIFICATION layer. This test connects, emits an OSC 9 carrying a
+// `(win N)` source-window hint, and asserts the host's POST path ran for that
+// session — observed via the task-isolate `clifecycle` ring (forwarded to the
+// UI ring, #766), which records `posted notification session <id>` at the
+// detection point. We can't read the system tray from an integration test, so
+// the lifecycle marker is the test seam (mirrors the Slice-1 measurement style:
+// lenient but real — it asserts the poster was INVOKED, not the OS render).
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+
+@Tags(['integration'])
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('OSC 9 over a live session triggers an attention-notification '
+      'post for that session', (tester) async {
+    FlutterForegroundTask.initCommunicationPort();
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
+
+    // Reach the terminal screen, accepting the host-key prompt if shown.
+    var connected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        connected = true;
+        break;
+      }
+    }
+    expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after connect');
+    final proxy = entry!.proxy;
+    final sid = entry.id;
+
+    final out = <int>[];
+    final sub = proxy.output.listen(out.addAll);
+    addTearDown(sub.cancel);
+
+    void send(String cmd) =>
+        proxy.sendInput(Uint8List.fromList(utf8.encode(cmd)));
+
+    // Wait for the shell prompt (proves the PTY is live).
+    for (var i = 0; i < 40 && out.isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+    expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+    // Background the app so this active session is NOT suppressed (the test
+    // would otherwise be looking right at it). On a backgrounded session the
+    // poster always fires.
+    proxy.setActive(false, activeSessionId: sid);
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final before = lifecycleLogSnapshot().length;
+
+    // Emit an OSC 9 carrying a (win N) hint over the live PTY.
+    send("printf '\\033]9;Claude — testwin (win 2)\\007'\n");
+
+    // Give the byte round-trip + scanner + post path time to log.
+    var posted = false;
+    for (var i = 0; i < 24; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+      final ring = lifecycleLogSnapshot();
+      for (var j = before; j < ring.length; j++) {
+        final line = ring[j];
+        if (line.contains('[attention]') &&
+            line.contains('posted notification') &&
+            line.contains(sid)) {
+          posted = true;
+          break;
+        }
+      }
+      if (posted) break;
+    }
+
+    final sb = StringBuffer();
+    sb.writeln('ATTENTION840S2 ===== POST FINDINGS (#840 Slice 2) =====');
+    sb.writeln('ATTENTION840S2 session=$sid posted=$posted');
+    for (final line in lifecycleLogSnapshot()) {
+      if (line.contains('[attention]')) sb.writeln('ATTENTION840S2 $line');
+    }
+    debugPrint(sb.toString());
+
+    expect(
+      posted,
+      isTrue,
+      reason: 'no attention-notification post was logged for the session after '
+          'an OSC 9 — the Slice-2 poster path is not wired. Findings:\n$sb',
+    );
+  });
+}

--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'diagnostics/crash_reporter.dart';
 import 'platform/desktop.dart';
 import 'ssh/ssh_session.dart';
+import 'state/attention_providers.dart';
 import 'state/connection_providers.dart';
 import 'state/keepalive_providers.dart';
 import 'state/lifecycle_providers.dart';
@@ -112,6 +113,20 @@ class _RootRouterState extends ConsumerState<RootRouter> {
   final Set<String> _everConnected = <String>{};
 
   @override
+  void initState() {
+    super.initState();
+    // #840 Slice 2: cold-start consume of a pending attention focus. If the app
+    // was launched (process was dead) by tapping an attention notification, the
+    // tap recorded a pending focus in process-death-surviving storage. Consume
+    // it once the first frame settles so sessions exist to focus. Deferred to a
+    // post-frame callback so provider reads happen after the widget mounts.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(ref.read(attentionFocusRouterProvider).consumePending());
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     // Touch the keepalive controller so it attaches to the SSH session
     // controller at app start; this is what starts/stops the foreground
@@ -152,7 +167,12 @@ class _RootRouterState extends ConsumerState<RootRouter> {
         // push (the UI is about to unbind and discard snapshots — the push,
         // incl. a ~4KB scrollback decode, is wasted battery). Task-global, so
         // one send suffices. Does NOT touch the SSH socket / keepalive / locks.
-        if (entries.isNotEmpty) entries.first.proxy.setActive(false);
+        if (entries.isNotEmpty) {
+          entries.first.proxy.setActive(
+            false,
+            activeSessionId: ref.read(sessionsProvider).activeId,
+          );
+        }
         for (final e in entries) {
           e.proxy.unbind();
         }
@@ -169,10 +189,20 @@ class _RootRouterState extends ConsumerState<RootRouter> {
         // snapshot timer and emits one fresh full snapshot per session
         // immediately (instant repaint). Task-global → one send. The per-proxy
         // rebind below still runs the cached-frame repaint + SshRequestSnapshot.
-        if (entries.isNotEmpty) entries.first.proxy.setActive(true);
+        if (entries.isNotEmpty) {
+          entries.first.proxy.setActive(
+            true,
+            activeSessionId: ref.read(sessionsProvider).activeId,
+          );
+        }
         for (final e in entries) {
           e.proxy.rebind();
         }
+        // #840 Slice 2: a tapped attention notification recorded a pending focus
+        // that survives process death. Consume it on resume (warm) — switch to
+        // the originating session and, if it parses a `(win N)` hint and that
+        // session is a tmux client, select that window.
+        unawaited(ref.read(attentionFocusRouterProvider).consumePending());
         setState(() {});
       }
     });

--- a/native/lib/services/attention_focus_router.dart
+++ b/native/lib/services/attention_focus_router.dart
@@ -1,0 +1,61 @@
+// Attention focus router (#840, Slice 2).
+//
+// Consumes a pending focus recorded by a tapped attention notification (via
+// [PendingFocusBridge]) and routes the UI to the originating session:
+//
+//   1. `setActive(sessionId)` — switch the front-most tab (no-op if the session
+//      no longer exists; the router tolerates a stale id).
+//   2. GUARDED enhancement: if the payload parsed a `(win N)` source-window hint
+//      AND that session is a tmux client, send a `select-window N` over the live
+//      PTY using the same default-prefix select-window sequence the terminal's
+//      wheel/window-select infra relies on. Defensive: no hint → skip silently.
+//
+// The platform/UI wiring (which sessionId is valid, how to send PTY bytes, how
+// to detect tmux) is injected so this class is unit-testable without Flutter.
+
+import 'session_attention_notification.dart';
+import 'tmux_window_select.dart';
+
+/// Routes a pending notification-tap focus to the right session + window.
+class AttentionFocusRouter {
+  AttentionFocusRouter({
+    required PendingFocusBridge bridge,
+    required void Function(String sessionId) setActive,
+    required bool Function(String sessionId) sessionExists,
+    required void Function(String sessionId, List<int> bytes) sendInput,
+    bool Function(String sessionId)? isTmux,
+  }) : _bridge = bridge,
+       _setActive = setActive,
+       _sessionExists = sessionExists,
+       _sendInput = sendInput,
+       _isTmux = isTmux;
+
+  // ignore_for_file: prefer_initializing_formals
+  final PendingFocusBridge _bridge;
+  final void Function(String sessionId) _setActive;
+  final bool Function(String sessionId) _sessionExists;
+  final void Function(String sessionId, List<int> bytes) _sendInput;
+  final bool Function(String sessionId)? _isTmux;
+
+  /// One-shot consume of any pending focus. Safe to call on init (cold start)
+  /// AND resume (warm) — `takePending` clears the record so a later resume
+  /// doesn't re-focus the same session. Returns the focused sessionId, or null
+  /// when there was nothing pending (or the session no longer exists).
+  Future<String?> consumePending() async {
+    final pending = await _bridge.takePending();
+    final sid = pending.sessionId;
+    if (sid == null) return null;
+    if (!_sessionExists(sid)) return null;
+
+    _setActive(sid);
+
+    // GUARDED source-window navigation (device-gated, may be flaky under
+    // multi-client tmux). Only when a window hint parsed AND the session is a
+    // tmux client. Absent hint or non-tmux → skip silently.
+    final win = pending.sourceWindow;
+    if (win != null && (_isTmux?.call(sid) ?? false)) {
+      _sendInput(sid, tmuxSelectWindowSequence(win));
+    }
+    return sid;
+  }
+}

--- a/native/lib/services/attention_notifier_fln.dart
+++ b/native/lib/services/attention_notifier_fln.dart
@@ -1,0 +1,155 @@
+// Platform-binding attention notifier (#840, Slice 2).
+//
+// Binds the PURE [AttentionNotifier] / [KeyValueStore] seams (in
+// session_attention_notification.dart) to the real plugins:
+//
+//   * `flutter_local_notifications` posts the HIGH-importance `mobissh_attention`
+//     notification (loud, dismissible) from the FOREGROUND-TASK ISOLATE — the
+//     isolate that runs the AttentionSignalScanner and is always alive, so a
+//     backgrounded / non-active session still fires.
+//   * `FlutterForegroundTask.saveData/getData/removeData` backs the
+//     process-death-surviving [PendingFocusBridge] store (cold-start safe).
+//
+// The tap handler runs in a background isolate (`@pragma('vm:entry-point')`); it
+// records the tapped notification's payload as pending focus, then the UI
+// isolate consumes it on init / resume.
+//
+// This file binds platform channels, so it is NOT exercised by `flutter_test`
+// unit runs (those inject the in-memory fakes). It is compiled by the gate and
+// exercised on the emulator.
+
+import 'dart:async';
+
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import '../diagnostics/connect_trace.dart';
+import 'session_attention_notification.dart';
+
+/// Top-level background tap handler. Must be a top-level / static function with
+/// `@pragma('vm:entry-point')` so the AOT compiler keeps it for the background
+/// isolate the plugin spawns on tap.
+@pragma('vm:entry-point')
+void attentionNotificationTapBackground(NotificationResponse response) {
+  // Best-effort: record the tapped payload so the UI isolate routes focus on
+  // its next init/resume. Runs in a short-lived background isolate — keep it
+  // tiny + tolerant.
+  final payload = response.payload;
+  unawaited(
+    PendingFocusBridge(FftKeyValueStore()).setPendingFromPayload(payload),
+  );
+}
+
+/// `flutter_local_notifications`-backed [AttentionNotifier].
+///
+/// Lazily initializes the plugin + the HIGH-importance `mobissh_attention`
+/// Android channel on first use. Posting from the foreground-task isolate works
+/// because the plugin only needs the app's notification context, which the FGS
+/// already holds (POST_NOTIFICATIONS is granted via flutter_foreground_task at
+/// service start — see keepalive_task.dart).
+class FlnAttentionNotifier implements AttentionNotifier {
+  FlnAttentionNotifier({FlutterLocalNotificationsPlugin? plugin})
+    : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  bool _initialized = false;
+
+  Future<void> _ensureInit() async {
+    if (_initialized) return;
+    const initSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+    );
+    await _plugin.initialize(
+      initSettings,
+      onDidReceiveNotificationResponse: (response) {
+        // Foreground tap (app alive): record pending focus; the UI consumes it
+        // on the next resume. The background variant covers a dead app.
+        unawaited(
+          PendingFocusBridge(FftKeyValueStore())
+              .setPendingFromPayload(response.payload),
+        );
+      },
+      onDidReceiveBackgroundNotificationResponse:
+          attentionNotificationTapBackground,
+    );
+    // Create the HIGH channel explicitly so importance is correct on first post.
+    final android = _plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    await android?.createNotificationChannel(
+      const AndroidNotificationChannel(
+        kAttentionChannelId,
+        kAttentionChannelName,
+        description: kAttentionChannelDescription,
+        importance: Importance.high,
+      ),
+    );
+    _initialized = true;
+  }
+
+  /// Stable integer notification id derived from the per-session tag so a repeat
+  /// from the same session REPLACES (same id) rather than stacks.
+  int _idFor(String tag) => tag.hashCode & 0x7fffffff;
+
+  @override
+  Future<void> post(AttentionNotification n) async {
+    await _ensureInit();
+    final details = AndroidNotificationDetails(
+      kAttentionChannelId,
+      kAttentionChannelName,
+      channelDescription: kAttentionChannelDescription,
+      importance: Importance.high,
+      priority: Priority.high,
+      tag: n.tag,
+      autoCancel: true,
+    );
+    await _plugin.show(
+      _idFor(n.tag),
+      n.title,
+      n.body,
+      NotificationDetails(android: details),
+      payload: n.payload,
+    );
+    ctrace('ui.attention', 'posted ${n.tag}');
+  }
+
+  @override
+  Future<void> cancel(String sessionId) async {
+    await _ensureInit();
+    final tag = 'mobissh.attention.$sessionId';
+    await _plugin.cancel(_idFor(tag), tag: tag);
+  }
+}
+
+/// [KeyValueStore] backed by `FlutterForegroundTask.saveData/getData`. This
+/// store survives process death (the plugin persists to disk), so a tap that
+/// cold-starts the app still routes focus correctly.
+class FftKeyValueStore implements KeyValueStore {
+  const FftKeyValueStore();
+
+  @override
+  Future<String?> getString(String key) async {
+    try {
+      return await FlutterForegroundTask.getData<String>(key: key);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> setString(String key, String value) async {
+    try {
+      await FlutterForegroundTask.saveData(key: key, value: value);
+    } catch (_) {
+      /* ignore — focus routing is best-effort */
+    }
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    try {
+      await FlutterForegroundTask.removeData(key: key);
+    } catch (_) {
+      /* ignore */
+    }
+  }
+}

--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -17,6 +17,7 @@ import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import '../diagnostics/connect_trace.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
+import 'attention_notifier_fln.dart';
 import 'session_host.dart';
 import 'session_messages.dart';
 import 'task_ssh_gateway.dart';
@@ -138,8 +139,14 @@ class KeepaliveTaskHandler extends TaskHandler {
 /// the [KeepaliveTaskHandler] without binding to FFT statics.
 typedef SessionHostBuilder = SessionHost Function(TaskSshGateway gateway);
 
-SessionHost _defaultHostBuilder(TaskSshGateway gateway) =>
-    SessionHost(gateway: gateway);
+SessionHost _defaultHostBuilder(TaskSshGateway gateway) => SessionHost(
+  gateway: gateway,
+  // #840 Slice 2: post attention notifications from the task isolate (where the
+  // AttentionSignalScanner runs and is always alive, so backgrounded sessions
+  // still fire). Bound here — desktop/test hosts construct SessionHost without a
+  // notifier, so they fall back to Slice-1 log-only behaviour.
+  attentionNotifier: FlnAttentionNotifier(),
+);
 
 /// Thin wrapper over the static `FlutterForegroundTask` API. Lets us inject a
 /// fake in tests so we don't bind to platform method channels.

--- a/native/lib/services/session_attention_notification.dart
+++ b/native/lib/services/session_attention_notification.dart
@@ -1,0 +1,275 @@
+// Attention NOTIFICATION layer (#840, Slice 2).
+//
+// Slice 1 shipped [AttentionSignalScanner], which detects in-band agent-attention
+// signals (BEL / OSC 9 / OSC 777 / the notify-bell line) per session in the
+// foreground-task isolate. Slice 2 turns a detection into a tappable Android
+// notification whose tap returns the user to the EXACT originating session.
+//
+// This module owns the PURE, headless-testable pieces of that path so the
+// platform-binding poster (`flutter_local_notifications`) and the cross-isolate
+// hand-off stay thin:
+//
+//   1. [AttentionNotification] — maps a detected [AttentionSignal] (+ the
+//      sessionId and an optional human session label) to the notification's
+//      title/body, a per-session tag (so repeated signals from one session
+//      REPLACE rather than stack — PWA notification-tag parity), and the opaque
+//      JSON payload the tap carries back. The payload is exactly
+//      `{sessionId, sourceWindow?}` plus a fixed human phrase — never auth
+//      material (see the "no secret material" test).
+//
+//   2. [parseSourceWindow] — pulls a trailing `(win N)` source-window hint out of
+//      the scanner's parsed text (the owner's tmux `alert-bell` hook appends it).
+//      Defensive: absent / malformed → null.
+//
+//   3. [shouldPostAttention] — the suppression predicate. We do NOT post when the
+//      signalling session is BOTH the active session AND the app is foregrounded
+//      (the user is already looking at it).
+//
+//   4. [PendingFocusBridge] over a [KeyValueStore] — the cross-isolate hand-off.
+//      The tap is delivered to the foreground-task isolate (or a background
+//      callback); it records the originating sessionId in a store that survives
+//      process death (production = FFT `saveData/getData`), and the UI isolate
+//      reads + clears it on init (cold start) AND resume (warm) →
+//      `sessionsProvider.notifier.setActive(sessionId)`.
+//
+// SECURITY: a notification only ever carries the opaque sessionId, an optional
+// integer source-window, and a FIXED human phrase. It never carries a password,
+// passphrase, key, host, or username — see `session_attention_notification_test`.
+
+import 'dart:convert';
+
+import 'attention_signal_scanner.dart';
+
+/// Fixed, human-readable notification title. Intentionally generic + carries no
+/// session-identifying material (the session is identified by the opaque tag /
+/// payload, not the visible text).
+const String kAttentionTitle = 'MobiSSH — Claude needs attention';
+
+/// Tag prefix so an attention notification never collides with the
+/// foreground-service keep-alive notification (channel `mobissh_keepalive`).
+const String _tagPrefix = 'mobissh.attention.';
+
+/// Android channel id for attention notifications — HIGH importance (loud,
+/// dismissible), DISTINCT from the LOW `mobissh_keepalive` FGS channel.
+const String kAttentionChannelId = 'mobissh_attention';
+const String kAttentionChannelName = 'MobiSSH attention';
+const String kAttentionChannelDescription =
+    'Loud, dismissible alert when a remote session (e.g. Claude) asks for '
+    'your attention.';
+
+/// An immutable description of a tappable attention notification. Pure data —
+/// the platform posting happens in [AttentionNotifier] implementations.
+class AttentionNotification {
+  const AttentionNotification({
+    required this.title,
+    required this.body,
+    required this.tag,
+    required this.payload,
+    this.sourceWindow,
+  });
+
+  /// Notification title — the fixed [kAttentionTitle]. The session is NOT named
+  /// in the title (no host/user leakage in the visible text).
+  final String title;
+
+  /// Notification body — the scanner's parsed text (the OSC-9 / OSC-777 /
+  /// hook-line message), or a fixed fallback phrase when the signal had no text
+  /// (a bare BEL). Stripped of any trailing `(win N)` hint, which is structured
+  /// into [sourceWindow]/[payload] instead.
+  final String body;
+
+  /// Android notification tag. Keyed by sessionId so a later signal from the
+  /// same session REPLACES the prior notification rather than stacking, while
+  /// distinct sessions get distinct tags (PWA notification-tag parity).
+  final String tag;
+
+  /// Opaque JSON payload the tap carries: `{"sessionId": "...", "sourceWindow": N?}`.
+  /// Routes the tap back to the originating session (and optionally its tmux
+  /// source window). NEVER contains auth material.
+  final String payload;
+
+  /// Parsed tmux source-window number from a trailing `(win N)` hint, or null.
+  final int? sourceWindow;
+
+  /// Fixed fallback body for a text-less signal (a bare bell).
+  static const String _fallbackBody = 'Session needs attention';
+
+  /// Build a notification description for [sessionId] from a detected [signal].
+  ///
+  /// The body is the signal's parsed text with any trailing `(win N)` removed;
+  /// the window number (when present) is structured into [sourceWindow] and the
+  /// payload. A text-less signal (bare bell) uses [_fallbackBody].
+  static AttentionNotification build({
+    required String sessionId,
+    required AttentionSignal signal,
+  }) {
+    final raw = signal.text?.trim();
+    final win = parseSourceWindow(raw);
+    final stripped = _stripSourceWindow(raw);
+    final body = (stripped == null || stripped.isEmpty) ? _fallbackBody : stripped;
+    final payloadMap = <String, dynamic>{'sessionId': sessionId};
+    if (win != null) payloadMap['sourceWindow'] = win;
+    return AttentionNotification(
+      title: kAttentionTitle,
+      body: body,
+      tag: '$_tagPrefix$sessionId',
+      payload: jsonEncode(payloadMap),
+      sourceWindow: win,
+    );
+  }
+
+  /// Parse a payload JSON string back into `(sessionId, sourceWindow?)`.
+  /// Tolerant: a null/empty/malformed payload → `(null, null)` ("no focus").
+  /// Also accepts a bare sessionId string (legacy / defensive).
+  static ({String? sessionId, int? sourceWindow}) parsePayload(String? payload) {
+    if (payload == null || payload.isEmpty) {
+      return (sessionId: null, sourceWindow: null);
+    }
+    try {
+      final decoded = jsonDecode(payload);
+      if (decoded is Map) {
+        final sid = decoded['sessionId'];
+        final win = decoded['sourceWindow'];
+        return (
+          sessionId: (sid is String && sid.isNotEmpty) ? sid : null,
+          sourceWindow: win is int ? win : null,
+        );
+      }
+      // Not a map — treat the whole string as a bare sessionId.
+      return (sessionId: payload, sourceWindow: null);
+    } catch (_) {
+      // Not JSON — treat as a bare sessionId (defensive against older payloads).
+      return (sessionId: payload, sourceWindow: null);
+    }
+  }
+}
+
+/// Match a trailing `(win N)` hint, e.g. `Claude — main (win 3)`. The window
+/// number is captured; surrounding whitespace tolerated.
+final RegExp _winRe = RegExp(r'\(\s*win\s+(\d+)\s*\)\s*$', caseSensitive: false);
+
+/// Pull the tmux source-window number out of a parsed signal [text]. Returns
+/// null when there is no well-formed `(win N)` suffix (absent OR malformed —
+/// e.g. `(win)`, `(win abc)`, `win 3` without parens). Defensive by design: the
+/// guarded source-window navigation must SKIP silently on a miss.
+int? parseSourceWindow(String? text) {
+  if (text == null) return null;
+  final m = _winRe.firstMatch(text);
+  if (m == null) return null;
+  return int.tryParse(m.group(1)!);
+}
+
+/// Remove a trailing `(win N)` hint (and the whitespace before it) from [text],
+/// so the notification body reads cleanly. Returns null for null input.
+String? _stripSourceWindow(String? text) {
+  if (text == null) return null;
+  return text.replaceFirst(_winRe, '').trimRight();
+}
+
+/// Suppression predicate (#840 Slice 2, step 3). Do NOT post when the signalling
+/// session is BOTH the active session AND the app is foregrounded — the user is
+/// already looking at it. Post in every other case (backgrounded, OR a non-active
+/// session even while foregrounded).
+///
+/// [signalSessionId] — the session that produced the signal.
+/// [activeSessionId] — the currently-active (front-most tab) session, or null.
+/// [foreground] — whether the app/UI is foregrounded.
+bool shouldPostAttention({
+  required String signalSessionId,
+  required String? activeSessionId,
+  required bool foreground,
+}) {
+  final isActive = activeSessionId != null && activeSessionId == signalSessionId;
+  return !(isActive && foreground);
+}
+
+/// Posts (and cancels) attention notifications. Abstracted so the task isolate
+/// can bind it to `flutter_local_notifications` in production while unit + the
+/// integration test inject a recording fake (no platform-channel binding).
+abstract class AttentionNotifier {
+  /// Post (or REPLACE, keyed by [AttentionNotification.tag]) the notification.
+  Future<void> post(AttentionNotification n);
+
+  /// Cancel a session's attention notification (e.g. once the user focuses it).
+  Future<void> cancel(String sessionId);
+}
+
+/// In-memory [AttentionNotifier] for tests + the integration test seam. Records
+/// every posted notification so a test can assert what would have shown.
+class RecordingAttentionNotifier implements AttentionNotifier {
+  final List<AttentionNotification> posted = <AttentionNotification>[];
+  final List<String> cancelled = <String>[];
+
+  @override
+  Future<void> post(AttentionNotification n) async => posted.add(n);
+
+  @override
+  Future<void> cancel(String sessionId) async => cancelled.add(sessionId);
+}
+
+/// Minimal key/value persistence seam. Production binds this to the
+/// foreground-task plugin's cross-isolate data store
+/// (`FlutterForegroundTask.saveData/getData/removeData`), which survives process
+/// death — so a tap on a cold-started app still routes to the right session.
+/// Tests use [MapKeyValueStore].
+abstract class KeyValueStore {
+  Future<String?> getString(String key);
+  Future<void> setString(String key, String value);
+  Future<void> remove(String key);
+}
+
+/// In-memory [KeyValueStore] for tests.
+class MapKeyValueStore implements KeyValueStore {
+  final Map<String, String> _m = {};
+
+  @override
+  Future<String?> getString(String key) async => _m[key];
+
+  @override
+  Future<void> setString(String key, String value) async {
+    _m[key] = value;
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    _m.remove(key);
+  }
+}
+
+/// Cross-isolate "session to focus on next resume/init" hand-off (#840 Slice 2).
+///
+/// The notification tap is handled outside the UI's Riverpod containers. It
+/// records the originating sessionId (+ optional tmux source window) here; the
+/// UI isolate reads + clears it on init (cold) and resume (warm) and calls
+/// `sessionsProvider.notifier.setActive(sessionId)` (then optionally selects the
+/// source window).
+class PendingFocusBridge {
+  PendingFocusBridge(this._store);
+
+  final KeyValueStore _store;
+
+  /// Storage key. Namespaced to avoid clashing with other app data.
+  static const String _key = 'mobissh.attention.pendingFocus';
+
+  /// Record a pending focus from a notification [payload]. Latest write wins.
+  /// A payload that parses to no sessionId is a no-op (nothing to focus).
+  Future<void> setPendingFromPayload(String? payload) async {
+    final parsed = AttentionNotification.parsePayload(payload);
+    if (parsed.sessionId == null) return;
+    await _store.setString(_key, payload!);
+  }
+
+  /// Non-destructive read of the pending focus, or `(null, null)` when none.
+  Future<({String? sessionId, int? sourceWindow})> readPending() async {
+    final raw = await _store.getString(_key);
+    return AttentionNotification.parsePayload(raw);
+  }
+
+  /// One-shot consume: returns the pending `(sessionId, sourceWindow?)` AND
+  /// clears it so a later resume doesn't re-focus the same session.
+  Future<({String? sessionId, int? sourceWindow})> takePending() async {
+    final raw = await _store.getString(_key);
+    if (raw != null) await _store.remove(_key);
+    return AttentionNotification.parsePayload(raw);
+  }
+}

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -29,6 +29,7 @@ import '../ssh/ssh_session.dart';
 import '../ssh/ssh_shell.dart';
 import '../ssh/sftp_session.dart';
 import 'attention_signal_scanner.dart';
+import 'session_attention_notification.dart';
 import 'session_messages.dart';
 import 'task_ssh_gateway.dart';
 
@@ -64,10 +65,12 @@ class SessionHost {
     this.resumeStaleThreshold = const Duration(seconds: 20),
     this.resumeNudgeWindow = const Duration(seconds: 2),
     int Function()? nowMs,
+    AttentionNotifier? attentionNotifier,
   }) : _gateway = gateway,
        _factory = controllerFactory ?? _defaultControllerFactory,
        _sftpOpener = sftpOpener,
        _shellOpener = shellOpener ?? _defaultShellOpener,
+       _attentionNotifier = attentionNotifier,
        _nowMs = nowMs ?? (() => DateTime.now().millisecondsSinceEpoch) {
     _commandSub = _gateway.incoming.listen(_dispatch);
     _snapshotTimer = Timer.periodic(snapshotInterval, (_) => _pushSnapshots());
@@ -143,6 +146,20 @@ class SessionHost {
   /// only happens with the UI foregrounded, and resume re-asserts it anyway.
   bool _active = true;
 
+  /// The currently front-most (active) session id, as last reported by the UI
+  /// via [SshSetActiveCommand.activeSessionId] (#840 Slice 2). Null when unknown.
+  /// Combined with [_active], this drives attention-notification SUPPRESSION:
+  /// the session the user is already looking at (active + foreground) does not
+  /// get a notification.
+  String? _activeSessionId;
+
+  /// Posts attention notifications when a Slice-1 signal is detected (#840
+  /// Slice 2). Null on platforms / tests where no notifier is wired — then the
+  /// detection still LOGS to `clifecycle` (Slice 1 behaviour) but posts nothing.
+  /// Injected so the task isolate binds `flutter_local_notifications` in
+  /// production while tests record posts in memory.
+  final AttentionNotifier? _attentionNotifier;
+
   /// The exact lifecycle-forwarder closure this host installed into the global
   /// [lifecycleForwarder] (#766). Held so dispose detaches OUR closure only —
   /// it won't clobber a forwarder a different host installed afterward (matters
@@ -211,7 +228,7 @@ class SessionHost {
         // terminal/audit, so it carries the full payload (#806 C).
         if (s != null) _emitSnapshot(cmd.sessionId, s, includeScrollback: true);
       case SshSetActiveCommand():
-        _handleSetActive(cmd.active);
+        _handleSetActive(cmd.active, cmd.activeSessionId);
       case SshHostKeyDecisionCommand():
         _handleHostKeyDecision(cmd);
       case SshUiHelloCommand():
@@ -637,18 +654,7 @@ class SessionHost {
           // durable lifecycle ring so the first on-device awaiting-moment proves
           // which form arrives. Defensive — a malformed sequence must never
           // crash the session.
-          try {
-            final signals = hosted.attentionScanner.feed(forward);
-            for (final sig in signals) {
-              clifecycle(
-                'attention',
-                '${sig.kind.name} ${sig.text == null ? '(no text)' : '"${sig.text}"'} '
-                    '(session $sessionId)',
-              );
-            }
-          } catch (e) {
-            clifecycle('attention', 'scan-error: $e (session $sessionId)');
-          }
+          _scanAttention(sessionId, hosted, forward);
           hosted.appendScrollback(forward);
           _gateway.send(
             SshOutputEvent(sessionId: sessionId, bytes: forward).toJson(),
@@ -1006,8 +1012,12 @@ class SessionHost {
   /// from current state without waiting for the next tick. Idempotent: a repeat
   /// of the current state is a no-op so duplicate lifecycle events don't churn
   /// the timer. Does NOT touch the SSH session, keepalive, or locks.
-  void _handleSetActive(bool active) {
+  void _handleSetActive(bool active, [String? activeSessionId]) {
     if (_disposed) return;
+    // Always track the reported active session id (#840 Slice 2) — even when
+    // [active] is unchanged the front-most TAB may have switched, and that must
+    // update suppression. A null id (older UI / none) leaves it unknown.
+    _activeSessionId = activeSessionId;
     if (_active == active) return;
     _active = active;
     if (active) {
@@ -1022,6 +1032,76 @@ class SessionHost {
     } else {
       _snapshotTimer?.cancel();
       _snapshotTimer = null;
+    }
+  }
+
+  /// Observe (don't alter) post-DA2-strip bytes for in-band agent-attention
+  /// signals (#840). Slice 1 LOGS each detection to the durable lifecycle ring;
+  /// Slice 2 ALSO posts an attention notification (with per-session tag +
+  /// suppression). Defensive — a malformed sequence must never crash the
+  /// session, so the whole scan is wrapped.
+  void _scanAttention(String sessionId, _HostedSession hosted, List<int> bytes) {
+    try {
+      final signals = hosted.attentionScanner.feed(bytes);
+      for (final sig in signals) {
+        // Slice 1: durable lifecycle log (kept).
+        clifecycle(
+          'attention',
+          '${sig.kind.name} ${sig.text == null ? '(no text)' : '"${sig.text}"'} '
+              '(session $sessionId)',
+        );
+        // Slice 2: post an attention notification, unless suppressed because
+        // the user is already looking at this session.
+        _maybePostAttention(sessionId, sig);
+      }
+    } catch (e) {
+      clifecycle('attention', 'scan-error: $e (session $sessionId)');
+    }
+  }
+
+  /// Drive the attention scan + post path from a test, mirroring the live PTY
+  /// listener (which `ingestOutputForTest` deliberately does NOT exercise).
+  /// Used by the #840 Slice-2 host test + the emulator integration test seam.
+  @visibleForTesting
+  void feedAttentionForTest(String sessionId, List<int> bytes) {
+    final hosted = _sessions[sessionId];
+    if (hosted == null) return;
+    _scanAttention(sessionId, hosted, bytes);
+  }
+
+  /// Post an attention notification for a Slice-1 detection (#840 Slice 2),
+  /// honouring the suppression rule: skip when [sessionId] is the active session
+  /// AND the app is foregrounded (the user is already looking at it). The
+  /// notification is per-session tagged so a repeat from the same session
+  /// REPLACES rather than stacks. Defensive — never throws into the output
+  /// listener (a post failure must not crash the session). No-op when no
+  /// notifier is wired (e.g. desktop / a test that didn't inject one), in which
+  /// case the Slice-1 `clifecycle` log is the only effect.
+  void _maybePostAttention(String sessionId, AttentionSignal sig) {
+    final notifier = _attentionNotifier;
+    if (notifier == null) return;
+    final post = shouldPostAttention(
+      signalSessionId: sessionId,
+      activeSessionId: _activeSessionId,
+      foreground: _active,
+    );
+    if (!post) {
+      clifecycle('attention', 'suppressed (active+foreground) session $sessionId');
+      return;
+    }
+    try {
+      final n = AttentionNotification.build(sessionId: sessionId, signal: sig);
+      // Fire-and-forget — the post is async (platform channel) but the output
+      // listener is sync; a failure is swallowed (logged) so it can't break the
+      // session byte pipeline.
+      unawaited(
+        notifier.post(n).catchError((Object e) {
+          clifecycle('attention', 'post-error: $e (session $sessionId)');
+        }),
+      );
+      clifecycle('attention', 'posted notification session $sessionId');
+    } catch (e) {
+      clifecycle('attention', 'build-error: $e (session $sessionId)');
     }
   }
 

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -219,7 +219,10 @@ sealed class SshTaskCommand {
       case SshTaskCommandKind.reconnect:
         return SshReconnectCommand(sessionId: sessionId);
       case SshTaskCommandKind.setActive:
-        return SshSetActiveCommand(active: json['active'] as bool);
+        return SshSetActiveCommand(
+          active: json['active'] as bool,
+          activeSessionId: json['activeSessionId'] as String?,
+        );
       case SshTaskCommandKind.sftpList:
         return SftpListCommand(
           sessionId: sessionId,
@@ -483,11 +486,19 @@ class SshReconnectCommand extends SshTaskCommand {
 /// UI repaints from current state. Task-global, so [sessionId] is the empty
 /// sentinel (mirrors [SshUiHelloCommand]).
 class SshSetActiveCommand extends SshTaskCommand {
-  const SshSetActiveCommand({required this.active}) : super('');
+  const SshSetActiveCommand({required this.active, this.activeSessionId})
+    : super('');
 
   /// True = UI foregrounded (resume periodic snapshots); false = backgrounded
   /// (stop the periodic timer until the next resume).
   final bool active;
+
+  /// The currently front-most (active) session id, or null when none / unknown
+  /// (#840 Slice 2). The host uses this together with [active] to SUPPRESS an
+  /// attention notification for the session the user is already looking at.
+  /// Optional + back-compatible: an older UI that omits it leaves the host's
+  /// active-session unknown, which only means it never suppresses (safe).
+  final String? activeSessionId;
 
   @override
   SshTaskCommandKind get kind => SshTaskCommandKind.setActive;
@@ -497,6 +508,7 @@ class SshSetActiveCommand extends SshTaskCommand {
     'kind': kind.name,
     'sessionId': sessionId,
     'active': active,
+    if (activeSessionId != null) 'activeSessionId': activeSessionId,
   };
 }
 

--- a/native/lib/services/tmux_window_select.dart
+++ b/native/lib/services/tmux_window_select.dart
@@ -1,0 +1,34 @@
+// tmux select-window byte-sequence builder (#840, Slice 2 — guarded enhancement).
+//
+// After a tapped attention notification routes focus to the originating session,
+// if the payload carried a `(win N)` source-window hint AND the session is a
+// tmux client, we issue a `select-window` so the user lands on the exact pane
+// that asked for attention.
+//
+// We use tmux's COMMAND-PROMPT form rather than the single-digit `prefix N`
+// binding so it works for ANY window index (incl. >= 10) and doesn't depend on
+// the default numeric window-select key bindings being present:
+//
+//     <prefix> : select-window -t N <Enter>
+//
+// where <prefix> defaults to Ctrl-B (0x02). This is best-effort + device-gated:
+// a non-default prefix, a detached client, or multi-client size churn can make
+// it a no-op — by design we send it and don't assert it landed.
+
+/// Default tmux prefix key: Ctrl-B.
+const int _tmuxPrefix = 0x02;
+
+/// Build the byte sequence that selects tmux window [n] via the command prompt.
+/// Throws [ArgumentError] for a negative window index (callers parse `(win N)`
+/// with `\d+`, so this is purely defensive).
+List<int> tmuxSelectWindowSequence(int n) {
+  if (n < 0) {
+    throw ArgumentError.value(n, 'n', 'window index must be >= 0');
+  }
+  // prefix (Ctrl-B), ':' to open the command prompt, the select-window command,
+  // then Enter (\r) to run it.
+  return <int>[
+    _tmuxPrefix,
+    ...':select-window -t $n\r'.codeUnits,
+  ];
+}

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -149,9 +149,15 @@ class SshSessionProxy {
   /// sentinel sessionId, so calling it on ONE proxy suffices (all proxies share
   /// the gateway). On resume the task re-emits a fresh snapshot itself; the
   /// proxy's own [rebind] still runs for the cached-frame repaint.
-  void setActive(bool active) {
+  /// [activeSessionId] (#840 Slice 2) tells the task which session is front-most
+  /// so it can SUPPRESS an attention notification for the session the user is
+  /// already looking at (active + foreground). Optional + back-compatible.
+  void setActive(bool active, {String? activeSessionId}) {
     if (_disposed) return;
-    gateway.send(SshSetActiveCommand(active: active).toJson());
+    gateway.send(
+      SshSetActiveCommand(active: active, activeSessionId: activeSessionId)
+          .toJson(),
+    );
   }
 
   /// Send a connect command across the gateway. The task-side host turns

--- a/native/lib/state/attention_providers.dart
+++ b/native/lib/state/attention_providers.dart
@@ -1,0 +1,41 @@
+// Attention focus router provider (#840, Slice 2).
+//
+// Wires the pure [AttentionFocusRouter] to the live UI: the FFT-backed
+// [PendingFocusBridge] (process-death-surviving), `sessionsProvider.setActive`,
+// session existence, and PTY input for the guarded tmux select-window.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/attention_focus_router.dart';
+import '../services/attention_notifier_fln.dart';
+import '../services/session_attention_notification.dart';
+import 'sessions.dart';
+
+/// Builds the [AttentionFocusRouter] bound to the live session collection.
+///
+/// `isTmux` heuristic: the `(win N)` source-window hint is emitted by the
+/// owner's tmux `alert-bell` hook — a non-tmux shell does not produce it — so a
+/// parsed hint is itself a strong tmux signal. We therefore treat any session
+/// that reached the router with a hint as a tmux client. (A precise per-session
+/// tmux flag from the DA2 handshake is a future refinement; the navigation is
+/// device-gated + best-effort and skips silently on a miss either way.)
+final attentionFocusRouterProvider = Provider<AttentionFocusRouter>((ref) {
+  final bridge = PendingFocusBridge(const FftKeyValueStore());
+  return AttentionFocusRouter(
+    bridge: bridge,
+    setActive: (id) => ref.read(sessionsProvider.notifier).setActive(id),
+    sessionExists: (id) =>
+        ref.read(sessionsProvider).entries.any((e) => e.id == id),
+    sendInput: (id, bytes) {
+      for (final e in ref.read(sessionsProvider).entries) {
+        if (e.id == id) {
+          e.proxy.sendInput(Uint8List.fromList(bytes));
+          return;
+        }
+      }
+    },
+    // See doc above: a parsed (win N) hint implies the owner's tmux setup.
+    isTmux: (_) => true,
+  );
+});

--- a/native/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/native/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import device_info_plus
+import flutter_local_notifications
 import flutter_secure_storage_macos
 import local_auth_darwin
 import package_info_plus
@@ -15,6 +16,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/native/pubspec.lock
+++ b/native/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.17.1"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.13"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -282,6 +290,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      url: "https://pub.dev"
+    source: hosted
+    version: "18.0.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -1067,6 +1099,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.17"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -71,6 +71,14 @@ dependencies:
   # Persist profile list, settings; small JSON blobs only
   shared_preferences: ^2.3.5
 
+  # Loud, dismissible attention notifications when a remote session (e.g. Claude)
+  # signals for attention (#840 Slice 2). Distinct from the LOW-importance
+  # foreground-service keep-alive notification (flutter_foreground_task) — this
+  # is its own HIGH-importance `mobissh_attention` channel. Posted from the
+  # foreground-task isolate (where the AttentionSignalScanner runs) so it fires
+  # for backgrounded / non-active sessions too.
+  flutter_local_notifications: ^18.0.1
+
   # PBKDF2-HMAC-SHA256 + AES-GCM-256 for vault decryption parity with the
   # PWA's WebCrypto vault (#510). Pure-Dart; no platform channel; runs in
   # flutter_test without a device.

--- a/native/test/services/attention_focus_router_test.dart
+++ b/native/test/services/attention_focus_router_test.dart
@@ -1,0 +1,142 @@
+// Unit tests for the attention focus router + tmux select-window builder
+// (#840, Slice 2).
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/attention_focus_router.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+import 'package:mobissh/services/tmux_window_select.dart';
+
+void main() {
+  group('AttentionFocusRouter.consumePending', () {
+    test('routes to the pending session via setActive', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': 'A'}));
+
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+      );
+
+      final focused = await router.consumePending();
+      expect(focused, 'A');
+      expect(activated, ['A']);
+    });
+
+    test('one-shot: a second consume does nothing', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': 'A'}));
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+      );
+      await router.consumePending();
+      await router.consumePending();
+      expect(activated, ['A']); // only once
+    });
+
+    test('stale session id (no longer exists) → no setActive', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': 'gone'}));
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => false,
+        sendInput: (a, b) {},
+      );
+      final focused = await router.consumePending();
+      expect(focused, isNull);
+      expect(activated, isEmpty);
+    });
+
+    test('nothing pending → null, no calls', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+      );
+      expect(await router.consumePending(), isNull);
+      expect(activated, isEmpty);
+    });
+
+    test('GUARDED (win N): sends select-window only when tmux', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(
+        jsonEncode({'sessionId': 'A', 'sourceWindow': 4}),
+      );
+      final sent = <(String, List<int>)>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => true,
+        sendInput: (id, bytes) => sent.add((id, bytes)),
+        isTmux: (_) => true,
+      );
+      await router.consumePending();
+      expect(sent, hasLength(1));
+      expect(sent.single.$1, 'A');
+      expect(sent.single.$2, tmuxSelectWindowSequence(4));
+    });
+
+    test('GUARDED: NON-tmux session → no select-window sent', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(
+        jsonEncode({'sessionId': 'A', 'sourceWindow': 4}),
+      );
+      final sent = <(String, List<int>)>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => true,
+        sendInput: (id, bytes) => sent.add((id, bytes)),
+        isTmux: (_) => false,
+      );
+      await router.consumePending();
+      expect(sent, isEmpty);
+    });
+
+    test('GUARDED: no (win N) hint → no select-window even if tmux', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': 'A'}));
+      final sent = <(String, List<int>)>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => true,
+        sendInput: (id, bytes) => sent.add((id, bytes)),
+        isTmux: (_) => true,
+      );
+      await router.consumePending();
+      expect(sent, isEmpty);
+    });
+  });
+
+  group('tmuxSelectWindowSequence', () {
+    test('builds prefix + :select-window -t N + Enter', () {
+      final seq = tmuxSelectWindowSequence(7);
+      expect(seq.first, 0x02); // Ctrl-B prefix
+      final tail = String.fromCharCodes(seq.sublist(1));
+      expect(tail, ':select-window -t 7\r');
+    });
+
+    test('works for >= 10', () {
+      final seq = tmuxSelectWindowSequence(12);
+      expect(String.fromCharCodes(seq.sublist(1)), ':select-window -t 12\r');
+    });
+
+    test('negative index throws', () {
+      expect(() => tmuxSelectWindowSequence(-1), throwsArgumentError);
+    });
+  });
+}

--- a/native/test/services/session_attention_notification_test.dart
+++ b/native/test/services/session_attention_notification_test.dart
@@ -1,0 +1,185 @@
+// Unit tests for the attention NOTIFICATION layer (#840, Slice 2).
+//
+// Covers the PURE pieces: AttentionSignal → notification mapping, the
+// "no secret material" payload guarantee, the suppression predicate, the
+// (win N) source-window parser, and the PendingFocusBridge consume→id flow.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/attention_signal_scanner.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+
+void main() {
+  group('AttentionNotification.build', () {
+    test('maps an OSC9 signal to title/body/tag/payload', () {
+      const sig = AttentionSignal(AttentionKind.osc9, 'Claude — main (win 3)');
+      final n = AttentionNotification.build(sessionId: 'sess-A', signal: sig);
+
+      expect(n.title, kAttentionTitle);
+      // (win N) is stripped from the visible body and structured into payload.
+      expect(n.body, 'Claude — main');
+      expect(n.tag, 'mobissh.attention.sess-A');
+      expect(n.sourceWindow, 3);
+
+      final payload = jsonDecode(n.payload) as Map;
+      expect(payload['sessionId'], 'sess-A');
+      expect(payload['sourceWindow'], 3);
+    });
+
+    test('per-session tag differs across sessions; same within a session', () {
+      const sig = AttentionSignal(AttentionKind.osc9, 'ready');
+      final a1 = AttentionNotification.build(sessionId: 'A', signal: sig);
+      final a2 = AttentionNotification.build(sessionId: 'A', signal: sig);
+      final b = AttentionNotification.build(sessionId: 'B', signal: sig);
+      expect(a1.tag, a2.tag); // replace, not stack
+      expect(a1.tag, isNot(b.tag)); // distinct sessions distinct tags
+    });
+
+    test('text-less bare bell gets a fixed fallback body, no sourceWindow', () {
+      const sig = AttentionSignal(AttentionKind.bell, null);
+      final n = AttentionNotification.build(sessionId: 'A', signal: sig);
+      expect(n.body, isNotEmpty);
+      expect(n.sourceWindow, isNull);
+      final payload = jsonDecode(n.payload) as Map;
+      expect(payload.containsKey('sourceWindow'), isFalse);
+    });
+
+    test('osc777 title:body text is carried as the body', () {
+      const sig = AttentionSignal(AttentionKind.osc777, 'MobiSSH: build done');
+      final n = AttentionNotification.build(sessionId: 'A', signal: sig);
+      expect(n.body, 'MobiSSH: build done');
+    });
+
+    test('PAYLOAD CARRIES NO SECRET MATERIAL', () {
+      // Even if the parsed text somehow contained secret-looking material, the
+      // payload is strictly {sessionId, sourceWindow?} — the body text is NOT
+      // in the payload. Assert the payload contains only the allowed keys and
+      // no password/passphrase/key/host/user fields.
+      const sig = AttentionSignal(
+        AttentionKind.osc9,
+        'password=hunter2 passphrase=secret (win 1)',
+      );
+      final n = AttentionNotification.build(sessionId: 'sess-A', signal: sig);
+      final payload = jsonDecode(n.payload) as Map<String, dynamic>;
+      expect(payload.keys.toSet(), {'sessionId', 'sourceWindow'});
+      final lower = n.payload.toLowerCase();
+      expect(lower.contains('hunter2'), isFalse);
+      expect(lower.contains('password'), isFalse);
+      expect(lower.contains('passphrase'), isFalse);
+      expect(lower.contains('secret'), isFalse);
+    });
+  });
+
+  group('parseSourceWindow', () {
+    test('present: extracts N', () {
+      expect(parseSourceWindow('Claude (win 2)'), 2);
+      expect(parseSourceWindow('done (win 12)'), 12);
+      expect(parseSourceWindow('x (WIN 4)'), 4); // case-insensitive
+    });
+    test('absent: null', () {
+      expect(parseSourceWindow('Claude is waiting'), isNull);
+      expect(parseSourceWindow(null), isNull);
+      expect(parseSourceWindow(''), isNull);
+    });
+    test('malformed: null (skips silently)', () {
+      expect(parseSourceWindow('(win)'), isNull);
+      expect(parseSourceWindow('(win abc)'), isNull);
+      expect(parseSourceWindow('win 3'), isNull); // no parens
+      expect(parseSourceWindow('(window 3)'), isNull);
+    });
+  });
+
+  group('shouldPostAttention suppression', () {
+    test('active session AND foreground → suppress (no post)', () {
+      expect(
+        shouldPostAttention(
+          signalSessionId: 'A',
+          activeSessionId: 'A',
+          foreground: true,
+        ),
+        isFalse,
+      );
+    });
+    test('active session but BACKGROUNDED → post', () {
+      expect(
+        shouldPostAttention(
+          signalSessionId: 'A',
+          activeSessionId: 'A',
+          foreground: false,
+        ),
+        isTrue,
+      );
+    });
+    test('NON-active session while foreground → post', () {
+      expect(
+        shouldPostAttention(
+          signalSessionId: 'B',
+          activeSessionId: 'A',
+          foreground: true,
+        ),
+        isTrue,
+      );
+    });
+    test('no active session → post', () {
+      expect(
+        shouldPostAttention(
+          signalSessionId: 'A',
+          activeSessionId: null,
+          foreground: true,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('PendingFocusBridge', () {
+    test('consume a pending payload → sessionId + sourceWindow, then cleared', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final n = AttentionNotification.build(
+        sessionId: 'sess-Z',
+        signal: const AttentionSignal(AttentionKind.osc9, 'x (win 5)'),
+      );
+      await bridge.setPendingFromPayload(n.payload);
+
+      final taken = await bridge.takePending();
+      expect(taken.sessionId, 'sess-Z');
+      expect(taken.sourceWindow, 5);
+
+      // One-shot: a second take returns nothing.
+      final again = await bridge.takePending();
+      expect(again.sessionId, isNull);
+    });
+
+    test('a payload with no sessionId is a no-op', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(null);
+      await bridge.setPendingFromPayload('{}');
+      final taken = await bridge.takePending();
+      expect(taken.sessionId, isNull);
+    });
+
+    test('readPending is non-destructive', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(
+        jsonEncode({'sessionId': 'A', 'sourceWindow': 1}),
+      );
+      final r1 = await bridge.readPending();
+      final r2 = await bridge.readPending();
+      expect(r1.sessionId, 'A');
+      expect(r2.sessionId, 'A'); // still there
+    });
+  });
+
+  group('RecordingAttentionNotifier', () {
+    test('records posts', () async {
+      final notifier = RecordingAttentionNotifier();
+      final n = AttentionNotification.build(
+        sessionId: 'A',
+        signal: const AttentionSignal(AttentionKind.osc9, 'hi'),
+      );
+      await notifier.post(n);
+      expect(notifier.posted.single.tag, 'mobissh.attention.A');
+    });
+  });
+}

--- a/native/test/services/session_host_attention_post_test.dart
+++ b/native/test/services/session_host_attention_post_test.dart
@@ -1,0 +1,139 @@
+// SessionHost attention NOTIFICATION posting + suppression (#840, Slice 2).
+//
+// At the Slice-1 detection point the host now posts an attention notification
+// (per-session tag) UNLESS the signalling session is the active one AND the app
+// is foregrounded. This drives that path through the test seam
+// `feedAttentionForTest` (mirrors the live PTY listener) against a recording
+// notifier — no platform channels.
+//
+// Headless via InMemoryGatewayPair + an inert controller so the test owns the
+// `connected` transition.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+class _NoConnectController extends SshSessionController {
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+Future<({InMemoryGatewayPair pair, SessionHost host, RecordingAttentionNotifier notifier})>
+_setup({String sid = 'h:22:u:1'}) async {
+  late SshSessionController controller;
+  final pair = InMemoryGatewayPair();
+  final notifier = RecordingAttentionNotifier();
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: () {
+      controller = _NoConnectController();
+      return controller;
+    },
+    snapshotInterval: const Duration(milliseconds: 50),
+    attentionNotifier: notifier,
+  );
+  pair.uiSide.send(
+    SshConnectCommand(
+      sessionId: sid,
+      host: 'h',
+      port: 22,
+      username: 'u',
+      authJson: const {'type': 'password', 'password': 'p'},
+    ).toJson(),
+  );
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  controller.debugSetConnectedForTest(_params);
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  return (pair: pair, host: host, notifier: notifier);
+}
+
+/// OSC 9 bytes carrying [text].
+List<int> _osc9(String text) => [0x1b, 0x5d, ...utf8.encode('9;$text'), 0x07];
+
+void main() {
+  test('OSC9 detection posts an attention notification for that session', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    // Foreground but NO active session set yet → not suppressed → posts.
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('Claude — main (win 3)'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(s.notifier.posted, hasLength(1));
+    final n = s.notifier.posted.single;
+    expect(n.tag, 'mobissh.attention.h:22:u:1');
+    expect(n.body, 'Claude — main');
+    expect(n.sourceWindow, 3);
+    final payload = jsonDecode(n.payload) as Map;
+    expect(payload['sessionId'], 'h:22:u:1');
+  });
+
+  test('SUPPRESSED when session is active AND app foregrounded', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    // UI reports foreground + this session active.
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(active: true, activeSessionId: 'h:22:u:1')
+          .toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('ready'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(s.notifier.posted, isEmpty,
+        reason: 'active + foreground session must not notify');
+  });
+
+  test('POSTS when backgrounded even if this session is active', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(active: false, activeSessionId: 'h:22:u:1')
+          .toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('ready'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(s.notifier.posted, hasLength(1));
+  });
+
+  test('POSTS for a NON-active session while foregrounded', () async {
+    final s = await _setup(sid: 'h:22:u:1');
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    // Foreground, but a DIFFERENT session is active.
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(active: true, activeSessionId: 'other')
+          .toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('ready'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(s.notifier.posted, hasLength(1));
+  });
+}


### PR DESCRIPTION
## Slice 2 of #840 — attention NOTIFICATION layer

Builds on the merged Slice-1 detector (`AttentionSignalScanner`). At the existing
task-isolate detection point in `session_host.dart`, in addition to the kept
`clifecycle` log, posts a HIGH-importance, loud, dismissible Android notification
on a new `mobissh_attention` channel (distinct from the LOW keepalive FGS channel).

This PR **refs #840 but does not close it** — later slices remain.

### Isolate decision: POST FROM THE TASK ISOLATE
The scanner runs in the always-alive foreground-task isolate, so posting there
fires for backgrounded / non-active sessions (the whole point). The poster is an
injected `AttentionNotifier` seam — production binds `flutter_local_notifications`;
unit + integration tests inject a recording fake (no platform channels). Hosts
built without a notifier (desktop/tests) fall back to Slice-1 log-only behaviour.

### What's included
- **Per-session tag** (sessionId) — a repeat from one session REPLACES, not stacks.
- **Suppression** — no post when the signalling session is the active session AND
  the app is foregrounded. `SshSetActiveCommand` gains an optional, back-compatible
  `activeSessionId`; `main.dart`'s lifecycle hook passes it.
- **Tap → session (cold + warm)** — tap records process-death-surviving pending
  focus (`PendingFocusBridge` over an FFT-`saveData` `KeyValueStore`); `main.dart`
  consumes it on init (cold start) AND resume (warm) → `sessionsProvider.setActive`.
- **No secrets** — payload is strictly `{sessionId, sourceWindow?}` + a fixed
  phrase; an explicit test asserts no password/passphrase/secret reaches it.
- **GUARDED `(win N)` nav** — parse a trailing `(win N)` and, after `setActive`,
  if the session is a tmux client, issue `:select-window -t N` via the
  default-prefix command sequence. Defensive: absent/malformed hint or non-tmux →
  skip silently. The core works + is tested independently of this enhancement.

### Tests (TDD red→green)
- `session_attention_notification_test.dart` — builder mapping, **payload-has-no-secret**,
  suppression matrix, `(win N)` parser (present/absent/malformed), PendingFocusBridge.
- `attention_focus_router_test.dart` — consume→setActive (cold/warm, one-shot,
  stale id, nothing-pending), guarded select-window gating, tmux sequence builder.
- `session_host_attention_post_test.dart` — host post + suppression via a
  `feedAttentionForTest` seam.
- `integration_test/attention_notification_post_test.dart` — emulator: emit OSC 9
  `(win 2)` over a live session, assert the post path ran (via the lifecycle ring).
  Authored + compiles; the orchestrator runs the integration suite on the emulator.

Fast gate green (analyze clean, 1105 unit tests pass).

### Device validation pending
The guarded tmux `select-window` and the cold-start tap route are device-gated and
best-effort; they should be validated on the emulator / real hardware before this
ships to users.

Refs #840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)