### PR TITLE
fix(#842): retain in-progress compose text on IME dismiss

### DIFF
--- a/native/lib/state/compose_history_providers.dart
+++ b/native/lib/state/compose_history_providers.dart
@@ -51,3 +51,52 @@ final composeHistoryProvider =
     NotifierProvider<ComposeHistoryNotifier, Map<String, List<String>>>(
       ComposeHistoryNotifier.new,
     );
+
+/// Per-session restorable compose DRAFT (#842) — the single in-progress
+/// (unsent) buffer that survives the compose bar being dismissed.
+///
+/// WHY (the #842 bug): tapping the bar's X (or toggling the IME off) destroys
+/// the compose bar's `State`, discarding whatever the owner was composing —
+/// often swipe/voice multi-word text that is costly to re-type. The X sits next
+/// to the ▲/▼ history arrows, so it is an easy mis-tap.
+///
+/// On dismissal with non-empty text the bar pushes that text into the
+/// [composeHistoryProvider] ring (the recoverable-via-▲ FLOOR), AND stashes it
+/// here as a single draft. On REOPEN the bar repopulates its field from this
+/// draft (the nicer "restore exactly where you were" UX) and consumes it
+/// ([clear]). Like the history ring it is per-session and lives OUTSIDE the
+/// widget so it survives the bar's teardown. Ephemeral (in-memory) — a draft is
+/// a working buffer, not a durable artifact, so it does not persist across an
+/// app restart.
+class ComposeDraftNotifier extends Notifier<Map<String, String>> {
+  @override
+  Map<String, String> build() => const {};
+
+  /// The stashed draft for [sessionId], or `null` if none.
+  String? draftOf(String sessionId) => state[sessionId];
+
+  /// Stash [text] as the restorable draft for [sessionId]. Empty/whitespace-only
+  /// text CLEARS the slot (a blank buffer is not a draft worth restoring) so a
+  /// later reopen does not repopulate with nothing. Touches ONLY this session's
+  /// entry (per-session isolation).
+  void set(String sessionId, String text) {
+    if (text.trim().isEmpty) {
+      clear(sessionId);
+      return;
+    }
+    state = {...state, sessionId: text};
+  }
+
+  /// Drop the draft for [sessionId] (called once the bar has consumed it on
+  /// reopen, or after a successful send). No-op for an unknown session.
+  void clear(String sessionId) {
+    if (!state.containsKey(sessionId)) return;
+    final next = {...state}..remove(sessionId);
+    state = next;
+  }
+}
+
+final composeDraftProvider =
+    NotifierProvider<ComposeDraftNotifier, Map<String, String>>(
+      ComposeDraftNotifier.new,
+    );

--- a/native/lib/ui/compose_bar.dart
+++ b/native/lib/ui/compose_bar.dart
@@ -118,6 +118,23 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
   void initState() {
     super.initState();
     _controller.addListener(_onChanged);
+    // #842 (ideal restore): if a draft was stashed when the bar was last
+    // dismissed with in-progress text, repopulate the field with it and CONSUME
+    // the slot, so the owner returns to exactly where they were. The draft is
+    // read once at open (a fresh State is created per open, keyed by session id
+    // in terminal_screen), so reading it in initState is the right moment.
+    final draftNotifier = ref.read(composeDraftProvider.notifier);
+    final draft = draftNotifier.draftOf(widget.sessionId);
+    if (draft != null && draft.isNotEmpty) {
+      _controller.value = TextEditingValue(
+        text: draft,
+        selection: TextSelection.collapsed(offset: draft.length),
+      );
+      // Consume the slot, but DEFER the write — mutating a provider in initState
+      // throws "Tried to modify a provider while the widget tree was building".
+      final sessionId = widget.sessionId;
+      Future.microtask(() => draftNotifier.clear(sessionId));
+    }
     // Grab focus + raise the keyboard the instant the compose bar opens, so the
     // owner can go straight into voice/swipe typing (autofocus alone loses the
     // race against the terminal's focus management). Request after the first
@@ -147,6 +164,54 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
         });
       }
     }
+  }
+
+  /// #842: capture in-progress (unsent) compose text BEFORE the buffer is torn
+  /// down, so an accidental dismissal never silently loses it. Called from
+  /// [deactivate] — NOT dispose: Riverpod invalidates `ref` by the time
+  /// `dispose` runs ("Cannot use ref after the widget was disposed"), whereas in
+  /// `deactivate` the element is being removed from the tree but `ref` is still
+  /// live. `deactivate` is the ONE teardown point shared by EVERY dismissal path
+  /// — X tap, IME toggle-off, programmatic close, session switch — since they
+  /// all remove this `State` from the tree. Empty/whitespace-only text is a
+  /// no-op (never pollute the history ring with a blank entry).
+  ///
+  /// On non-empty text it does two things:
+  ///   1. MINIMUM (the floor): push the text into the per-session history ring
+  ///      so the ▲ "scroll back arrow buffer" recovers it. The ring already
+  ///      dedups a consecutive identical entry, so text that was JUST sent
+  ///      (which clears the controller first, making this a no-op) — or an
+  ///      identical re-dismiss — never double-records.
+  ///   2. IDEAL (clean restore): stash the same text as the single restorable
+  ///      draft so the next open repopulates the field exactly where it was.
+  void _captureBeforeClear() {
+    final text = _controller.text;
+    if (text.trim().isEmpty) return;
+    final sessionId = widget.sessionId;
+    // The notifier objects live in the ProviderContainer, not the widget, so
+    // they outlive this teardown. Resolve them while `ref` is still valid, then
+    // defer the WRITE: deactivate fires DURING the rebuild that removes this
+    // widget (the dismissal toggled a provider), and mutating a provider mid-
+    // build throws "Tried to modify a provider while the widget tree was
+    // building". A microtask runs the writes after the frame settles.
+    final historyNotifier = ref.read(composeHistoryProvider.notifier);
+    final draftNotifier = ref.read(composeDraftProvider.notifier);
+    Future.microtask(() {
+      // MINIMUM (floor): recoverable via the ▲ history ring (dedupes a
+      // consecutive identical entry, so a just-sent command never doubles).
+      historyNotifier.push(sessionId, text);
+      // IDEAL (clean restore): single restorable draft for the next reopen.
+      draftNotifier.set(sessionId, text);
+    });
+  }
+
+  @override
+  void deactivate() {
+    // #842: capture-before-clear on EVERY dismissal path (this fires on X tap,
+    // IME toggle-off, programmatic close, and session switch alike). Done in
+    // deactivate (not dispose) so `ref` is still usable.
+    _captureBeforeClear();
+    super.deactivate();
   }
 
   @override
@@ -184,6 +249,9 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
     }
     _controller.clear();
     _resetHistoryCursor();
+    // #842: the text was just sent — drop any stashed draft so the subsequent
+    // dispose-time capture is a no-op and a reopen does NOT restore sent text.
+    ref.read(composeDraftProvider.notifier).clear(widget.sessionId);
     // #614: hide the panel after sending (both commit and submit).
     widget.onClose();
   }
@@ -243,6 +311,9 @@ class _ComposeBarState extends ConsumerState<ComposeBar> {
   void _clear() {
     _controller.clear();
     _resetHistoryCursor();
+    // #842: an explicit clear is a deliberate discard — drop the stashed draft
+    // too, so dispose doesn't re-capture cleared text and a reopen stays empty.
+    ref.read(composeDraftProvider.notifier).clear(widget.sessionId);
     _focusNode.requestFocus();
   }
 

--- a/native/test/state/compose_history_providers_test.dart
+++ b/native/test/state/compose_history_providers_test.dart
@@ -77,4 +77,52 @@ void main() {
       expect(notifier.historyOf('s2'), ['alpha']);
     });
   });
+
+  group('compose draft slot (#842)', () {
+    test('set stashes a draft, draftOf returns it', () {
+      final c = makeContainer();
+      final notifier = c.read(composeDraftProvider.notifier);
+      notifier.set('s1', 'in progress text');
+      expect(notifier.draftOf('s1'), 'in progress text');
+    });
+
+    test('unknown session has no draft (null)', () {
+      final c = makeContainer();
+      expect(c.read(composeDraftProvider.notifier).draftOf('nope'), isNull);
+    });
+
+    test('set with empty text clears the slot (no blank draft)', () {
+      final c = makeContainer();
+      final notifier = c.read(composeDraftProvider.notifier);
+      notifier.set('s1', 'something');
+      notifier.set('s1', '');
+      expect(notifier.draftOf('s1'), isNull);
+    });
+
+    test('set with whitespace-only text clears the slot', () {
+      final c = makeContainer();
+      final notifier = c.read(composeDraftProvider.notifier);
+      notifier.set('s1', 'something');
+      notifier.set('s1', '   \n\t ');
+      expect(notifier.draftOf('s1'), isNull);
+    });
+
+    test('clear drops the draft', () {
+      final c = makeContainer();
+      final notifier = c.read(composeDraftProvider.notifier);
+      notifier.set('s1', 'draft');
+      notifier.clear('s1');
+      expect(notifier.draftOf('s1'), isNull);
+    });
+
+    test('per-session isolation: a draft in s1 never leaks into s2', () {
+      final c = makeContainer();
+      final notifier = c.read(composeDraftProvider.notifier);
+      notifier.set('s1', 'one');
+      notifier.set('s2', 'two');
+      notifier.clear('s1');
+      expect(notifier.draftOf('s1'), isNull);
+      expect(notifier.draftOf('s2'), 'two');
+    });
+  });
 }

--- a/native/test/widget/compose_bar_test.dart
+++ b/native/test/widget/compose_bar_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/state/compose_history_providers.dart';
 import 'package:mobissh/state/lifecycle_providers.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
 import 'package:mobissh/ui/compose_bar.dart';
 import 'package:xterm/xterm.dart';
 
@@ -547,6 +548,254 @@ void main() {
         expect(controllerText(tester), 'draft');
       },
     );
+  });
+
+  group('#842 — retain in-progress text on dismissal (no silent loss)', () {
+    // Mounts the bar under a session-keyed visibility toggle, mirroring
+    // terminal_screen (the bar is keyed by session id and only present when
+    // `composeBarVisibleProvider` is true). Removing it from the tree — exactly
+    // what X tap / IME toggle-off / programmatic close do — disposes the State,
+    // which is the universal capture-before-clear point.
+    Future<void> pumpToggleable(
+      WidgetTester tester,
+      ProviderContainer container, {
+      String sessionId = 'sess',
+    }) async {
+      final terminal = Terminal();
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  Consumer(
+                    builder: (context, ref, _) {
+                      final visible = ref.watch(composeBarVisibleProvider);
+                      if (!visible) return const SizedBox.shrink();
+                      return ComposeBar(
+                        key: ValueKey('compose-bar-$sessionId'),
+                        terminal: terminal,
+                        sessionId: sessionId,
+                        onClose: () => ref
+                            .read(composeBarVisibleProvider.notifier)
+                            .set(false),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    String controllerText(WidgetTester tester) => tester
+        .widget<TextField>(find.byKey(const Key('compose-bar-input')))
+        .controller!
+        .text;
+
+    testWidgets('X tap with non-empty text pushes it to the history ring', (
+      tester,
+    ) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await pumpToggleable(tester, container);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'the quick brown fox',
+      );
+      await tester.pump();
+
+      // Tap X — hides the bar, which disposes the State.
+      await tester.tap(find.byKey(const Key('compose-bar-close')));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(composeHistoryProvider.notifier).historyOf('sess'),
+        ['the quick brown fox'],
+        reason: 'X-dismissed text must land in the history ring (#842 floor)',
+      );
+    });
+
+    testWidgets('dismissing with EMPTY text is a no-op (no blank entry)', (
+      tester,
+    ) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await pumpToggleable(tester, container);
+
+      // Nothing typed.
+      await tester.tap(find.byKey(const Key('compose-bar-close')));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(composeHistoryProvider.notifier).historyOf('sess'),
+        isEmpty,
+        reason: 'empty dismissal must not pollute the ring',
+      );
+      expect(
+        container.read(composeDraftProvider.notifier).draftOf('sess'),
+        isNull,
+      );
+    });
+
+    testWidgets('whitespace-only text on dismissal is a no-op', (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await pumpToggleable(tester, container);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        '   \n  ',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-close')));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(composeHistoryProvider.notifier).historyOf('sess'),
+        isEmpty,
+      );
+    });
+
+    testWidgets('IME toggle-off (provider set false) captures before clear', (
+      tester,
+    ) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await pumpToggleable(tester, container);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'half typed command',
+      );
+      await tester.pump();
+
+      // Toggle the IME off WITHOUT touching the X — same as the session-bar
+      // compose toggle (terminal_screen's onToggleCompose → toggle()).
+      container.read(composeBarVisibleProvider.notifier).set(false);
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(composeHistoryProvider.notifier).historyOf('sess'),
+        ['half typed command'],
+        reason: 'toggle-off must also capture before clear (#842)',
+      );
+    });
+
+    testWidgets('a JUST-SENT command is not double-recorded on close', (
+      tester,
+    ) async {
+      // Send (commit) clears the controller AND closes the bar in one shot, so
+      // the dispose-time capture sees an empty buffer. The ring must hold the
+      // sent command exactly once (no duplicate from the dispose path).
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await pumpToggleable(tester, container);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'ls -la',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-commit')));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(composeHistoryProvider.notifier).historyOf('sess'),
+        ['ls -la'],
+        reason: 'sent command recorded once, not duplicated by close-capture',
+      );
+    });
+
+    testWidgets('reopening the IME restores the dismissed draft (ideal)', (
+      tester,
+    ) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await pumpToggleable(tester, container);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'restore me exactly',
+      );
+      await tester.pump();
+
+      // Dismiss (X) then reopen.
+      await tester.tap(find.byKey(const Key('compose-bar-close')));
+      await tester.pumpAndSettle();
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await tester.pumpAndSettle();
+
+      expect(
+        controllerText(tester),
+        'restore me exactly',
+        reason: 'reopen must repopulate the field from the stashed draft (#842)',
+      );
+    });
+
+    testWidgets('a sent command does NOT come back as a draft on reopen', (
+      tester,
+    ) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await pumpToggleable(tester, container);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'echo done',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('compose-bar-commit')));
+      await tester.pumpAndSettle();
+
+      // Reopen — the sent text must NOT be restored (it was sent, not abandoned).
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await tester.pumpAndSettle();
+
+      expect(controllerText(tester), '');
+    });
+
+    testWidgets('explicit Clear discards the draft (no restore on reopen)', (
+      tester,
+    ) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await pumpToggleable(tester, container);
+
+      await tester.enterText(
+        find.byKey(const Key('compose-bar-input')),
+        'discard this',
+      );
+      await tester.pump();
+      // Backspace/clear button is a deliberate discard.
+      await tester.tap(find.byKey(const Key('compose-bar-clear')));
+      await tester.pump();
+      // Now dismiss with the field empty.
+      await tester.tap(find.byKey(const Key('compose-bar-close')));
+      await tester.pumpAndSettle();
+
+      // Reopen — nothing restored, and the cleared text isn't in the ring.
+      container.read(composeBarVisibleProvider.notifier).set(true);
+      await tester.pumpAndSettle();
+      expect(controllerText(tester), '');
+      expect(
+        container.read(composeHistoryProvider.notifier).historyOf('sess'),
+        isEmpty,
+      );
+    });
   });
 
   group('#819 — unified Fix/Copy/Paste pills, flush-right on the top border', () {


### PR DESCRIPTION
Closes #842.

## Problem
Tapping the compose bar's **X** — or toggling the IME off — while in-progress text was in the box **silently discarded it**. The X sits right next to the ▲/▼ history arrows (easy mis-tap), and swipe/voice-composed multi-word text is costly to re-type.

## Fix — capture-before-clear on EVERY dismissal path
Both the owner's **minimum** (history-ring fallback) and the **ideal** (restorable draft) shipped, since they share one capture point and the draft was clean.

- New per-session `composeDraftProvider` (in-memory, mirrors the #797 history-ring provider; `set()` clears the slot on empty/whitespace-only text).
- `ComposeBar._captureBeforeClear()` runs from `deactivate()` — the ONE teardown point shared by **X tap, IME toggle-off, programmatic `set(false)`, and session switch** (all remove the State from the tree). On non-empty text it:
  1. **Minimum (floor):** pushes the text to the #797 history ring, recoverable via the ▲ "scroll back arrow buffer".
  2. **Ideal (restore):** stashes the same text as a single restorable draft.
- `initState` repopulates the field from the draft on reopen and consumes the slot — reopening restores exactly where you were.
- `_send`/`_clear` drop the draft so sent or deliberately-cleared text never reappears. After `_send` the controller is already empty, so the deactivate-capture is a no-op; the history ring also dedupes a consecutive identical entry, so a just-sent command is never double-recorded.

## Edge cases
- Empty / whitespace-only buffer on dismissal → **no-op** (never pollutes the ring with a blank entry).
- Draft is **ephemeral** (in-memory only) — a typed password fragment is never persisted at rest.

## Riverpod note (for reviewers)
Capture must happen in `deactivate` (ref still valid), **not** `dispose` ("Cannot use ref after the widget was disposed"). And because `deactivate` fires *during* the dismissal rebuild, the provider WRITE is deferred via `Future.microtask` (the notifier is resolved synchronously first) — a direct write throws "Tried to modify a provider while the widget tree was building". The same deferral applies to consuming the draft in `initState`.

## Tests (TDD, red→green)
- `+6` `composeDraftProvider` unit tests (set/clear, empty/whitespace clears, per-session isolation).
- `+8` compose-bar widget tests: each dismissal path captures before clear (X tap, IME toggle-off); empty + whitespace no-op; just-sent command not double-recorded; reopen restores the draft; sent text and explicitly-cleared text do NOT restore.
- Native fast gate green: `analyze` pass, 1119 tests pass.

Device feel (mis-tap recovery) to be validated on hardware by the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)