### PR TITLE
fix(#847): notification UX — FGS informative text + host-level attention policy

### DIFF
--- a/native/integration_test/attention_host_suppression_test.dart
+++ b/native/integration_test/attention_host_suppression_test.dart
@@ -1,0 +1,216 @@
+// On-emulator HOST-LEVEL attention suppression (#847).
+//
+// #840 shipped attention notifications; on-device the owner had TWO sessions to
+// the SAME host (fd-dev) and a single Claude bell reached BOTH PTYs → two
+// stacked identical alerts, with NO suppression even though he was foregrounded
+// looking at one of them. #847 makes the unit of attention the HOST: while the
+// app is FOREGROUNDED on any session to a host, a bell from ANY session to that
+// SAME host is suppressed (and cross-session repeats dedup to one slot).
+//
+// This test connects TWO sessions to the same test-sshd via two ports
+// (127.0.0.1:2222 and :2223 — both resolve to the SAME host `127.0.0.1`), keeps
+// the app FOREGROUNDED with one session active, then emits an OSC 9 bell over
+// EACH session's live PTY and asserts ZERO attention-notification POSTS were
+// logged — every bell is host-suppressed. Observed via the task-isolate
+// `clifecycle` ring (forwarded to the UI ring, #766): the host logs
+// `suppressed (foreground same-host)` at the decision point and NEVER
+// `posted notification` while foregrounded on that host.
+//
+// We can't read the system tray from an integration test (mirrors the Slice-1
+// measurement style: lenient but real — it asserts the POLICY decision, not the
+// OS render). The FGS "Connected — …" text (Part 1) is covered by unit tests
+// (`keepalive_task_test.dart`) since `updateService` output isn't tray-readable.
+//
+// Bridge: scripts/native-connect-test.sh with BRIDGE_PORT2=2223 (two socat+adb
+// reverses → the one Alpine test-sshd).
+
+@Tags(['integration'])
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/ssh/ssh_session.dart' show SshSessionState;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'two sessions to the SAME host, foregrounded on one → bells on both are '
+    'HOST-suppressed (zero posts) (#847)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      bool bothConnected() {
+        final entries = container.read(sessionsProvider).entries;
+        return entries.length == 2 &&
+            entries.every(
+              (e) => e.proxy.data.state == SshSessionState.connected,
+            );
+      }
+
+      // Session A on 127.0.0.1:2222.
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      final reachedA = await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+      );
+      expect(reachedA, isTrue, reason: 'session A never reached the terminal');
+
+      // New session → session B on 127.0.0.1:2223 (SAME host, different port).
+      await tester.tap(find.byKey(const Key('session-menu-button')));
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      await tester.tap(find.byKey(const Key('session-menu-new')));
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2223',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      final connectedBoth = await _pumpUntil(tester, bothConnected);
+      expect(
+        connectedBoth,
+        isTrue,
+        reason: 'both same-host sessions did not reach connected',
+      );
+
+      final entries = container.read(sessionsProvider).entries;
+      expect(entries.length, 2);
+      final sessA = entries.firstWhere((e) => e.port == 2222);
+      final sessB = entries.firstWhere((e) => e.port == 2223);
+
+      // FOREGROUNDED, active session = A (host 127.0.0.1). The unit of attention
+      // is the host, so a bell on EITHER session (both host 127.0.0.1) must be
+      // suppressed. main.dart pushes activeHost on the activeId change, but drive
+      // it explicitly here so the test owns the foreground+active state.
+      sessA.proxy.setActive(
+        true,
+        activeSessionId: sessA.id,
+        activeHost: sessA.host,
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Wait for both PTYs to be live (prompt bytes).
+      final outA = <int>[];
+      final outB = <int>[];
+      final subA = sessA.proxy.output.listen(outA.addAll);
+      final subB = sessB.proxy.output.listen(outB.addAll);
+      addTearDown(subA.cancel);
+      addTearDown(subB.cancel);
+      for (var i = 0; i < 40 && (outA.isEmpty || outB.isEmpty); i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(outA.isNotEmpty && outB.isNotEmpty, isTrue,
+          reason: 'a PTY never produced a prompt — dead shell');
+
+      final before = lifecycleLogSnapshot().length;
+
+      void bell(dynamic proxy) => proxy.sendInput(
+            Uint8List.fromList(
+              utf8.encode("printf '\\033]9;Claude needs attention\\007'\n"),
+            ),
+          );
+
+      // One bell on each same-host session.
+      bell(sessA.proxy);
+      await tester.pump(const Duration(milliseconds: 300));
+      bell(sessB.proxy);
+
+      // Let the byte round-trip + scanner + suppression decision log.
+      var suppressedCount = 0;
+      var postedCount = 0;
+      for (var i = 0; i < 24; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        final ring = lifecycleLogSnapshot();
+        suppressedCount = 0;
+        postedCount = 0;
+        for (var j = before; j < ring.length; j++) {
+          final line = ring[j];
+          if (!line.contains('[attention]')) continue;
+          if (line.contains('posted notification')) postedCount++;
+          if (line.contains('suppressed') || line.contains('deduped')) {
+            suppressedCount++;
+          }
+        }
+        if (suppressedCount >= 1) break;
+      }
+
+      final sb = StringBuffer();
+      sb.writeln('HOST847 ===== HOST-SUPPRESSION FINDINGS (#847) =====');
+      sb.writeln('HOST847 hostA=${sessA.host} hostB=${sessB.host}');
+      sb.writeln('HOST847 suppressed=$suppressedCount posted=$postedCount');
+      for (final line in lifecycleLogSnapshot()) {
+        if (line.contains('[attention]')) sb.writeln('HOST847 $line');
+      }
+      debugPrint(sb.toString());
+
+      // The POLICY assertion: foregrounded on this host → NO attention post for
+      // any same-host session.
+      expect(
+        postedCount,
+        0,
+        reason: 'a bell was POSTED while foregrounded on the same host — '
+            'host-level suppression did not fire. Findings:\n$sb',
+      );
+      expect(
+        suppressedCount,
+        greaterThanOrEqualTo(1),
+        reason: 'expected at least one suppressed/deduped attention decision. '
+            'Findings:\n$sb',
+      );
+    },
+  );
+}

--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -149,6 +149,27 @@ class _RootRouterState extends ConsumerState<RootRouter> {
     // live session on resume even while the user is on the terminal screen.
     ref.watch(resumeRebindListenerProvider);
 
+    // #847: when the front-most session changes while the app is FOREGROUNDED
+    // (a tab switch — `sessionsProvider.notifier.setActive`), push the new
+    // active session id + HOST to the task isolate so attention suppression
+    // follows the user. Without this the task only learned the active session on
+    // pause/resume, so switching tabs while foregrounded left a stale activeHost
+    // and suppressed/fired against the wrong Claude. Only fires on a real
+    // activeId change (not every list mutation) and only while foregrounded
+    // (pause/resume already pushes the state on lifecycle edges).
+    ref.listen<String?>(activeSessionIdProvider, (prevId, nextId) {
+      if (!mounted) return;
+      if (prevId == nextId) return;
+      final sessions = ref.read(sessionsProvider);
+      final entries = sessions.entries;
+      if (entries.isEmpty) return;
+      entries.first.proxy.setActive(
+        true,
+        activeSessionId: sessions.activeId,
+        activeHost: sessions.active?.host,
+      );
+    });
+
     // Phase 4 (#524) lifecycle hook: on `resumed`, force a rebuild so
     // session UI repaints from the existing controller state without
     // reconnecting. The SshSessionController instances live in this isolate
@@ -168,9 +189,15 @@ class _RootRouterState extends ConsumerState<RootRouter> {
         // incl. a ~4KB scrollback decode, is wasted battery). Task-global, so
         // one send suffices. Does NOT touch the SSH socket / keepalive / locks.
         if (entries.isNotEmpty) {
+          final sessions = ref.read(sessionsProvider);
           entries.first.proxy.setActive(
             false,
-            activeSessionId: ref.read(sessionsProvider).activeId,
+            activeSessionId: sessions.activeId,
+            // #847: carry the active session's HOST so the task suppresses by
+            // host (the unit of attention is the Claude/host). On background
+            // `active:false` means nothing is suppressed anyway, but we send it
+            // so the host's last-known activeHost stays accurate.
+            activeHost: sessions.active?.host,
           );
         }
         for (final e in entries) {
@@ -190,9 +217,13 @@ class _RootRouterState extends ConsumerState<RootRouter> {
         // immediately (instant repaint). Task-global → one send. The per-proxy
         // rebind below still runs the cached-frame repaint + SshRequestSnapshot.
         if (entries.isNotEmpty) {
+          final sessions = ref.read(sessionsProvider);
           entries.first.proxy.setActive(
             true,
-            activeSessionId: ref.read(sessionsProvider).activeId,
+            activeSessionId: sessions.activeId,
+            // #847: carry the active session's HOST so the task host-suppresses
+            // a bell from any (possibly different) session to the same host.
+            activeHost: sessions.active?.host,
           );
         }
         for (final e in entries) {

--- a/native/lib/services/attention_notifier_fln.dart
+++ b/native/lib/services/attention_notifier_fln.dart
@@ -115,7 +115,9 @@ class FlnAttentionNotifier implements AttentionNotifier {
   @override
   Future<void> cancel(String sessionId) async {
     await _ensureInit();
-    final tag = 'mobissh.attention.$sessionId';
+    // #847: notifications are keyed per-HOST, so cancel the host's slot (a tap
+    // / focus on any session to this host clears the one shared notification).
+    final tag = 'mobissh.attention.${hostOfSessionId(sessionId)}';
     await _plugin.cancel(_idFor(tag), tag: tag);
   }
 }

--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -162,7 +162,64 @@ abstract class KeepaliveGateway {
     required String notificationText,
   });
 
+  /// Update the RUNNING foreground-service notification's title + text in place
+  /// (#847). Called on every session-state transition so the persistent (LOW,
+  /// silent) FGS notification reflects the live count instead of being frozen on
+  /// the "Connecting…" text it was started with. `onlyAlertOnce: true` keeps the
+  /// update SILENT (the plugin re-alerts on every update otherwise). A no-op when
+  /// the service isn't running.
+  Future<void> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  });
+
   Future<bool> stopService();
+}
+
+/// A connected session's identity for the FGS notification text (#847). Carries
+/// just the human label fields so [keepaliveNotificationText] can render a
+/// single connected session as `user@host`.
+class KeepaliveSessionInfo {
+  const KeepaliveSessionInfo({this.host, this.username});
+
+  final String? host;
+  final String? username;
+
+  /// `user@host`, falling back to whichever part is known, or a generic phrase
+  /// when neither is. Never leaks a port / auth material — host + user only.
+  String get label {
+    final h = (host != null && host!.isNotEmpty) ? host : null;
+    final u = (username != null && username!.isNotEmpty) ? username : null;
+    if (u != null && h != null) return '$u@$h';
+    if (h != null) return h;
+    if (u != null) return u;
+    return 'session';
+  }
+}
+
+/// Pure FGS-notification text mapper (#847). Drives the persistent foreground
+/// service notification from the live session state so it never sits frozen on
+/// "Connecting…" once a session is up. Priority order:
+///   1. ANY session reconnecting → "Reconnecting… (N connected)".
+///   2. 0 connected (handshaking / nothing up yet) → "Connecting…".
+///   3. exactly 1 connected → "Connected — user@host".
+///   4. N connected → "Connected — N sessions".
+String keepaliveNotificationText({
+  required int connectedCount,
+  required bool anyReconnecting,
+  KeepaliveSessionInfo? singleConnected,
+}) {
+  if (anyReconnecting) {
+    return 'Reconnecting… ($connectedCount connected)';
+  }
+  if (connectedCount <= 0) {
+    return 'Connecting…';
+  }
+  if (connectedCount == 1) {
+    final label = singleConnected?.label ?? 'session';
+    return 'Connected — $label';
+  }
+  return 'Connected — $connectedCount sessions';
 }
 
 /// Build the `ForegroundTaskOptions` we hand to `FlutterForegroundTask.init`.
@@ -218,6 +275,12 @@ class NoopKeepaliveGateway implements KeepaliveGateway {
     required String notificationTitle,
     required String notificationText,
   }) async => true;
+
+  @override
+  Future<void> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {}
 
   @override
   Future<bool> stopService() async => true;
@@ -288,6 +351,26 @@ class FlutterForegroundTaskGateway implements KeepaliveGateway {
   }
 
   @override
+  Future<void> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    // #847: re-render the running FGS notification's text in place. The channel
+    // is `onlyAlertOnce: true` (set in init), so this is SILENT — no buzz on
+    // every transition (the plugin re-alert bug). Tolerant of a missing plugin /
+    // a not-running service: the plugin no-ops or throws MissingPluginException
+    // off-Android, which we swallow so a desktop/test build can't crash here.
+    try {
+      await FlutterForegroundTask.updateService(
+        notificationTitle: notificationTitle,
+        notificationText: notificationText,
+      );
+    } catch (e) {
+      ctrace('ui.keepalive', 'updateService failed — $e');
+    }
+  }
+
+  @override
   Future<bool> stopService() async {
     final result = await FlutterForegroundTask.stopService();
     return result is ServiceRequestSuccess;
@@ -334,6 +417,13 @@ class KeepaliveController {
   bool _enabled = true;
   int _connectedCount = 0;
   final Map<Object, StreamSubscription<SshSessionData>> _subscriptions = {};
+
+  /// Latest observed [SshSessionData] per attached session (#847). Drives the
+  /// informative FGS notification text: the controller already listens to every
+  /// session's state stream for the connected-count, so it also keeps the most
+  /// recent snapshot here and recomputes the notification text on each
+  /// transition (count, host/user, reconnecting). Cleared on detach/dispose.
+  final Map<Object, SshSessionData> _latestData = {};
 
   /// Whether the keep-alive service is allowed to run at all. Setting this
   /// to false stops a running service immediately; setting back to true
@@ -405,12 +495,16 @@ class KeepaliveController {
     if (_subscriptions.containsKey(session)) return;
     final (Stream<SshSessionData> stream, SshSessionData Function() snapshot) =
         _viewOf(session);
+    _latestData[session] = snapshot();
     var wasConnected = _holdsService(snapshot().state);
     if (wasConnected) {
       _connectedCount += 1;
       unawaited(_startIfStopped());
     }
     _subscriptions[session] = stream.listen((data) {
+      // #847: keep the freshest snapshot so the FGS text reflects host/user +
+      // reconnecting state, not just the count.
+      _latestData[session] = data;
       final isConnected = _holdsService(data.state);
       if (isConnected && !wasConnected) {
         _connectedCount += 1;
@@ -428,7 +522,31 @@ class KeepaliveController {
         unawaited(_stopIfRunning());
       }
       wasConnected = isConnected;
+      // #847: on EVERY transition refresh the running FGS notification text so
+      // it never sits frozen on "Connecting…" once a session is up (and shows
+      // "Reconnecting…" mid-reconnect). Silent (onlyAlertOnce). No-op when the
+      // service isn't running.
+      unawaited(_refreshNotification());
     });
+  }
+
+  /// Build the live FGS notification text from the per-session snapshots (#847)
+  /// and push it to the running service. Counts `connected` sessions, detects
+  /// any `reconnecting`, and renders `user@host` for a lone connected session.
+  /// A no-op when the service isn't running (start path renders its own text).
+  Future<void> _refreshNotification() async {
+    if (!_gateway.isInitialized) return;
+    // When the count just dropped to zero the service is being (or has been)
+    // stopped — do NOT race an `updateService` against that stop (it would
+    // re-render "Connecting…" onto a notification that's going away, and clobber
+    // the `stop`-last invariant existing tests assert). Only refresh while at
+    // least one session still holds the service.
+    if (_connectedCount == 0) return;
+    if (!await _gateway.isRunningService) return;
+    await _gateway.updateService(
+      notificationTitle: 'MobiSSH',
+      notificationText: _currentNotificationText(),
+    );
   }
 
   /// A terminal session state: the connect attempt is over and not holding the
@@ -445,11 +563,14 @@ class KeepaliveController {
     final sub = _subscriptions.remove(session);
     if (sub == null) return;
     await sub.cancel();
+    _latestData.remove(session);
     final (_, SshSessionData Function() snapshot) = _viewOf(session);
     if (_holdsService(snapshot().state)) {
       _connectedCount = (_connectedCount - 1).clamp(0, 1 << 30);
       if (_connectedCount == 0) await _stopIfRunning();
     }
+    // #847: a remaining session may now be the lone connected one — refresh.
+    await _refreshNotification();
   }
 
   /// Coerce a session-shaped object to the stream + snapshot pair. Avoids a
@@ -475,6 +596,7 @@ class KeepaliveController {
       await sub.cancel();
     }
     _subscriptions.clear();
+    _latestData.clear();
     _connectedCount = 0;
     // notifyGateway: false — on dispose the whole ProviderContainer is tearing
     // down, so reading taskSshGatewayProvider from the callback would throw
@@ -504,15 +626,39 @@ class KeepaliveController {
       return;
     }
     ctrace('ui.keepalive', '_startIfStopped: calling startService...');
+    // #847: render the START text from the live snapshots too (not just the
+    // raw count) so a service started AT the moment a session reaches connected
+    // already shows "Connected — user@host" instead of "Connecting…".
     final ok = await _gateway.startService(
       notificationTitle: 'MobiSSH',
-      notificationText: _connectedCount == 0
-          ? 'Connecting…'
-          : _connectedCount == 1
-          ? '1 session connected'
-          : '$_connectedCount sessions connected',
+      notificationText: _currentNotificationText(),
     );
     ctrace('ui.keepalive', '_startIfStopped: startService → $ok');
+    // Belt-and-suspenders (#847): if a `connected` transition raced the start
+    // (service was mid-start when the listener fired and its refresh no-op'd
+    // because isRunningService was still false), correct the text now.
+    if (ok) await _refreshNotification();
+  }
+
+  /// Compute the live FGS notification text from the per-session snapshots
+  /// (#847). Shared by the start path and [_refreshNotification].
+  String _currentNotificationText() {
+    var connected = 0;
+    var anyReconnecting = false;
+    KeepaliveSessionInfo? single;
+    for (final data in _latestData.values) {
+      if (data.state == SshSessionState.reconnecting) anyReconnecting = true;
+      if (data.state == SshSessionState.connected) {
+        connected += 1;
+        single = KeepaliveSessionInfo(host: data.host, username: data.username);
+      }
+    }
+    if (connected != 1) single = null;
+    return keepaliveNotificationText(
+      connectedCount: connected,
+      anyReconnecting: anyReconnecting,
+      singleConnected: single,
+    );
   }
 
   Future<void> _stopIfRunning({bool notifyGateway = true}) async {

--- a/native/lib/services/session_attention_notification.dart
+++ b/native/lib/services/session_attention_notification.dart
@@ -47,7 +47,27 @@ const String kAttentionTitle = 'MobiSSH — Claude needs attention';
 
 /// Tag prefix so an attention notification never collides with the
 /// foreground-service keep-alive notification (channel `mobissh_keepalive`).
+/// Keyed by HOST (#847), not session: the unit of attention is the host (the
+/// Claude), so two sessions to the same host share one tag → a repeat REPLACES
+/// rather than stacks (the #847 "two stacked identical alerts" bug).
 const String _tagPrefix = 'mobissh.attention.';
+
+/// Cross-session attention dedup window (#847). Multiple bells from multiple
+/// sessions to the SAME host within this window collapse to ONE notification —
+/// a single underlying Claude event reaching two PTYs should not double-alert.
+/// Tunable; 30s is the owner's starting point.
+const Duration kAttentionDedupWindow = Duration(seconds: 30);
+
+/// Derive the HOST from a sessionId (#847). The session id format is
+/// `host:port:user:createdAtMs` (see `state/sessions.dart`), so the host is the
+/// segment before the first colon. Falls back to the whole id when it has no
+/// colon (defensive — e.g. a synthetic test id), so dedup/suppression still
+/// keys on a stable value. Never returns null.
+String hostOfSessionId(String sessionId) {
+  final i = sessionId.indexOf(':');
+  if (i <= 0) return sessionId;
+  return sessionId.substring(0, i);
+}
 
 /// Android channel id for attention notifications — HIGH importance (loud,
 /// dismissible), DISTINCT from the LOW `mobissh_keepalive` FGS channel.
@@ -78,9 +98,11 @@ class AttentionNotification {
   /// into [sourceWindow]/[payload] instead.
   final String body;
 
-  /// Android notification tag. Keyed by sessionId so a later signal from the
-  /// same session REPLACES the prior notification rather than stacking, while
-  /// distinct sessions get distinct tags (PWA notification-tag parity).
+  /// Android notification tag. Keyed by HOST (#847) so a later signal from the
+  /// same host — including a DIFFERENT session to that host — REPLACES the prior
+  /// notification rather than stacking (the #847 "two stacked identical alerts"
+  /// bug), while distinct hosts get distinct tags. The payload still routes the
+  /// tap to the exact originating session.
   final String tag;
 
   /// Opaque JSON payload the tap carries: `{"sessionId": "...", "sourceWindow": N?}`.
@@ -112,7 +134,10 @@ class AttentionNotification {
     return AttentionNotification(
       title: kAttentionTitle,
       body: body,
-      tag: '$_tagPrefix$sessionId',
+      // Per-HOST tag (#847): two sessions to the same host collapse to one
+      // notification slot (replace, not stack). The tap payload still carries
+      // the exact sessionId so focus routing is unchanged.
+      tag: '$_tagPrefix${hostOfSessionId(sessionId)}',
       payload: jsonEncode(payloadMap),
       sourceWindow: win,
     );
@@ -166,21 +191,72 @@ String? _stripSourceWindow(String? text) {
   return text.replaceFirst(_winRe, '').trimRight();
 }
 
-/// Suppression predicate (#840 Slice 2, step 3). Do NOT post when the signalling
-/// session is BOTH the active session AND the app is foregrounded — the user is
-/// already looking at it. Post in every other case (backgrounded, OR a non-active
-/// session even while foregrounded).
+/// Host-level suppression predicate (#847; supersedes the #840 session-level
+/// rule). The unit of attention is the HOST (the Claude), not the individual
+/// session. Do NOT post when the app is FOREGROUNDED and the front-most session's
+/// HOST equals the signalling session's HOST — the user is already looking at
+/// that Claude, even via a DIFFERENT session to the same host. Post in every
+/// other case: backgrounded, OR foregrounded on a session to a DIFFERENT host.
 ///
 /// [signalSessionId] — the session that produced the signal.
 /// [activeSessionId] — the currently-active (front-most tab) session, or null.
+/// [activeHost] — the HOST of the front-most session, or null when unknown.
 /// [foreground] — whether the app/UI is foregrounded.
 bool shouldPostAttention({
   required String signalSessionId,
   required String? activeSessionId,
+  String? activeHost,
   required bool foreground,
 }) {
-  final isActive = activeSessionId != null && activeSessionId == signalSessionId;
-  return !(isActive && foreground);
+  if (!foreground) return true;
+  final signalHost = hostOfSessionId(signalSessionId);
+  // Prefer the explicit activeHost (the host of the front-most session as
+  // reported by the UI). Fall back to deriving it from activeSessionId so an
+  // older UI (or a path that only knows the id) still host-suppresses correctly.
+  final frontHost = (activeHost != null && activeHost.isNotEmpty)
+      ? activeHost
+      : (activeSessionId != null ? hostOfSessionId(activeSessionId) : null);
+  if (frontHost == null) return true;
+  // Suppress when foregrounded on the SAME host (any session to that host).
+  return frontHost != signalHost;
+}
+
+/// Host-level cross-session dedup (#847). Multiple bells from multiple sessions
+/// to the SAME host within [window] collapse to ONE notification: a single
+/// Claude event reaching two PTYs must not double-alert. Pure + clock-injected
+/// so it is deterministically unit-testable; the host owns one instance and
+/// consults it right before posting.
+class AttentionDedupTracker {
+  AttentionDedupTracker({
+    this.window = kAttentionDedupWindow,
+    int Function()? nowMs,
+  }) : _nowMs = nowMs ?? (() => DateTime.now().millisecondsSinceEpoch);
+
+  /// Dedup window. A post for a host within [window] of its last ALLOWED post is
+  /// suppressed.
+  final Duration window;
+  final int Function() _nowMs;
+
+  /// Last ALLOWED post time per host (ms since epoch).
+  final Map<String, int> _lastPostMs = {};
+
+  /// Record a post for [host] and return whether it should actually fire. The
+  /// FIRST post for a host (or the first after the window elapses) returns true
+  /// and stamps the time; a repeat within [window] returns false WITHOUT moving
+  /// the stamp (so the window measures from the last fired post, not the last
+  /// attempt). Keyed by host so two sessions to the same host dedup together.
+  bool allow(String host) {
+    final now = _nowMs();
+    final last = _lastPostMs[host];
+    if (last != null && (now - last) < window.inMilliseconds) {
+      return false;
+    }
+    _lastPostMs[host] = now;
+    return true;
+  }
+
+  /// Forget a host's last-post stamp (e.g. on shell re-open / reset).
+  void reset() => _lastPostMs.clear();
 }
 
 /// Posts (and cancels) attention notifications. Abstracted so the task isolate

--- a/native/lib/services/session_attention_notification.dart
+++ b/native/lib/services/session_attention_notification.dart
@@ -69,6 +69,19 @@ String hostOfSessionId(String sessionId) {
   return sessionId.substring(0, i);
 }
 
+/// Short, human display label for the host of [sessionId] — the first
+/// dot-segment of the host (e.g. `fd-dev` from `fd-dev.tailbe5094.ts.net`), so
+/// an attention notification is differentiated BY SERVER (#847 owner request:
+/// "at minimum differentiate by server") without the long tailnet FQDN. These
+/// are the owner's own machines on a private tailnet — the short host name is
+/// not sensitive and is what the owner uses to tell sessions apart. Falls back
+/// to the full host when there is no dot.
+String hostLabelOfSessionId(String sessionId) {
+  final host = hostOfSessionId(sessionId);
+  final dot = host.indexOf('.');
+  return dot <= 0 ? host : host.substring(0, dot);
+}
+
 /// Android channel id for attention notifications — HIGH importance (loud,
 /// dismissible), DISTINCT from the LOW `mobissh_keepalive` FGS channel.
 const String kAttentionChannelId = 'mobissh_attention';
@@ -92,10 +105,11 @@ class AttentionNotification {
   /// in the title (no host/user leakage in the visible text).
   final String title;
 
-  /// Notification body — the scanner's parsed text (the OSC-9 / OSC-777 /
-  /// hook-line message), or a fixed fallback phrase when the signal had no text
-  /// (a bare BEL). Stripped of any trailing `(win N)` hint, which is structured
-  /// into [sourceWindow]/[payload] instead.
+  /// Notification body — leads with the short host label (#847: differentiate by
+  /// server) followed by the scanner's parsed text (the OSC-9 / OSC-777 /
+  /// hook-line message): `"server — text"`. A text-less signal (a bare BEL) is
+  /// just `"server"`. Stripped of any trailing `(win N)` hint, which is
+  /// structured into [sourceWindow]/[payload] instead.
   final String body;
 
   /// Android notification tag. Keyed by HOST (#847) so a later signal from the
@@ -113,9 +127,6 @@ class AttentionNotification {
   /// Parsed tmux source-window number from a trailing `(win N)` hint, or null.
   final int? sourceWindow;
 
-  /// Fixed fallback body for a text-less signal (a bare bell).
-  static const String _fallbackBody = 'Session needs attention';
-
   /// Build a notification description for [sessionId] from a detected [signal].
   ///
   /// The body is the signal's parsed text with any trailing `(win N)` removed;
@@ -128,7 +139,13 @@ class AttentionNotification {
     final raw = signal.text?.trim();
     final win = parseSourceWindow(raw);
     final stripped = _stripSourceWindow(raw);
-    final body = (stripped == null || stripped.isEmpty) ? _fallbackBody : stripped;
+    // #847: lead the body with the short host label so alerts are differentiated
+    // BY SERVER (owner: "at minimum differentiate by server"). A bare bell (no
+    // text) shows just the server; a signal with text shows "server — text".
+    final label = hostLabelOfSessionId(sessionId);
+    final body = (stripped == null || stripped.isEmpty)
+        ? label
+        : '$label — $stripped';
     final payloadMap = <String, dynamic>{'sessionId': sessionId};
     if (win != null) payloadMap['sourceWindow'] = win;
     return AttentionNotification(

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -153,6 +153,21 @@ class SessionHost {
   /// get a notification.
   String? _activeSessionId;
 
+  /// The HOST of the currently front-most (active) session (#847), as reported
+  /// by the UI via [SshSetActiveCommand.activeHost]. The unit of attention is the
+  /// host: while foregrounded on ANY session to this host, a bell from ANY
+  /// session to the SAME host is suppressed. Null when unknown (degrades to the
+  /// session-id-derived host inside [shouldPostAttention]).
+  String? _activeHost;
+
+  /// Host-level cross-session dedup (#847): collapses multiple bells from
+  /// multiple sessions to the same host (one Claude event reaching two PTYs)
+  /// into ONE notification within [kAttentionDedupWindow]. Shares the host's
+  /// injectable clock so tests are deterministic.
+  late final AttentionDedupTracker _attentionDedup = AttentionDedupTracker(
+    nowMs: _nowMs,
+  );
+
   /// Posts attention notifications when a Slice-1 signal is detected (#840
   /// Slice 2). Null on platforms / tests where no notifier is wired — then the
   /// detection still LOGS to `clifecycle` (Slice 1 behaviour) but posts nothing.
@@ -228,7 +243,7 @@ class SessionHost {
         // terminal/audit, so it carries the full payload (#806 C).
         if (s != null) _emitSnapshot(cmd.sessionId, s, includeScrollback: true);
       case SshSetActiveCommand():
-        _handleSetActive(cmd.active, cmd.activeSessionId);
+        _handleSetActive(cmd.active, cmd.activeSessionId, cmd.activeHost);
       case SshHostKeyDecisionCommand():
         _handleHostKeyDecision(cmd);
       case SshUiHelloCommand():
@@ -1012,12 +1027,18 @@ class SessionHost {
   /// from current state without waiting for the next tick. Idempotent: a repeat
   /// of the current state is a no-op so duplicate lifecycle events don't churn
   /// the timer. Does NOT touch the SSH session, keepalive, or locks.
-  void _handleSetActive(bool active, [String? activeSessionId]) {
+  void _handleSetActive(
+    bool active, [
+    String? activeSessionId,
+    String? activeHost,
+  ]) {
     if (_disposed) return;
-    // Always track the reported active session id (#840 Slice 2) — even when
-    // [active] is unchanged the front-most TAB may have switched, and that must
-    // update suppression. A null id (older UI / none) leaves it unknown.
+    // Always track the reported active session id (#840 Slice 2) + host (#847) —
+    // even when [active] is unchanged the front-most TAB may have switched, and
+    // that must update suppression. A null id/host (older UI / none) leaves it
+    // unknown (degrades to "never host-suppress").
     _activeSessionId = activeSessionId;
+    _activeHost = activeHost;
     if (_active == active) return;
     _active = active;
     if (active) {
@@ -1080,13 +1101,29 @@ class SessionHost {
   void _maybePostAttention(String sessionId, AttentionSignal sig) {
     final notifier = _attentionNotifier;
     if (notifier == null) return;
+    // #847: host-level suppression — looking at ANY session to this host (incl.
+    // a different one) while foregrounded suppresses the bell.
     final post = shouldPostAttention(
       signalSessionId: sessionId,
       activeSessionId: _activeSessionId,
+      activeHost: _activeHost,
       foreground: _active,
     );
     if (!post) {
-      clifecycle('attention', 'suppressed (active+foreground) session $sessionId');
+      clifecycle(
+        'attention',
+        'suppressed (foreground same-host) session $sessionId',
+      );
+      return;
+    }
+    // #847: host-level cross-session dedup — a second bell from another session
+    // to the SAME host within the window collapses into the first notification.
+    final host = hostOfSessionId(sessionId);
+    if (!_attentionDedup.allow(host)) {
+      clifecycle(
+        'attention',
+        'deduped (host $host within window) session $sessionId',
+      );
       return;
     }
     try {

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -222,6 +222,7 @@ sealed class SshTaskCommand {
         return SshSetActiveCommand(
           active: json['active'] as bool,
           activeSessionId: json['activeSessionId'] as String?,
+          activeHost: json['activeHost'] as String?,
         );
       case SshTaskCommandKind.sftpList:
         return SftpListCommand(
@@ -486,11 +487,16 @@ class SshReconnectCommand extends SshTaskCommand {
 /// UI repaints from current state. Task-global, so [sessionId] is the empty
 /// sentinel (mirrors [SshUiHelloCommand]).
 class SshSetActiveCommand extends SshTaskCommand {
-  const SshSetActiveCommand({required this.active, this.activeSessionId})
-    : super('');
+  const SshSetActiveCommand({
+    required this.active,
+    this.activeSessionId,
+    this.activeHost,
+  }) : super('');
 
   /// True = UI foregrounded (resume periodic snapshots); false = backgrounded
-  /// (stop the periodic timer until the next resume).
+  /// (stop the periodic timer until the next resume). This IS the "foregrounded"
+  /// signal the #847 host-level attention policy consumes — the app is
+  /// foreground exactly when its periodic-snapshot gate is open.
   final bool active;
 
   /// The currently front-most (active) session id, or null when none / unknown
@@ -499,6 +505,14 @@ class SshSetActiveCommand extends SshTaskCommand {
   /// Optional + back-compatible: an older UI that omits it leaves the host's
   /// active-session unknown, which only means it never suppresses (safe).
   final String? activeSessionId;
+
+  /// The HOST of the currently front-most (active) session (#847). The unit of
+  /// attention is the HOST (the Claude), not the individual session: while the
+  /// app is foregrounded on ANY session to this host, an attention bell from ANY
+  /// (possibly different) session to the SAME host is suppressed — the user is
+  /// already looking at that Claude. Null when none / unknown (older UI), which
+  /// degrades safely to "never host-suppress". Carries no port/auth material.
+  final String? activeHost;
 
   @override
   SshTaskCommandKind get kind => SshTaskCommandKind.setActive;
@@ -509,6 +523,7 @@ class SshSetActiveCommand extends SshTaskCommand {
     'sessionId': sessionId,
     'active': active,
     if (activeSessionId != null) 'activeSessionId': activeSessionId,
+    if (activeHost != null) 'activeHost': activeHost,
   };
 }
 

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -152,11 +152,17 @@ class SshSessionProxy {
   /// [activeSessionId] (#840 Slice 2) tells the task which session is front-most
   /// so it can SUPPRESS an attention notification for the session the user is
   /// already looking at (active + foreground). Optional + back-compatible.
-  void setActive(bool active, {String? activeSessionId}) {
+  /// [activeHost] (#847) carries the front-most session's HOST so the task can
+  /// suppress an attention bell from ANY session to the SAME host (the unit of
+  /// attention is the host/Claude, not the individual session).
+  void setActive(bool active, {String? activeSessionId, String? activeHost}) {
     if (_disposed) return;
     gateway.send(
-      SshSetActiveCommand(active: active, activeSessionId: activeSessionId)
-          .toJson(),
+      SshSetActiveCommand(
+        active: active,
+        activeSessionId: activeSessionId,
+        activeHost: activeHost,
+      ).toJson(),
     );
   }
 

--- a/native/test/services/gateway_rehandshake_test.dart
+++ b/native/test/services/gateway_rehandshake_test.dart
@@ -58,6 +58,14 @@ class _FakeRunningGateway implements KeepaliveGateway {
   }
 
   @override
+  Future<void> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    calls.add('update');
+  }
+
+  @override
   Future<bool> stopService() async {
     calls.add('stop');
     running = false;

--- a/native/test/services/keepalive_task_test.dart
+++ b/native/test/services/keepalive_task_test.dart
@@ -47,6 +47,14 @@ class FakeKeepaliveGateway implements KeepaliveGateway {
   }
 
   @override
+  Future<void> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    calls.add('update:$notificationText');
+  }
+
+  @override
   Future<bool> stopService() async {
     calls.add('stop');
     _running = false;
@@ -68,8 +76,8 @@ class StubSession implements SshSessionController {
   @override
   Stream<SshSessionData> get stream => _ctrl.stream;
 
-  void emit(SshSessionState state) {
-    _data = _data.copyWith(state: state);
+  void emit(SshSessionState state, {String? host, String? username}) {
+    _data = _data.copyWith(state: state, host: host, username: username);
     _ctrl.add(_data);
   }
 
@@ -279,6 +287,136 @@ void main() {
 
       await controller.dispose();
       await session.dispose();
+    });
+  });
+
+  group('keepaliveNotificationText mapper (#847)', () {
+    test('0 connected → Connecting…', () {
+      expect(
+        keepaliveNotificationText(connectedCount: 0, anyReconnecting: false),
+        'Connecting…',
+      );
+    });
+    test('1 connected → Connected — user@host', () {
+      expect(
+        keepaliveNotificationText(
+          connectedCount: 1,
+          anyReconnecting: false,
+          singleConnected:
+              const KeepaliveSessionInfo(host: 'fd-dev', username: 'mfrazier'),
+        ),
+        'Connected — mfrazier@fd-dev',
+      );
+    });
+    test('1 connected, host only → Connected — host', () {
+      expect(
+        keepaliveNotificationText(
+          connectedCount: 1,
+          anyReconnecting: false,
+          singleConnected: const KeepaliveSessionInfo(host: 'fd-dev'),
+        ),
+        'Connected — fd-dev',
+      );
+    });
+    test('N connected → Connected — N sessions', () {
+      expect(
+        keepaliveNotificationText(connectedCount: 3, anyReconnecting: false),
+        'Connected — 3 sessions',
+      );
+    });
+    test('any reconnecting takes priority → Reconnecting… (N connected)', () {
+      expect(
+        keepaliveNotificationText(connectedCount: 2, anyReconnecting: true),
+        'Reconnecting… (2 connected)',
+      );
+      // Even with 0 connected, reconnecting reflects it.
+      expect(
+        keepaliveNotificationText(connectedCount: 0, anyReconnecting: true),
+        'Reconnecting… (0 connected)',
+      );
+    });
+    test('NEVER sits on Connecting… once a session is up', () {
+      final text = keepaliveNotificationText(
+        connectedCount: 1,
+        anyReconnecting: false,
+        singleConnected: const KeepaliveSessionInfo(host: 'h', username: 'u'),
+      );
+      expect(text, isNot('Connecting…'));
+    });
+  });
+
+  group('KeepaliveController FGS text updates (#847)', () {
+    test('updates notification to Connected — user@host on connect', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(
+        SshSessionState.connected,
+        host: 'fd-dev',
+        username: 'mfrazier',
+      );
+      await _drain();
+
+      // The running service no longer sits on "Connecting…".
+      expect(
+        gateway.calls.any((c) => c == 'update:Connected — mfrazier@fd-dev') ||
+            gateway.calls.any((c) => c == 'start:Connected — mfrazier@fd-dev'),
+        isTrue,
+        reason: 'FGS text must reflect the connected session, not Connecting…\n'
+            '${gateway.calls}',
+      );
+      // It must NOT remain on a Connecting… text after connect.
+      expect(gateway.calls.last.contains('Connecting…'), isFalse);
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('reflects reconnecting in the FGS text', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected, host: 'h', username: 'u');
+      await _drain();
+      session.emit(SshSessionState.reconnecting, host: 'h', username: 'u');
+      await _drain();
+
+      expect(
+        gateway.calls.any((c) => c.startsWith('update:Reconnecting…')),
+        isTrue,
+        reason: 'reconnect must surface in the FGS text\n${gateway.calls}',
+      );
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('N connected → Connected — N sessions', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final a = StubSession();
+      final b = StubSession();
+      controller.attach(a);
+      controller.attach(b);
+
+      a.emit(SshSessionState.connected, host: 'h1', username: 'u');
+      await _drain();
+      b.emit(SshSessionState.connected, host: 'h2', username: 'u');
+      await _drain();
+
+      expect(
+        gateway.calls.any((c) => c == 'update:Connected — 2 sessions'),
+        isTrue,
+        reason: 'two connected sessions must read "2 sessions"\n${gateway.calls}',
+      );
+
+      await controller.dispose();
+      await a.dispose();
+      await b.dispose();
     });
   });
 

--- a/native/test/services/session_attention_notification_test.dart
+++ b/native/test/services/session_attention_notification_test.dart
@@ -27,13 +27,37 @@ void main() {
       expect(payload['sourceWindow'], 3);
     });
 
-    test('per-session tag differs across sessions; same within a session', () {
+    test('per-HOST tag: same host → same tag (replace, not stack); '
+        'different host → distinct tag (#847)', () {
       const sig = AttentionSignal(AttentionKind.osc9, 'ready');
-      final a1 = AttentionNotification.build(sessionId: 'A', signal: sig);
-      final a2 = AttentionNotification.build(sessionId: 'A', signal: sig);
-      final b = AttentionNotification.build(sessionId: 'B', signal: sig);
-      expect(a1.tag, a2.tag); // replace, not stack
-      expect(a1.tag, isNot(b.tag)); // distinct sessions distinct tags
+      // Two DISTINCT sessions to the SAME host (different ports/nonces).
+      final h1a = AttentionNotification.build(
+        sessionId: 'fd-dev:22:user:111',
+        signal: sig,
+      );
+      final h1b = AttentionNotification.build(
+        sessionId: 'fd-dev:2222:user:222',
+        signal: sig,
+      );
+      final h2 = AttentionNotification.build(
+        sessionId: 'other-host:22:user:333',
+        signal: sig,
+      );
+      expect(h1a.tag, h1b.tag,
+          reason: 'same host → one tag → repeats REPLACE, not stack');
+      expect(h1a.tag, isNot(h2.tag), reason: 'distinct hosts → distinct tags');
+      expect(h1a.tag, 'mobissh.attention.fd-dev');
+    });
+
+    test('payload still carries the EXACT originating sessionId (tag is host)',
+        () {
+      const sig = AttentionSignal(AttentionKind.osc9, 'ready');
+      final n = AttentionNotification.build(
+        sessionId: 'fd-dev:2222:user:222',
+        signal: sig,
+      );
+      final payload = jsonDecode(n.payload) as Map;
+      expect(payload['sessionId'], 'fd-dev:2222:user:222');
     });
 
     test('text-less bare bell gets a fixed fallback body, no sourceWindow', () {
@@ -90,46 +114,139 @@ void main() {
     });
   });
 
-  group('shouldPostAttention suppression', () {
-    test('active session AND foreground → suppress (no post)', () {
+  group('hostOfSessionId (#847)', () {
+    test('parses host from host:port:user:nonce', () {
+      expect(hostOfSessionId('fd-dev:22:user:1781037380521'), 'fd-dev');
+      expect(hostOfSessionId('127.0.0.1:2223:testuser:999'), '127.0.0.1');
+    });
+    test('no colon → whole id (defensive)', () {
+      expect(hostOfSessionId('synthetic-id'), 'synthetic-id');
+    });
+    test('leading colon → whole id (degrades safely)', () {
+      expect(hostOfSessionId(':22:user:1'), ':22:user:1');
+    });
+  });
+
+  group('shouldPostAttention HOST-LEVEL suppression (#847)', () {
+    // sessions A and B are DIFFERENT sessions to the SAME host (fd-dev);
+    // session C is to a DIFFERENT host.
+    const sessA = 'fd-dev:22:user:111';
+    const sessB = 'fd-dev:2222:user:222';
+    const sessC = 'other:22:user:333';
+
+    test('foreground + SAME host (same session) → suppress', () {
       expect(
         shouldPostAttention(
-          signalSessionId: 'A',
-          activeSessionId: 'A',
+          signalSessionId: sessA,
+          activeSessionId: sessA,
+          activeHost: 'fd-dev',
           foreground: true,
         ),
         isFalse,
       );
     });
-    test('active session but BACKGROUNDED → post', () {
+    test('foreground + SAME host (DIFFERENT session to that host) → suppress', () {
+      // Looking at session B (same host) while session A bells → suppress.
       expect(
         shouldPostAttention(
-          signalSessionId: 'A',
-          activeSessionId: 'A',
+          signalSessionId: sessA,
+          activeSessionId: sessB,
+          activeHost: 'fd-dev',
+          foreground: true,
+        ),
+        isFalse,
+      );
+    });
+    test('foreground + DIFFERENT host → fire', () {
+      expect(
+        shouldPostAttention(
+          signalSessionId: sessC,
+          activeSessionId: sessA,
+          activeHost: 'fd-dev',
+          foreground: true,
+        ),
+        isTrue,
+      );
+    });
+    test('BACKGROUNDED → always fire (even same host)', () {
+      expect(
+        shouldPostAttention(
+          signalSessionId: sessA,
+          activeSessionId: sessA,
+          activeHost: 'fd-dev',
           foreground: false,
         ),
         isTrue,
       );
     });
-    test('NON-active session while foreground → post', () {
+    test('no activeHost but activeSessionId same host → suppress (fallback)', () {
       expect(
         shouldPostAttention(
-          signalSessionId: 'B',
-          activeSessionId: 'A',
+          signalSessionId: sessA,
+          activeSessionId: sessB, // same host fd-dev
           foreground: true,
         ),
-        isTrue,
+        isFalse,
       );
     });
-    test('no active session → post', () {
+    test('no active host info at all → fire', () {
       expect(
         shouldPostAttention(
-          signalSessionId: 'A',
+          signalSessionId: sessA,
           activeSessionId: null,
           foreground: true,
         ),
         isTrue,
       );
+    });
+  });
+
+  group('AttentionDedupTracker host-level window (#847)', () {
+    test('2 sessions to SAME host within window → 1 allowed', () {
+      var now = 1000;
+      final dedup = AttentionDedupTracker(
+        window: const Duration(seconds: 30),
+        nowMs: () => now,
+      );
+      // First bell (session A on fd-dev) fires.
+      expect(dedup.allow('fd-dev'), isTrue);
+      // 5s later, session B on the SAME host bells → deduped.
+      now += 5000;
+      expect(dedup.allow('fd-dev'), isFalse);
+    });
+
+    test('2 DIFFERENT hosts → both allowed', () {
+      var now = 1000;
+      final dedup = AttentionDedupTracker(
+        window: const Duration(seconds: 30),
+        nowMs: () => now,
+      );
+      expect(dedup.allow('host-a'), isTrue);
+      expect(dedup.allow('host-b'), isTrue);
+    });
+
+    test('same host OUTSIDE the window → allowed again', () {
+      var now = 1000;
+      final dedup = AttentionDedupTracker(
+        window: const Duration(seconds: 30),
+        nowMs: () => now,
+      );
+      expect(dedup.allow('fd-dev'), isTrue);
+      now += 31000; // past the 30s window
+      expect(dedup.allow('fd-dev'), isTrue);
+    });
+
+    test('window measures from last FIRED post, not last attempt', () {
+      var now = 1000;
+      final dedup = AttentionDedupTracker(
+        window: const Duration(seconds: 30),
+        nowMs: () => now,
+      );
+      expect(dedup.allow('h'), isTrue); // fires at t=1000
+      now += 20000; // t=21000, within window → deduped, stamp NOT moved
+      expect(dedup.allow('h'), isFalse);
+      now += 11000; // t=32000, 31s after the FIRED post → allowed again
+      expect(dedup.allow('h'), isTrue);
     });
   });
 

--- a/native/test/services/session_attention_notification_test.dart
+++ b/native/test/services/session_attention_notification_test.dart
@@ -18,7 +18,8 @@ void main() {
 
       expect(n.title, kAttentionTitle);
       // (win N) is stripped from the visible body and structured into payload.
-      expect(n.body, 'Claude — main');
+      // #847: body leads with the host label (differentiate by server).
+      expect(n.body, 'sess-A — Claude — main');
       expect(n.tag, 'mobissh.attention.sess-A');
       expect(n.sourceWindow, 3);
 
@@ -60,19 +61,44 @@ void main() {
       expect(payload['sessionId'], 'fd-dev:2222:user:222');
     });
 
-    test('text-less bare bell gets a fixed fallback body, no sourceWindow', () {
+    test('text-less bare bell body is the host label (differentiate by server), '
+        'no sourceWindow', () {
       const sig = AttentionSignal(AttentionKind.bell, null);
-      final n = AttentionNotification.build(sessionId: 'A', signal: sig);
-      expect(n.body, isNotEmpty);
+      final n = AttentionNotification.build(
+        sessionId: 'fd-dev.tailbe5094.ts.net:22:user:1',
+        signal: sig,
+      );
+      // #847: even a context-less bell names the server (short host label).
+      expect(n.body, 'fd-dev');
       expect(n.sourceWindow, isNull);
       final payload = jsonDecode(n.payload) as Map;
       expect(payload.containsKey('sourceWindow'), isFalse);
     });
 
-    test('osc777 title:body text is carried as the body', () {
+    test('body differentiates by server: distinct hosts → distinct bodies (#847)',
+        () {
+      const sig = AttentionSignal(AttentionKind.bell, null);
+      final a = AttentionNotification.build(
+        sessionId: 'fd-dev.tailbe5094.ts.net:22:u:1',
+        signal: sig,
+      );
+      final b = AttentionNotification.build(
+        sessionId: 'nv-dev.tailbe5094.ts.net:22:u:2',
+        signal: sig,
+      );
+      expect(a.body, 'fd-dev');
+      expect(b.body, 'nv-dev');
+      expect(a.body, isNot(b.body),
+          reason: 'two servers must never show identical notification text');
+    });
+
+    test('osc777 title:body text is carried as the body, host-prefixed', () {
       const sig = AttentionSignal(AttentionKind.osc777, 'MobiSSH: build done');
-      final n = AttentionNotification.build(sessionId: 'A', signal: sig);
-      expect(n.body, 'MobiSSH: build done');
+      final n = AttentionNotification.build(
+        sessionId: 'fd-dev.tailbe5094.ts.net:22:u:1',
+        signal: sig,
+      );
+      expect(n.body, 'fd-dev — MobiSSH: build done');
     });
 
     test('PAYLOAD CARRIES NO SECRET MATERIAL', () {

--- a/native/test/services/session_host_attention_post_test.dart
+++ b/native/test/services/session_host_attention_post_test.dart
@@ -76,11 +76,38 @@ void main() {
 
     expect(s.notifier.posted, hasLength(1));
     final n = s.notifier.posted.single;
-    expect(n.tag, 'mobissh.attention.h:22:u:1');
+    // #847: tag is now per-HOST (host `h`), not per-session.
+    expect(n.tag, 'mobissh.attention.h');
     expect(n.body, 'Claude — main');
     expect(n.sourceWindow, 3);
     final payload = jsonDecode(n.payload) as Map;
+    // Payload still routes the tap to the EXACT session.
     expect(payload['sessionId'], 'h:22:u:1');
+  });
+
+  test('#847 SUPPRESSED when foregrounded on a DIFFERENT session to the SAME '
+      'host', () async {
+    // Signalling session is h:22:u:1 (host h). The user is foregrounded on a
+    // DIFFERENT session to the SAME host (h:2222:u:2) — the unit of attention is
+    // the host, so the bell is suppressed.
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(
+        active: true,
+        activeSessionId: 'h:2222:u:2',
+        activeHost: 'h',
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('ready'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(s.notifier.posted, isEmpty,
+        reason: 'foregrounded on the same host (different session) → suppress');
   });
 
   test('SUPPRESSED when session is active AND app foregrounded', () async {

--- a/native/test/services/session_host_attention_post_test.dart
+++ b/native/test/services/session_host_attention_post_test.dart
@@ -78,7 +78,8 @@ void main() {
     final n = s.notifier.posted.single;
     // #847: tag is now per-HOST (host `h`), not per-session.
     expect(n.tag, 'mobissh.attention.h');
-    expect(n.body, 'Claude — main');
+    // #847: body leads with the host label (differentiate by server).
+    expect(n.body, 'h — Claude — main');
     expect(n.sourceWindow, 3);
     final payload = jsonDecode(n.payload) as Map;
     // Payload still routes the tap to the EXACT session.

--- a/native/test/services/task_bootstrap_test.dart
+++ b/native/test/services/task_bootstrap_test.dart
@@ -53,6 +53,14 @@ class FakeKeepaliveGateway implements KeepaliveGateway {
   }
 
   @override
+  Future<void> updateService({
+    required String notificationTitle,
+    required String notificationText,
+  }) async {
+    calls.add('update');
+  }
+
+  @override
   Future<bool> stopService() async {
     calls.add('stop');
     _running = false;

--- a/native/test/services/task_ipc_test.dart
+++ b/native/test/services/task_ipc_test.dart
@@ -101,6 +101,28 @@ void main() {
       }
     });
 
+    test('SshSetActiveCommand round-trips activeSessionId + activeHost (#847)',
+        () {
+      final cmd = SshSetActiveCommand(
+        active: true,
+        activeSessionId: 'fd-dev:22:user:1',
+        activeHost: 'fd-dev',
+      );
+      final restored =
+          SshTaskCommand.fromJson(cmd.toJson()) as SshSetActiveCommand;
+      expect(restored.active, isTrue);
+      expect(restored.activeSessionId, 'fd-dev:22:user:1');
+      expect(restored.activeHost, 'fd-dev');
+    });
+
+    test('SshSetActiveCommand omits null activeHost (back-compat)', () {
+      final cmd = SshSetActiveCommand(active: false, activeSessionId: 'x:1:u:1');
+      final json = cmd.toJson();
+      expect(json.containsKey('activeHost'), isFalse);
+      final restored = SshTaskCommand.fromJson(json) as SshSetActiveCommand;
+      expect(restored.activeHost, isNull);
+    });
+
     test('unknown kind throws FormatException', () {
       expect(
         () => SshTaskCommand.fromJson({'kind': 'bogus', 'sessionId': 'sid'}),


### PR DESCRIPTION
Fixes #847. Follow-up to #840 (attention notifications shipped in v0.1.10+48), which surfaced two real device bugs.

## Part 1 — FGS notification informative (kills frozen "Connecting…")
- Added `updateService(title, text)` to `KeepaliveGateway` (FFT impl + Noop desktop).
- Pure `keepaliveNotificationText` mapper:
  - 0 connected / handshaking → `Connecting…`
  - any reconnecting → `Reconnecting… (N connected)`
  - 1 connected → `Connected — user@host`
  - N connected → `Connected — N sessions`
- `KeepaliveController` already observes every attached session's state stream; it now keeps the freshest per-session snapshot and pushes refreshed text on **every** transition (and the start path uses the same mapper). `onlyAlertOnce: true` kept so updates are silent. The refresh is skipped at `connectedCount == 0` so it can't race the service stop.

## Part 2 — host-level attention policy (the unit of attention is the HOST)
- Extended `SshSetActiveCommand` with `activeHost`; pushed from `main.dart`'s `AppLifecycleState` observer **and** on active-session change (new `ref.listen(activeSessionIdProvider)`), through `ssh_session_proxy`.
- `shouldPostAttention` is now **host-keyed**: suppress when foregrounded and the front-most session's host == the signalling session's host — including a *different* session to the same host. Host derived from sessionId (`host:port:user:nonce` → segment before first colon).
- **Host-level cross-session dedup** (`AttentionDedupTracker`, **30s** tunable window): multiple bells from multiple sessions to one host collapse to one notification.
- **Per-HOST notification tag** so a repeat REPLACES rather than stacks (was the "two stacked identical alerts" bug). The tap payload still carries the exact originating sessionId for focus routing.

## How foreground/host state is propagated
`main.dart` (UI isolate) → `SshSessionProxy.setActive(active, activeSessionId, activeHost)` → `SshSetActiveCommand` over the gateway → `SessionHost._handleSetActive` (task isolate) stores `_active` (foreground) + `_activeHost`, which feed the host-keyed suppression predicate + dedup tracker at the post point.

## Tests (TDD red→green)
- **Unit:** FGS text mapper matrix (0/1/N/reconnecting); host-keyed suppression matrix (foreground+same-host→suppress incl. different session, foreground+other-host→fire, background→fire); host dedup window (2 same-host→1, 2 hosts→2, outside window→2, window measures from last fired post); `hostOfSessionId`; `SshSetActiveCommand` `activeHost` round-trip; per-host tag.
- **Emulator** (`integration_test/attention_host_suppression_test.dart`): two sessions to the same host (`127.0.0.1:2222` + `:2223`), foregrounded on one, a bell on each → **zero** attention posts (host-suppressed), asserted via the lifecycle ring.

## Gate
`scripts/native-fast-gate.sh` green (analyze + 1147 unit tests). The emulator integration suite is the merge gate (#589) — run on a booted AVD before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)