### PR TITLE
fix(#848): kill keyboard-hide resize storm (no-op guard + settle debounce)

### DIFF
--- a/native/lib/services/task_ssh_gateway.dart
+++ b/native/lib/services/task_ssh_gateway.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 import '../diagnostics/connect_trace.dart';
@@ -24,17 +25,27 @@ import 'session_messages.dart';
 /// multi-session traces show which session each event belongs to —
 /// previously every `recv state` / `recv closed` looked identical regardless
 /// of session, making it impossible to tell which session dropped.
+@visibleForTesting
+String gwLabel(Map<String, dynamic> p) => _gwLabel(p);
+
 String _gwLabel(Map<String, dynamic> p) {
   final kind = p['kind'] ?? p['type'] ?? '?';
+  // #848 telemetry hygiene: a resize is the storm payload — carry its grid in
+  // the label so a real dimension change is VISIBLE and so consecutive
+  // same-session resize lines (now rare thanks to the no-op guard) collapse via
+  // ctrace's ×N path instead of looking distinct line-to-line.
+  final dims = kind == 'resize' && p['cols'] is int && p['rows'] is int
+      ? ' ${p['cols']}x${p['rows']}'
+      : '';
   final sid = p['sessionId'];
   if (sid is String && sid.isNotEmpty) {
     final parts = sid.split(':');
     // sessionId format: host:port:user:createdAtMs — host:port is the unique
     // human-readable handle that maps cleanly to a profile.
-    if (parts.length >= 2) return '$kind sid=${parts[0]}:${parts[1]}';
-    return '$kind sid=$sid';
+    if (parts.length >= 2) return '$kind sid=${parts[0]}:${parts[1]}$dims';
+    return '$kind sid=$sid$dims';
   }
-  return '$kind';
+  return '$kind$dims';
 }
 
 /// One half of the UI ↔ task channel. The UI proxy holds the

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -72,6 +72,21 @@ class SshSessionProxy {
   bool _bound = false;
   bool _disposed = false;
 
+  /// The PTY grid dimensions LAST SENT for this session via [sendResize] (#848).
+  /// `null` until the first resize. The no-op guard drops a resize whose
+  /// (cols, rows) match these — re-sending identical dims to the PTY is wasteful
+  /// AND makes tmux redraw (the duplicated/ghosted content in the keyboard-hide
+  /// resize storm). One pair per proxy → the guard is inherently per-session.
+  int? _lastSentCols;
+  int? _lastSentRows;
+
+  /// One-shot bypass for the [sendResize] no-op guard (#848/#666). The #666
+  /// connect-resync drives `terminal.resize` with the SAME dims to re-sync a
+  /// stale remote; that fires `onResize` → `sendResize` (sessions.dart) with no
+  /// `force` argument of its own. Arming this just before that `terminal.resize`
+  /// lets the resulting `sendResize` punch through the guard exactly once.
+  bool _forceNextResize = false;
+
   /// Most recent state snapshot. Always non-null.
   SshSessionData get data => _data;
 
@@ -262,12 +277,31 @@ class SshSessionProxy {
   }
 
   /// Send a PTY resize to the remote.
+  ///
+  /// #848 — NO-OP GUARD: a resize whose (cols, rows) are IDENTICAL to the last
+  /// grid sent for this session is DROPPED (no PTY write, no gateway log). On
+  /// keyboard hide the fit/resize path re-fired the same dimensions on every
+  /// animation frame, for every session; each identical resize made tmux redraw
+  /// (the duplicated content) and flooded the connect ring. Deduping at the
+  /// emission point kills most of the storm at the source.
+  ///
+  /// Pass [force] to bypass the guard and re-send identical dims — the #666
+  /// connect-resync deliberately re-pushes the SAME size to re-sync a remote
+  /// that attached at the stale default before layout settled.
   void sendResize(
     int cols,
     int rows, {
     int pixelWidth = 0,
     int pixelHeight = 0,
+    bool force = false,
   }) {
+    final bypass = force || _forceNextResize;
+    _forceNextResize = false;
+    if (!bypass && cols == _lastSentCols && rows == _lastSentRows) {
+      return;
+    }
+    _lastSentCols = cols;
+    _lastSentRows = rows;
     gateway.send(
       SshResizeCommand(
         sessionId: sessionId,
@@ -277,6 +311,15 @@ class SshSessionProxy {
         pixelHeight: pixelHeight,
       ).toJson(),
     );
+  }
+
+  /// Arm a ONE-SHOT bypass of the [sendResize] no-op guard (#848/#666). The
+  /// next `sendResize` for this session — even with identical dims — is forwarded
+  /// to the PTY, then the arm clears. Used by the connect-fit force-resync path,
+  /// which drives `terminal.resize` (→ `onResize` → `sendResize`) to re-sync a
+  /// stale remote without the fit code threading a `force` flag through xterm.
+  void armForceResize() {
+    _forceNextResize = true;
   }
 
   /// Tear down the proxy. The task-side session continues running unless

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -31,6 +31,7 @@ import 'package:xterm/xterm.dart';
 import '../diagnostics/connect_trace.dart';
 import '../diagnostics/session_byte_recorder.dart';
 import '../ssh/ssh_session.dart';
+import '../ssh/ssh_session_proxy.dart';
 import '../state/sessions.dart';
 import '../state/terminal_backend.dart';
 import '../state/terminal_providers.dart';
@@ -103,6 +104,22 @@ int debugOffstageFitSkipCount = 0;
 /// the tap→cell→URL path end to end without UI scraping. Reset in test `setUp`.
 @visibleForTesting
 String? debugLastHitUrl;
+
+/// Test-only counter: incremented each time a DEBOUNCED metrics fit actually
+/// fires (#848). `didChangeMetrics` no longer fits per animation frame — it
+/// resets a short settle timer, and only when the keyboard-inset animation stops
+/// does ONE coalesced fit run. A device keyboard hide raises didChangeMetrics
+/// ~once per frame; the old code fitted (and resized every session) on each,
+/// driving the resize storm + 53-row overgrow. This counter lets a widget test
+/// prove N rapid metrics events coalesce into ONE fit. Reset in test `setUp`.
+@visibleForTesting
+int debugMetricsFitCount = 0;
+
+/// The debounce window (#848) that coalesces a keyboard-inset animation's
+/// per-frame `didChangeMetrics` events into a SINGLE settled fit. Long enough to
+/// span the soft-keyboard show/hide animation (~100-250ms on Android), short
+/// enough that a real rotation/resize re-fits promptly.
+const Duration kMetricsSettleDelay = Duration(milliseconds: 120);
 
 class TerminalScreen extends ConsumerWidget {
   const TerminalScreen({super.key});
@@ -519,6 +536,15 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
   /// are cancelled on dispose and never fire against a gone widget.
   final List<Timer> _connectRemeasureTimers = <Timer>[];
 
+  /// #848 — debounce timer for `didChangeMetrics`. A keyboard show/hide animates
+  /// the viewport inset over many frames, each raising didChangeMetrics. Fitting
+  /// on every frame recomputed cols/rows off a TRANSIENT mid-animation height
+  /// (→ the 53-row overgrow) and re-sent a resize to every session each frame
+  /// (the storm). We instead reset this timer on each metrics event and fit ONCE
+  /// after it SETTLES — off the final, chrome-correct viewport. Cancelled on
+  /// dispose so a gone widget is never touched.
+  Timer? _metricsSettleTimer;
+
   /// #666: subscription to the proxy's `shellReady` stream — the
   /// PRODUCTION-reliable "the task-side shell now EXISTS" signal. The #659 arm
   /// hooked `sshShellProvider`, which (unlike the widget-test override) never
@@ -715,6 +741,13 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
       // keyboard toggle / second connect did this incidentally; force makes it
       // deterministic. Only on connect-path triggers (mount/connect/burst) so
       // steady-state fits (metrics/font) don't spam PTY resizes.
+      //
+      // #848: the proxy now DEDUPES identical (cols, rows) at sendResize — which
+      // is exactly this case (local size unchanged). Arm the proxy's one-shot
+      // force bypass so this deliberate re-sync still reaches the PTY through the
+      // dedupe guard. Harmless when the resize routes elsewhere (e.g. the widget
+      // test rewires onResize → transport, not the proxy).
+      _proxyForSession()?.armForceResize();
       terminal.resize(cols, rows, cell.width.round(), cell.height.round());
       debugForcedPtyResyncCount += 1;
       action = 'RESYNC';
@@ -736,6 +769,16 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
 
   static String _fmtSize(Size s) =>
       '${s.width.toStringAsFixed(1)}x${s.height.toStringAsFixed(1)}';
+
+  /// The [SshSessionProxy] backing THIS body's session, or null if the entry is
+  /// gone (mid-teardown). Used by the #666 force-resync to arm the proxy's
+  /// one-shot no-op-guard bypass (#848) before driving `terminal.resize`.
+  SshSessionProxy? _proxyForSession() {
+    for (final e in ref.read(sessionsProvider).entries) {
+      if (e.id == widget.sessionId) return e.proxy;
+    }
+    return null;
+  }
 
   /// #659 — drive an explicit fit on FIRST CONNECT, without needing a keyboard
   /// toggle.
@@ -901,7 +944,20 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
   /// rendered size (#600). Mirrors the PWA's visualViewport resize → re-fit.
   @override
   void didChangeMetrics() {
-    _scheduleExplicitFit('metrics');
+    // #848: DEBOUNCE. A keyboard show/hide animation raises didChangeMetrics
+    // once per frame; fitting per frame measured a transient mid-animation
+    // height (the 53-row overgrow) and re-sent a resize to every session each
+    // frame (the storm tmux redrew into duplicated content). Reset the settle
+    // timer on each event so we fit exactly ONCE, after the inset stops moving —
+    // off the final, chrome-correct viewport. The proxy's no-op guard (#848)
+    // then drops the fit's resize entirely if the settled size is unchanged.
+    if (!mounted) return;
+    _metricsSettleTimer?.cancel();
+    _metricsSettleTimer = Timer(kMetricsSettleDelay, () {
+      if (!mounted) return;
+      debugMetricsFitCount += 1;
+      _scheduleExplicitFit('metrics');
+    });
   }
 
   @override
@@ -909,6 +965,7 @@ class _SessionTerminalBodyState extends ConsumerState<_SessionTerminalBody>
     PaintingBinding.instance.systemFonts.removeListener(_onSystemFontsChanged);
     WidgetsBinding.instance.removeObserver(this);
     _shellReadySub?.cancel();
+    _metricsSettleTimer?.cancel();
     _disarmConnectRemeasure();
     _scrollController.dispose();
     super.dispose();

--- a/native/test/ssh/proxy_resize_dedupe_test.dart
+++ b/native/test/ssh/proxy_resize_dedupe_test.dart
@@ -1,0 +1,185 @@
+// Unit tests for the no-op PTY resize guard on `SshSessionProxy.sendResize`
+// (#848).
+//
+// The keyboard-hide resize STORM (#848) was driven by the fit/resize path
+// re-emitting IDENTICAL (cols, rows) to the PTY on every keyboard-animation
+// frame, for every mounted session. Each identical resize made tmux redraw —
+// the duplicated/ghosted content — and flooded the connect ring with
+// `send resize sid=… → transport` lines that drowned every other event.
+//
+// The fix dedupes at the EMISSION point: `sendResize` only forwards to the
+// gateway when the dimensions ACTUALLY CHANGED from the last grid sent for this
+// session. A `force` bypass keeps the #666 connect-resync (which deliberately
+// re-sends the SAME dims to re-sync a stale remote) working.
+//
+// These tests run against an `InMemoryGatewayPair`: the proxy's `sendResize`
+// pushes `SshResizeCommand`s onto the UI→task channel, which we observe on the
+// task side. Per-session independence is exercised with two proxies that share
+// the channel but carry different session ids.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+
+/// Collects the (cols, rows) of every `resize` command that reached the task
+/// side of the pair, in order. SFTP/connect/etc. payloads are ignored.
+List<({String sid, int cols, int rows})> _resizes(
+  List<Map<String, dynamic>> seen,
+) {
+  return [
+    for (final p in seen)
+      if (p['kind'] == SshTaskCommandKind.resize.name)
+        (
+          sid: p['sessionId'] as String,
+          cols: p['cols'] as int,
+          rows: p['rows'] as int,
+        ),
+  ];
+}
+
+void main() {
+  late InMemoryGatewayPair pair;
+  late List<Map<String, dynamic>> seen;
+
+  setUp(() {
+    pair = InMemoryGatewayPair();
+    seen = <Map<String, dynamic>>[];
+    pair.taskSide.incoming.listen(seen.add);
+  });
+
+  tearDown(() async {
+    await pair.dispose();
+  });
+
+  // Pump the in-memory channel: the broadcast stream delivers asynchronously,
+  // so we yield the event loop before asserting on what the task side saw.
+  Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+  test(
+    'identical dimensions sent twice emit only ONE resize (no-op guard)',
+    () async {
+      final proxy = SshSessionProxy(sessionId: 's1', gateway: pair.uiSide);
+      addTearDown(proxy.dispose);
+
+      proxy.sendResize(80, 24);
+      proxy.sendResize(80, 24);
+      proxy.sendResize(80, 24);
+      await settle();
+
+      final r = _resizes(seen);
+      expect(
+        r.length,
+        1,
+        reason:
+            'three IDENTICAL resizes must collapse to one PTY write — the #848 '
+            'storm is half identical no-ops that make tmux redraw. Got: $r',
+      );
+      expect(r.single.cols, 80);
+      expect(r.single.rows, 24);
+    },
+  );
+
+  test('a CHANGED dimension after a no-op run is emitted', () async {
+    final proxy = SshSessionProxy(sessionId: 's1', gateway: pair.uiSide);
+    addTearDown(proxy.dispose);
+
+    proxy.sendResize(80, 24); // emit
+    proxy.sendResize(80, 24); // drop (no-op)
+    proxy.sendResize(80, 30); // emit (rows changed)
+    proxy.sendResize(90, 30); // emit (cols changed)
+    proxy.sendResize(90, 30); // drop (no-op)
+    await settle();
+
+    final r = _resizes(seen);
+    expect(
+      r.map((e) => '${e.cols}x${e.rows}').toList(),
+      ['80x24', '80x30', '90x30'],
+      reason: 'only real dimension changes reach the PTY (#848). Got: $r',
+    );
+  });
+
+  test(
+    'force: true re-emits identical dimensions (the #666 connect-resync path)',
+    () async {
+      final proxy = SshSessionProxy(sessionId: 's1', gateway: pair.uiSide);
+      addTearDown(proxy.dispose);
+
+      proxy.sendResize(80, 24); // emit
+      proxy.sendResize(80, 24); // drop (no-op)
+      proxy.sendResize(80, 24, force: true); // emit — forced resync
+      await settle();
+
+      final r = _resizes(seen);
+      expect(
+        r.length,
+        2,
+        reason:
+            'force must bypass the no-op guard so a stale remote can be '
+            're-synced with the SAME dims (#666). Got: $r',
+      );
+      expect(r.every((e) => e.cols == 80 && e.rows == 24), isTrue);
+    },
+  );
+
+  test('the no-op guard is PER-SESSION — sessions never cross-suppress',
+      () async {
+    final s1 = SshSessionProxy(sessionId: 's1', gateway: pair.uiSide);
+    final s2 = SshSessionProxy(sessionId: 's2', gateway: pair.uiSide);
+    addTearDown(s1.dispose);
+    addTearDown(s2.dispose);
+
+    // Both sessions settle on 80x24. Each must emit its OWN first resize even
+    // though the dims are identical — the last-sent grid is tracked per proxy,
+    // so s2's first 80x24 is NOT suppressed by s1's.
+    s1.sendResize(80, 24); // emit (s1)
+    s2.sendResize(80, 24); // emit (s2 — independent)
+    s1.sendResize(80, 24); // drop (s1 no-op)
+    s2.sendResize(80, 24); // drop (s2 no-op)
+    await settle();
+
+    final r = _resizes(seen);
+    expect(
+      r.where((e) => e.sid == 's1').length,
+      1,
+      reason: 's1 must emit exactly one resize. Got: $r',
+    );
+    expect(
+      r.where((e) => e.sid == 's2').length,
+      1,
+      reason:
+          's2 must emit its OWN first resize — it must NOT be suppressed by '
+          's1 having already sent the same dims (per-session guard). Got: $r',
+    );
+  });
+
+  group('telemetry hygiene (#848/#836)', () {
+    test('the gateway resize label carries cols×rows so a real change is '
+        'visible and identical lines collapse', () {
+      final label = gwLabel(
+        const SshResizeCommand(sessionId: 'fd-dev:22:u:1', cols: 80, rows: 24)
+            .toJson(),
+      );
+      // The session handle (host:port) AND the grid must both be present: the
+      // grid is what tells a reader a resize actually CHANGED the size, and two
+      // identical resize lines now read identically → ctrace ×N collapse.
+      expect(label, contains('sid=fd-dev:22'));
+      expect(
+        label,
+        contains('80x24'),
+        reason:
+            'the resize log label must carry the grid dims (#848) — without '
+            'them the connect ring can not show what changed and consecutive '
+            'identical resizes do not collapse. Got: "$label"',
+      );
+    });
+
+    test('a non-resize payload label is unchanged (no spurious dims)', () {
+      final label = gwLabel(<String, dynamic>{
+        'kind': 'input',
+        'sessionId': 'fd-dev:22:u:1',
+      });
+      expect(label, 'input sid=fd-dev:22');
+    });
+  });
+}

--- a/native/test/widget/terminal_remeasure_test.dart
+++ b/native/test/widget/terminal_remeasure_test.dart
@@ -179,6 +179,7 @@ void main() {
     debugExplicitFitAppliedCount = 0;
     debugForcedPtyResyncCount = 0;
     debugOffstageFitSkipCount = 0;
+    debugMetricsFitCount = 0;
     clearConnectLog();
   });
 
@@ -252,6 +253,134 @@ void main() {
         }
 
         expect(s.entry.terminal.viewHeight, fitted);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'a STORM of metrics events (keyboard-hide animation) coalesces into ONE '
+      'settled fit — not one fit per animation frame (#848 debounce)',
+      (tester) async {
+        // The #848 device storm: keyboard hide animates the viewport inset over
+        // many frames; each frame raised didChangeMetrics, which fitted +
+        // resized EVERY frame, for every session. The fix DEBOUNCES the metrics
+        // fit — many rapid inset changes settle into a single fit after the
+        // animation stops. This test fires a burst of metrics events spaced
+        // INSIDE the debounce window and asserts the fit runs exactly ONCE,
+        // after the window elapses — not N times.
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final s = await _setup(tester, transport);
+        expect(s.entry.terminal.viewHeight, greaterThan(24));
+
+        debugMetricsFitCount = 0;
+
+        // 12 metrics events 10ms apart (~one keyboard-animation worth), all
+        // INSIDE the ~120ms debounce window. A per-frame fit would run ~12×;
+        // the debounce must run 0× while the storm is in flight (each event
+        // resets the settle timer).
+        for (var i = 0; i < 12; i++) {
+          tester.binding.handleMetricsChanged();
+          await tester.pump(const Duration(milliseconds: 10));
+        }
+        expect(
+          debugMetricsFitCount,
+          0,
+          reason:
+              'a metrics fit ran WHILE the inset animation was still firing — '
+              'the storm was not debounced. Each event must reset the settle '
+              'timer so no fit runs mid-animation (#848).',
+        );
+
+        // Let the debounce window elapse with no further events — the storm has
+        // SETTLED, so exactly one coalesced fit runs.
+        await tester.pump(const Duration(milliseconds: 200));
+        expect(
+          debugMetricsFitCount,
+          1,
+          reason:
+              'the settled keyboard-hide must drive exactly ONE fit, not one '
+              'per animation frame (#848). Got: $debugMetricsFitCount',
+        );
+
+        // A LATER, separate metrics event (a second keyboard toggle) debounces
+        // independently into one more fit.
+        tester.binding.handleMetricsChanged();
+        await tester.pump(const Duration(milliseconds: 200));
+        expect(
+          debugMetricsFitCount,
+          2,
+          reason:
+              'a subsequent settled metrics event must drive its own single '
+              'fit. Got: $debugMetricsFitCount',
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'the settled fit computes rows from the CHROME-EXCLUDED terminal box, not '
+      'the full screen height — no 53-row overgrow (#848)',
+      (tester) async {
+        // The #848 overgrow: a mid-animation fit measured a TRANSIENT height
+        // (the keybar/compose/status chrome had not re-laid-out yet) → 53 rows,
+        // abnormally tall. Because the terminal is laid out inside an Expanded
+        // ABOVE that chrome, its render-box height is ALREADY chrome-excluded;
+        // the bug was reading it mid-animation. With the debounce we fit off the
+        // SETTLED box. This asserts the fitted rows equal what the laid-out
+        // RenderTerminal actually affords — never the (larger) full-screen rows.
+        final transport = FakeSshShellTransport();
+        addTearDown(transport.close);
+        final s = await _setup(tester, transport);
+
+        // Drive a settled metrics fit (the keyboard-hide analog).
+        tester.binding.handleMetricsChanged();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        // The terminal's RenderTerminal box — laid out INSIDE the Expanded above
+        // the keybar/session-bar chrome, so its height is already chrome-
+        // excluded. The fit reads exactly this box (production: _explicitFit).
+        final state = tester.state<TerminalViewState>(
+          find.byType(TerminalView),
+        );
+        final box = state.renderTerminal;
+        const pad = 4.0;
+        final affordedRows = ((box.size.height - pad * 2) ~/ box.cellSize.height)
+            .clamp(1, 1 << 20);
+
+        // The full SCREEN height (the chrome-INCLUDED measurement a mid-animation
+        // fit transiently used → the 53-row overgrow). The chrome-excluded box is
+        // strictly shorter, so it must afford strictly FEWER rows.
+        final screenH = tester.view.physicalSize.height /
+            tester.view.devicePixelRatio;
+        final fullHeightRows =
+            ((screenH - pad * 2) ~/ box.cellSize.height).clamp(1, 1 << 20);
+
+        expect(
+          s.entry.terminal.viewHeight,
+          affordedRows,
+          reason:
+              'the terminal rows must match the chrome-excluded box height '
+              '($affordedRows), proving the settled fit measured the real '
+              'terminal area, not a transient. Got ${s.entry.terminal.viewHeight}',
+        );
+        expect(
+          affordedRows,
+          lessThan(fullHeightRows),
+          reason:
+              'the chrome-excluded box ($affordedRows rows) must be SHORTER '
+              'than a full-screen-height fit ($fullHeightRows rows) — proving '
+              'the chrome is excluded. A fit off the full height is the #848 '
+              '53-row overgrow.',
+        );
+        expect(
+          s.entry.terminal.viewHeight,
+          lessThan(fullHeightRows),
+          reason:
+              'the fitted rows (${s.entry.terminal.viewHeight}) must stay below '
+              'the full-screen-height rows ($fullHeightRows) — the #848 '
+              '53-row overgrow is exactly a full-height (chrome-included) fit',
+        );
         expect(tester.takeException(), isNull);
       },
     );


### PR DESCRIPTION
Fixes #848.

## Problem
On keyboard hide the viewport-inset animation drove `didChangeMetrics` → explicit fit on **every frame**, for **every mounted session**. Each fit re-sent an **identical** resize to the PTY (tmux redrew → the duplicated/ghosted content), and a mid-animation fit transiently measured the full height → the **53-row overgrow**. The 200-event connect ring was 100% `send resize … → transport` spam, drowning every other event (same failure mode as #836).

## Fix
1. **No-op resize guard** at the emission point (`SshSessionProxy.sendResize`): drop a resize whose `(cols, rows)` match the last grid sent for that session. Tracked per-proxy → inherently per-session. A `force` arg + one-shot `armForceResize()` preserve the #666 connect-resync (which deliberately re-sends identical dims to re-sync a stale remote); `terminal_screen` arms it before the RESYNC `terminal.resize`.
2. **Settle/debounce** the keyboard-driven fit: `didChangeMetrics` resets a 120ms timer (`kMetricsSettleDelay`) and fits **once** after the inset stops animating — off the final, chrome-correct viewport, not a transient. Cancelled on dispose.
3. **Correct height**: the fit already reads the laid-out `RenderTerminal` box (inside the `Expanded` above the keybar/compose/status chrome); the debounce guarantees it reads the **settled** box. New widget test proves the fitted rows match the chrome-excluded box and stay below a full-screen-height fit (the 53-row case).
4. **Telemetry hygiene** (#836 pattern): the gateway resize label now carries `cols×rows` so a real dimension change is visible and consecutive identical resize lines collapse via ctrace's `×N` path.

## Tests (TDD red→green)
- `native/test/ssh/proxy_resize_dedupe_test.dart` — no-op guard (same→1 emit, changed→emit, force→bypass, per-session independence) + the enriched `gwLabel` dims.
- `native/test/widget/terminal_remeasure_test.dart` — a metrics **storm** coalesces into **one** settled fit; the settled fit's rows are chrome-excluded (no 53-row overgrow). Existing #659/#666/#836 tests stay green.

Native fast gate green: `flutter analyze` clean + 1156 unit tests pass.

## Device validation (owner-gated)
The keyboard-inset animation is not drivable headless. On device: show keyboard → hide → grid returns to the correct row count (no 53-row overgrow), **no** duplicated/ghosted content, and the connect log shows **one** settled resize per session (not a storm). Exercise with ≥2 sessions — the storm scaled with session count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)