### PR TITLE
fix(#851): suppress attention notifications for replayed bells on (re)connect

### DIFF
--- a/native/lib/services/session_attention_notification.dart
+++ b/native/lib/services/session_attention_notification.dart
@@ -58,6 +58,16 @@ const String _tagPrefix = 'mobissh.attention.';
 /// Tunable; 30s is the owner's starting point.
 const Duration kAttentionDedupWindow = Duration(seconds: 30);
 
+/// (Re)connect REPLAY-suppression window (#851). A signal that arrives within
+/// this cooldown AFTER a session reaches `connected` (initial connect AND every
+/// reconnect / softDisconnected→connected) is treated as REPLAYED scrollback /
+/// catch-up — tmux re-attach, shell re-init, or buffered history — NOT a live
+/// "Claude needs you now" moment, so it does NOT post a notification (the owner:
+/// "notifications shouldn't bubble up the second I reconnect"). After the window
+/// settles, live signals post normally. The host re-arms this window on every
+/// connected transition. Tunable; 1.5s is the owner's starting point.
+const Duration kAttentionReplayWindow = Duration(milliseconds: 1500);
+
 /// Derive the HOST from a sessionId (#847). The session id format is
 /// `host:port:user:createdAtMs` (see `state/sessions.dart`), so the host is the
 /// segment before the first colon. Falls back to the whole id when it has no

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -66,6 +66,7 @@ class SessionHost {
     this.resumeNudgeWindow = const Duration(seconds: 2),
     int Function()? nowMs,
     AttentionNotifier? attentionNotifier,
+    this.replayWindow = kAttentionReplayWindow,
   }) : _gateway = gateway,
        _factory = controllerFactory ?? _defaultControllerFactory,
        _sftpOpener = sftpOpener,
@@ -174,6 +175,17 @@ class SessionHost {
   /// Injected so the task isolate binds `flutter_local_notifications` in
   /// production while tests record posts in memory.
   final AttentionNotifier? _attentionNotifier;
+
+  /// (Re)connect REPLAY-suppression window (#851). An attention signal detected
+  /// within this cooldown of the session's most recent `connected` transition
+  /// (see [_HostedSession.connectedAtMs], re-stamped on EVERY connected
+  /// transition — initial connect AND reconnect/softDisconnected→connected) is
+  /// treated as REPLAYED scrollback / catch-up and is NOT posted; only live
+  /// output after the window settles posts. Composes with — does not replace —
+  /// the #847 foreground host-suppression and cross-session dedup. Injectable so
+  /// tests can disable it ([Duration.zero]) or set a deterministic span; the
+  /// window is measured against the host's injected [_nowMs] clock.
+  final Duration replayWindow;
 
   /// The exact lifecycle-forwarder closure this host installed into the global
   /// [lifecycleForwarder] (#766). Held so dispose detaches OUR closure only —
@@ -1072,8 +1084,9 @@ class SessionHost {
               '(session $sessionId)',
         );
         // Slice 2: post an attention notification, unless suppressed because
-        // the user is already looking at this session.
-        _maybePostAttention(sessionId, sig);
+        // the user is already looking at this session (#847) or the signal
+        // arrived inside the (re)connect replay window (#851).
+        _maybePostAttention(sessionId, hosted, sig);
       }
     } catch (e) {
       clifecycle('attention', 'scan-error: $e (session $sessionId)');
@@ -1098,9 +1111,32 @@ class SessionHost {
   /// listener (a post failure must not crash the session). No-op when no
   /// notifier is wired (e.g. desktop / a test that didn't inject one), in which
   /// case the Slice-1 `clifecycle` log is the only effect.
-  void _maybePostAttention(String sessionId, AttentionSignal sig) {
+  void _maybePostAttention(
+    String sessionId,
+    _HostedSession hosted,
+    AttentionSignal sig,
+  ) {
     final notifier = _attentionNotifier;
     if (notifier == null) return;
+    // #851: (re)connect REPLAY suppression. A signal within `replayWindow` of
+    // the session's most recent `connected` transition is REPLAYED scrollback /
+    // catch-up (tmux re-attach, shell re-init, buffered history), not a live
+    // moment — so it must NOT post. `connectedAtMs` is re-stamped on EVERY
+    // connected transition (initial AND reconnect/softDisconnected→connected),
+    // so the window auto-re-arms per reconnect. This is an ADDITIONAL gate that
+    // composes with the #847 foreground-suppression + dedup below.
+    final connectedAt = hosted.connectedAtMs;
+    if (connectedAt != null && replayWindow > Duration.zero) {
+      final sinceConnectedMs = _nowMs() - connectedAt;
+      if (sinceConnectedMs < replayWindow.inMilliseconds) {
+        clifecycle(
+          'attention',
+          'suppressed (reconnect-replay ${sinceConnectedMs}ms < '
+              '${replayWindow.inMilliseconds}ms) session $sessionId',
+        );
+        return;
+      }
+    }
     // #847: host-level suppression — looking at ANY session to this host (incl.
     // a different one) while foregrounded suppresses the bell.
     final post = shouldPostAttention(

--- a/native/test/services/session_host_attention_post_test.dart
+++ b/native/test/services/session_host_attention_post_test.dart
@@ -44,6 +44,11 @@ _setup({String sid = 'h:22:u:1'}) async {
     },
     snapshotInterval: const Duration(milliseconds: 50),
     attentionNotifier: notifier,
+    // #851: these tests feed the signal immediately after `connected`; disable
+    // the (re)connect replay-suppression window so they exercise ONLY the #847
+    // foreground/host-dedup suppression they predate (the replay gate has its
+    // own coverage in session_host_attention_replay_test.dart).
+    replayWindow: Duration.zero,
   );
   pair.uiSide.send(
     SshConnectCommand(

--- a/native/test/services/session_host_attention_replay_test.dart
+++ b/native/test/services/session_host_attention_replay_test.dart
@@ -1,0 +1,187 @@
+// SessionHost attention REPLAY-WINDOW suppression (#851).
+//
+// A bell that arrives within the post-`connected` (re)connect scrollback-REPLAY
+// / catch-up window is HISTORICAL — replayed when the session re-attaches (tmux
+// re-attach, shell re-init, buffered scrollback) — not a genuinely live "Claude
+// needs you now" moment. The owner: "notifications shouldn't bubble up the
+// second I reconnect." So the host suppresses attention POSTS for a short,
+// tunable cooldown (`kAttentionReplayWindow`) after EVERY connected transition
+// (initial connect AND reconnect/softDisconnected→connected), re-arming the
+// window on each one. After the window, live signals post normally.
+//
+// This is an ADDITIONAL gate composing with the #847 host-suppression + dedup —
+// it does not replace them.
+//
+// The window is gated on the host's injected clock (`nowMs`) and an injected
+// `replayWindow`, so it is deterministic without wall-clock sleeps.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// A controller whose `connect` is inert so the TEST owns every state
+/// transition (it drives `connected` via [debugSetConnectedForTest] and drops
+/// via [handleTransportClosed]).
+class _NoConnectController extends SshSessionController {
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+/// Bare BEL — a text-less bell, exactly the generic signal #851 calls out.
+List<int> _bell() => [0x07];
+
+void main() {
+  // Mutable injected clock (ms). Tests advance `now` to cross the replay window
+  // without any real-time sleep.
+  late int now;
+  late InMemoryGatewayPair pair;
+  late SessionHost host;
+  late RecordingAttentionNotifier notifier;
+  late SshSessionController controller;
+  const sid = 'h:22:u:1';
+  const replay = Duration(milliseconds: 1500);
+
+  Future<void> setUpHost() async {
+    now = 1000;
+    pair = InMemoryGatewayPair();
+    notifier = RecordingAttentionNotifier();
+    host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: () {
+        controller = _NoConnectController();
+        return controller;
+      },
+      snapshotInterval: const Duration(milliseconds: 50),
+      attentionNotifier: notifier,
+      nowMs: () => now,
+      replayWindow: replay,
+    );
+    pair.uiSide.send(
+      SshConnectCommand(
+        sessionId: sid,
+        host: 'h',
+        port: 22,
+        username: 'u',
+        authJson: const {'type': 'password', 'password': 'p'},
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+
+  /// Drive the controller to `connected` (re)stamping the host's window.
+  Future<void> reachConnected() async {
+    controller.debugSetConnectedForTest(_params);
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+
+  Future<void> tearDownHost() async {
+    await host.dispose();
+    await pair.dispose();
+  }
+
+  test('bell WITHIN the post-connect replay window is NOT posted '
+      '(suppressed as replay)', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await reachConnected(); // window armed at now=1000
+
+    now += 500; // 0.5s into the 1.5s window → replay
+    host.feedAttentionForTest(sid, _bell());
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(notifier.posted, isEmpty,
+        reason: 'a bell inside the (re)connect replay window is historical');
+  });
+
+  test('the SAME bell AFTER the window posts (live output)', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await reachConnected(); // armed at now=1000
+
+    now += 1600; // past the 1.5s window → live
+    host.feedAttentionForTest(sid, _bell());
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(notifier.posted, hasLength(1),
+        reason: 'after the window settles, live attention posts normally');
+  });
+
+  test('reconnect (softDisconnected→connected) RE-ARMS the window', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await reachConnected(); // armed at now=1000
+
+    // Move well past the first window so we are firmly in "live" territory.
+    now += 5000;
+    // Drop the transport cleanly: connected → softDisconnected (→ reconnect).
+    controller.handleTransportClosed(null);
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    // Reconnect lands back on `connected` LATER — this re-stamps the window.
+    now += 1000;
+    await reachConnected(); // window RE-armed at the new `now`
+
+    // A bell immediately after the reconnect is replayed scrollback → suppress.
+    now += 400; // inside the re-armed 1.5s window
+    host.feedAttentionForTest(sid, _bell());
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(notifier.posted, isEmpty,
+        reason: 'each reconnect re-suppresses its own replay burst');
+  });
+
+  test('live attention LONG after connect still posts', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await reachConnected(); // armed at now=1000
+
+    now += 60000; // a full minute later — unmistakably live
+    host.feedAttentionForTest(sid, _bell());
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(notifier.posted, hasLength(1));
+  });
+
+  test('composes with #847 host-suppression: foregrounded same-host is '
+      'suppressed REGARDLESS of the replay window', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await reachConnected();
+    // Foreground on the SAME host (#847 host-suppression applies).
+    pair.uiSide.send(
+      const SshSetActiveCommand(
+        active: true,
+        activeSessionId: sid,
+        activeHost: 'h',
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    // Inside the window → suppressed (replay).
+    now += 200;
+    host.feedAttentionForTest(sid, _bell());
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(notifier.posted, isEmpty);
+
+    // Outside the window, but STILL foregrounded same-host → #847 suppresses.
+    now += 2000;
+    host.feedAttentionForTest(sid, _bell());
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(notifier.posted, isEmpty,
+        reason: 'host-suppression holds independently of the replay gate');
+  });
+
+  test('default replay window is the tunable const (~1.5s)', () {
+    expect(kAttentionReplayWindow, const Duration(milliseconds: 1500));
+  });
+}


### PR DESCRIPTION
## Summary

Closes #851.

Attention notifications fired for bells **replayed** during the (re)connect
scrollback / catch-up burst (tmux re-attach, shell re-init, buffered history) —
historical signals, not live "Claude needs you now" moments. #847 already fixed
*repetitive* (host dedup) + *generic* (host label) + *foreground-same-host*, but a
**backgrounded** reconnect (or a reconnect to a host you're not viewing) still
posted one alert per host for replayed history. Owner: "notifications shouldn't
bubble up the second I reconnect."

## The fix

A per-session post-`connected` **REPLAY-suppression window**
(`kAttentionReplayWindow` = **1500ms**, tunable). In `_maybePostAttention`, a
signal detected within the window of the session's most recent `connected`
transition is logged (`clifecycle: suppressed (reconnect-replay …)`) but **not**
posted; live output after the window posts normally.

- **Re-arms on every reconnect for free.** `_HostedSession.connectedAtMs` is
  already re-stamped on EVERY connected transition (initial connect AND
  reconnect/softDisconnected→connected, `session_host.dart:486-489`), so no new
  state is needed — the gate compares `_nowMs()` to that timestamp.
- **Additive.** Runs BEFORE the #847 foreground host-suppression + cross-session
  dedup, which are untouched and still apply.
- **Timer, not a byte-signal.** No explicit replay-vs-live byte signal exists —
  the shell output listener pipes replayed scrollback and live bytes through one
  undifferentiated stream — so the post-`connected` timer is the robust approach
  (the issue's accepted fallback).
- **Injectable.** `replayWindow` is a `SessionHost` ctor param (default the const,
  `Duration.zero` to disable) measured against the host's injected `_nowMs` clock,
  so it is deterministic in unit tests.

## Tests

New `native/test/services/session_host_attention_replay_test.dart`:

- a bell **within** the post-connect replay window → NOT posted (suppressed as replay)
- the same bell **after** the window → posted (live)
- reconnect (**softDisconnected→reconnecting→connected**) **re-arms** the window
- live attention **long after** connect still posts
- **composes** with #847 host-suppression (foreground same-host stays suppressed
  inside AND outside the window)
- the default window const is ~1.5s

`session_host_attention_post_test.dart` now injects `replayWindow: Duration.zero`
(its immediate-feed tests predate this gate and only cover #847).

## Gate

`scripts/native-fast-gate.sh`: `flutter analyze` clean, **1162** unit tests pass.

Refs #840, #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)