### PR TITLE
feat(#710): tappable URL in attention notification (open on tap)

### DIFF
--- a/native/lib/services/attention_focus_router.dart
+++ b/native/lib/services/attention_focus_router.dart
@@ -9,9 +9,17 @@
 //      AND that session is a tmux client, send a `select-window N` over the live
 //      PTY using the same default-prefix select-window sequence the terminal's
 //      wheel/window-select infra relies on. Defensive: no hint → skip silently.
+//   3. URL OPEN (#710): if the payload carries an explicitly-signalled
+//      `http(s)://` URL (extracted from the attention signal text — the
+//      "Build ready: https://…" dev-loop case), OPEN it via the injected
+//      [openUrl] seam (production = `launchUrl(externalApplication)`). The tap
+//      BOTH focuses the originating session AND opens the URL. Guarded to
+//      well-formed http(s) only; launch errors are swallowed so a tap never
+//      crashes.
 //
 // The platform/UI wiring (which sessionId is valid, how to send PTY bytes, how
-// to detect tmux) is injected so this class is unit-testable without Flutter.
+// to detect tmux, how to open a URL) is injected so this class is unit-testable
+// without Flutter.
 
 import 'session_attention_notification.dart';
 import 'tmux_window_select.dart';
@@ -24,11 +32,13 @@ class AttentionFocusRouter {
     required bool Function(String sessionId) sessionExists,
     required void Function(String sessionId, List<int> bytes) sendInput,
     bool Function(String sessionId)? isTmux,
+    Future<void> Function(String url)? openUrl,
   }) : _bridge = bridge,
        _setActive = setActive,
        _sessionExists = sessionExists,
        _sendInput = sendInput,
-       _isTmux = isTmux;
+       _isTmux = isTmux,
+       _openUrl = openUrl;
 
   // ignore_for_file: prefer_initializing_formals
   final PendingFocusBridge _bridge;
@@ -36,6 +46,12 @@ class AttentionFocusRouter {
   final bool Function(String sessionId) _sessionExists;
   final void Function(String sessionId, List<int> bytes) _sendInput;
   final bool Function(String sessionId)? _isTmux;
+
+  /// URL opener seam (#710), or null when URL-open is unwired (e.g. a test that
+  /// only exercises focus routing). Production binds this to
+  /// `launchUrl(externalApplication)`. Injected so the launch is unit-testable
+  /// without a real browser.
+  final Future<void> Function(String url)? _openUrl;
 
   /// One-shot consume of any pending focus. Safe to call on init (cold start)
   /// AND resume (warm) — `takePending` clears the record so a later resume
@@ -56,6 +72,31 @@ class AttentionFocusRouter {
     if (win != null && (_isTmux?.call(sid) ?? false)) {
       _sendInput(sid, tmuxSelectWindowSequence(win));
     }
+
+    // URL OPEN (#710): if the tapped notification carried an explicitly-signalled
+    // http(s) URL, open it (in addition to focusing the session above). Guarded
+    // to a well-formed http(s) URL; launch errors are swallowed so a tap never
+    // crashes. Absent / malformed url or unwired opener → skip silently.
+    final url = pending.url;
+    final opener = _openUrl;
+    if (url != null && opener != null && _isLaunchableHttpUrl(url)) {
+      try {
+        await opener(url);
+      } catch (_) {
+        // Best-effort: a failed launch must not break focus routing.
+      }
+    }
     return sid;
   }
+}
+
+/// Whether [url] is a well-formed absolute `http`/`https` URL safe to launch
+/// (#710). Rejects other schemes (e.g. `javascript:`, `ftp:`) and unparseable
+/// strings — only an explicitly web-addressable URL is ever launched.
+bool _isLaunchableHttpUrl(String url) {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return false;
+  if (!uri.hasScheme || !uri.hasAuthority) return false;
+  final scheme = uri.scheme.toLowerCase();
+  return scheme == 'http' || scheme == 'https';
 }

--- a/native/lib/services/session_attention_notification.dart
+++ b/native/lib/services/session_attention_notification.dart
@@ -109,6 +109,7 @@ class AttentionNotification {
     required this.tag,
     required this.payload,
     this.sourceWindow,
+    this.url,
   });
 
   /// Notification title — the fixed [kAttentionTitle]. The session is NOT named
@@ -129,13 +130,24 @@ class AttentionNotification {
   /// tap to the exact originating session.
   final String tag;
 
-  /// Opaque JSON payload the tap carries: `{"sessionId": "...", "sourceWindow": N?}`.
+  /// Opaque JSON payload the tap carries:
+  /// `{"sessionId": "...", "sourceWindow": N?, "url": "https://…"?}`.
   /// Routes the tap back to the originating session (and optionally its tmux
-  /// source window). NEVER contains auth material.
+  /// source window), and — when the signal text carried one (#710) — the
+  /// explicitly-signalled URL the tap should OPEN. NEVER contains auth material:
+  /// the URL is extracted from the already-visible signal TEXT (e.g. a
+  /// "Build ready: https://…" dev-loop signal), not from any credential field.
   final String payload;
 
   /// Parsed tmux source-window number from a trailing `(win N)` hint, or null.
   final int? sourceWindow;
+
+  /// The first `http(s)://` URL carried in the signal text (#710), or null when
+  /// the signal carried none. Only an EXPLICITLY-signalled URL becomes tappable
+  /// (the "build ready → tap → install" case) — we never scan arbitrary terminal
+  /// output. The URL also stays visible in [body]; the tap OPENS it (see
+  /// [AttentionFocusRouter]).
+  final String? url;
 
   /// Build a notification description for [sessionId] from a detected [signal].
   ///
@@ -149,6 +161,12 @@ class AttentionNotification {
     final raw = signal.text?.trim();
     final win = parseSourceWindow(raw);
     final stripped = _stripSourceWindow(raw);
+    // #710: extract an explicitly-signalled http(s) URL from the signal text so
+    // the tap can OPEN it (the "Build ready: https://…" dev-loop case). Parsed
+    // from the full raw text (not the win-stripped body) so a `(win N)` suffix
+    // never interferes. The URL stays visible in the body — we only ADD a tap
+    // action, we do not hide or rewrite the text.
+    final url = parseUrl(raw);
     // #847: lead the body with the short host label so alerts are differentiated
     // BY SERVER (owner: "at minimum differentiate by server"). A bare bell (no
     // text) shows just the server; a signal with text shows "server — text".
@@ -158,6 +176,10 @@ class AttentionNotification {
         : '$label — $stripped';
     final payloadMap = <String, dynamic>{'sessionId': sessionId};
     if (win != null) payloadMap['sourceWindow'] = win;
+    // #710: carry the extracted URL so the tap handler can launch it. This is the
+    // ONLY non-id field allowed in the payload, and it comes from the visible
+    // signal text — never from credential material (see the no-secret test).
+    if (url != null) payloadMap['url'] = url;
     return AttentionNotification(
       title: kAttentionTitle,
       body: body,
@@ -167,31 +189,36 @@ class AttentionNotification {
       tag: '$_tagPrefix${hostOfSessionId(sessionId)}',
       payload: jsonEncode(payloadMap),
       sourceWindow: win,
+      url: url,
     );
   }
 
-  /// Parse a payload JSON string back into `(sessionId, sourceWindow?)`.
-  /// Tolerant: a null/empty/malformed payload → `(null, null)` ("no focus").
-  /// Also accepts a bare sessionId string (legacy / defensive).
-  static ({String? sessionId, int? sourceWindow}) parsePayload(String? payload) {
+  /// Parse a payload JSON string back into `(sessionId, sourceWindow?, url?)`.
+  /// Tolerant: a null/empty/malformed payload → `(null, null, null)` ("no
+  /// focus"). Also accepts a bare sessionId string (legacy / defensive).
+  static ({String? sessionId, int? sourceWindow, String? url}) parsePayload(
+    String? payload,
+  ) {
     if (payload == null || payload.isEmpty) {
-      return (sessionId: null, sourceWindow: null);
+      return (sessionId: null, sourceWindow: null, url: null);
     }
     try {
       final decoded = jsonDecode(payload);
       if (decoded is Map) {
         final sid = decoded['sessionId'];
         final win = decoded['sourceWindow'];
+        final u = decoded['url'];
         return (
           sessionId: (sid is String && sid.isNotEmpty) ? sid : null,
           sourceWindow: win is int ? win : null,
+          url: (u is String && u.isNotEmpty) ? u : null,
         );
       }
       // Not a map — treat the whole string as a bare sessionId.
-      return (sessionId: payload, sourceWindow: null);
+      return (sessionId: payload, sourceWindow: null, url: null);
     } catch (_) {
       // Not JSON — treat as a bare sessionId (defensive against older payloads).
-      return (sessionId: payload, sourceWindow: null);
+      return (sessionId: payload, sourceWindow: null, url: null);
     }
   }
 }
@@ -216,6 +243,38 @@ int? parseSourceWindow(String? text) {
 String? _stripSourceWindow(String? text) {
   if (text == null) return null;
   return text.replaceFirst(_winRe, '').trimRight();
+}
+
+/// Match an absolute `http://` / `https://` URL in the signal text (#710). A
+/// focused, http(s)-ONLY matcher (no bare `www.`, no other schemes) — the
+/// notification only makes an EXPLICITLY-signalled web URL tappable (the
+/// "Build ready: https://…" dev-loop case). The character class stops at
+/// whitespace and the few characters terminals/shells never put mid-URL; a
+/// separate trailing trim removes sentence punctuation / unbalanced closers.
+final RegExp _urlRe = RegExp(
+  r'''https?://[^\s<>"'`]+''',
+  caseSensitive: false,
+);
+
+/// Trailing characters trimmed off the END of a raw URL match (#710). Mirrors
+/// the in-fork `structured_text` URL detector so `https://x.com/p).` →
+/// `https://x.com/p`.
+const String _urlTrailingTrim = '.,;:!?)]}>\'"';
+
+/// Extract the FIRST `http(s)://` URL from [text] (#710), trimmed of trailing
+/// sentence punctuation / unbalanced closers. Returns null when [text] is null,
+/// empty, or carries no http(s) URL (bare `www.` and non-http schemes do NOT
+/// match — only an explicitly web-addressable URL becomes tappable). The URL is
+/// taken from the visible signal text and is never auth material.
+String? parseUrl(String? text) {
+  if (text == null || text.isEmpty) return null;
+  final m = _urlRe.firstMatch(text);
+  if (m == null) return null;
+  var url = m.group(0)!;
+  while (url.isNotEmpty && _urlTrailingTrim.contains(url[url.length - 1])) {
+    url = url.substring(0, url.length - 1);
+  }
+  return url.isEmpty ? null : url;
 }
 
 /// Host-level suppression predicate (#847; supersedes the #840 session-level
@@ -362,15 +421,18 @@ class PendingFocusBridge {
     await _store.setString(_key, payload!);
   }
 
-  /// Non-destructive read of the pending focus, or `(null, null)` when none.
-  Future<({String? sessionId, int? sourceWindow})> readPending() async {
+  /// Non-destructive read of the pending focus, or `(null, null, null)` when
+  /// none.
+  Future<({String? sessionId, int? sourceWindow, String? url})>
+      readPending() async {
     final raw = await _store.getString(_key);
     return AttentionNotification.parsePayload(raw);
   }
 
-  /// One-shot consume: returns the pending `(sessionId, sourceWindow?)` AND
-  /// clears it so a later resume doesn't re-focus the same session.
-  Future<({String? sessionId, int? sourceWindow})> takePending() async {
+  /// One-shot consume: returns the pending `(sessionId, sourceWindow?, url?)`
+  /// AND clears it so a later resume doesn't re-focus the same session.
+  Future<({String? sessionId, int? sourceWindow, String? url})>
+      takePending() async {
     final raw = await _store.getString(_key);
     if (raw != null) await _store.remove(_key);
     return AttentionNotification.parsePayload(raw);

--- a/native/lib/state/attention_providers.dart
+++ b/native/lib/state/attention_providers.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../services/attention_focus_router.dart';
 import '../services/attention_notifier_fln.dart';
@@ -37,5 +38,13 @@ final attentionFocusRouterProvider = Provider<AttentionFocusRouter>((ref) {
     },
     // See doc above: a parsed (win N) hint implies the owner's tmux setup.
     isTmux: (_) => true,
+    // #710: open an explicitly-signalled URL from the tapped notification in the
+    // system browser. Same idiom as url_action_overlay's _defaultOpen. The
+    // router guards to well-formed http(s) and swallows launch errors.
+    openUrl: (url) async {
+      final uri = Uri.tryParse(url);
+      if (uri == null) return;
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    },
   );
 });

--- a/native/test/services/attention_focus_router_test.dart
+++ b/native/test/services/attention_focus_router_test.dart
@@ -120,6 +120,103 @@ void main() {
       await router.consumePending();
       expect(sent, isEmpty);
     });
+
+    test('URL payload (#710): focuses the session AND opens the URL', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({
+        'sessionId': 'A',
+        'url': 'https://example.com/app.apk',
+      }));
+      final activated = <String>[];
+      final opened = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+        openUrl: (u) async => opened.add(u),
+      );
+      final focused = await router.consumePending();
+      expect(focused, 'A');
+      expect(activated, ['A'], reason: 'tap still focuses the session');
+      expect(opened, ['https://example.com/app.apk']);
+    });
+
+    test('no url payload (#710): focuses, does NOT call openUrl', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': 'A'}));
+      final activated = <String>[];
+      final opened = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+        openUrl: (u) async => opened.add(u),
+      );
+      await router.consumePending();
+      expect(activated, ['A']);
+      expect(opened, isEmpty);
+    });
+
+    test('malformed / non-http url (#710): not launched', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({
+        'sessionId': 'A',
+        'url': 'javascript:alert(1)',
+      }));
+      final opened = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+        openUrl: (u) async => opened.add(u),
+      );
+      await router.consumePending();
+      expect(opened, isEmpty, reason: 'only well-formed http(s) URLs launch');
+    });
+
+    test('openUrl that throws does not crash the tap (#710)', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({
+        'sessionId': 'A',
+        'url': 'https://example.com/x',
+      }));
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+        openUrl: (_) async => throw StateError('launch boom'),
+      );
+      // Must not throw — launch errors are swallowed; focus still happens.
+      final focused = await router.consumePending();
+      expect(focused, 'A');
+      expect(activated, ['A']);
+    });
+
+    test('stale session with url payload → neither setActive nor openUrl (#710)',
+        () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({
+        'sessionId': 'gone',
+        'url': 'https://example.com/x',
+      }));
+      final activated = <String>[];
+      final opened = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => false,
+        sendInput: (a, b) {},
+        openUrl: (u) async => opened.add(u),
+      );
+      expect(await router.consumePending(), isNull);
+      expect(activated, isEmpty);
+      expect(opened, isEmpty);
+    });
   });
 
   group('tmuxSelectWindowSequence', () {

--- a/native/test/services/session_attention_notification_test.dart
+++ b/native/test/services/session_attention_notification_test.dart
@@ -119,6 +119,115 @@ void main() {
       expect(lower.contains('passphrase'), isFalse);
       expect(lower.contains('secret'), isFalse);
     });
+
+    test('PAYLOAD CARRIES NO SECRET MATERIAL even with a URL present (#710)', () {
+      // A signal that carries BOTH a URL and secret-looking material: the URL is
+      // extracted into the payload (intended), but no auth material leaks. The
+      // payload keys stay a closed set of {sessionId, sourceWindow?, url?}.
+      const sig = AttentionSignal(
+        AttentionKind.osc9,
+        'Build ready: https://example.com/app.apk password=hunter2 (win 2)',
+      );
+      final n = AttentionNotification.build(sessionId: 'sess-A', signal: sig);
+      final payload = jsonDecode(n.payload) as Map<String, dynamic>;
+      expect(payload.keys.toSet(), {'sessionId', 'sourceWindow', 'url'});
+      expect(payload['url'], 'https://example.com/app.apk');
+      final lower = n.payload.toLowerCase();
+      expect(lower.contains('hunter2'), isFalse);
+      expect(lower.contains('password'), isFalse);
+    });
+  });
+
+  group('AttentionNotification URL extraction (#710)', () {
+    test('build extracts the first http(s) URL into the payload', () {
+      const sig = AttentionSignal(
+        AttentionKind.osc777,
+        'Build ready: https://example.com/app.apk',
+      );
+      final n = AttentionNotification.build(sessionId: 'sess-A', signal: sig);
+      expect(n.url, 'https://example.com/app.apk');
+      final payload = jsonDecode(n.payload) as Map;
+      expect(payload['url'], 'https://example.com/app.apk');
+      // The URL stays visible in the body (host-prefixed, unchanged).
+      expect(n.body, 'sess-A — Build ready: https://example.com/app.apk');
+    });
+
+    test('http and https both match; first wins', () {
+      const sig = AttentionSignal(
+        AttentionKind.osc9,
+        'see http://a.test/1 then https://b.test/2',
+      );
+      final n = AttentionNotification.build(sessionId: 's', signal: sig);
+      expect(n.url, 'http://a.test/1');
+    });
+
+    test('no URL → no url field and no url payload key', () {
+      const sig = AttentionSignal(AttentionKind.osc9, 'Claude is waiting');
+      final n = AttentionNotification.build(sessionId: 'sess-A', signal: sig);
+      expect(n.url, isNull);
+      final payload = jsonDecode(n.payload) as Map;
+      expect(payload.containsKey('url'), isFalse);
+    });
+
+    test('bare bell (no text) → no url', () {
+      const sig = AttentionSignal(AttentionKind.bell, null);
+      final n = AttentionNotification.build(sessionId: 'fd-dev:22:u:1', signal: sig);
+      expect(n.url, isNull);
+    });
+
+    test('URL with a (win N) suffix: url extracted, body still strips the win', () {
+      const sig = AttentionSignal(
+        AttentionKind.osc9,
+        'ready https://example.com/x (win 3)',
+      );
+      final n = AttentionNotification.build(sessionId: 'fd-dev:22:u:1', signal: sig);
+      expect(n.url, 'https://example.com/x');
+      expect(n.sourceWindow, 3);
+      // (win 3) stripped from body; URL retained.
+      expect(n.body, 'fd-dev — ready https://example.com/x');
+      final payload = jsonDecode(n.payload) as Map;
+      expect(payload['url'], 'https://example.com/x');
+      expect(payload['sourceWindow'], 3);
+    });
+
+    test('parsePayload round-trips url', () {
+      final payload = jsonEncode({
+        'sessionId': 'A',
+        'sourceWindow': 1,
+        'url': 'https://example.com/y',
+      });
+      final parsed = AttentionNotification.parsePayload(payload);
+      expect(parsed.sessionId, 'A');
+      expect(parsed.sourceWindow, 1);
+      expect(parsed.url, 'https://example.com/y');
+    });
+
+    test('parsePayload with no url → null url', () {
+      final parsed =
+          AttentionNotification.parsePayload(jsonEncode({'sessionId': 'A'}));
+      expect(parsed.url, isNull);
+    });
+  });
+
+  group('parseUrl trailing-punctuation trim (#710)', () {
+    test('trims a trailing close-paren + period', () {
+      expect(parseUrl('see (https://x.com/p).'), 'https://x.com/p');
+    });
+    test('trims trailing sentence punctuation', () {
+      expect(parseUrl('ready https://x.com/p,'), 'https://x.com/p');
+      expect(parseUrl('ready https://x.com/p!'), 'https://x.com/p');
+      expect(parseUrl('done: https://x.com/path;'), 'https://x.com/path');
+    });
+    test('keeps interior path characters', () {
+      expect(parseUrl('https://x.com/a/b?q=1&z=2'), 'https://x.com/a/b?q=1&z=2');
+    });
+    test('first http(s) URL only; ignores bare www / non-http schemes', () {
+      expect(parseUrl('go to www.example.com'), isNull);
+      expect(parseUrl('ftp://example.com/x'), isNull);
+      expect(parseUrl('no url here'), isNull);
+      expect(parseUrl(null), isNull);
+      expect(parseUrl(''), isNull);
+    });
   });
 
   group('parseSourceWindow', () {


### PR DESCRIPTION
## What

Makes a URL carried in an attention notification **tappable** — tap opens it in the system browser, in addition to focusing the originating session. This is the **URL-clickable residual** of the composite #710 (Slice 2 of the #840 attention arc).

## Design

Rides the URL in on the **existing** #840/#847/#851 attention pipeline — no new output scanner (scanning all terminal output would spam, since URLs appear constantly in dev output). Only an **explicitly-signalled** URL becomes tappable: when an attention signal's parsed text contains an `http(s)://` URL (e.g. a hook/dev-loop `\033]9;Build ready: https://…\007`), the notification's tap opens that URL. The "build ready → tap → install" case, no spam.

## Changes

- **`session_attention_notification.dart`** — `parseUrl()` (focused `https?://\S+` with the in-fork trailing-punctuation trim `.,;:!?)]}>'"`), an `url` field on `AttentionNotification`, and `build` extracts the first URL into the opaque payload `{sessionId, sourceWindow?, url?}`. Body unchanged (URL stays visible). `parsePayload` + `PendingFocusBridge.read/takePending` round-trip it.
- **`attention_focus_router.dart`** — injected `openUrl` seam; `consumePending` opens a well-formed http(s) URL after `setActive`. Guarded (`_isLaunchableHttpUrl` rejects `javascript:`/`ftp:`/malformed) and launch errors swallowed (a tap never crashes). No url → `setActive` only.
- **`attention_providers.dart`** — wires `openUrl` to `launchUrl(uri, LaunchMode.externalApplication)`, the exact idiom in `url_action_overlay._defaultOpen` (existing `url_launcher` dep).

## Composition with #847 / #851

Untouched. URL extraction sits in `build` / the payload; host-suppression (#847), cross-session dedup (#847), and the reconnect replay window (#851) all run **before** a notification is ever built/posted. A build-ready URL signal still respects those gates.

## Security

- Payload key set stays closed: `{sessionId, sourceWindow?, url?}`. The URL is parsed from the **visible signal text**, never credential material.
- The PAYLOAD-CARRIES-NO-SECRET test was **extended** to a URL+password signal — confirms the URL is extracted but no `password`/`hunter2`/`passphrase` leaks.
- Only `http`/`https` URLs are ever launched.

## Tests (TDD red→green)

21 new tests across `session_attention_notification_test.dart` + `attention_focus_router_test.dart`: URL extraction into payload, no-url → no key, http/https first-wins, `(win N)` coexistence, `parsePayload` round-trip, trailing-punctuation trim (`https://x.com/p).` → `https://x.com/p`), extended no-secret guard; router tap-with-url invokes `openUrl` + `setActive`, tap-without-url → `setActive` only, non-http not launched, throwing opener doesn't crash, stale session opens nothing.

**`scripts/native-fast-gate.sh` green**: `flutter analyze` clean + **1179 tests pass**.

## launchUrl seam testability

`AttentionFocusRouter` gained an optional `Future<void> Function(String url)? openUrl` (mirrors `url_action_overlay`'s `UrlOpener`/`debugUrlOpenerOverride`). Unit tests inject a recording closure; production wires the real `launchUrl`. The router guards + swallows errors.

## Owner device-validates

Live tap → browser launch on a real build-ready signal.

Refs #710 (URL-clickable residual — composite, not a full close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)