### PR TITLE
feat(#854): native markdown viewer — rendered + raw toggle (PWA parity)

### DIFF
--- a/native/lib/services/text_file_detect.dart
+++ b/native/lib/services/text_file_detect.dart
@@ -55,3 +55,32 @@ bool isTextEntry(SftpEntry entry, {String? mime}) {
   if (entry.isDirectory) return false;
   return hasTextExtension(entry.name) || isTextMime(mime);
 }
+
+/// Markdown extensions (lowercase, no leading dot). A subset of
+/// [_textExtensions] that the dedicated markdown viewer renders (#854).
+const Set<String> _markdownExtensions = {'md', 'markdown'};
+
+/// True when [name] ends with a markdown extension (`.md` / `.markdown`,
+/// case-insensitive).
+bool hasMarkdownExtension(String name) {
+  final dot = name.lastIndexOf('.');
+  if (dot <= 0 || dot == name.length - 1) return false;
+  return _markdownExtensions.contains(name.substring(dot + 1).toLowerCase());
+}
+
+/// True when [mime] denotes markdown content (`text/markdown` /
+/// `text/x-markdown`). MIME parameters (`; charset=…`) are ignored.
+bool isMarkdownMime(String? mime) {
+  if (mime == null || mime.isEmpty) return false;
+  final base = mime.split(';').first.trim().toLowerCase();
+  return base == 'text/markdown' || base == 'text/x-markdown';
+}
+
+/// True when [entry] is a regular markdown file, by extension or an explicit
+/// markdown [mime]. Directories are never markdown. Used by the viewer registry
+/// to route `.md`/`.markdown` to the dedicated rendered markdown viewer (#854)
+/// BEFORE the generic monospace text viewer (first-match-wins).
+bool isMarkdownEntry(SftpEntry entry, {String? mime}) {
+  if (entry.isDirectory) return false;
+  return hasMarkdownExtension(entry.name) || isMarkdownMime(mime);
+}

--- a/native/lib/ui/file_viewer_registry.dart
+++ b/native/lib/ui/file_viewer_registry.dart
@@ -22,6 +22,7 @@ import '../services/pdf_detect.dart';
 import '../services/session_messages.dart';
 import '../services/text_file_detect.dart';
 import 'file_browser_screen.dart';
+import 'markdown_file_viewer.dart';
 import 'text_file_viewer.dart';
 
 /// A single registered in-app viewer.
@@ -56,8 +57,13 @@ class FileViewerRegistry {
 
 /// The active viewer registry. Defaults to the PDF viewer (#557, routed through
 /// the existing [pdfTapInterceptorProvider] so its null-override / spy seam is
-/// preserved) and the text/code viewer (#776). Tests can override this to add,
-/// remove, or stub viewers.
+/// preserved), the markdown viewer (#854), and the text/code viewer (#776).
+/// Tests can override this to add, remove, or stub viewers.
+///
+/// ORDER MATTERS — first match wins. The markdown viewer is registered BEFORE
+/// the generic text viewer so a `.md` / `.markdown` file (which `isTextEntry`
+/// also matches) routes to the rendered markdown viewer, not the raw monospace
+/// one.
 final fileViewerRegistryProvider = Provider<FileViewerRegistry>((ref) {
   return FileViewerRegistry([
     // PDF (#557): delegate to the existing interceptor provider so callers that
@@ -70,7 +76,21 @@ final fileViewerRegistryProvider = Provider<FileViewerRegistry>((ref) {
         ref.read(pdfTapInterceptorProvider)!(context, sessionId, entry);
       },
     ),
-    // Text / code / markdown (#776): read-only preview.
+    // Markdown (#854): rendered HTML + raw toggle (PWA parity). MUST precede the
+    // generic text viewer — `.md`/`.markdown` are also text, first match wins.
+    FileViewer(
+      matches: (entry, {mime}) => isMarkdownEntry(entry, mime: mime),
+      open: (context, sessionId, entry) {
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) =>
+                MarkdownFileViewerScreen(sessionId: sessionId, entry: entry),
+          ),
+        );
+      },
+    ),
+    // Text / code (#776): read-only monospace preview (the fallback for all
+    // other previewable text/code formats).
     FileViewer(
       matches: (entry, {mime}) => isTextEntry(entry, mime: mime),
       open: (context, sessionId, entry) {

--- a/native/lib/ui/markdown_file_viewer.dart
+++ b/native/lib/ui/markdown_file_viewer.dart
@@ -1,0 +1,274 @@
+// In-app markdown viewer (#854) — PWA parity.
+//
+// Opened from the SFTP file browser when a `.md` / `.markdown` file is tapped
+// (via the [fileViewerRegistryProvider], which routes markdown here BEFORE the
+// generic monospace [TextFileViewerScreen]). On mount it streams the remote file
+// into memory through the shared [TextFileFetcher] (the same SFTP download seam
+// the text/code viewer uses), then renders it.
+//
+// Two view modes, mirroring the PWA's markdown viewer:
+//   - RENDERED (default): markdown formatted to headings / bold / italic /
+//     lists / links / code blocks / tables, via `flutter_markdown_plus`. Links
+//     open in the system browser through url_launcher (externalApplication —
+//     the same idiom as the terminal URL handler).
+//   - RAW: the monospace source (identical to the text/code viewer), reachable
+//     via a single chrome toggle in the AppBar (a monochrome Material glyph, no
+//     emoji).
+//
+// READ-ONLY in this slice (#854 render+toggle). Editable SFTP round-trip is a
+// focused follow-up — it needs a new SFTP WRITE path through the UI↔task IPC
+// (no write/upload seam exists yet). State is per-route (sessionId + entry) —
+// no global viewer state, so multiple sessions don't share preview state.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../services/session_messages.dart';
+import '../services/text_file_fetcher.dart';
+
+/// Opens a markdown link [href] in the system browser (externalApplication).
+/// Mirrors the terminal URL handler idiom. Injected as a typedef so widget
+/// tests can spy on launches without a platform channel.
+typedef MarkdownLinkOpener = Future<void> Function(String href);
+
+Future<void> _defaultOpenMarkdownLink(String href) async {
+  final uri = Uri.tryParse(href);
+  if (uri == null) return;
+  await launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+/// Full-screen markdown preview route for a single remote [entry] on
+/// [sessionId]. Rendered by default; toggle to raw source.
+class MarkdownFileViewerScreen extends ConsumerStatefulWidget {
+  const MarkdownFileViewerScreen({
+    super.key,
+    required this.sessionId,
+    required this.entry,
+    this.openLink = _defaultOpenMarkdownLink,
+  });
+
+  final String sessionId;
+  final SftpEntry entry;
+
+  /// Seam for opening tapped links — production launches the system browser;
+  /// tests inject a spy.
+  final MarkdownLinkOpener openLink;
+
+  @override
+  ConsumerState<MarkdownFileViewerScreen> createState() =>
+      _MarkdownFileViewerScreenState();
+}
+
+enum _Phase { fetching, ready, error }
+
+class _MarkdownFileViewerScreenState
+    extends ConsumerState<MarkdownFileViewerScreen> {
+  _Phase _phase = _Phase.fetching;
+  String? _errorMessage;
+  String? _content;
+  int _received = 0;
+  int? _total;
+  bool _started = false;
+
+  /// View mode: rendered (default) vs raw source. Per-route — no global state.
+  bool _raw = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_started) return;
+    _started = true;
+    unawaited(_fetch());
+  }
+
+  Future<void> _fetch() async {
+    final fetcher = ref.read(textFileFetcherProvider);
+    try {
+      final text = await fetcher.fetch(
+        widget.sessionId,
+        widget.entry,
+        onProgress: (received, total) {
+          if (!mounted) return;
+          setState(() {
+            _received = received;
+            _total = total;
+          });
+        },
+      );
+      if (!mounted) return;
+      setState(() {
+        _content = text;
+        _phase = _Phase.ready;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _phase = _Phase.error;
+        _errorMessage = e.toString();
+      });
+    }
+  }
+
+  void _toggleRaw() {
+    setState(() => _raw = !_raw);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.entry.name, overflow: TextOverflow.ellipsis),
+        actions: [
+          if (_phase == _Phase.ready)
+            IconButton(
+              key: const Key('markdown-raw-toggle'),
+              // Monochrome Material glyph (no emoji): show the "code" glyph to
+              // switch INTO raw source, the "article" glyph to switch back to
+              // the rendered document.
+              icon: Icon(_raw ? Icons.article_outlined : Icons.code),
+              tooltip: _raw ? 'Show rendered' : 'Show raw source',
+              onPressed: _toggleRaw,
+            ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    switch (_phase) {
+      case _Phase.fetching:
+        return _Fetching(received: _received, total: _total);
+      case _Phase.error:
+        return _ErrorView(message: _errorMessage);
+      case _Phase.ready:
+        final text = _content ?? '';
+        return _raw
+            ? _RawContent(text: text)
+            : _RenderedContent(text: text, openLink: widget.openLink);
+    }
+  }
+}
+
+/// Rendered markdown. `flutter_markdown_plus` does its own scrolling +
+/// selection; links route through [openLink].
+class _RenderedContent extends StatelessWidget {
+  const _RenderedContent({required this.text, required this.openLink});
+
+  final String text;
+  final MarkdownLinkOpener openLink;
+
+  @override
+  Widget build(BuildContext context) {
+    if (text.isEmpty) {
+      return const Center(
+        key: Key('markdown-viewer-empty'),
+        child: Text('(empty file)'),
+      );
+    }
+    return Markdown(
+      key: const Key('markdown-viewer-rendered'),
+      data: text,
+      selectable: true,
+      padding: const EdgeInsets.all(12),
+      // `Markdown` defaults extensionSet to gitHubFlavored — tables,
+      // strikethrough, fenced code blocks, etc. (PWA-parity feature set).
+      onTapLink: (txt, href, title) {
+        if (href != null && href.isNotEmpty) {
+          unawaited(openLink(href));
+        }
+      },
+    );
+  }
+}
+
+/// Raw monospace source — the read-only fallback, identical to the text/code
+/// viewer's presentation so toggling feels seamless.
+class _RawContent extends StatelessWidget {
+  const _RawContent({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final style =
+        Theme.of(context).textTheme.bodyMedium?.copyWith(
+          fontFamily: 'monospace',
+          fontFamilyFallback: const ['RobotoMono', 'monospace'],
+        ) ??
+        const TextStyle(fontFamily: 'monospace');
+    return Scrollbar(
+      child: SingleChildScrollView(
+        primary: true,
+        padding: const EdgeInsets.all(12),
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: SelectableText(
+            text.isEmpty ? '(empty file)' : text,
+            key: const Key('markdown-viewer-raw'),
+            style: style,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Fetching extends StatelessWidget {
+  const _Fetching({required this.received, this.total});
+
+  final int received;
+  final int? total;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = total;
+    final value = (t != null && t > 0) ? (received / t).clamp(0.0, 1.0) : null;
+    return Center(
+      key: const Key('markdown-viewer-loading'),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(width: 160, child: LinearProgressIndicator(value: value)),
+          const SizedBox(height: 16),
+          Text('Loading…', style: Theme.of(context).textTheme.bodyMedium),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({this.message});
+
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Center(
+      key: const Key('markdown-viewer-error'),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.broken_image_outlined, size: 48, color: scheme.error),
+            const SizedBox(height: 12),
+            Text(
+              message?.isNotEmpty == true
+                  ? message!
+                  : 'Could not open this file',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/native/pubspec.lock
+++ b/native/pubspec.lock
@@ -314,6 +314,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.0"
+  flutter_markdown_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -93,6 +93,14 @@ dependencies:
   # <queries> https intent in AndroidManifest to resolve a browser (added).
   url_launcher: ^6.3.0
 
+  # Render markdown files to formatted output in the in-app viewer (#854,
+  # PWA parity). The original `flutter_markdown` was DISCONTINUED by the Flutter
+  # team; `flutter_markdown_plus` is the maintained community fork with the same
+  # `Markdown`/`MarkdownBody` API. Headings, bold/italic, lists, links, code
+  # blocks, and GitHub-flavored tables. Links open via url_launcher
+  # (externalApplication) — same idiom as the terminal URL handler.
+  flutter_markdown_plus: ^1.0.0
+
   # Crash telemetry pipeline (#501 crash-on-launch).
   # http: bridge upload. path_provider: app-docs dir shared with the Kotlin
   # crash writer. device_info_plus + package_info_plus: enrich crash JSON.

--- a/native/test/services/markdown_detect_test.dart
+++ b/native/test/services/markdown_detect_test.dart
@@ -1,0 +1,80 @@
+// Markdown file detection (#854).
+//
+// Pure helpers deciding whether a tapped SFTP entry should route to the
+// dedicated rendered markdown viewer (vs the generic monospace text viewer).
+// Detection is by `.md`/`.markdown` extension (case-insensitive) and/or an
+// explicit `text/markdown` MIME type. Dependency-free for trivial unit testing.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/text_file_detect.dart';
+
+void main() {
+  SftpEntry file(String name) =>
+      SftpEntry(name: name, path: '/$name', isDirectory: false);
+  SftpEntry dir(String name) =>
+      SftpEntry(name: name, path: '/$name', isDirectory: true);
+
+  group('hasMarkdownExtension', () {
+    test('matches .md and .markdown', () {
+      expect(hasMarkdownExtension('README.md'), isTrue);
+      expect(hasMarkdownExtension('NOTES.markdown'), isTrue);
+      expect(hasMarkdownExtension('a/b/CHANGELOG.md'), isTrue);
+    });
+
+    test('is case-insensitive', () {
+      expect(hasMarkdownExtension('README.MD'), isTrue);
+      expect(hasMarkdownExtension('Notes.Markdown'), isTrue);
+    });
+
+    test('does not match other text extensions', () {
+      for (final n in ['a.txt', 'main.dart', 'config.yaml', 'page.html']) {
+        expect(hasMarkdownExtension(n), isFalse, reason: n);
+      }
+    });
+
+    test('does not match a bare name or a dotfile-only name', () {
+      expect(hasMarkdownExtension('README'), isFalse);
+      expect(hasMarkdownExtension('md'), isFalse);
+      expect(hasMarkdownExtension('.md'), isFalse);
+      expect(hasMarkdownExtension('trailing.'), isFalse);
+    });
+  });
+
+  group('isMarkdownMime', () {
+    test('matches text/markdown and text/x-markdown', () {
+      expect(isMarkdownMime('text/markdown'), isTrue);
+      expect(isMarkdownMime('text/x-markdown'), isTrue);
+      expect(isMarkdownMime('text/markdown; charset=utf-8'), isTrue);
+      expect(isMarkdownMime('TEXT/MARKDOWN'), isTrue);
+    });
+
+    test('does not match other text mimes or null/empty', () {
+      expect(isMarkdownMime('text/plain'), isFalse);
+      expect(isMarkdownMime('application/json'), isFalse);
+      expect(isMarkdownMime(null), isFalse);
+      expect(isMarkdownMime(''), isFalse);
+    });
+  });
+
+  group('isMarkdownEntry', () {
+    test('matches markdown files by extension', () {
+      expect(isMarkdownEntry(file('README.md')), isTrue);
+      expect(isMarkdownEntry(file('NOTES.markdown')), isTrue);
+    });
+
+    test('matches by explicit markdown mime even without the extension', () {
+      expect(isMarkdownEntry(file('README'), mime: 'text/markdown'), isTrue);
+    });
+
+    test('does not match non-markdown text files', () {
+      expect(isMarkdownEntry(file('a.txt')), isFalse);
+      expect(isMarkdownEntry(file('main.dart')), isFalse);
+    });
+
+    test('never matches directories', () {
+      expect(isMarkdownEntry(dir('docs.md')), isFalse);
+      expect(isMarkdownEntry(dir('docs'), mime: 'text/markdown'), isFalse);
+    });
+  });
+}

--- a/native/test/widget/markdown_file_viewer_widget_test.dart
+++ b/native/test/widget/markdown_file_viewer_widget_test.dart
@@ -1,0 +1,311 @@
+// Widget tests for the in-app markdown viewer + its registry routing (#854).
+//
+// Assert:
+//   - tapping a `.md` / `.markdown` entry in the file browser routes to
+//     [MarkdownFileViewerScreen] (via the registry, which orders markdown
+//     BEFORE the generic text viewer — first match wins), NOT the text viewer
+//     and NOT the download path,
+//   - the viewer fetches the source via the injected fetcher and RENDERS it by
+//     default (a `Markdown` widget is present; the literal source — `# `, `**`
+//     — is NOT shown as raw text),
+//   - the chrome toggle switches rendered ⇄ raw (raw shows the monospace
+//     source verbatim),
+//   - tapping a rendered link routes through the injected opener (url_launcher
+//     seam), not a real platform channel.
+//
+// Mirrors the wiring in text_file_viewer_widget_test.dart (InMemoryGatewayPair
+// + FileBrowserScreen + a canned TextFileFetcher override) so the markdown
+// viewer is exercised through the same browser → registry → route path the user
+// hits, without a real SSH socket.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/services/text_file_fetcher.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/ui/markdown_file_viewer.dart';
+import 'package:mobissh/ui/text_file_viewer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+class _ScriptedSftpSession implements SftpSession {
+  _ScriptedSftpSession(this._byPath);
+  final Map<String, List<SftpEntry>> _byPath;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async => _byPath[path] ?? const [];
+  @override
+  Future<int?> sizeOf(String path) async => 0;
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async => 0;
+  @override
+  Future<void> close() async {}
+}
+
+/// Injectable text fetcher: returns canned markdown without touching SFTP.
+class _CannedTextFetcher implements TextFileFetcher {
+  _CannedTextFetcher(this.text);
+  final String text;
+  SftpEntry? lastEntry;
+
+  @override
+  Future<String> fetch(
+    String sessionId,
+    SftpEntry entry, {
+    int maxBytes = 2 * 1024 * 1024,
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    lastEntry = entry;
+    return text;
+  }
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+({ProviderContainer container, SessionEntry session, SessionHost host}) _wire(
+  WidgetTester tester, {
+  required Map<String, List<SftpEntry>> byPath,
+  required String markdown,
+}) {
+  final pair = InMemoryGatewayPair();
+  addTearDown(pair.dispose);
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: _stubControllerFactory,
+    sftpOpener: (_) async => _ScriptedSftpSession(byPath),
+    snapshotInterval: const Duration(hours: 1),
+  );
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      textFileFetcherProvider.overrideWithValue(_CannedTextFetcher(markdown)),
+    ],
+  );
+  addTearDown(container.dispose);
+  const params = SshConnectParams(
+    host: 'h',
+    port: 22,
+    username: 'u',
+    auth: SshAuth.password('p'),
+  );
+  final session = container.read(sessionsProvider.notifier).addOrActivate(
+    params,
+  );
+  session.proxy.connect(params);
+  return (container: container, session: session, host: host);
+}
+
+const _sampleMarkdown =
+    '# Heading One\n\n'
+    'Some **bold** and *italic* text with a [link](https://example.com).\n\n'
+    '- first item\n'
+    '- second item\n\n'
+    '```dart\nvoid main() {}\n```\n';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<SessionHost> openMarkdown(WidgetTester tester, String name) async {
+    final w = _wire(
+      tester,
+      byPath: {
+        '/': [
+          SftpEntry(name: name, path: '/$name', isDirectory: false, size: 20),
+        ],
+      },
+      markdown: _sampleMarkdown,
+    );
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: w.container,
+        child: MaterialApp(home: FileBrowserScreen(sessionId: w.session.id)),
+      ),
+    );
+    await _pump(tester);
+    await tester.tap(find.byKey(Key('file-entry-$name')));
+    await _pump(tester);
+    // Returned so each test can dispose the host SYNCHRONOUSLY at the end of its
+    // body (before the framework's pending-timer assertion) — the SessionHost's
+    // periodic snapshot timer would otherwise trip "pending timers".
+    return w.host;
+  }
+
+  testWidgets('.md routes to the markdown viewer, not the text viewer', (
+    tester,
+  ) async {
+    final host = await openMarkdown(tester, 'README.md');
+    expect(find.byType(MarkdownFileViewerScreen), findsOneWidget);
+    expect(find.byType(TextFileViewerScreen), findsNothing);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('.markdown routes to the markdown viewer', (tester) async {
+    final host = await openMarkdown(tester, 'NOTES.markdown');
+    expect(find.byType(MarkdownFileViewerScreen), findsOneWidget);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('renders markdown by default (formatted, not raw source)', (
+    tester,
+  ) async {
+    final host = await openMarkdown(tester, 'README.md');
+
+    // Rendered: a Markdown widget is present.
+    expect(find.byType(Markdown), findsOneWidget);
+    expect(find.byKey(const Key('markdown-viewer-rendered')), findsOneWidget);
+    // Raw monospace source is NOT shown.
+    expect(find.byKey(const Key('markdown-viewer-raw')), findsNothing);
+    // The heading TEXT is rendered (without the literal '# ' syntax).
+    expect(find.textContaining('Heading One'), findsOneWidget);
+    // The literal markdown syntax must NOT appear verbatim in rendered mode.
+    expect(find.textContaining('# Heading One'), findsNothing);
+    expect(find.textContaining('**bold**'), findsNothing);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('toggle switches rendered ⇄ raw and back', (tester) async {
+    final host = await openMarkdown(tester, 'README.md');
+
+    // Default: rendered.
+    expect(find.byKey(const Key('markdown-viewer-rendered')), findsOneWidget);
+    expect(find.byKey(const Key('markdown-viewer-raw')), findsNothing);
+
+    // Toggle → raw: the verbatim source (with '# ' and '**') is shown.
+    await tester.tap(find.byKey(const Key('markdown-raw-toggle')));
+    await _pump(tester);
+    expect(find.byKey(const Key('markdown-viewer-raw')), findsOneWidget);
+    expect(find.byKey(const Key('markdown-viewer-rendered')), findsNothing);
+    expect(find.byType(Markdown), findsNothing);
+    expect(find.textContaining('# Heading One'), findsOneWidget);
+
+    // Toggle back → rendered.
+    await tester.tap(find.byKey(const Key('markdown-raw-toggle')));
+    await _pump(tester);
+    expect(find.byKey(const Key('markdown-viewer-rendered')), findsOneWidget);
+    expect(find.byKey(const Key('markdown-viewer-raw')), findsNothing);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('empty markdown shows an empty-file placeholder', (tester) async {
+    final w = _wire(
+      tester,
+      byPath: {
+        '/': const [
+          SftpEntry(
+            name: 'EMPTY.md',
+            path: '/EMPTY.md',
+            isDirectory: false,
+            size: 0,
+          ),
+        ],
+      },
+      markdown: '',
+    );
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: w.container,
+        child: MaterialApp(home: FileBrowserScreen(sessionId: w.session.id)),
+      ),
+    );
+    await _pump(tester);
+    await tester.tap(find.byKey(const Key('file-entry-EMPTY.md')));
+    await _pump(tester);
+
+    expect(find.byType(MarkdownFileViewerScreen), findsOneWidget);
+    expect(find.byKey(const Key('markdown-viewer-empty')), findsOneWidget);
+
+    w.host.disposeSyncForTest();
+  });
+
+  testWidgets('tapping a rendered link routes through the link opener seam', (
+    tester,
+  ) async {
+    // Build the viewer directly with an injected opener spy so we can assert the
+    // url_launcher seam is invoked without a real platform channel.
+    final opened = <String>[];
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: _stubControllerFactory,
+      sftpOpener: (_) async => _ScriptedSftpSession(const {}),
+      snapshotInterval: const Duration(hours: 1),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+        textFileFetcherProvider.overrideWithValue(
+          _CannedTextFetcher('[click me](https://example.com)'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    const params = SshConnectParams(
+      host: 'h',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    );
+    final session = container.read(sessionsProvider.notifier).addOrActivate(
+      params,
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: MarkdownFileViewerScreen(
+            sessionId: session.id,
+            entry: const SftpEntry(
+              name: 'L.md',
+              path: '/L.md',
+              isDirectory: false,
+            ),
+            openLink: (href) async {
+              opened.add(href);
+            },
+          ),
+        ),
+      ),
+    );
+    await _pump(tester);
+
+    expect(find.byType(Markdown), findsOneWidget);
+    await tester.tap(find.textContaining('click me'));
+    await _pump(tester);
+
+    expect(opened, ['https://example.com']);
+    host.disposeSyncForTest();
+  });
+}

--- a/native/test/widget/text_file_viewer_widget_test.dart
+++ b/native/test/widget/text_file_viewer_widget_test.dart
@@ -27,6 +27,7 @@ import 'package:mobissh/ssh/ssh_session.dart';
 import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
 import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/ui/markdown_file_viewer.dart';
 import 'package:mobissh/ui/pdf_viewer_screen.dart';
 import 'package:mobissh/ui/text_file_viewer.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -222,8 +223,43 @@ void main() {
     await routesToTextViewer(tester, 'main.dart');
   });
 
-  testWidgets('tapping a .md routes to the text viewer', (tester) async {
-    await routesToTextViewer(tester, 'README.md');
+  testWidgets('tapping a .md routes to the markdown viewer (#854)', (
+    tester,
+  ) async {
+    // #854: `.md` now routes to the dedicated rendered markdown viewer, NOT the
+    // generic monospace text viewer — even though `isTextEntry` also matches it
+    // (the registry orders markdown first; first match wins).
+    final fetcher = _CannedTextFetcher('# Title\n\nbody');
+    final w = _wire(
+      tester,
+      byPath: {
+        '/': const [
+          SftpEntry(
+            name: 'README.md',
+            path: '/README.md',
+            isDirectory: false,
+            size: 14,
+          ),
+        ],
+      },
+      overrides: [textFileFetcherProvider.overrideWithValue(fetcher)],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: w.container,
+        child: MaterialApp(home: FileBrowserScreen(sessionId: w.session.id)),
+      ),
+    );
+    await _pump(tester);
+
+    await tester.tap(find.byKey(const Key('file-entry-README.md')));
+    await _pump(tester);
+
+    expect(find.byType(MarkdownFileViewerScreen), findsOneWidget);
+    expect(find.byType(TextFileViewerScreen), findsNothing);
+
+    w.host.disposeSyncForTest();
   });
 
   testWidgets('tapping a .pdf still routes to the PDF viewer (registry)', (


### PR DESCRIPTION
## Summary

Brings the native `.md`/`.markdown` viewer to PWA parity: **rendered (default) + raw toggle**. The old viewer (`text_file_viewer.dart`) showed markdown as raw monospace only; this adds a dedicated rendered viewer with a one-tap raw-source toggle.

Closes part 1 + 2 of #854. Part 3 (edit-save) is split to a focused follow-up (see below).

## What changed

- **`MarkdownFileViewerScreen`** (`native/lib/ui/markdown_file_viewer.dart`) — rendered markdown by default: headings, bold/italic, lists, links, code blocks, GitHub-flavored tables, via `flutter_markdown_plus`. Raw toggle in the AppBar (monochrome Material glyph, code ⇄ article, no emoji) swaps rendered ⇄ raw monospace source.
- **Registry routing** (`file_viewer_registry.dart`) — `.md`/`.markdown` route to the markdown viewer **before** the generic text viewer (first-match-wins), via a new pure `isMarkdownEntry` helper in `text_file_detect.dart`.
- **Reuse** — the existing `TextFileFetcher` SFTP download seam (no new read plumbing) and the same `url_launcher` externalApplication idiom as the terminal URL handler (behind an injectable `MarkdownLinkOpener` seam so the tap is unit-testable).

## Dependency note

The issue named `flutter_markdown`, but that package was **discontinued by the Flutter team**. This uses the maintained community fork **`flutter_markdown_plus`** (`^1.0.0` → resolved 1.0.7), which has the same `Markdown`/`MarkdownBody` API. Noted in the pubspec comment.

## Scope: edit-save split to a follow-up

Part 3 (edit + save back over SFTP) is **deliberately not in this PR**. The native app has **no SFTP write path** — `sftp_session.dart` explicitly defers upload/mkdir/rename/delete to a future slice. Adding edit-save requires a full new UI↔task IPC write chain (command kind + class + `fromJson` case + host handler + `SftpSession.upload` + done/error events + proxy method + writer seam + IPC round-trip tests). That is materially larger and riskier than render+toggle, so — per the issue's own scoping note ("If edit+save is materially bigger than render+toggle, ship render+toggle first and split edit into a follow-up") — it ships separately. A follow-up issue will cover the write seam + the #842 capture-before-clear discipline.

## Tests

- **Unit** (`markdown_detect_test.dart`): `hasMarkdownExtension` / `isMarkdownMime` / `isMarkdownEntry` (extension, mime, case, directories).
- **Widget** (`markdown_file_viewer_widget_test.dart`): `.md`/`.markdown` route to the markdown viewer (not text); render-by-default (Markdown widget present, raw syntax not literal); rendered ⇄ raw toggle; empty-file placeholder; link tap routes through the opener seam.
- Updated the now-stale `.md routes to text viewer` assertion in `text_file_viewer_widget_test.dart`.
- `scripts/native-fast-gate.sh`: analyzer clean, **1195 tests pass**.

## Device validation

Labeled `device` — rendered-output quality, raw toggle, and large-file scroll smoothness should be verified on hardware before merge (per project device-testing rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)