### PR TITLE
fix(#856): just-switched grace window suppresses redundant attention on session switch

### DIFF
--- a/native/lib/services/session_attention_notification.dart
+++ b/native/lib/services/session_attention_notification.dart
@@ -68,6 +68,22 @@ const Duration kAttentionDedupWindow = Duration(seconds: 30);
 /// connected transition. Tunable; 1.5s is the owner's starting point.
 const Duration kAttentionReplayWindow = Duration(milliseconds: 1500);
 
+/// JUST-SWITCHED grace window (#856). When the user switches TO a session (the
+/// app foregrounds it / it becomes the active host), the host flushes that
+/// session's catch-up output; a bell in that burst would post a REDUNDANT
+/// attention notification for the very session the user just switched to (the
+/// owner: "I switched to fddev and immediately got a pop up that fddev needed my
+/// attention — should not get that, it's redundant"). #847 host-suppression keys
+/// on `activeHost`, but the catch-up output is scanned BEFORE the
+/// `setActive(newHost)` command lands (async gateway race), and #851's replay
+/// window only re-arms on a CONNECT transition — not on a session SWITCH (the
+/// session was already connected). So when the active HOST changes, the host arms
+/// this short grace for the newly-active host: a signal for that host within the
+/// window is suppressed (logged) rather than posted. After the window, posts
+/// normally. Composes with — does not replace — #847 + #851. Tunable; 1.5s
+/// mirrors the replay window's catch-up-burst rationale.
+const Duration kAttentionSwitchGraceWindow = Duration(milliseconds: 1500);
+
 /// Derive the HOST from a sessionId (#847). The session id format is
 /// `host:port:user:createdAtMs` (see `state/sessions.dart`), so the host is the
 /// segment before the first colon. Falls back to the whole id when it has no

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -67,6 +67,7 @@ class SessionHost {
     int Function()? nowMs,
     AttentionNotifier? attentionNotifier,
     this.replayWindow = kAttentionReplayWindow,
+    this.switchGraceWindow = kAttentionSwitchGraceWindow,
   }) : _gateway = gateway,
        _factory = controllerFactory ?? _defaultControllerFactory,
        _sftpOpener = sftpOpener,
@@ -186,6 +187,28 @@ class SessionHost {
   /// tests can disable it ([Duration.zero]) or set a deterministic span; the
   /// window is measured against the host's injected [_nowMs] clock.
   final Duration replayWindow;
+
+  /// JUST-SWITCHED grace window (#856). When [_handleSetActive] changes the
+  /// active HOST (the user switched TO a session on a different host, or the app
+  /// foregrounded onto it), the host arms a short grace for the newly-active
+  /// host: an attention signal for that host within the window is the switch
+  /// CATCH-UP burst (flushed when the session became front-most), not a live
+  /// moment — so it is suppressed (logged `just-switched`) rather than posted.
+  /// This closes the activeHost-propagation RACE the #847 host-suppression can't
+  /// (the catch-up output is scanned before `setActive` lands) and the SWITCH
+  /// case the #851 replay window can't (it only re-arms on a CONNECT, not a
+  /// session switch). Stamped per host in [_switchGraceUntilMs] on the active-host
+  /// CHANGE only (re-asserting the same active host does NOT re-arm, so the window
+  /// can't be extended indefinitely). Composes with — does not replace — #847 +
+  /// #851. Injectable + measured against [_nowMs] so tests are deterministic
+  /// ([Duration.zero] disables it).
+  final Duration switchGraceWindow;
+
+  /// Per-host expiry (ms since epoch, via [_nowMs]) of the just-switched grace
+  /// (#856). A signal whose host has an entry here that is still in the future is
+  /// suppressed as the switch catch-up burst. Stamped on each active-host change
+  /// in [_handleSetActive].
+  final Map<String, int> _switchGraceUntilMs = {};
 
   /// The exact lifecycle-forwarder closure this host installed into the global
   /// [lifecycleForwarder] (#766). Held so dispose detaches OUR closure only —
@@ -1049,8 +1072,20 @@ class SessionHost {
     // even when [active] is unchanged the front-most TAB may have switched, and
     // that must update suppression. A null id/host (older UI / none) leaves it
     // unknown (degrades to "never host-suppress").
+    final prevActiveHost = _activeHost;
     _activeSessionId = activeSessionId;
     _activeHost = activeHost;
+    // #856: when the active HOST actually CHANGES, arm the just-switched grace
+    // for the newly-active host so its switch catch-up burst doesn't post a
+    // redundant attention notification. Only on a real change (new != previous)
+    // so re-asserting the same active host can't extend the window forever, and
+    // only for a known host. The signal-side gate lives in [_maybePostAttention].
+    if (activeHost != null &&
+        activeHost != prevActiveHost &&
+        switchGraceWindow > Duration.zero) {
+      _switchGraceUntilMs[activeHost] =
+          _nowMs() + switchGraceWindow.inMilliseconds;
+    }
     if (_active == active) return;
     _active = active;
     if (active) {
@@ -1135,6 +1170,29 @@ class SessionHost {
               '${replayWindow.inMilliseconds}ms) session $sessionId',
         );
         return;
+      }
+    }
+    // #856: JUST-SWITCHED grace. A signal whose host was made active within the
+    // grace window (see [_handleSetActive]) is the switch CATCH-UP burst flushed
+    // when the user switched TO this session — redundant, since they're now
+    // looking at it. Suppress (log) rather than post. Keyed on the signal's HOST
+    // to match #847's host unit, and gated on the host's injected clock. This
+    // closes the activeHost-propagation race the foreground gate below can't.
+    final signalHost = hostOfSessionId(sessionId);
+    if (switchGraceWindow > Duration.zero) {
+      final graceUntil = _switchGraceUntilMs[signalHost];
+      if (graceUntil != null) {
+        final nowMs = _nowMs();
+        if (nowMs < graceUntil) {
+          clifecycle(
+            'attention',
+            'suppressed (just-switched ${graceUntil - nowMs}ms remaining, host '
+                '$signalHost) session $sessionId',
+          );
+          return;
+        }
+        // Window elapsed — drop the stale stamp so the map doesn't grow.
+        _switchGraceUntilMs.remove(signalHost);
       }
     }
     // #847: host-level suppression — looking at ANY session to this host (incl.

--- a/native/test/services/session_host_attention_switch_grace_test.dart
+++ b/native/test/services/session_host_attention_switch_grace_test.dart
@@ -1,0 +1,252 @@
+// SessionHost attention JUST-SWITCHED grace window (#856).
+//
+// Switching TO a session flushes its catch-up output; a bell in that burst would
+// otherwise post a redundant attention notification for the session the user just
+// switched to (foreground + now-active). The #847 host-suppression keys on
+// `activeHost`, but there is a RACE: the catch-up output is scanned by the task
+// isolate BEFORE the `setActive(newHost)` command lands, so the suppression check
+// still sees the OLD active host → posts. #851's replay window only re-arms on a
+// CONNECT transition, not on a session SWITCH, so it doesn't cover this.
+//
+// Fix: when `setActive` CHANGES the active host, arm a short "just-switched" grace
+// window for the newly-active HOST. A signal for that host within the window is
+// suppressed (logged `suppressed (just-switched …)`) but not posted; after the
+// window, posts normally. Additive to + composes with #847 + #851.
+//
+// The window is gated on the host's injected clock (`nowMs`) and an injected
+// `switchGraceWindow`, so it is deterministic without wall-clock sleeps.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+/// A controller whose `connect` is inert so the TEST owns every state
+/// transition (it drives `connected` via [debugSetConnectedForTest]).
+class _NoConnectController extends SshSessionController {
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// Bare BEL — a text-less bell, the generic attention signal.
+List<int> _bell() => [0x07];
+
+void main() {
+  // Mutable injected clock (ms). Tests advance `now` to cross the grace window
+  // without any real-time sleep.
+  late int now;
+  late InMemoryGatewayPair pair;
+  late SessionHost host;
+  late RecordingAttentionNotifier notifier;
+  // sessionId → its controller, captured at connect time so tests can drive
+  // `connected` (to arm the #851 replay window).
+  late Map<String, SshSessionController> controllers;
+  // The session id of the in-flight connect, so the factory (called once per
+  // connect, in order) can bind the new controller to it.
+  String? pendingSid;
+
+  // Session H on host `h`; session G on a DIFFERENT host `g`.
+  const sidH = 'h:22:u:1';
+  const sidG = 'g:22:u:2';
+  const grace = Duration(milliseconds: 1500);
+  // A long replay window OFF for the grace-specific tests (so the replay gate
+  // doesn't mask whether the grace gate is doing the work). The compose-with-#851
+  // test re-enables it.
+  const noReplay = Duration.zero;
+
+  Future<void> setUpHost({Duration replay = noReplay}) async {
+    now = 1000;
+    controllers = {};
+    pair = InMemoryGatewayPair();
+    notifier = RecordingAttentionNotifier();
+    pendingSid = null;
+    // The factory is called once per connect, in connect order. We bind each new
+    // controller to the most-recently-requested session id (set in connectSession
+    // right before sending the connect command).
+    host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: () {
+        final c = _NoConnectController();
+        final sid = pendingSid;
+        if (sid != null) controllers[sid] = c;
+        return c;
+      },
+      snapshotInterval: const Duration(milliseconds: 50),
+      attentionNotifier: notifier,
+      nowMs: () => now,
+      replayWindow: replay,
+      switchGraceWindow: grace,
+    );
+  }
+
+  Future<void> connectSession(String sid, String host_) async {
+    pendingSid = sid;
+    pair.uiSide.send(
+      SshConnectCommand(
+        sessionId: sid,
+        host: host_,
+        port: 22,
+        username: 'u',
+        authJson: const {'type': 'password', 'password': 'p'},
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+
+  /// Drive [sid]'s controller to `connected` so the #851 replay window arms.
+  Future<void> reachConnected(String sid) async {
+    controllers[sid]!.debugSetConnectedForTest(_params);
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+
+  void setActive(String activeSessionId, String activeHost) {
+    pair.uiSide.send(
+      SshSetActiveCommand(
+        active: true,
+        activeSessionId: activeSessionId,
+        activeHost: activeHost,
+      ).toJson(),
+    );
+  }
+
+  Future<void> pump() => Future<void>.delayed(const Duration(milliseconds: 10));
+
+  Future<void> tearDownHost() async {
+    await host.dispose();
+    await pair.dispose();
+  }
+
+  test('bell for host H WITHIN the just-switched grace window after '
+      'setActive(H) is NOT posted', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await connectSession(sidH, 'h');
+    // Switch TO host H (active-host change null→h arms the grace at now=1000).
+    setActive(sidH, 'h');
+    await pump();
+
+    now += 500; // 0.5s into the 1.5s grace → catch-up burst
+    host.feedAttentionForTest(sidH, _bell());
+    await pump();
+
+    expect(notifier.posted, isEmpty,
+        reason: 'a bell in the switch catch-up burst is redundant');
+  });
+
+  test('the SAME bell AFTER the grace window posts (live output)', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await connectSession(sidH, 'h');
+    await connectSession(sidG, 'g');
+    setActive(sidH, 'h'); // grace armed for h at now=1000
+    await pump();
+    // Move foreground to a DIFFERENT host so #847 foreground-suppression does NOT
+    // apply to h — we want to verify the GRACE alone, not host-suppression.
+    setActive(sidG, 'g');
+    await pump();
+
+    now += 1600; // past h's 1.5s grace → live
+    host.feedAttentionForTest(sidH, _bell());
+    await pump();
+
+    expect(notifier.posted, hasLength(1),
+        reason: 'after the grace settles, live attention posts normally');
+  });
+
+  test('setActive to a DIFFERENT host does NOT grace-suppress H', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await connectSession(sidH, 'h');
+    await connectSession(sidG, 'g');
+    // Switch to host G — only G is graced; H is NOT in the foreground.
+    setActive(sidG, 'g');
+    await pump();
+
+    now += 500; // inside G's grace, but the bell is from H
+    host.feedAttentionForTest(sidH, _bell());
+    await pump();
+
+    expect(notifier.posted, hasLength(1),
+        reason: 'graceing the newly-active host G must not suppress host H');
+  });
+
+  test('grace composes with #847: foregrounded same-host stays suppressed '
+      'AFTER the grace window', () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await connectSession(sidH, 'h');
+    setActive(sidH, 'h'); // grace armed; foreground on host h (#847 applies)
+    await pump();
+
+    // Inside the grace → suppressed (just-switched).
+    now += 200;
+    host.feedAttentionForTest(sidH, _bell());
+    await pump();
+    expect(notifier.posted, isEmpty);
+
+    // Outside the grace, but STILL foregrounded same-host → #847 suppresses.
+    now += 2000;
+    host.feedAttentionForTest(sidH, _bell());
+    await pump();
+    expect(notifier.posted, isEmpty,
+        reason: 'host-suppression holds independently of the grace gate');
+  });
+
+  test('grace composes with #851: post-connect replay still suppresses', () async {
+    // Replay window ON (1.5s). A bell right after connect is replay-suppressed
+    // even with no switch — the gates stack, neither removes the other.
+    await setUpHost(replay: const Duration(milliseconds: 1500));
+    addTearDown(tearDownHost);
+    await connectSession(sidH, 'h');
+    await reachConnected(sidH); // replay window armed at now=1000
+    // No setActive → grace NOT armed; the #851 replay gate must do the work.
+    now += 400; // inside the replay window
+    host.feedAttentionForTest(sidH, _bell());
+    await pump();
+    expect(notifier.posted, isEmpty,
+        reason: 'the #851 replay gate is unaffected by the grace gate');
+  });
+
+  test('re-asserting the SAME active host does NOT extend the grace window',
+      () async {
+    await setUpHost();
+    addTearDown(tearDownHost);
+    await connectSession(sidH, 'h');
+    await connectSession(sidG, 'g');
+    setActive(sidH, 'h'); // grace armed for h at now=1000, expires at 2500
+    await pump();
+
+    // Re-assert the SAME active host repeatedly as time advances. If re-assert
+    // re-armed the grace, the window would never close.
+    now += 1000; // 2000
+    setActive(sidH, 'h');
+    await pump();
+    now += 1000; // 3000 — past the ORIGINAL 1500ms window from now=1000
+    setActive(sidH, 'h');
+    await pump();
+
+    // Move foreground OFF host h so #847 doesn't mask the grace check. h's grace
+    // (armed at 1000) must already be expired and NOT re-armed by the re-asserts.
+    setActive(sidG, 'g');
+    await pump();
+
+    host.feedAttentionForTest(sidH, _bell());
+    await pump();
+    expect(notifier.posted, hasLength(1),
+        reason: 're-asserting the same active host must not re-arm the grace');
+  });
+
+  test('default switch-grace window is the tunable const (~1.5s)', () {
+    expect(kAttentionSwitchGraceWindow, const Duration(milliseconds: 1500));
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #856 — switching TO a session fired a redundant attention notification for that session.

Switching TO a session flushes its catch-up output; a bell in that burst posted a **redundant** attention notification for the very session the user just switched to (foreground + now-active). The #847 host-suppression keys on `activeHost`, but the catch-up output is scanned by the task isolate **before** the `setActive(newHost)` command lands (async gateway race), so the suppression check still saw the OLD active host and posted. #851's replay window only re-arms on a CONNECT transition, not on a session SWITCH (the session was already connected), so it didn't cover this.

## Fix (additive grace window — composes with #847 + #851)

- New const `kAttentionSwitchGraceWindow` (1.5s) in `session_attention_notification.dart`, sibling to `kAttentionReplayWindow`.
- `SessionHost` gains an injectable `switchGraceWindow` + a per-host `_switchGraceUntilMs` map.
- `_handleSetActive` captures the previous active host and stamps the grace for the newly-active host **only on an active-host CHANGE** (re-asserting the same active host does not re-arm → no indefinite extension).
- `_maybePostAttention` suppresses (logs `suppressed (just-switched …)`) a signal whose host is within its grace window — placed **after** the #851 replay gate and **before** the #847 foreground gate. Gated on the host's injected `_nowMs` clock. Stale stamps are pruned on expiry.

This is purely additive — it does not alter or remove the #847 host-suppression/dedup or the #851 replay window.

## Approach note

The issue offered an ordering fix (apply the activeHost update before scanning subsequent output) as the preferred alternative "if clean", else the grace window. The UI→task gateway is async, so the ordering fix is not obviously race-free — the **grace window** (the specced robust fallback) is used.

## Tests

`native/test/services/session_host_attention_switch_grace_test.dart` (7 tests, injected clock, no wall-clock sleeps), mirroring the #851 replay-test patterns:

- bell for host H within the grace window after `setActive(H)` → NOT posted
- same bell after the window → posted
- `setActive` to a DIFFERENT host does not grace-suppress H
- composes with #847 (foreground same-host still suppresses after the grace)
- composes with #851 (post-connect replay still suppresses)
- re-asserting the same active host does not extend the window indefinitely
- default const is ~1.5s

Native fast gate (analyze + unit) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)