### PR TITLE
fix(#857): attention notification tap host-fallback when exact sessionId stale

### DIFF
--- a/native/lib/services/attention_focus_router.dart
+++ b/native/lib/services/attention_focus_router.dart
@@ -21,6 +21,8 @@
 // to detect tmux, how to open a URL) is injected so this class is unit-testable
 // without Flutter.
 
+import 'dart:developer' as developer;
+
 import 'session_attention_notification.dart';
 import 'tmux_window_select.dart';
 
@@ -33,12 +35,14 @@ class AttentionFocusRouter {
     required void Function(String sessionId, List<int> bytes) sendInput,
     bool Function(String sessionId)? isTmux,
     Future<void> Function(String url)? openUrl,
+    String? Function(String host)? resolveLiveSessionForHost,
   }) : _bridge = bridge,
        _setActive = setActive,
        _sessionExists = sessionExists,
        _sendInput = sendInput,
        _isTmux = isTmux,
-       _openUrl = openUrl;
+       _openUrl = openUrl,
+       _resolveLiveSessionForHost = resolveLiveSessionForHost;
 
   // ignore_for_file: prefer_initializing_formals
   final PendingFocusBridge _bridge;
@@ -46,6 +50,15 @@ class AttentionFocusRouter {
   final bool Function(String sessionId) _sessionExists;
   final void Function(String sessionId, List<int> bytes) _sendInput;
   final bool Function(String sessionId)? _isTmux;
+
+  /// Host-fallback seam (#857). Given a HOST, returns the id of the most-recent
+  /// LIVE session to that host, or null when the host has no live session.
+  /// Used when the payload's EXACT sessionId is no longer live — the host
+  /// reconnected with a fresh `createdAtMs` nonce, so the exact id is stale but
+  /// the user still wants the tap to land on that host's session (NOT the
+  /// previously-active, different-host session — the #857 bug). Null/unwired →
+  /// no fallback (the router gives up on a stale id, as before).
+  final String? Function(String host)? _resolveLiveSessionForHost;
 
   /// URL opener seam (#710), or null when URL-open is unwired (e.g. a test that
   /// only exercises focus routing). Production binds this to
@@ -59,15 +72,46 @@ class AttentionFocusRouter {
   /// when there was nothing pending (or the session no longer exists).
   Future<String?> consumePending() async {
     final pending = await _bridge.takePending();
-    final sid = pending.sessionId;
+    final payloadSid = pending.sessionId;
+    if (payloadSid == null) return null;
+    final host = hostOfSessionId(payloadSid);
+
+    // Resolve the session to actually focus (#857). Prefer the EXACT payload id
+    // when it's still live. Otherwise fall back to the most-recent live session
+    // for the SAME HOST — the host reconnected with a new `createdAtMs` nonce so
+    // the exact id is stale, but the tap must still land on that host (NOT the
+    // previously-active, different-host session — that was the #857 bug). Only
+    // give up when the host has no live session.
+    String? sid;
+    String route;
+    if (_sessionExists(payloadSid)) {
+      sid = payloadSid;
+      route = 'setActive';
+    } else {
+      final fallback = _resolveLiveSessionForHost?.call(host);
+      if (fallback != null && _sessionExists(fallback)) {
+        sid = fallback;
+        route = 'host-fallback';
+      } else {
+        sid = null;
+        route = 'none';
+      }
+    }
+
+    developer.log(
+      'focus: payload sid=$payloadSid host=$host → '
+      '${sid == null ? 'none' : 'setActive(matched sid=$sid) | $route'}',
+      name: 'attention',
+    );
+
     if (sid == null) return null;
-    if (!_sessionExists(sid)) return null;
 
     _setActive(sid);
 
     // GUARDED source-window navigation (device-gated, may be flaky under
     // multi-client tmux). Only when a window hint parsed AND the session is a
-    // tmux client. Absent hint or non-tmux → skip silently.
+    // tmux client. Targets the RESOLVED live session (#857), not the stale
+    // payload id. Absent hint or non-tmux → skip silently.
     final win = pending.sourceWindow;
     if (win != null && (_isTmux?.call(sid) ?? false)) {
       _sendInput(sid, tmuxSelectWindowSequence(win));

--- a/native/lib/state/attention_providers.dart
+++ b/native/lib/state/attention_providers.dart
@@ -36,6 +36,28 @@ final attentionFocusRouterProvider = Provider<AttentionFocusRouter>((ref) {
         }
       }
     },
+    // #857: host fallback. When the tapped notification's EXACT sessionId is no
+    // longer live (the host reconnected with a new `createdAtMs` nonce), route
+    // to the MOST-RECENT live session for that host — never the previously-active
+    // session to a different host. Session id format is
+    // `host:port:user:createdAtMs`, so "most recent" = the largest trailing
+    // createdAt segment among entries whose host matches.
+    resolveLiveSessionForHost: (host) {
+      String? bestId;
+      int bestCreatedAt = -1;
+      for (final e in ref.read(sessionsProvider).entries) {
+        if (hostOfSessionId(e.id) != host) continue;
+        final lastColon = e.id.lastIndexOf(':');
+        final createdAt = lastColon < 0
+            ? -1
+            : (int.tryParse(e.id.substring(lastColon + 1)) ?? -1);
+        if (createdAt >= bestCreatedAt) {
+          bestCreatedAt = createdAt;
+          bestId = e.id;
+        }
+      }
+      return bestId;
+    },
     // See doc above: a parsed (win N) hint implies the owner's tmux setup.
     isTmux: (_) => true,
     // #710: open an explicitly-signalled URL from the tapped notification in the

--- a/native/test/services/attention_focus_router_test.dart
+++ b/native/test/services/attention_focus_router_test.dart
@@ -199,6 +199,9 @@ void main() {
 
     test('stale session with url payload → neither setActive nor openUrl (#710)',
         () async {
+      // NOTE: with the #857 host-fallback this only holds when the host has NO
+      // live session. `resolveLiveSessionForHost` defaults to returning null, so
+      // a router with no host-resolver still gives up on a stale id.
       final bridge = PendingFocusBridge(MapKeyValueStore());
       await bridge.setPendingFromPayload(jsonEncode({
         'sessionId': 'gone',
@@ -216,6 +219,116 @@ void main() {
       expect(await router.consumePending(), isNull);
       expect(activated, isEmpty);
       expect(opened, isEmpty);
+    });
+  });
+
+  // #857: tapping an attention notification must route to the notification's OWN
+  // session, NOT the previously-active one. The bug: when the payload's exact
+  // sessionId is no longer live (the host reconnected with a new `createdAtMs`
+  // nonce), the router no-op'd → UI stayed on the current (wrong) session.
+  group('AttentionFocusRouter host fallback (#857)', () {
+    test('exact-id live: routes to host-B session, not current A', () async {
+      const bId = 'fddev:22:me:200';
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': bId}));
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (id) => id == bId, // current active is raserver (A)
+        sendInput: (a, b) {},
+        resolveLiveSessionForHost: (_) => null,
+      );
+      final focused = await router.consumePending();
+      expect(focused, bId);
+      expect(activated, [bId], reason: 'routes to B, never the current A');
+    });
+
+    test('exact id NOT live but host B has a live session (diff nonce) → '
+        'setActive that B session, not A', () async {
+      // Payload carries the OLD fddev id; fddev reconnected with a new nonce.
+      const staleB = 'fddev:22:me:100';
+      const liveB = 'fddev:22:me:999';
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': staleB}));
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (id) => id == liveB, // staleB is gone; liveB is current B
+        sendInput: (a, b) {},
+        resolveLiveSessionForHost: (host) => host == 'fddev' ? liveB : null,
+      );
+      final focused = await router.consumePending();
+      expect(focused, liveB, reason: 'falls back to the live host-B session');
+      expect(activated, [liveB],
+          reason: 'must NOT stay on the current (raserver) session');
+    });
+
+    test('host has NO live session → no switch (stay)', () async {
+      const staleB = 'fddev:22:me:100';
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': staleB}));
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => false,
+        sendInput: (a, b) {},
+        resolveLiveSessionForHost: (_) => null,
+      );
+      final focused = await router.consumePending();
+      expect(focused, isNull);
+      expect(activated, isEmpty);
+    });
+
+    test('host fallback + url: BOTH setActive the live B session AND openUrl',
+        () async {
+      const staleB = 'fddev:22:me:100';
+      const liveB = 'fddev:22:me:999';
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({
+        'sessionId': staleB,
+        'url': 'https://example.com/app.apk',
+      }));
+      final activated = <String>[];
+      final opened = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (id) => id == liveB,
+        sendInput: (a, b) {},
+        resolveLiveSessionForHost: (host) => host == 'fddev' ? liveB : null,
+        openUrl: (u) async => opened.add(u),
+      );
+      final focused = await router.consumePending();
+      expect(focused, liveB);
+      expect(activated, [liveB]);
+      expect(opened, ['https://example.com/app.apk'],
+          reason: 'the #710 url-open must still fire on the host-fallback path');
+    });
+
+    test('host fallback sends select-window to the RESOLVED live B session',
+        () async {
+      const staleB = 'fddev:22:me:100';
+      const liveB = 'fddev:22:me:999';
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(
+        jsonEncode({'sessionId': staleB, 'sourceWindow': 4}),
+      );
+      final sent = <(String, List<int>)>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (id) => id == liveB,
+        sendInput: (id, bytes) => sent.add((id, bytes)),
+        isTmux: (_) => true,
+        resolveLiveSessionForHost: (host) => host == 'fddev' ? liveB : null,
+      );
+      await router.consumePending();
+      expect(sent, hasLength(1));
+      expect(sent.single.$1, liveB,
+          reason: 'window-select goes to the live session, not the stale id');
     });
   });
 


### PR DESCRIPTION
## Summary
Fixes #857 — tapping a session's attention notification routed to the WRONG
(previously-active) session.

## Root cause
`AttentionFocusRouter.consumePending` short-circuited with
`if (!_sessionExists(sid)) return null;`. When the notified host reconnected, its
session id gained a fresh `createdAtMs` nonce (id format
`host:port:user:createdAtMs`), so the payload's OLD exact id was no longer a live
session → the router no-op'd and the UI stayed on the previously-active, different
host (the reported "fddev notification returned me to raserver"). This was **not**
the #710 url-open regression — that branch runs after `setActive` and composed
correctly.

## Fix
- Added a `resolveLiveSessionForHost(host)` seam on `AttentionFocusRouter`.
- `consumePending` now: exact payload id live → use it; else fall back to the
  **most-recent live session for the same host** (`hostOfSessionId`); only give up
  (no switch) when that host has no live session.
- `setActive`, the #710 URL-open, and the guarded tmux `select-window` all target
  the **resolved** id (not the stale payload id).
- Added a cycle log: `focus: payload sid=… host=… → setActive(matched sid=…) | host-fallback | none`.
- Provider wiring resolves over `sessionsProvider.entries`, picking the host-matched
  entry with the greatest trailing `createdAtMs`.

## Tests (red→green)
Added to `attention_focus_router_test.dart`:
- exact-id-live → `setActive(B)`, not current A
- stale exact id, host B has a live session (diff nonce) → `setActive` that B session, not A
- host has no live session → no switch (stays), logged `none`
- host-fallback + url → BOTH `setActive` the live B session AND `openUrl`
- host-fallback `select-window` targets the resolved live session

## Gate
- `flutter analyze`: no issues
- `scripts/native-fast-gate.sh`: all 1207 tests pass

## Note
Routing logic only; device validation of the actual tap is human-only (notification
subsystem). Refs #710, #847, #856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)