### PR TITLE
fix(#863): unify URL paint + tap hit-test geometry (off-by-1 / tap-miss)

### DIFF
--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -2688,7 +2688,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     final box = context.findRenderObject();
     if (box is! RenderBox || !box.hasSize) return const [];
     final controller = _controller;
-    final offset = controller == null ? 0 : _viewportOffsetOf(controller);
+    // #863: resolve viewport rows from the PAINTED offset (the offset the bubble
+    // decorator / [HighlightPainter] actually drew with), NOT the live
+    // `scrollbar.offset` (`_viewportOffsetOf`). The painted offset can trail the
+    // live offset by a frame during a tmux-redraw scroll (#803); building these
+    // long-press-menu highlight rects from the live offset put the menu's
+    // outline a row off the painted bubble + the tappable region. Consuming
+    // `controller.paintedViewportOffset` here keeps the menu rects, the painted
+    // bubble, and the [matchAt] hit-test all on ONE geometry source.
+    final offset = controller == null ? 0 : controller.paintedViewportOffset;
     final origin = box.localToGlobal(Offset.zero);
     final rects = <Rect>[];
     for (final range in match.ranges) {

--- a/native/test/terminal/replay_paint_hit_unify_863_test.dart
+++ b/native/test/terminal/replay_paint_hit_unify_863_test.dart
@@ -1,0 +1,241 @@
+@Tags(['ffi'])
+library;
+
+// INVARIANT (#863): the URL PAINT geometry and the TAP HIT-TEST geometry must
+// AGREE. Two device reports (0.1.10+53) shared one root — the highlight bubble
+// PAINTS its anchor rects against the controller's PAINTED viewport offset
+// (`anchorRects` -> `AnchorGeometry.rectsFor`: `viewRow = absRow -
+// paintedViewportOffset`), but `matchAt` (the tap hit-test) mapped the tapped
+// viewport row to absolute via the LIVE `scrollbar.offset`. When those offsets
+// diverged (during/after a tmux-redraw scroll, #803) the bubble drew at row N
+// while the tappable cell sat at row N+/-1 -> the tap fell through to selection
+// instead of copy/open, and the highlight looked a line off.
+//
+// THE FIX (unify on ONE geometry source): `matchAt`/`highlightAt` now map
+// viewport->absolute via `paintedViewportOffset` — the SAME offset the painter
+// uses. So a hit-test at the CENTER (and corners) of any PAINTED URL rect must
+// resolve to THAT match, even under a forced live!=painted offset skew.
+//
+// This is the #791 WIDGET/PIXEL replay tier: it mounts the REAL flterm
+// `TerminalView` (so the render box paints + reports its painted offset to the
+// controller), replays a REAL captured wrapped-URL grid, and asserts the
+// paint==hit invariant — at painted offset 0, with a forced live!=painted skew
+// (the exact #863 frame-skew condition), and on a non-URL row. The byte stream
+// IS the real grid; the round-trip catches the divergence the device reports
+// describe with no device.
+
+import 'package:flutter/material.dart';
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'replay_trace_harness.dart' show lfToCrlf;
+import 'replay_url_detection_test.dart' show loadCast;
+
+// The owner's REAL 55-col tmux capture: a plain-text URL the Claude TUI wraps at
+// the content width into TWO physical rows (the +22..+28 saga grid). Exercises
+// the wrapped multi-row URL case the #863 spec calls out.
+const _kFixture = 'test/fixtures/replay/claude_wrapped_url_55col.cast.json';
+const _kFullUrl = 'https://mobissh.tailbe5094.ts.net/'
+    'mobissh-native-20260605T200823+0000.apk';
+
+const double _kPadding = 4.0;
+
+Future<TerminalController> _replayMounted(WidgetTester tester) async {
+  final cast = loadCast(_kFixture);
+  final controller = TerminalController(
+    config: TerminalConfig(cols: cast.cols, rows: cast.rows),
+  );
+  controller.registerTextPattern(TextPattern.url());
+  for (final chunk in cast.chunks) {
+    // capture-pane separates visual rows with bare LF; map to CRLF (idempotent)
+    // so each row returns to column 0 — mirrors `replayCast`.
+    controller.write(lfToCrlf(chunk));
+  }
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Stack(
+          children: [
+            Positioned.fill(
+              child: TerminalView(
+                controller: controller,
+                autofocus: false,
+                theme: TerminalTheme.dark().copyWith(fontSize: 14),
+                padding: const EdgeInsets.all(_kPadding),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  // Let the render box paint + report its painted offset, and let detection
+  // settle (debounced ~120ms).
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+  await tester.pump();
+  return controller;
+}
+
+/// The detected wrapped-URL anchor (one anchor spanning both physical rows) —
+/// the PAINT source whose per-row [ranges] feed `anchorRects`.
+StructuredAnchor _urlAnchor(TerminalController controller) {
+  final hits = controller.anchors.where((a) => a.payload == _kFullUrl).toList();
+  expect(
+    hits,
+    hasLength(1),
+    reason: 'the wrapped URL must be ONE detected anchor (the paint source)',
+  );
+  return hits.single;
+}
+
+/// Resolve the live cell size from a single painted row rect: its height IS one
+/// cell height, and its width covers `(bottomCol-topCol)` cells of that row's
+/// range.
+Size _cellSizeFor(Rect rect, HighlightRange range) {
+  final cols = range.bottomCol - range.topCol;
+  return Size(rect.width / cols, rect.height);
+}
+
+/// Convert a painted point to the VIEWPORT (row, col) the gesture router would
+/// compute (mirrors `ghosttyCellForPosition`: subtract the grid padding, divide
+/// by the live cell size, floor). `anchorRects` returns rects in the grid's
+/// padded LOCAL space, which is the same space `details.localPosition` is in.
+(int row, int col) _viewportCellAt(Offset local, Size cell) {
+  final col = ((local.dx - _kPadding) / cell.width).floor();
+  final row = ((local.dy - _kPadding) / cell.height).floor();
+  return (row, col);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('#863 — URL paint geometry and tap hit-test agree', () {
+    testWidgets(
+      'a hit-test at the CENTER + CORNERS of every PAINTED URL rect resolves to '
+      'THAT match (painted offset 0, wrapped multi-row URL)',
+      (tester) async {
+        final controller = await _replayMounted(tester);
+        addTearDown(controller.dispose);
+
+        final anchor = _urlAnchor(controller);
+        // The wrapped URL spans >= 2 rows — the multi-row case the spec requires.
+        final spannedRows = {for (final r in anchor.ranges) r.topRow};
+        expect(spannedRows.length, greaterThanOrEqualTo(2),
+            reason: 'the captured URL wraps across rows (multi-row coverage)');
+
+        var checkedCells = 0;
+        for (final range in anchor.ranges) {
+          final rects = controller.anchorRects(range);
+          for (final rect in rects) {
+            final cell = _cellSizeFor(rect, range);
+            expect(cell.width, greaterThan(0));
+            final cols = (rect.width / cell.width).round();
+            // Sample the center of EVERY painted cell in this rect (left edge,
+            // right edge, and middle are all covered as cols grows). A tap on
+            // ANY painted cell of the URL must resolve to the URL match.
+            for (var i = 0; i < cols; i++) {
+              final p = Offset(
+                rect.left + (i + 0.5) * cell.width,
+                rect.center.dy,
+              );
+              final (row, col) = _viewportCellAt(p, cell);
+              final hit = controller.matchAt(row: row, col: col);
+              expect(
+                hit?.payload,
+                _kFullUrl,
+                reason: 'tap at painted cell $i point $p -> viewport ($row,$col) '
+                    'must resolve the painted URL (paint==hit invariant #863)',
+              );
+              checkedCells++;
+            }
+          }
+        }
+        expect(checkedCells, greaterThan(0),
+            reason: 'the URL must paint at least one on-screen cell to test');
+      },
+    );
+
+    testWidgets(
+      'a viewport row NOT covered by the painted URL does not resolve the URL '
+      '(no false-positive hit off the painted region)',
+      (tester) async {
+        final controller = await _replayMounted(tester);
+        addTearDown(controller.dispose);
+
+        final anchor = _urlAnchor(controller);
+        // The viewport rows the URL paints on.
+        final urlViewRows = <int>{};
+        for (final range in anchor.ranges) {
+          for (final rect in controller.anchorRects(range)) {
+            final cell = _cellSizeFor(rect, range);
+            final (row, _) = _viewportCellAt(rect.center, cell);
+            urlViewRows.add(row);
+          }
+        }
+        expect(urlViewRows, isNotEmpty,
+            reason: 'the URL paints on at least one viewport row');
+
+        var checkedEmpty = 0;
+        final cast = loadCast(_kFixture);
+        for (var row = 0; row < cast.rows && checkedEmpty < 5; row++) {
+          if (urlViewRows.contains(row)) continue;
+          final hit = controller.matchAt(row: row, col: 0);
+          expect(hit?.payload, isNot(_kFullUrl),
+              reason: 'a non-URL viewport row must not resolve the URL (#863)');
+          checkedEmpty++;
+        }
+        expect(checkedEmpty, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'matchAt follows the PAINTED offset, not the live scrollbar offset — under '
+      'a forced live!=painted skew (the #863 frame-skew) a tap on the PAINTED '
+      'URL rect still resolves the URL',
+      (tester) async {
+        final controller = await _replayMounted(tester);
+        addTearDown(controller.dispose);
+
+        // At rest the render box has painted, so painted == live (== 0 here).
+        final painted = controller.paintedViewportOffset;
+        final anchor = _urlAnchor(controller);
+
+        // FORCE the divergence: report a STALE painted offset one row off the
+        // live one — the exact #803/#863 condition where the painted glyphs lag
+        // the live `scrollbar.offset` by a frame. Skew DOWN by one row
+        // (painted-1) so the top-row URL's painted rect shifts down a row and
+        // stays on screen (`anchorRects`: `viewRow = absRow - (painted-1)`).
+        // Both the paint geometry (`anchorRects`) and the hit-test (`matchAt`)
+        // now read this SAME (forced) painted offset, so the rect the bubble
+        // draws and the cell the tap maps to stay in lockstep — we re-derive the
+        // painted rect's viewport cell and confirm the tap still resolves.
+        final skewed = painted - 1;
+        controller.reportPaintedViewportOffset(skewed);
+        await tester.pump(); // flush the post-frame notify
+        expect(controller.paintedViewportOffset, skewed,
+            reason: 'the painted offset is now skewed from the live offset');
+
+        var checked = 0;
+        for (final range in anchor.ranges) {
+          for (final rect in controller.anchorRects(range)) {
+            final cell = _cellSizeFor(rect, range);
+            final (row, col) = _viewportCellAt(rect.center, cell);
+            final hit = controller.matchAt(row: row, col: col);
+            expect(hit?.payload, _kFullUrl,
+                reason: 'SKEW: tap at the painted rect center -> ($row,$col) '
+                    'still resolves the URL — matchAt consumes the painted '
+                    'offset, so paint and hit-test cannot drift apart (#863)');
+            checked++;
+          }
+        }
+        expect(checked, greaterThan(0),
+            reason: 'the URL still paints rects at the skewed offset');
+
+        // Drain the #812 scroll-settle timer that reportPaintedViewportOffset
+        // armed, so no timer is pending when the widget tree is torn down.
+        await tester.pump(const Duration(milliseconds: 200));
+      },
+    );
+  });
+}

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
@@ -108,9 +108,14 @@ abstract class TerminalController extends ChangeNotifier
   ///
   /// [row] and [col] are VIEWPORT-relative (row 0 is the top visible row),
   /// matching the coordinates a gesture detector produces from a pointer
-  /// position. The returned range's [HighlightRange.payload] recovers what the
-  /// cells represent (e.g. the URL behind a tap). When ranges overlap, the
-  /// last matching range in [highlights] wins.
+  /// position. The controller maps them to the absolute buffer frame via the
+  /// PAINTED viewport offset (`absRow = row + paintedViewportOffset`) — the SAME
+  /// offset [anchorRects] / the [HighlightPainter] resolve the on-screen rects
+  /// against — so the hit-test and the paint geometry stay unified and a tap
+  /// never lands a row off the drawn highlight (#863). The returned range's
+  /// [HighlightRange.payload] recovers what the cells represent (e.g. the URL
+  /// behind a tap). When ranges overlap, the last matching range in
+  /// [highlights] wins.
   HighlightRange? highlightAt({required int row, required int col});
 
   /// Registers a structured-text [pattern] for in-terminal detection (#767).
@@ -136,11 +141,18 @@ abstract class TerminalController extends ChangeNotifier
   /// ([row], [col]), or null when none covers it (#767).
   ///
   /// [row]/[col] are VIEWPORT-relative (row 0 is the top visible row); the
-  /// controller maps them to the absolute buffer frame (`absRow = row +
-  /// scrollbar.offset`) and snaps [col] to a wide-character boundary before
-  /// hit-testing. The returned [StructuredMatch.payload] recovers what the
-  /// cells represent (e.g. the URL behind a tap/long-press). When matches
-  /// overlap, the last detected one wins.
+  /// controller maps them to the absolute buffer frame via the PAINTED viewport
+  /// offset (`absRow = row + paintedViewportOffset`) — the SAME offset the URL
+  /// bubble's paint geometry uses ([anchorRects] / [AnchorGeometry.rectsFor]:
+  /// `viewRow = absRow - paintedViewportOffset`) — and snaps [col] to a
+  /// wide-character boundary before hit-testing. Using the painted offset (not
+  /// the live `scrollbar.offset`, which can lead the painted glyphs by a frame
+  /// during a tmux-redraw scroll, #803) keeps the tappable cell unified with the
+  /// drawn bubble, so a tap anywhere on a painted URL (incl. a `:port` URL or a
+  /// wrapped multi-row URL) resolves to its match instead of landing a row off
+  /// (#863). The returned [StructuredMatch.payload] recovers what the cells
+  /// represent (e.g. the URL behind a tap/long-press). When matches overlap, the
+  /// last detected one wins.
   StructuredMatch? matchAt({required int row, required int col});
 
   /// The current detected structured-text ANCHORS (#767 Slice B).

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -242,7 +242,15 @@ class TerminalControllerImpl extends TerminalController
   @override
   HighlightRange? highlightAt({required int row, required int col}) {
     if (_highlights.isEmpty) return null;
-    final absRow = row + scrollbar.offset;
+    // #863: map the VIEWPORT row to absolute via the PAINTED offset — the SAME
+    // offset the highlight PAINT geometry uses ([anchorRects]/
+    // [AnchorGeometry.rectsFor]: `viewRow = absRow - _paintedViewportOffset`).
+    // Hit-testing against the LIVE `scrollbar.offset` (which can run a frame
+    // ahead of the painted glyphs during a tmux-redraw scroll, #803) maps the
+    // tapped row to a DIFFERENT absolute row than the one drawn → the tap lands
+    // off the highlight. Resolving both against [_paintedViewportOffset] keeps
+    // paint and hit-test on ONE geometry source so they cannot diverge.
+    final absRow = row + _paintedViewportOffset;
     HighlightRange? match;
     for (final range in _highlights) {
       if (range.contains(absRow, col)) match = range;
@@ -272,7 +280,19 @@ class TerminalControllerImpl extends TerminalController
   @override
   StructuredMatch? matchAt({required int row, required int col}) {
     if (_detectionMatches.isEmpty) return null;
-    final absRow = row + scrollbar.offset;
+    // #863: UNIFY hit-test with paint. The widget-layer URL bubble PAINTS its
+    // anchor rects via [anchorRects] -> [AnchorGeometry.rectsFor], which resolves
+    // a viewport row from the PAINTED offset (`viewRow = absRow -
+    // _paintedViewportOffset`). The tap router maps the tapped pixel to a
+    // viewport `row` and calls this; if we mapped it to absolute via the LIVE
+    // `scrollbar.offset` instead (which can lead the painted glyphs by a frame
+    // during a tmux-redraw scroll, #803), the tappable cell would sit a row off
+    // the painted bubble — the #863 "tap selects instead of copying" + the
+    // off-by-1 highlight. Mapping via [_paintedViewportOffset] makes the tap
+    // consume the EXACT offset the bubble was painted with, so a tap anywhere on
+    // the painted URL (incl. a :port URL or a wrapped multi-row URL) resolves to
+    // its match. They share ONE geometry source and cannot diverge.
+    final absRow = row + _paintedViewportOffset;
     final snappedCol = terminal.snapColToWideBoundary(
       row,
       col,


### PR DESCRIPTION
## What

Fixes the #863 URL tap-miss + off-by-1 highlight on scroll by unifying the URL
PAINT geometry and the TAP HIT-TEST geometry on ONE offset source.

## Root cause (the divergence)

The highlight bubble PAINTED its anchor rects against the controller's PAINTED
viewport offset, but the tap hit-test mapped the tapped row via the LIVE
scrollbar offset:

- PAINT — `anchorRects` -> `AnchorGeometry.rectsFor`:
  `viewRow = absRow - _paintedViewportOffset`
- HIT-TEST — `matchAt` / `highlightAt`:
  `absRow = row + scrollbar.offset`

During/after a tmux-redraw scroll the live `scrollbar.offset` leads the painted
glyphs by a frame (#803), so the bubble drew at row N while the tappable cell sat
at row N±1 — the tap fell through to selection (13:33 report) and the highlight
looked a line off until paint resynced (13:37 report).

## Fix (surgical, one geometry source)

- `matchAt` + `highlightAt` now map viewport->absolute via `_paintedViewportOffset`
  — the SAME offset the painter uses. Both consume ONE offset and cannot diverge.
  (The render frame-builder's own highlight hit-test already used the painted
  `viewportOffset`; this aligns the structured-match path with it.)
- `ghostty_terminal_view._urlGlobalRects` (long-press menu rects) switched from the
  live `_viewportOffsetOf` to `controller.paintedViewportOffset` so the menu
  outline matches the painted bubble and the tappable region.
- Updated the `matchAt`/`highlightAt` interface docs to state the painted-offset
  mapping.

No bubble visual changes (that's #864); no suppression/notification changes.

## Test (the invariant)

`native/test/terminal/replay_paint_hit_unify_863_test.dart` (ffi) mounts the REAL
`TerminalView` (so the render box reports its painted offset), replays the owner's
REAL captured wrapped (multi-row, ports-in-URL) grid, and asserts the paint==hit
invariant:

1. a hit-test at EVERY painted cell of the URL resolves to THAT match (painted
   offset 0, wrapped multi-row URL);
2. a non-URL viewport row resolves to NO URL (no false hit off the painted region);
3. under a FORCED live!=painted offset skew (the exact #863 frame-skew), a tap on
   the painted rect still resolves the URL — proving `matchAt` consumes the painted
   offset.

RED verified: temporarily reverting `matchAt` to the live `scrollbar.offset` fails
test 3 exactly as the device reports describe (painted rect -> viewport (1,26),
`matchAt` returns null -> tap misses).

## Gate

`scripts/native-fast-gate.sh` green — analyze clean, 1214 unit/widget tests pass
(incl. the existing `replay_hide_on_scroll` #812, `replay_url_miss_834`,
`replay_markup_dance` #803, `replay_scroll_repaint_perf` #805 — no regressions).

Device validation (owner): tap the URL + scroll, confirm tap-to-copy lands and the
highlight tracks scroll without the off-by-1 lag.

Closes #863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)