### PR TITLE
feat(native): URL bubble visual polish — vertical centering, horizontal padding, single affordance (#864)

### DIFF
--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -42,6 +42,20 @@ const String kGhosttyOsc8PatternId = 'osc8';
 /// to [PathDecorator] (a distinct treatment from the URL bubble).
 const String kGhosttyPathPatternId = 'path';
 
+/// #864: the URL/OSC-8 pattern highlight style — DELIBERATELY EMPTY (no
+/// background fill, no underline). The bubble ([UrlBubbleDecorator]) is the
+/// SINGLE app affordance for a URL: a rounded outline chip. Device feedback
+/// (0.1.10+53) found the chip PLUS an underline read "slap"/redundant, so the
+/// app paints NO underline of its own — the chip stands alone. The fork's
+/// [HighlightPainter] only draws a fill/underline when a range's style opts in,
+/// so a null-on-both style leaves the glyphs untouched and the only URL
+/// affordance is the bubble. Named + asserted so a future change can't silently
+/// reintroduce a co-rendered underline. (A genuine SGR-4 underline emitted by
+/// the remote is the shell's own ink and is unaffected — this only governs the
+/// APP's structured-text decoration.)
+const HighlightStyle kGhosttyUrlHighlightStyle =
+    HighlightStyle(background: null, underline: null);
+
 /// Per-anchor render input handed to a [GhosttyTerminalDecorator] (#767 B).
 ///
 /// [rects] are the anchor's CURRENT viewport pixel rects (one per visible
@@ -142,11 +156,28 @@ class _UrlBubblePainter extends CustomPainter {
 
   final List<GhosttyDecoratedAnchor> anchors;
 
-  /// Outline stroke width and how much the bubble is inflated beyond the raw
-  /// cell rects, in logical px — a hair of breathing room so the outline hugs
-  /// without clipping the glyphs.
+  /// Outline stroke width, in logical px.
   static const double _stroke = 1.5;
-  static const double _inset = 1.0;
+
+  /// #864 visual polish (device feedback, 0.1.10+53):
+  ///
+  /// HORIZONTAL padding added on BOTH sides so the chip FRAMES the URL with a
+  /// little breathing room instead of clipping the first/last glyph — wider than
+  /// the old uniform 1px hug.
+  static const double _padX = 3.0;
+
+  /// VERTICAL inset: the chip is drawn TIGHTER than the raw cell rect on the
+  /// vertical axis. flterm's cell rect spans the full typographic line height
+  /// (ascender + descender slack), so a symmetric inflate left the glyph sitting
+  /// HIGH in the chip with a band of empty space above it ("too much vertical
+  /// space on the first line"). Insetting the box vertically shrinks that slack.
+  static const double _padY = 1.0;
+
+  /// DOWNWARD shift: after insetting, nudge the whole chip DOWN a few logical px
+  /// so it sits CENTERED on the glyphs rather than top-heavy (the cell's empty
+  /// band is at the TOP, so shifting down recentres the outline on the ink).
+  static const double _shiftY = 1.5;
+
   static const double _radius = 5.0;
 
   @override
@@ -158,12 +189,19 @@ class _UrlBubblePainter extends CustomPainter {
         ..strokeWidth = _stroke
         ..color = anchor.color
         ..isAntiAlias = true;
-      // One rounded outline per row segment (a wrapped URL → a chip per row),
-      // each inflated a touch and clamped non-negative so a zero-size rect can't
-      // invert. Drawing per-segment (not one merged path) keeps each wrap row's
-      // chip hugging exactly its cells.
+      // One rounded outline per row segment (a wrapped URL → a chip per row).
+      // #864: pad horizontally (frame the URL), inset vertically (drop the
+      // top-heavy slack), then shift the box DOWN so the chip is vertically
+      // CENTERED on the glyph cell. Clamped non-negative so a zero-size rect
+      // can't invert. Drawing per-segment (not one merged path) keeps each wrap
+      // row's chip hugging exactly its cells.
       for (final rect in anchor.rects) {
-        final bubble = rect.inflate(_inset);
+        final bubble = Rect.fromLTRB(
+          rect.left - _padX,
+          rect.top + _padY + _shiftY,
+          rect.right + _padX,
+          rect.bottom - _padY + _shiftY,
+        );
         if (bubble.width <= 0 || bubble.height <= 0) continue;
         canvas.drawRRect(
           RRect.fromRectAndRadius(bubble, const Radius.circular(_radius)),

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -2074,8 +2074,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // `https://…` over a hyperlink's visible text is suppressed), so a
     // hyperlinked URL yields ONE exact anchor spanning all its wrapped rows. A
     // plain-text URL (no OSC-8) still falls to the regex pattern unchanged.
-    controller.registerTextPattern(TextPattern.osc8(id: _kOsc8PatternId));
-    controller.registerTextPattern(TextPattern.url(id: _kUrlPatternId));
+    // #864: register both URL sources with the EMPTY highlight style (no fill,
+    // no underline) so the bubble decorator is the SINGLE affordance — the app
+    // never co-renders an underline that reads redundant with the chip.
+    controller.registerTextPattern(
+      TextPattern.osc8(id: _kOsc8PatternId, style: kGhosttyUrlHighlightStyle),
+    );
+    controller.registerTextPattern(
+      TextPattern.url(id: _kUrlPatternId, style: kGhosttyUrlHighlightStyle),
+    );
     // #778 paths Slice 1: also detect absolute file paths. A `path` anchor gets
     // its own decorator (folder glyph + dotted underline) and routes a tap to
     // the SFTP explorer; `://` contexts are rejected so a URL stays a URL.

--- a/native/test/ui/ghostty_terminal_decorators_test.dart
+++ b/native/test/ui/ghostty_terminal_decorators_test.dart
@@ -97,7 +97,77 @@ StructuredAnchor _urlAnchor(String url, {int row = 2, int startCol = 4}) {
   );
 }
 
+/// A recording [Canvas] that captures every `drawRRect` so a test can assert
+/// the bubble geometry the [UrlBubbleDecorator] painter produces (#864). Only
+/// the methods the painter calls are recorded; everything else is a no-op.
+class _RecordingCanvas implements Canvas {
+  final List<RRect> rrects = <RRect>[];
+
+  @override
+  void drawRRect(RRect rrect, Paint paint) => rrects.add(rrect);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
 void main() {
+  group('#864 URL bubble visual polish', () {
+    test('URL highlight style drops the underline AND the fill', () {
+      // The app paints NO underline/background of its own for a URL — the chip
+      // is the single affordance, so neither co-renders (was "slap"/redundant).
+      expect(kGhosttyUrlHighlightStyle.underline, isNull);
+      expect(kGhosttyUrlHighlightStyle.background, isNull);
+    });
+
+    testWidgets('bubble is padded horizontally and centered DOWN on the cell',
+        (tester) async {
+      // Build the painter for a single-row URL anchor and capture the RRect it
+      // draws, then compare it to the raw cell rect it was given.
+      const cell = Rect.fromLTWH(40, 40, 200, 20);
+      late Widget painter;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Builder(
+            builder: (context) => painter = const UrlBubbleDecorator().build(
+              context,
+              const [
+                GhosttyDecoratedAnchor(
+                  payload: 'https://example.com',
+                  rects: [cell],
+                  color: Color(0xFF00FF00),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      // Reach the painter via the CustomPaint the decorator builds.
+      final customPaint = (painter as IgnorePointer).child! as CustomPaint;
+      final canvas = _RecordingCanvas();
+      customPaint.painter!.paint(canvas, const Size(400, 400));
+
+      expect(canvas.rrects, hasLength(1));
+      final bubble = canvas.rrects.single.outerRect;
+
+      // HORIZONTAL: the chip is WIDER than the cell — padded on BOTH sides so it
+      // frames the URL rather than clipping the first/last glyph.
+      expect(bubble.left, lessThan(cell.left),
+          reason: 'left edge padded outward');
+      expect(bubble.right, greaterThan(cell.right),
+          reason: 'right edge padded outward');
+      expect(bubble.width, greaterThan(cell.width));
+
+      // VERTICAL: the chip is shifted DOWN — its vertical center sits BELOW the
+      // cell's center (recentred on the glyph ink, not top-heavy).
+      expect(bubble.center.dy, greaterThan(cell.center.dy),
+          reason: 'chip nudged down to centre on the glyphs');
+      // …and it is no taller than the cell (the top slack was insetted away, not
+      // inflated), so the chip hugs the glyph row.
+      expect(bubble.height, lessThanOrEqualTo(cell.height));
+    });
+  });
+
   group('GhosttyDecoratorRegistry', () {
     test('defaults registers the url bubble decorator', () {
       final registry = GhosttyDecoratorRegistry.defaults();


### PR DESCRIPTION
## What

URL highlight bubble visual polish (#864) — cosmetic, device feedback from 0.1.10+53. Sequenced after #863's paint+hit-test geometry unification; builds on the corrected rects without touching geometry/offset.

## Changes (visual only)

`_UrlBubblePainter` (`native/lib/ui/ghostty_terminal_decorators.dart`) — replaced the uniform `rect.inflate(1.0)` chip with explicit insets:
- `_padX = 3.0` — horizontal padding on BOTH sides so the chip frames the URL instead of clipping the first/last glyph.
- `_padY = 1.0` — vertical inset shrinks the top-heavy typographic slack (flterm's cell rect spans the full line height).
- `_shiftY = 1.5` — nudges the chip DOWN so it sits centered on the glyph ink, not high on line 1.
- `_radius`/`_stroke` unchanged.

Underline (the "drop redundant underline" ask):
- The `url`/`osc8` `TextPattern`s already defaulted to an empty `HighlightStyle()` (null underline) and were registered with no style, so there was never an app-painted underline.
- Made the bubble the explicit, guaranteed-sole app affordance via a named `kGhosttyUrlHighlightStyle` (background: null, underline: null); `_registerUrlPattern` now registers `url` + `osc8` with it, so a future change can't silently reintroduce a co-rendered app underline.
- A genuine remote SGR-4 underline (Claude CLI / gh underlined links) is the shell's own ink and is unaffected — this governs only the app's structured-text decoration.

## Not touched

#863 geometry/offset/hit-test/detection/notification — the painter consumes the already-corrected `anchorRects`.

## Tests

`native/test/ui/ghostty_terminal_decorators_test.dart` (#864 group):
- URL highlight style drops the underline AND the fill (asserts the const).
- Bubble is wider than the cell (both edges padded outward) and centered DOWN (chip center.dy > cell center.dy; height <= cell height), via a recording `Canvas` capturing the drawn `RRect`.

Native fast gate: green (1216 tests, analyze clean). Exact inset feel is device-validated by the owner (cosmetic).

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)