### PR TITLE
fix(#867): expand ~ in SFTP paths + friendlier file-browser errors

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -955,8 +955,15 @@ class SessionHost {
         ).toJson(),
       );
     } catch (e) {
+      // Keep the raw error (incl. the SftpStatusError code) in the diagnostic
+      // log; show the browser a clean empty-state message instead of dumping
+      // `SftpStatusError: No such file(code 2)` in the body (#867).
       ctrace('task.host', 'sftp ls FAILED path=${cmd.path} — $e');
-      _emitSftpError(cmd.sessionId, cmd.requestId, 'List failed: $e');
+      _emitSftpError(
+        cmd.sessionId,
+        cmd.requestId,
+        friendlySftpListError(e, cmd.path),
+      );
     }
   }
 

--- a/native/lib/ssh/sftp_session.dart
+++ b/native/lib/ssh/sftp_session.dart
@@ -35,6 +35,53 @@ String parentRemotePath(String path) {
   return p.substring(0, idx);
 }
 
+/// Expand a shell-style `~` / `~user` (or a relative) [path] to an absolute
+/// remote path (#867). SFTP has no shell, so it never expands `~` itself — the
+/// browser would pass a literal `~/.claude/...` to `listdir`, which the server
+/// can't resolve (`No such file`, code 2). We expand it here, in the single
+/// SFTP layer every list/stat/read routes through (so the tap-to-navigate path
+/// from #777/#778 is covered too).
+///
+/// [home] is the session's resolved home directory (the realpath of the SFTP
+/// cwd at open, via `SftpClient.absolute('.')`). Rules:
+///   - `~`             → [home]
+///   - `~/rest`        → [home] joined with `rest`
+///   - `~user[/rest]`  → left UNCHANGED. Resolving another user's home cheaply
+///                       needs `/etc/passwd`; rather than guess wrong we defer
+///                       to the server's realpath / the friendly error path.
+///   - absolute (`/…`) → unchanged.
+///   - relative (`rest`) → joined onto [home] (the cwd at SFTP open), so a bare
+///                       `foo` resolves like the shell would.
+String expandTilde(String path, String home) {
+  if (path.isEmpty) return home;
+  if (path == '~') return home;
+  if (path.startsWith('~/')) {
+    return joinRemotePath(home, path.substring(2)); // drop the leading "~/"
+  }
+  // `~user` (not `~` or `~/…`): leave to the server / error path.
+  if (path.startsWith('~')) return path;
+  if (path.startsWith('/')) return path; // already absolute
+  return joinRemotePath(home, path); // relative → resolve against home/cwd
+}
+
+/// Map a raw SFTP list error to a clean, user-facing empty-state message
+/// (#867). The raw `SftpStatusError: No such file(code 2)` is dumped into the
+/// diagnostic log by the caller; the UI shows this friendlier line instead.
+///   - code 2 (no such file)     → `Folder not found: <path>`
+///   - code 3 (permission denied)→ `Permission denied: <path>`
+///   - anything else             → `Couldn't open <path>`
+String friendlySftpListError(Object error, String path) {
+  if (error is SftpStatusError) {
+    switch (error.code) {
+      case 2:
+        return 'Folder not found: $path';
+      case 3:
+        return 'Permission denied: $path';
+    }
+  }
+  return "Couldn't open $path";
+}
+
 /// Abstraction the [SessionHost] talks to. One per live SSH session, opened
 /// lazily on the first SFTP command and reused for subsequent ones.
 abstract class SftpSession {
@@ -71,9 +118,23 @@ class DartSshSftpSession implements SftpSession {
 
   final SftpClient _client;
 
+  /// The session's home directory (realpath of the SFTP cwd at open), resolved
+  /// once via `absolute('.')` and cached. Used to expand `~` (#867).
+  String? _home;
+
+  /// Resolve + cache the session home, then expand any `~`/relative [path] to
+  /// an absolute path the server can resolve (SFTP has no shell). Called by
+  /// every op (list/stat/download) so the literal `~/…` the browser builds
+  /// (incl. the #777/#778 tap path) never reaches `listdir` unexpanded.
+  Future<String> _resolve(String path) async {
+    final home = _home ??= await _client.absolute('.');
+    return expandTilde(path, home);
+  }
+
   @override
   Future<List<SftpEntry>> list(String path) async {
-    final names = await _client.listdir(path);
+    final resolved = await _resolve(path);
+    final names = await _client.listdir(resolved);
     final entries = <SftpEntry>[];
     for (final n in names) {
       // Skip the "." / ".." pseudo-entries — the browser navigates with the
@@ -82,7 +143,9 @@ class DartSshSftpSession implements SftpSession {
       final attr = n.attr;
       entries.add(SftpEntry(
         name: n.filename,
-        path: joinRemotePath(path, n.filename),
+        // Build child paths off the RESOLVED absolute dir so navigation into a
+        // subfolder doesn't re-introduce a `~` segment.
+        path: joinRemotePath(resolved, n.filename),
         isDirectory: attr.isDirectory,
         size: attr.isDirectory ? null : attr.size,
         modifyTime: attr.modifyTime,
@@ -95,7 +158,7 @@ class DartSshSftpSession implements SftpSession {
 
   @override
   Future<int?> sizeOf(String path) async {
-    final attr = await _client.stat(path);
+    final attr = await _client.stat(await _resolve(path));
     return attr.size;
   }
 
@@ -105,7 +168,7 @@ class DartSshSftpSession implements SftpSession {
     required void Function(Uint8List chunk, int offset) onChunk,
     int chunkSize = 64 * 1024,
   }) async {
-    final file = await _client.open(path);
+    final file = await _client.open(await _resolve(path));
     try {
       var offset = 0;
       var total = 0;

--- a/native/test/services/sftp_host_test.dart
+++ b/native/test/services/sftp_host_test.dart
@@ -7,6 +7,7 @@
 
 import 'dart:typed_data';
 
+import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/services/session_host.dart';
 import 'package:mobissh/services/session_messages.dart';
@@ -34,12 +35,17 @@ class FakeSftpSession implements SftpSession {
     this.fileBytes = const [],
     this.throwOnList = false,
     this.throwOnDownload = false,
+    this.listError,
   });
 
   final List<SftpEntry> entries;
   final List<int> fileBytes;
   final bool throwOnList;
   final bool throwOnDownload;
+
+  /// When set, [list] throws this instead of the generic boom (#867: exercise
+  /// the SftpStatusError → friendly-message mapping through the host).
+  final Object? listError;
   bool closed = false;
   String? lastListedPath;
   String? lastDownloadedPath;
@@ -47,6 +53,7 @@ class FakeSftpSession implements SftpSession {
   @override
   Future<List<SftpEntry>> list(String path) async {
     lastListedPath = path;
+    if (listError != null) throw listError!;
     if (throwOnList) throw Exception('boom-list');
     return entries;
   }
@@ -183,9 +190,37 @@ void main() {
 
     expect(err, isNotNull);
     expect(err!.requestId, 'sid-err#0');
-    expect(err!.message, contains('List failed'));
+    // #867: a generic (non-SftpStatusError) list failure surfaces the clean
+    // "Couldn't open <path>" message, not a raw exception dump.
+    expect(err!.message, "Couldn't open /nope");
     // The SSH session is still hosted — an SFTP error must not drop it.
     expect(ctx.host.sessionIds, contains('sid-err'));
+
+    await sub.cancel();
+  });
+
+  test('#867 SftpStatusError(code 2) surfaces a friendly "not found"',
+      () async {
+    final fake = FakeSftpSession(
+      listError: SftpStatusError(2, 'No such file'),
+    );
+    final ctx = await setUpConnected('sid-nf', fake);
+    addTearDown(ctx.pair.dispose);
+    addTearDown(ctx.host.dispose);
+    addTearDown(ctx.proxy.dispose);
+
+    SftpErrorEvent? err;
+    final sub = ctx.proxy.sftpEvents.listen((e) {
+      if (e is SftpErrorEvent) err = e;
+    });
+
+    ctx.proxy.sftpList(requestId: 'sid-nf#0', path: '/home/ra/.claude/missing');
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(err, isNotNull);
+    // The clean empty-state message, NOT the raw "SftpStatusError: …(code 2)".
+    expect(err!.message, 'Folder not found: /home/ra/.claude/missing');
+    expect(err!.message, isNot(contains('SftpStatusError')));
 
     await sub.cancel();
   });

--- a/native/test/ssh/sftp_path_test.dart
+++ b/native/test/ssh/sftp_path_test.dart
@@ -1,0 +1,92 @@
+// #867 — SFTP tilde expansion + friendlier error mapping.
+//
+// SFTP has no shell, so it does NOT expand `~`. The browser passed a literal
+// `~/.claude/...` path to listdir → `No such file (code 2)`. `expandTilde`
+// resolves `~` / `~/…` / relative paths against the session home (the realpath
+// of the SFTP cwd at open). `friendlySftpListError` maps raw SftpStatusError
+// codes to a clean empty-state message instead of dumping the raw error.
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+
+void main() {
+  group('#867 expandTilde', () {
+    const home = '/home/ra';
+
+    test('`~/rest` expands to home + rest', () {
+      expect(expandTilde('~/.claude/x', home), '/home/ra/.claude/x');
+    });
+
+    test('the real reported path resolves', () {
+      expect(
+        expandTilde('~/.claude/projects/-home-ra/memory/', home),
+        '/home/ra/.claude/projects/-home-ra/memory/',
+      );
+    });
+
+    test('bare `~` expands to home', () {
+      expect(expandTilde('~', home), '/home/ra');
+    });
+
+    test('a non-tilde ABSOLUTE path is unchanged', () {
+      expect(expandTilde('/etc/ssh/sshd_config', home), '/etc/ssh/sshd_config');
+      expect(expandTilde('/', home), '/');
+    });
+
+    test('a RELATIVE path is joined onto home/cwd', () {
+      expect(expandTilde('notes.txt', home), '/home/ra/notes.txt');
+      expect(expandTilde('dir/sub', home), '/home/ra/dir/sub');
+    });
+
+    test('an empty path resolves to home', () {
+      expect(expandTilde('', home), home);
+    });
+
+    test('`~user/…` is left UNCHANGED (server/realpath resolves it)', () {
+      // We cannot cheaply resolve another user's home without /etc/passwd, so
+      // we leave it to the server's realpath / the friendly error path rather
+      // than guess wrong.
+      expect(expandTilde('~bob/file', home), '~bob/file');
+      expect(expandTilde('~bob', home), '~bob');
+    });
+
+    test('a home with a trailing slash does not double the separator', () {
+      expect(expandTilde('~/x', '/home/ra/'), '/home/ra/x');
+    });
+  });
+
+  group('#867 friendlySftpListError', () {
+    test('code 2 (no such file) → "Folder not found: <path>"', () {
+      final e = SftpStatusError(2, 'No such file');
+      expect(
+        friendlySftpListError(e, '/home/ra/.claude/projects'),
+        'Folder not found: /home/ra/.claude/projects',
+      );
+    });
+
+    test('code 3 (permission denied) → "Permission denied: <path>"', () {
+      final e = SftpStatusError(3, 'Permission denied');
+      expect(
+        friendlySftpListError(e, '/root/secret'),
+        'Permission denied: /root/secret',
+      );
+    });
+
+    test('any other SftpStatusError code → generic "Couldn\'t open <path>"', () {
+      final e = SftpStatusError(4, 'Failure');
+      expect(
+        friendlySftpListError(e, '/some/path'),
+        "Couldn't open /some/path",
+      );
+    });
+
+    test('a non-SftpStatusError falls back to a generic message', () {
+      final e = Exception('boom');
+      expect(
+        friendlySftpListError(e, '/some/path'),
+        "Couldn't open /some/path",
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #867.

## Problem
The file browser failed on `~` paths with **"List failed: SftpStatusError: No such file(code 2)"**. SFTP has no shell, so `SftpClient.listdir` never expands `~`. The browser passed a literal `~/.claude/projects/-home-ra/memory/` (reached by tapping a `~`-prefixed terminal path, #777/#778) straight to `listdir`.

## Fix
Home-resolution approach — cached `SftpClient.absolute('.')`:

1. **Tilde expansion at the SFTP layer** (`native/lib/ssh/sftp_session.dart`):
   - Pure helper `expandTilde(path, home)`: `~`→home, `~/rest`→home+rest, `~user…`→unchanged (defer to server realpath; no /etc/passwd guess), absolute→unchanged, relative→joined onto home/cwd.
   - `DartSshSftpSession` resolves the session home once via `SftpClient.absolute('.')` (realpath of the SFTP cwd at open = the user's home), caches it, and applies `expandTilde` in **every** op (list/stat/download) — the single chokepoint all browser paths (including the #777/#778 tap path) route through, so no UI callsite changes were needed. Child entry paths are built off the resolved dir so navigating into a subfolder never re-introduces a `~`.
2. **Friendlier error** (`friendlySftpListError` + `session_host.dart` `_handleSftpList`): code 2→`Folder not found: <path>`, code 3→`Permission denied: <path>`, else `Couldn't open <path>`. The raw `SftpStatusError` stays in the `ctrace` diagnostic log only.

## Tests (red→green)
- `native/test/ssh/sftp_path_test.dart` (new): `expandTilde` cases (`~/`, `~`, `~user`, absolute, relative, empty, trailing-slash home) + `friendlySftpListError` code mapping (2/3/other/non-status).
- `native/test/services/sftp_host_test.dart`: updated the generic-error assertion to the new `Couldn't open <path>` message; added an end-to-end `SftpStatusError(code 2)` → "Folder not found" through the host (asserts the raw `SftpStatusError` text is NOT in the UI message).

Native fast gate green (1229 tests, 0 failures).

## Note for the reviewer
`~user` is intentionally left to the server's realpath (documented + tested). Per `.claude/rules/testing.md` (#589), SFTP changes should get the **emulator integration suite + an on-device `~`-path listing check** before merge — not covered by the headless fast gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)