### PR TITLE
fix(#870): capture focus-route telemetry + harden pending-focus race

### DIFF
--- a/native/lib/services/attention_focus_router.dart
+++ b/native/lib/services/attention_focus_router.dart
@@ -21,8 +21,6 @@
 // to detect tmux, how to open a URL) is injected so this class is unit-testable
 // without Flutter.
 
-import 'dart:developer' as developer;
-
 import 'session_attention_notification.dart';
 import 'tmux_window_select.dart';
 
@@ -36,13 +34,15 @@ class AttentionFocusRouter {
     bool Function(String sessionId)? isTmux,
     Future<void> Function(String url)? openUrl,
     String? Function(String host)? resolveLiveSessionForHost,
+    void Function(String where, String msg)? log,
   }) : _bridge = bridge,
        _setActive = setActive,
        _sessionExists = sessionExists,
        _sendInput = sendInput,
        _isTmux = isTmux,
        _openUrl = openUrl,
-       _resolveLiveSessionForHost = resolveLiveSessionForHost;
+       _resolveLiveSessionForHost = resolveLiveSessionForHost,
+       _log = log;
 
   // ignore_for_file: prefer_initializing_formals
   final PendingFocusBridge _bridge;
@@ -65,6 +65,13 @@ class AttentionFocusRouter {
   /// `launchUrl(externalApplication)`. Injected so the launch is unit-testable
   /// without a real browser.
   final Future<void> Function(String url)? _openUrl;
+
+  /// Capturable telemetry seam (#870). Production binds this to `ctrace` so the
+  /// CONSUME route decision lands in the uploaded connect-log ring (the previous
+  /// `developer.log` line was NOT captured, so the +54 wrong-host report had
+  /// zero telemetry). Null in unit tests that don't assert logging. Logs
+  /// sid/host/route only — never auth material.
+  final void Function(String where, String msg)? _log;
 
   /// One-shot consume of any pending focus. Safe to call on init (cold start)
   /// AND resume (warm) — `takePending` clears the record so a later resume
@@ -98,10 +105,14 @@ class AttentionFocusRouter {
       }
     }
 
-    developer.log(
+    // #870: route the focus decision through the injected `_log` seam (bound to
+    // `ctrace` in production) so it lands in the UPLOADED connect-log ring — the
+    // previous `developer.log` line was not captured, leaving the +54 wrong-host
+    // report with zero telemetry. Logs sid/host/route only (no auth material).
+    _log?.call(
+      'ui.attention',
       'focus: payload sid=$payloadSid host=$host → '
       '${sid == null ? 'none' : 'setActive(matched sid=$sid) | $route'}',
-      name: 'attention',
     );
 
     if (sid == null) return null;

--- a/native/lib/services/attention_notifier_fln.dart
+++ b/native/lib/services/attention_notifier_fln.dart
@@ -35,8 +35,12 @@ void attentionNotificationTapBackground(NotificationResponse response) {
   // its next init/resume. Runs in a short-lived background isolate — keep it
   // tiny + tolerant.
   final payload = response.payload;
+  // #870: bind the pending-WRITE log to `ctrace` so the write ORDER is visible
+  // in a capture (this runs in a short-lived background isolate — its ctrace
+  // ring is separate from the UI's, but logcat still shows it).
   unawaited(
-    PendingFocusBridge(FftKeyValueStore()).setPendingFromPayload(payload),
+    PendingFocusBridge(FftKeyValueStore(), log: ctrace)
+        .setPendingFromPayload(payload),
   );
 }
 
@@ -63,9 +67,10 @@ class FlnAttentionNotifier implements AttentionNotifier {
       initSettings,
       onDidReceiveNotificationResponse: (response) {
         // Foreground tap (app alive): record pending focus; the UI consumes it
-        // on the next resume. The background variant covers a dead app.
+        // on the next resume. The background variant covers a dead app. #870:
+        // bind the pending-WRITE log to `ctrace` so the write order is captured.
         unawaited(
-          PendingFocusBridge(FftKeyValueStore())
+          PendingFocusBridge(FftKeyValueStore(), log: ctrace)
               .setPendingFromPayload(response.payload),
         );
       },

--- a/native/lib/services/session_attention_notification.dart
+++ b/native/lib/services/session_attention_notification.dart
@@ -414,6 +414,46 @@ class MapKeyValueStore implements KeyValueStore {
   }
 }
 
+/// Internal JSON key used to stamp a pending-focus write with a monotonic
+/// sequence number (#870). It is an UNDERSCORE-prefixed, payload-internal field
+/// — `AttentionNotification.parsePayload` already ignores unknown keys, so a
+/// stamped payload round-trips through every existing reader unchanged (the
+/// stamp is never surfaced to the router and never reaches a notification). The
+/// stamp lets `takePending` resolve the write↔read race (#870): a fresh tap's
+/// write carries a HIGHER seq than a stale, never-consumed prior entry, so the
+/// consume can prefer the freshest write.
+const String _kPendingSeqKey = '_seq';
+
+/// Process-wide monotonic sequence source for pending-focus writes (#870).
+/// Each [PendingFocusBridge.setPendingFromPayload] stamps the next value. It is
+/// seeded from the wall clock (so writes from DIFFERENT isolates — the FGS task
+/// isolate's foreground tap vs. the background-tap isolate — order roughly by
+/// real time) but strictly increasing within an isolate (ties broken by an
+/// incrementing counter), so two writes in the same millisecond still order.
+int _lastPendingSeq = 0;
+int _nextPendingSeq() {
+  final now = DateTime.now().millisecondsSinceEpoch;
+  final next = now > _lastPendingSeq ? now : _lastPendingSeq + 1;
+  _lastPendingSeq = next;
+  return next;
+}
+
+/// Extract the `_seq` stamp from a stored pending payload, or null when absent
+/// (an unstamped legacy write, or a non-JSON payload). Defensive: never throws.
+int? _seqOf(String? raw) {
+  if (raw == null || raw.isEmpty) return null;
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is Map) {
+      final s = decoded[_kPendingSeqKey];
+      if (s is int) return s;
+    }
+  } catch (_) {
+    // Not JSON / malformed — treat as unstamped.
+  }
+  return null;
+}
+
 /// Cross-isolate "session to focus on next resume/init" hand-off (#840 Slice 2).
 ///
 /// The notification tap is handled outside the UI's Riverpod containers. It
@@ -421,20 +461,69 @@ class MapKeyValueStore implements KeyValueStore {
 /// UI isolate reads + clears it on init (cold) and resume (warm) and calls
 /// `sessionsProvider.notifier.setActive(sessionId)` (then optionally selects the
 /// source window).
+///
+/// #870 race hardening: a foreground tap WRITES the pending entry asynchronously
+/// (cross-isolate, to disk) while the SAME tap also foregrounds the app →
+/// `resumed` → `takePending` READS. If the read beats the write it consumes a
+/// STALE, never-consumed prior entry (e.g. an earlier nv-dev tap) and routes to
+/// the wrong host. `takePending` mitigates this by stamping each write with a
+/// monotonic seq and, on consume, yielding once to let an in-flight fresher
+/// write land — preferring the higher-seq entry so the JUST-TAPPED write wins.
 class PendingFocusBridge {
-  PendingFocusBridge(this._store);
+  PendingFocusBridge(
+    this._store, {
+    this.log,
+    this.raceGrace = const Duration(milliseconds: 16),
+  });
 
   final KeyValueStore _store;
+
+  /// Telemetry seam (#870). Production binds this to `ctrace` so the pending
+  /// WRITE lands in the uploaded connect-log ring; null in unit tests that don't
+  /// assert logging. Logs sid/host only — never auth material.
+  final void Function(String where, String msg)? log;
+
+  /// How long [takePending] yields to let an in-flight cross-isolate write land
+  /// before committing to a consume (#870). Injectable so a unit test can drive
+  /// the race deterministically (a write scheduled inside the grace must win).
+  final Duration raceGrace;
 
   /// Storage key. Namespaced to avoid clashing with other app data.
   static const String _key = 'mobissh.attention.pendingFocus';
 
   /// Record a pending focus from a notification [payload]. Latest write wins.
-  /// A payload that parses to no sessionId is a no-op (nothing to focus).
+  /// A payload that parses to no sessionId is a no-op (nothing to focus). The
+  /// stored value is stamped with a monotonic `_seq` (#870) so a later consume
+  /// can resolve the write↔read race in favour of the freshest write.
   Future<void> setPendingFromPayload(String? payload) async {
     final parsed = AttentionNotification.parsePayload(payload);
-    if (parsed.sessionId == null) return;
-    await _store.setString(_key, payload!);
+    final sid = parsed.sessionId;
+    if (sid == null) return;
+    final stamped = _stampSeq(payload!);
+    await _store.setString(_key, stamped);
+    // #870: log the WRITE so the write/read ORDER is visible in a capture (the
+    // next device report can show whether the consume raced ahead of this).
+    log?.call(
+      'ui.attention',
+      'pending set sid=$sid host=${hostOfSessionId(sid)}',
+    );
+  }
+
+  /// Re-encode [payload] with a fresh monotonic `_seq` stamp (#870). Falls back
+  /// to the raw payload if it isn't a JSON object (a bare-id legacy payload — it
+  /// still round-trips through `parsePayload`, just without a stamp).
+  String _stampSeq(String payload) {
+    try {
+      final decoded = jsonDecode(payload);
+      if (decoded is Map) {
+        final m = Map<String, dynamic>.from(decoded);
+        m[_kPendingSeqKey] = _nextPendingSeq();
+        return jsonEncode(m);
+      }
+    } catch (_) {
+      // Non-JSON payload — store verbatim (unstamped).
+    }
+    return payload;
   }
 
   /// Non-destructive read of the pending focus, or `(null, null, null)` when
@@ -447,10 +536,38 @@ class PendingFocusBridge {
 
   /// One-shot consume: returns the pending `(sessionId, sourceWindow?, url?)`
   /// AND clears it so a later resume doesn't re-focus the same session.
+  ///
+  /// #870: resolves the write↔read race. After the initial read it yields once
+  /// (the [_raceGrace] window) and re-reads; if a FRESHER write landed in the
+  /// meantime (a higher `_seq`, e.g. the just-tapped notification's pending
+  /// arriving from another isolate) that fresher entry is consumed instead of
+  /// the stale one. The entry is removed on consume so a never-re-consumed stale
+  /// tap can't be served later.
   Future<({String? sessionId, int? sourceWindow, String? url})>
       takePending() async {
-    final raw = await _store.getString(_key);
-    if (raw != null) await _store.remove(_key);
-    return AttentionNotification.parsePayload(raw);
+    final first = await _store.getString(_key);
+    // Yield once so an in-flight cross-isolate write (the just-tapped pending)
+    // can land before we commit to consuming. A single short yield is enough to
+    // let the FFT disk write flush + the store reflect it; it does NOT block the
+    // resume path meaningfully (sub-frame). We yield even when the first read
+    // was empty: the racing write may not have landed yet at all.
+    await Future<void>.delayed(raceGrace);
+    final second = await _store.getString(_key);
+
+    // Pick the FRESHER of the two reads by seq. If the second read produced a
+    // higher-seq entry (a newer write raced in), prefer it; otherwise keep the
+    // first. Unstamped (legacy) entries sort below any stamped one.
+    final firstSeq = _seqOf(first) ?? -1;
+    final secondSeq = _seqOf(second) ?? -1;
+    final chosen = (second != null && secondSeq > firstSeq) ? second : first;
+
+    if (chosen == null) {
+      return AttentionNotification.parsePayload(null);
+    }
+
+    // Clear the entry so a later resume doesn't re-focus the same session and a
+    // never-consumed stale tap can't be served later (#870).
+    await _store.remove(_key);
+    return AttentionNotification.parsePayload(chosen);
   }
 }

--- a/native/lib/state/attention_providers.dart
+++ b/native/lib/state/attention_providers.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../diagnostics/connect_trace.dart';
 import '../services/attention_focus_router.dart';
 import '../services/attention_notifier_fln.dart';
 import '../services/session_attention_notification.dart';
@@ -22,9 +23,17 @@ import 'sessions.dart';
 /// tmux flag from the DA2 handshake is a future refinement; the navigation is
 /// device-gated + best-effort and skips silently on a miss either way.)
 final attentionFocusRouterProvider = Provider<AttentionFocusRouter>((ref) {
-  final bridge = PendingFocusBridge(const FftKeyValueStore());
+  // #870: bind the bridge's pending-WRITE log to `ctrace` so the write lands in
+  // the uploaded connect-log (the UI-isolate consume side). The cold/warm
+  // consume happens here in the UI isolate; foreground/background tap WRITES
+  // happen in the task / background isolate (see attention_notifier_fln.dart),
+  // which bind their own ctrace.
+  final bridge = PendingFocusBridge(const FftKeyValueStore(), log: ctrace);
   return AttentionFocusRouter(
     bridge: bridge,
+    // #870: route the CONSUME focus decision through `ctrace` so the resolved
+    // route (setActive / host-fallback / none) is captured in the connect-log.
+    log: ctrace,
     setActive: (id) => ref.read(sessionsProvider.notifier).setActive(id),
     sessionExists: (id) =>
         ref.read(sessionsProvider).entries.any((e) => e.id == id),

--- a/native/test/services/attention_focus_router_test.dart
+++ b/native/test/services/attention_focus_router_test.dart
@@ -332,6 +332,185 @@ void main() {
     });
   });
 
+  // #870: the +54 wrong-host report (tap fd-dev → land on nv-dev) had ZERO
+  // telemetry because the route log went through `developer.log` (not captured
+  // in the uploaded connect-log) and the pending write↔consume race could serve
+  // a STALE prior entry. These tests pin (1) the capturable telemetry seams and
+  // (2) the seq-stamped race resolution.
+  group('AttentionFocusRouter capturable telemetry (#870)', () {
+    test('CONSUME route is logged via the injected log seam (→ ctrace)',
+        () async {
+      const sid = 'fddev:22:me:100';
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': sid}));
+      final logs = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+        log: (where, msg) => logs.add('[$where] $msg'),
+      );
+      await router.consumePending();
+      // The route line must be captured (sid + host + resolved route), so the
+      // NEXT device report shows exactly what was consumed.
+      expect(
+        logs,
+        contains(
+          '[ui.attention] focus: payload sid=$sid host=fddev → '
+          'setActive(matched sid=$sid) | setActive',
+        ),
+      );
+    });
+
+    test('CONSUME route logs the host-fallback decision (#857 path)', () async {
+      const staleB = 'fddev:22:me:100';
+      const liveB = 'fddev:22:me:999';
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': staleB}));
+      final logs = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (id) => id == liveB,
+        sendInput: (a, b) {},
+        resolveLiveSessionForHost: (host) => host == 'fddev' ? liveB : null,
+        log: (where, msg) => logs.add('[$where] $msg'),
+      );
+      await router.consumePending();
+      expect(
+        logs,
+        contains(
+          '[ui.attention] focus: payload sid=$staleB host=fddev → '
+          'setActive(matched sid=$liveB) | host-fallback',
+        ),
+      );
+    });
+
+    test('pending WRITE is logged via the bridge log seam (→ ctrace)', () async {
+      const sid = 'fddev:22:me:100';
+      final writes = <String>[];
+      final bridge = PendingFocusBridge(
+        MapKeyValueStore(),
+        log: (where, msg) => writes.add('[$where] $msg'),
+      );
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': sid}));
+      // The write line must be captured so the write/read ORDER is visible.
+      expect(writes, contains('[ui.attention] pending set sid=$sid host=fddev'));
+    });
+
+    test('write log carries sid/host ONLY — never auth material', () async {
+      // A payload only ever carries sessionId/sourceWindow/url; assert the log
+      // line is exactly the sid+host form (no password/passphrase/key leakage).
+      const sid = 'fddev:22:me:100';
+      final writes = <String>[];
+      final bridge = PendingFocusBridge(
+        MapKeyValueStore(),
+        log: (where, msg) => writes.add(msg),
+      );
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': sid}));
+      expect(writes.single, 'pending set sid=$sid host=fddev');
+    });
+  });
+
+  // #870 race: a foreground tap WRITES pending asynchronously (cross-isolate)
+  // while the same tap foregrounds the app → resume → consume READS. A read that
+  // beats the write must NOT consume a stale prior entry. The seq-stamp + the
+  // grace re-read make the freshest write win.
+  group('PendingFocusBridge stale↔fresh race (#870)', () {
+    test('a FRESH write landing during the consume grace WINS over a stale entry',
+        () async {
+      const staleA = 'nvdev:22:me:100'; // an earlier, never-consumed nv-dev tap
+      const freshB = 'fddev:22:me:200'; // the just-tapped fd-dev notification
+      final store = MapKeyValueStore();
+      // A generous grace so the fresh write deterministically lands inside it.
+      final bridge = PendingFocusBridge(
+        store,
+        raceGrace: const Duration(milliseconds: 50),
+      );
+
+      // The stale entry is already sitting in the store (un-consumed).
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': staleA}));
+
+      // Start the consume (first read gets stale A, then it enters the grace).
+      final consume = bridge.takePending();
+      // The just-tapped fd-dev write lands DURING the grace window — a HIGHER
+      // seq than the stale entry, so the re-read prefers it.
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': freshB}));
+
+      final got = await consume;
+      expect(got.sessionId, freshB,
+          reason: 'the just-tapped fd-dev write must win the race, not nv-dev');
+    });
+
+    test('consume CLEARS the entry (a second consume finds nothing)', () async {
+      const sid = 'fddev:22:me:100';
+      final store = MapKeyValueStore();
+      final bridge = PendingFocusBridge(store);
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': sid}));
+      final first = await bridge.takePending();
+      expect(first.sessionId, sid);
+      final second = await bridge.takePending();
+      expect(second.sessionId, isNull,
+          reason: 'a never-re-consumed stale tap must not be served later');
+    });
+
+    test('end-to-end via the router: stale nv-dev pending, fresh fd-dev tap → '
+        'router routes to fd-dev (not nv-dev)', () async {
+      const staleNv = 'nvdev:22:me:100';
+      const freshFd = 'fddev:22:me:200';
+      final store = MapKeyValueStore();
+      final bridge = PendingFocusBridge(
+        store,
+        raceGrace: const Duration(milliseconds: 50),
+      );
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': staleNv}));
+
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+      );
+
+      final consume = router.consumePending();
+      // The fd-dev tap's pending write lands during the consume grace.
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': freshFd}));
+      final focused = await consume;
+
+      expect(focused, freshFd);
+      expect(activated, [freshFd],
+          reason: 'tap fd-dev must land on fd-dev, never the stale nv-dev entry');
+    });
+
+    test('cold start (process-dead): the single pending is consumed from the '
+        'bridge (no racing write)', () async {
+      // Cold start has exactly ONE pending (written by the dead-app background
+      // tap before launch); no second write races in. It must still consume it.
+      const sid = 'fddev:22:me:100';
+      final store = MapKeyValueStore();
+      final bridge = PendingFocusBridge(store);
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': sid}));
+      final got = await bridge.takePending();
+      expect(got.sessionId, sid);
+    });
+
+    test('seq stamp is internal — parsePayload still surfaces only id/win/url',
+        () async {
+      const sid = 'fddev:22:me:100';
+      final store = MapKeyValueStore();
+      final bridge = PendingFocusBridge(store);
+      await bridge.setPendingFromPayload(
+        jsonEncode({'sessionId': sid, 'sourceWindow': 4, 'url': 'https://x.io/a'}),
+      );
+      final read = await bridge.readPending();
+      expect(read.sessionId, sid);
+      expect(read.sourceWindow, 4);
+      expect(read.url, 'https://x.io/a');
+    });
+  });
+
   group('tmuxSelectWindowSequence', () {
     test('builds prefix + :select-window -t N + Enter', () {
       final seq = tmuxSelectWindowSequence(7);


### PR DESCRIPTION
## Issue #870 — notification tap routes to wrong host (fd-dev → nv-dev) on +54

Fixes the +54 wrong-host tap (tap fd-dev → land on nv-dev, a DIFFERENT host
despite #857's host-fallback). The route logic is correct — the bug is upstream
in the pending-focus write↔consume lifecycle, and the report had ZERO telemetry
because the route log went through `developer.log` (not in the uploaded connect-log).

### Instrument first
- **`AttentionFocusRouter`** gained a `log` seam. The CONSUME route line
  (`focus: payload sid=… host=… → setActive(matched sid=…) | <route>`) now routes
  through it. Production binds it to `ctrace('ui.attention', …)` so the NEXT device
  report shows exactly what was consumed.
- **`PendingFocusBridge.setPendingFromPayload`** logs `pending set sid=… host=…` on
  every WRITE, so the write/read ORDER is visible in a capture. Bound to `ctrace` in
  the UI provider, the foreground-tap handler, and the background-tap isolate handler.
- Logs sid/host/route **only** — never auth material (asserted by a unit test).

### Harden the race — seq-stamp
- Each pending WRITE is stamped with a process-monotonic `_seq` (internal JSON key;
  `parsePayload` ignores unknown keys → fully backward-compatible).
- `takePending` reads, yields one `raceGrace` (default 16ms, injectable), re-reads,
  and consumes the **higher-seq** entry. A just-tapped write landing during the grace
  WINS over a stale, never-consumed prior entry. The entry is cleared on consume so a
  stale tap can't be served later.

### Mitigation choice: seq-stamp (not direct-foreground)
The FLN notifier is constructed + `initialize()`d in the **foreground-task isolate**,
so the foreground tap callback lands there, not in the UI isolate — a direct in-memory
hand-off would need new cross-isolate plumbing (invasive). The seq-stamp fixes the race
surgically within the existing FFT bridge for foreground, background, AND cold-start.

### Preserved
#857 host-fallback + #710 url-open behavior unchanged — existing tests pass.

### Tests
9 new unit tests in `attention_focus_router_test.dart`: route/write logging (incl. the
host-fallback variant + no-auth assertion), the stale↔fresh race (bridge + end-to-end
router routes to fd-dev not nv-dev), clear-on-consume, cold-start single-pending, and
the internal-seq round-trip. **Fast gate green (1225 tests, analyze clean).**

Refs #857, #710, #840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)