### PR TITLE
fix(#873): evict stale URL/path highlight anchors synchronously on redraw

### DIFF
--- a/native/test/terminal/redraw_anchor_eviction_873_test.dart
+++ b/native/test/terminal/redraw_anchor_eviction_873_test.dart
@@ -1,0 +1,199 @@
+@Tags(['ffi'])
+library;
+
+// INVARIANT (#873): a detection anchor (URL/path highlight) must be RE-VALIDATED
+// against the CURRENT grid cells when the grid is redrawn — IMMEDIATELY, not only
+// after the debounced full re-scan. A device report (0.1.10+55, "orphaned file
+// markups look like folder") described STRAY leftover highlight boxes stuck on
+// screen where a path/URL USED to be: the line was redrawn (tmux/app rewrote the
+// row with DIFFERENT text) or scrolled out of the bounded scrollback window, yet
+// the old anchor still painted over text that no longer contained the match.
+//
+// ROOT: discovery of new matches is DEBOUNCED (~120ms) and a streaming TUI keeps
+// cancelling/pushing the timer, so the stale match lingered in
+// `anchors`/`matchAt` (and thus the painted decorator) for the whole debounce
+// window — often far longer under continuous output. The fix re-validates live
+// anchors against the current cells SYNCHRONOUSLY on each redraw and drops any
+// whose cell-run no longer carries the match, so eviction never waits on the
+// debounce. (The full bounded-window re-scan still runs, debounced, to DISCOVER
+// new matches.)
+//
+// This facet is headless-reproducible (unlike the #868 during-scroll paint-lag
+// that needs a recording): the KEY assertion reads `anchors` BEFORE the debounce
+// fires (no settle) — against pre-fix code the stale anchor is still present.
+//
+// The test drives a REAL flterm TerminalController (real libghostty VT parser,
+// ffi-tagged): detect a URL/path, then redraw the row in place with non-matching
+// text (or scroll it past the bounded window), and assert the anchor is GONE.
+
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Detection re-scan is debounced (~120ms); settle past it before reading.
+  Future<void> settle() =>
+      Future<void>.delayed(const Duration(milliseconds: 250));
+
+  // A short tick that pumps async microtasks/timers but stays WELL UNDER the
+  // ~120ms detection debounce — so a stale anchor only survives if the
+  // SYNCHRONOUS re-validation (#873) failed to drop it.
+  Future<void> tick() =>
+      Future<void>.delayed(const Duration(milliseconds: 10));
+
+  Uint8List bytes(String s) => Uint8List.fromList(s.codeUnits);
+
+  // Move the cursor to viewport row [row] (1-based) col 1, erase the line, write
+  // [text]. This is how tmux/an app REDRAWS a line in place: absolute cursor
+  // position + erase-in-line + new content — no scroll, the content just changes.
+  Uint8List redrawRow(int row, String text) =>
+      bytes('\x1b[$row;1H\x1b[2K$text');
+
+  const url = 'https://example.com/some/path/page';
+
+  TerminalController newController({int rows = 24, int cols = 80}) {
+    final controller = TerminalController(
+      config: TerminalConfig(cols: cols, rows: rows),
+    );
+    controller.registerTextPattern(TextPattern.osc8());
+    controller.registerTextPattern(TextPattern.url());
+    controller.registerTextPattern(TextPattern.path());
+    return controller;
+  }
+
+  group('#873 — anchors re-validated against current cells on redraw', () {
+    test(
+      'a URL row REDRAWN in place is evicted IMMEDIATELY — BEFORE the debounced '
+      'rescan fires (the orphaned-box window: this is the #873 RED assertion)',
+      () async {
+        final controller = newController();
+        addTearDown(controller.dispose);
+
+        controller.write(bytes('line one\r\nline two\r\n'));
+        controller.write(bytes('$url\r\n'));
+        await settle();
+        expect(controller.anchors.where((a) => a.payload == url), hasLength(1),
+            reason: 'precondition: the URL is detected before the redraw');
+
+        // Redraw the URL's row in place with non-matching prose, then check
+        // WITHOUT settling — the debounce has NOT fired. Pre-fix, the stale
+        // anchor still paints the orphaned box for the whole debounce window.
+        controller.write(redrawRow(3, 'just some prose with no link here'));
+        await tick();
+
+        expect(controller.anchors.where((a) => a.payload == url), isEmpty,
+            reason: 'the redrawn row no longer holds the URL, so its anchor must '
+                'be evicted synchronously — a lingering anchor is the orphaned '
+                'box (#873)');
+
+        // matchAt at the redrawn viewport row must also resolve nothing for it.
+        final viewRow = 3 - 1 - controller.scrollbar.offset;
+        if (viewRow >= 0 && viewRow < 24) {
+          final hit = controller.matchAt(row: viewRow, col: 0);
+          expect(hit?.payload, isNot(url),
+              reason: 'matchAt at the redrawn row must not resolve the gone URL');
+        }
+      },
+    );
+
+    test(
+      'a PATH row REDRAWN in place is evicted immediately (pre-debounce)',
+      () async {
+        final controller = newController();
+        addTearDown(controller.dispose);
+
+        const path = '/etc/ssh/sshd_config';
+        controller.write(bytes('header\r\n'));
+        controller.write(bytes('$path\r\n'));
+        await settle();
+        expect(controller.anchors.where((a) => a.payload == path), hasLength(1),
+            reason: 'precondition: the path is detected');
+
+        controller.write(redrawRow(2, 'plain words only no path'));
+        await tick();
+
+        expect(controller.anchors.where((a) => a.payload == path), isEmpty,
+            reason: 'the redrawn row no longer holds the path; anchor evicted');
+      },
+    );
+
+    test(
+      'redrawing one match leaves a DIFFERENT, untouched match detected — '
+      'eviction is TARGETED, not a blanket clear',
+      () async {
+        final controller = newController();
+        addTearDown(controller.dispose);
+
+        const otherUrl = 'https://keep.me/around';
+        controller.write(bytes('$url\r\n'));
+        controller.write(bytes('$otherUrl\r\n'));
+        await settle();
+        expect(controller.anchors.where((a) => a.payload == url), hasLength(1));
+        expect(controller.anchors.where((a) => a.payload == otherUrl),
+            hasLength(1));
+
+        // Redraw only the FIRST URL's row (viewport row 1).
+        controller.write(redrawRow(1, 'no link now'));
+        await tick();
+
+        expect(controller.anchors.where((a) => a.payload == url), isEmpty,
+            reason: 'the redrawn URL is evicted');
+        expect(controller.anchors.where((a) => a.payload == otherUrl),
+            hasLength(1),
+            reason: 'the untouched URL stays detected — eviction is targeted');
+      },
+    );
+
+    test(
+      'a still-matching redraw KEEPS the anchor (no false eviction when the '
+      'redrawn content still carries the URL)',
+      () async {
+        final controller = newController();
+        addTearDown(controller.dispose);
+
+        controller.write(bytes('$url\r\n'));
+        await settle();
+        expect(controller.anchors.where((a) => a.payload == url), hasLength(1));
+
+        // Redraw the same row with the SAME URL (a benign repaint). The anchor
+        // must survive — the prune validates content, it does not blanket-clear
+        // on every notify.
+        controller.write(redrawRow(1, url));
+        await tick();
+
+        expect(controller.anchors.where((a) => a.payload == url), hasLength(1),
+            reason: 'a repaint that still carries the URL keeps its anchor');
+      },
+    );
+
+    test(
+      'a URL pushed PAST the bounded scrollback window is evicted (no anchor '
+      'lingers for content the scan can no longer see)',
+      () async {
+        // Small grid; push the URL well past the 200-row bounded window while the
+        // viewport stays at the live tail (no scroll-up).
+        final controller = newController(rows: 6, cols: 40);
+        addTearDown(controller.dispose);
+
+        controller.write(bytes('$url\r\n'));
+        await settle();
+        expect(controller.anchors.where((a) => a.payload == url), hasLength(1),
+            reason: 'precondition: detected at the live tail');
+
+        final filler = StringBuffer();
+        for (var i = 0; i < 400; i++) {
+          filler.write('filler line $i\r\n');
+        }
+        controller.write(bytes(filler.toString()));
+        await settle();
+
+        expect(controller.anchors.where((a) => a.payload == url), isEmpty,
+            reason: 'the URL scrolled past the bounded scan window; its anchor '
+                'must be evicted, not linger from a prior scan');
+      },
+    );
+  });
+}

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -437,6 +437,115 @@ class TerminalControllerImpl extends TerminalController
     );
   }
 
+  /// #873: SYNCHRONOUSLY re-validate the live detection anchors against the
+  /// CURRENT cells and DROP any whose anchored cell-run no longer carries the
+  /// matched text. Runs on every redraw notify ([_onTerminalChanged]), BEFORE the
+  /// debounced full [_rescanDetections] would fire.
+  ///
+  /// The full re-scan is DEBOUNCED (~120ms) and a streaming TUI keeps cancelling/
+  /// pushing the timer out, so a line REDRAWN in place (tmux/app rewrites the row
+  /// with different content) or SCROLLED past the bounded window left the old
+  /// [StructuredMatch] in [_detectionMatches] — and thus in [anchors]/[matchAt] —
+  /// for the whole debounce window (often far longer under streaming output). The
+  /// widget-layer decorator paints those stale anchors over text that no longer
+  /// contains the match: the "orphaned highlight box" device report (#873).
+  ///
+  /// EVICTION must not wait on the debounce. This prune is the immediate
+  /// counterpart to the rescan: discovery of NEW matches stays debounced (the
+  /// expensive bounded-window scan), but a match whose cells CHANGED is dropped
+  /// the moment the redraw is observed. It re-reads ONLY the rows each existing
+  /// match occupies (cheap) and, using the SAME scanner/patterns, keeps the match
+  /// only if an equivalent same-payload match still covers those cells — so wrap-
+  /// join, normalize (`www.`→`https://`), and OSC-8 grouping all re-validate
+  /// identically to a full scan. A match whose rows fell out of the live buffer
+  /// (evicted / scrolled past) reads zero cells → no re-match → dropped.
+  ///
+  /// Defensive like [_rescanDetections]: any FFI/scan hiccup must never crash the
+  /// session, so a failure leaves the existing matches untouched (the debounced
+  /// full rescan will still correct them) rather than throwing.
+  void _pruneStaleDetections() {
+    if (_detectionMatches.isEmpty) return;
+    // No patterns left (cleared) — nothing legitimately detectable; drop all.
+    if (_textPatterns.isEmpty) {
+      _detectionMatches = const [];
+      highlights = const [];
+      _decorationNotifier.notify();
+      return;
+    }
+    // Mirror [_rescanDetections]'s alt-screen suppression so a prune uses the
+    // SAME pattern set the (debounced) full scan would, and a regex match left
+    // over from the primary screen is re-validated against the OSC-8-only set on
+    // the alt screen (and thus dropped) rather than wrongly kept.
+    final suppressHeuristics =
+        _activeScreen == .alternate && _mouseTracking == .none;
+    final scanPatterns = suppressHeuristics
+        ? [for (final p in _textPatterns.values) if (p.isOsc8Source) p]
+        : _textPatterns.values.toList(growable: false);
+
+    List<StructuredMatch> survivors;
+    try {
+      _renderState.update(terminal);
+      final cols = _renderState.cols;
+      final visibleRows = _renderState.rows;
+      if (cols <= 0 || visibleRows <= 0) {
+        survivors = const [];
+      } else {
+        final scrollback = terminal.scrollbackRows;
+        final maxEndAbs = scrollback + visibleRows; // exclusive buffer bound
+        survivors = <StructuredMatch>[
+          for (final m in _detectionMatches)
+            if (_matchStillPresent(m, scanPatterns, cols, maxEndAbs)) m,
+        ];
+      }
+    } catch (_) {
+      // A read hiccup must not crash or spuriously clear anchors; leave the set
+      // as-is and let the debounced full rescan reconcile.
+      return;
+    }
+
+    if (survivors.length == _detectionMatches.length) return; // nothing dropped
+    _detectionMatches = survivors;
+    highlights = [for (final m in survivors) ...m.ranges];
+    // The anchor set shrank → wake the narrow decoration listener so the
+    // decorator re-resolves and the orphaned box vanishes immediately.
+    _decorationNotifier.notify();
+  }
+
+  /// #873: true iff [match] is STILL present in the current cells — i.e. a fresh
+  /// scan over exactly the rows it occupies (clamped to the live buffer) yields a
+  /// same-payload match. Re-uses the production scanner + patterns so re-
+  /// validation matches detection exactly.
+  bool _matchStillPresent(
+    StructuredMatch match,
+    List<TextPattern> scanPatterns,
+    int cols,
+    int maxEndAbs,
+  ) {
+    if (scanPatterns.isEmpty) return false;
+    var top = match.ranges.first.topRow;
+    var bottom = match.ranges.first.bottomRow;
+    for (final r in match.ranges) {
+      if (r.topRow < top) top = r.topRow;
+      if (r.bottomRow > bottom) bottom = r.bottomRow;
+    }
+    // Clamp to the live buffer; a match whose rows fell out of the buffer
+    // (evicted / scrolled past) yields an empty region → no re-match → drop.
+    final startAbs = top < 0 ? 0 : top;
+    final endAbs = (bottom + 1) > maxEndAbs ? maxEndAbs : bottom + 1; // exclusive
+    if (endAbs - startAbs <= 0) return false;
+    final reader = _ScreenCellReader(
+      terminal: terminal,
+      cols: cols,
+      startAbsRow: startAbs,
+      endAbsRow: endAbs,
+    );
+    final fresh = _detectionScanner.scan(reader, scanPatterns);
+    for (final f in fresh) {
+      if (f.payload == match.payload) return true;
+    }
+    return false;
+  }
+
   /// #767: re-scan the active screen plus a bounded scrollback window for every
   /// registered pattern, store the matches, and ASSIGN the resulting absolute-
   /// coordinate ranges to [highlights] (the existing painter draws them). A
@@ -608,6 +717,10 @@ class TerminalControllerImpl extends TerminalController
   /// scanned range, is never detected. Schedule the same debounced rescan the
   /// output path uses so a scroll burst coalesces into one scan.
   void _onScrollChanged() {
+    // #873: a scroll can move a match out of the bounded scan window; re-validate
+    // live anchors against the current cells immediately (the debounced rescan
+    // below handles DISCOVERY of newly-visible matches).
+    _pruneStaleDetections();
     _scheduleDetectionRescan();
     notifyListeners();
   }
@@ -1287,6 +1400,14 @@ class TerminalControllerImpl extends TerminalController
     }
 
     _scrollToBottomOnOutput();
+    // #873: a redraw may have rewritten the cells UNDER a live anchor (tmux/app
+    // repaints a row, or content scrolled past the bounded window). DISCOVERY of
+    // new matches stays debounced below, but EVICTION of a now-stale anchor must
+    // be immediate — synchronously re-validate the live anchors against the
+    // current cells and drop any whose run no longer carries the matched text, so
+    // no orphaned highlight box lingers through the debounce window. No-op when no
+    // anchors are live or no pattern is registered.
+    _pruneStaleDetections();
     // #767: a notify means the cells may have changed (output streamed) or the
     // viewport scrolled; re-scan registered structured-text patterns on a
     // debounce so the highlights track new content. No-op when none registered.


### PR DESCRIPTION
## #873 — stray/orphaned URL+path highlight boxes after redraw

Fixes #873.

### Root
Structured-text detection anchors (#767 URL, #777 path) were re-validated against
the current cells ONLY by the DEBOUNCED full re-scan (`_rescanDetections`,
~120ms). A streaming TUI keeps cancelling/pushing that timer, so a row REDRAWN in
place (tmux/app rewrites it with different content) or scrolled past the bounded
window left the old `StructuredMatch` in `_detectionMatches` — and thus in
`anchors`/`matchAt` and the painted decorator — for the whole debounce window
(often longer under continuous output). The widget-layer decorator painted that
stale anchor over text that no longer held the match: the orphaned box (device
0.1.10+55).

The issue framed it as "re-scan should REPLACE the anchor set." The full rescan
ALREADY replaced — the real gap was TIMING: replacement was debounced, so
eviction lagged behind the redraw.

### Fix — decouple eviction from discovery
Add `_pruneStaleDetections()`: a SYNCHRONOUS re-validation called from
`_onTerminalChanged` (redraw) and `_onScrollChanged`, BEFORE the debounced
rescan. For each live match it re-reads ONLY that match's rows (clamped to the
live buffer) via the existing `_ScreenCellReader` and re-runs the production
`StructuredTextScanner` with the same patterns; the match is kept only if a
same-`payload` match still covers those cells. So wrap-join, normalize
(`www.`→`https://`), OSC-8 grouping, and alt-screen suppression re-validate
identically to a full scan. A match whose rows fell out of the buffer (evicted /
scrolled past) reads zero cells → no re-match → dropped. Discovery of NEW matches
stays debounced (the expensive bounded-window scan). The prune notifies the
narrow `decorationListenable` only when the set actually shrinks, so the orphaned
box vanishes immediately.

Keeps #863 paint==hit geometry (`matchAt`/`anchorRects` untouched) and #812
hide-on-scroll intact (this is content staleness after the redraw settles, not
the during-scroll transient). Does NOT touch detection patterns (#874 owns the
path over-match), notification, or sftp.

### Test (headless invariant — RED-verified)
`native/test/terminal/redraw_anchor_eviction_873_test.dart` (ffi, real
libghostty parser):
- URL row redrawn in place → anchor evicted IMMEDIATELY, BEFORE the debounce
  fires (reads `anchors` with no settle — the #873 RED assertion).
- Path row redrawn in place → evicted (pre-debounce).
- Targeted eviction: redrawing one match leaves a different, untouched match.
- No false eviction: a repaint that still carries the URL keeps its anchor.
- A URL pushed past the bounded scrollback window is evicted.

RED-verified: with the prune disabled, 3/5 fail (the redrawn-row stays as a stale
anchor). With the fix, all 5 pass.

### Gates
- `scripts/native-fast-gate.sh`: analyze pass, **1246 tests pass** (5 skipped).
- `scripts/native-fork-test.sh`: **722 fork tests pass**.

### Files
- `native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart` —
  `_pruneStaleDetections()` + `_matchStillPresent()`; called from
  `_onTerminalChanged` and `_onScrollChanged`.
- `native/test/terminal/redraw_anchor_eviction_873_test.dart` — new invariant test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)