### PR TITLE
fix(#874): path detector terminates at shell delimiters, strips quotes

### DIFF
--- a/native/third_party/flterm/lib/src/foundation/structured_text.dart
+++ b/native/third_party/flterm/lib/src/foundation/structured_text.dart
@@ -179,11 +179,43 @@ final class TextPattern {
 /// OSC-8 source, whose detection walks cells rather than running a regex.
 final RegExp _kNeverMatch = RegExp(r'(?!x)x');
 
-/// Shell metacharacter / glob character class (#826). A real, tap-to-open
-/// filesystem path NEVER contains any of these. Members: `$ { } * ? [ ] ( ) `
-/// backtick ` | < > & ; = ' " \` — whitespace already bounds a token. Inside a
-/// `[...]` class only `] \ ^ -` need escaping; the rest are literal.
-const String _kPathMetachar = r'''${}*?\[\]()`|<>&;='"\\''';
+/// The shell metacharacter / glob set (#826) a real, tap-to-open filesystem path
+/// NEVER holds — `$ { } * ? [ ] ( ) ` backtick ` | < > & ; = ' " \` — is SPLIT
+/// into two roles (#874):
+///   * [_kPathTerminator] — separators/quotes that merely BOUND a path; the path
+///     TERMINATES at one and is the clean PREFIX before it (trim, don't reject).
+///   * [_kPathReject] — glob/var/command-sub chars whose presence means the token
+///     is NOT an openable path; the whole candidate is SUPPRESSED.
+/// Whitespace already bounds a token. Inside a `[...]` class only `] \ ^ -` need
+/// escaping; the rest are literal.
+
+/// Shell delimiters that merely BOUND a path and where the path TERMINATES
+/// (#874): a path followed by one of these is the clean prefix BEFORE it, not a
+/// path-plus-tail. Members: `; | & < > =` (command/redirect separators) and `'`
+/// `"` (quotes that wrap a path). [_validatePath] TRIMS the raw match at the
+/// first of these, keeping only the leading clean path — so
+/// `/tmp/tt.md; echo x` → `/tmp/tt.md`, `/a/b|grep` → `/a/b`, and `"/a/b"` →
+/// `/a/b` (quote-stripped). Inside a `[...]` class only `] ^ -` need escaping;
+/// the rest are literal.
+const String _kPathTerminator = r'''|&<>=;'"''';
+
+/// REJECT-class metachars (#826/#874): a path containing one of these adjacent
+/// to path chars is a glob / shell-var / command-substitution TOKEN, not an
+/// openable path, so [_validatePath] SUPPRESSES the whole candidate rather than
+/// trimming a clean-looking sub-path out of it (Dart's backtracking would
+/// otherwise carve `~/.zshrc.bak` out of `~/.zshrc.bak.*`). This is the full
+/// metachar set MINUS the [_kPathTerminator] separators that legitimately bound
+/// a path: it keeps `$ { } * ? [ ] ( ) ` backtick ` \`.
+const String _kPathReject = r'''${}*?\[\]()`\\''';
+
+/// The lookbehind metachar class (#874): the full metachar set MINUS the QUOTES
+/// (`'` `"`). The negative lookbehind keeps a path from anchoring mid-token
+/// (after a path char, `:`, `/`, or a glob/var metachar — the `://` and #826
+/// glob-tail cases). A QUOTE, however, legitimately PRECEDES a path (`"/a/b"`,
+/// `'/etc/hosts'`), so it must NOT block the anchor — the leading quote is a
+/// boundary like whitespace, and [_kPathTrailingTrim] / [_validatePath] strip the
+/// trailing quote. Dropping `'"` from the lookbehind lets a quoted path match.
+const String _kPathLookbehindMeta = r'''${}*?\[\]()`|<>&;=\\''';
 
 /// The ABSOLUTE FILE PATH regex (#778, paths Slice 1; precision #826). Matches
 /// three shapes that resolve WITHOUT a working directory:
@@ -210,37 +242,72 @@ const String _kPathMetachar = r'''${}*?\[\]()`|<>&;='"\\''';
 /// deliberately NOT matched (deferred to Slice 3) — only a leading `/`, `~`, `.`
 /// anchors a match.
 final RegExp _kPathPattern = RegExp(
-  '(?<![\\w.\\-~@+:/$_kPathMetachar])'
+  '(?<![\\w.\\-~@+:/$_kPathLookbehindMeta])'
   r'(?:'
   r'/(?:[\w.\-~@+]+/?)+' // absolute: /a/b/c
   r'|~/(?:[\w.\-~@+]+/?)*' // home: ~/a/b
   r'|~(?![\w.\-@+])' // bare ~ (not ~word)
   r'|\.\.?/(?:[\w.\-~@+]+/?|\.\.?/)*' // ./x ../x ../../ chains
   r')'
-  // #826: swallow any adjacent metachar/glob suffix so [_validatePath] can reject
-  // the WHOLE contaminated token (backtracking can't peel off a clean sub-path).
-  '(?:[$_kPathMetachar][^\\s]*)?',
+  // #826: swallow any adjacent REJECT-class (glob/var/command-sub) suffix so
+  // [_validatePath] can reject the WHOLE contaminated token (backtracking can't
+  // peel off a clean sub-path). #874: TERMINATOR chars (`; | & < > = ' "`) are
+  // deliberately NOT swallowed — they are not path chars, so the regex stops at
+  // them and the span ends at the clean path (no over-highlight of the tail);
+  // `_validatePath` still trims a terminator that a reject-class `[^\s]*` grab may
+  // span (e.g. `/a*;b`).
+  '(?:[$_kPathReject][^\\s]*)?',
 );
 
 /// Trailing characters trimmed off the END of a raw path match — a path that
 /// ends a sentence picks up `.,;:!?` and closers; mirrors the URL trim.
 const String _kPathTrailingTrim = '.,;:!?)]}>\'"';
 
-/// Shell metacharacter / glob detector (#826): true iff [raw] contains any char a
-/// real, tap-to-open filesystem path never holds. The path regex deliberately
+/// REJECT-class metachar detector (#826/#874): true iff [raw] contains a glob /
+/// shell-var / command-substitution char a real, tap-to-open filesystem path
+/// never holds (`$ { } * ? [ ] ( ) ` backtick ` \`). The path regex deliberately
 /// SWALLOWS an adjacent metachar/glob suffix into the raw match (see
 /// [_kPathPattern]) so this validate sees the whole contaminated token and can
 /// reject it — a backtracking-proof gate the trailing lookahead alone could not be.
-final RegExp _kPathMetacharProbe = RegExp('[$_kPathMetachar]');
+final RegExp _kPathRejectProbe = RegExp('[$_kPathReject]');
 
-/// Validate a raw path match (#826). Returns the path as its own payload, or
-/// `null` to SUPPRESS the candidate when it contains a shell metacharacter / glob
-/// char (`$ { } * ? [ ] ( ) ` backtick ` | < > & ; = ' " \`) — a glob/var token
-/// like `/tmp/.ssh_loaded_${UID}_*` or `~/.ssh/*.pub` is not an openable path.
-/// The scanner DROPS a match whose normalize returns null (the `://` URL case is
-/// additionally rejected by the lookbehind, so `file://…` stays a URL).
-String? _validatePath(String raw) =>
-    _kPathMetacharProbe.hasMatch(raw) ? null : raw;
+/// First-terminator detector (#874): the index of the first [_kPathTerminator]
+/// char (`; | & < > = ' "`) in a raw match, or `-1` if none. A path TERMINATES at
+/// such a separator/quote, so the openable path is the clean PREFIX before it.
+final RegExp _kPathTerminatorProbe = RegExp('[$_kPathTerminator]');
+
+/// Validate a raw path match (#826 + #874). Returns the openable path as its own
+/// payload, or `null` to SUPPRESS the candidate.
+///
+/// #874: a path TERMINATES at a shell separator/quote ([_kPathTerminator]: `; | &
+/// < > = ' "`). The swallow group in [_kPathPattern] may have grabbed such a tail
+/// (e.g. `/tmp/tt.md;`, `/a/b|grep`, or the trailing quote of `"/a/b"`), so first
+/// TRIM the raw at the first terminator — keeping only the leading clean path —
+/// and strip any leading quote left by the swallow/anchor (`"/a/b"` → `/a/b`).
+///
+/// #826: AFTER trimming, if the surviving prefix still holds a REJECT-class
+/// metachar ([_kPathReject]: `$ { } * ? [ ] ( ) ` backtick ` \`), the candidate is
+/// a glob / shell-var / command-substitution TOKEN (`/tmp/.ssh_loaded_${UID}_*`,
+/// `~/.ssh/*.pub`), NOT an openable path — SUPPRESS it (don't carve a clean-looking
+/// sub-path out of a glob). An empty prefix (the candidate was ALL tail) also
+/// suppresses. The scanner DROPS a match whose normalize returns null (the `://`
+/// URL case is additionally rejected by the lookbehind, so `file://…` stays a URL).
+String? _validatePath(String raw) {
+  var path = raw;
+  // #874: terminate at the first shell separator / quote — the path is the
+  // clean prefix before it.
+  final term = _kPathTerminatorProbe.firstMatch(path);
+  if (term != null) path = path.substring(0, term.start);
+  // Strip a leading quote the anchor/swallow may have included (`"/a/b"`); the
+  // trailing quote is already gone via the terminator trim above.
+  while (path.isNotEmpty && (path[0] == '"' || path[0] == "'")) {
+    path = path.substring(1);
+  }
+  if (path.isEmpty) return null;
+  // #826: a surviving glob/var/command-sub token is not an openable path.
+  if (_kPathRejectProbe.hasMatch(path)) return null;
+  return path;
+}
 
 /// The URL regex (moved verbatim from the app's `ghostty_url_detector.dart`,
 /// #767). Matches absolute http/https URLs and bare `www.` hosts; the

--- a/native/third_party/flterm/test/foundation/structured_text_test.dart
+++ b/native/third_party/flterm/test/foundation/structured_text_test.dart
@@ -855,4 +855,153 @@ void main() {
       expect(pathPayloads('file:///etc/hosts'), isEmpty);
     });
   });
+
+  // #874: the path detector over-matched a whole shell command as ONE file path.
+  // A device report (0.1.10+55) showed "the whole line in between blocks is
+  // presenting as a file". A path token must TERMINATE at a shell separator /
+  // quote (`; | & < > = ' "`) and yield only the clean prefix — so a command
+  // line like `/workspace/outl/scripts/top-task 2>&1 > /tmp/tt.md; …` underlines
+  // the two REAL paths, not the whole run. Quotes that wrap a path are stripped.
+  // The #826 glob/var/command-sub REJECTION must stay intact (a `$`/`*`/`[]`/`()`
+  // token is suppressed, NOT trimmed to a clean-looking sub-path).
+  group('TextPattern.path() — shell-delimiter termination (#874)', () {
+    final pathPattern = TextPattern.path();
+
+    List<String> pathPayloads(String row, {int? cols}) {
+      final reader = _FakeCellReader([row], cols: cols ?? (row.length + 2));
+      return scanner
+          .scan(reader, [pathPattern])
+          .where((m) => m.patternId == 'path')
+          .map((m) => '${m.payload}')
+          .toList();
+    }
+
+    test(
+      'the offending command line yields the TWO real paths, NOT one giant run',
+      () {
+        const line = '/workspace/outl/scripts/top-task 2>&1 > /tmp/tt.md; '
+            'echo "=== FLAGGED ==="; '
+            "sed -n '/^## Flagged/,/^##/{ /^## [F]/q; p }' /tmp/tt.md | "
+            'head -15; echo;';
+        final got = pathPayloads(line);
+        // The two distinct real paths are present...
+        expect(got, contains('/workspace/outl/scripts/top-task'));
+        expect(got, contains('/tmp/tt.md'));
+        // ...and the detected SET is exactly those two (the second /tmp/tt.md
+        // occurrence dedups in the set) — never the whole command as one path.
+        expect(got.toSet(),
+            {'/workspace/outl/scripts/top-task', '/tmp/tt.md'});
+        // Specifically: nothing swallowed the trailing shell syntax into a path.
+        for (final p in got) {
+          expect(p, isNot(contains(' ')));
+          expect(p, isNot(contains(';')));
+          expect(p, isNot(contains('|')));
+          expect(p, isNot(contains('>')));
+        }
+      },
+    );
+
+    test('a path followed by `; cmd` yields the path ONLY (semicolon)', () {
+      expect(pathPayloads('/tmp/tt.md; echo x'), contains('/tmp/tt.md'));
+      expect(pathPayloads('/tmp/tt.md; echo x'), everyElement(isNot(contains(';'))));
+    });
+
+    test('a path followed by ` | grep` yields the path ONLY (pipe)', () {
+      expect(pathPayloads('/a/b | grep'), contains('/a/b'));
+    });
+
+    test('a path adjacent to `|` (no space) terminates at the pipe', () {
+      expect(pathPayloads('/a/b|grep'), contains('/a/b'));
+      expect(pathPayloads('/a/b|grep'), everyElement(isNot(contains('|'))));
+    });
+
+    test('a path adjacent to `;` (no space) terminates at the semicolon', () {
+      expect(pathPayloads('/a/b;rm'), contains('/a/b'));
+    });
+
+    test('a redirect tail `> /out` yields the source path then the dest path',
+        () {
+      final got = pathPayloads('cat /etc/hosts > /tmp/out');
+      expect(got, contains('/etc/hosts'));
+      expect(got, contains('/tmp/out'));
+    });
+
+    test('a double-quoted path `"/a/b"` is detected, quote-stripped', () {
+      expect(pathPayloads('"/a/b"'), contains('/a/b'));
+      expect(pathPayloads('"/a/b"'), everyElement(isNot(contains('"'))));
+    });
+
+    test('a single-quoted path `\'/a/b\'` is detected, quote-stripped', () {
+      expect(pathPayloads("'/a/b'"), contains('/a/b'));
+      expect(pathPayloads("'/a/b'"), everyElement(isNot(contains("'"))));
+    });
+
+    test('a quoted absolute path inside a command is detected', () {
+      expect(pathPayloads('cat "/etc/ssh/sshd_config"'),
+          contains('/etc/ssh/sshd_config'));
+    });
+
+    test('`/a/b && /c/d` yields both paths (ampersand terminates)', () {
+      final got = pathPayloads('/a/b && /c/d');
+      expect(got, contains('/a/b'));
+      expect(got, contains('/c/d'));
+    });
+
+    // #826 regression guard — glob/var/command-sub tokens MUST still be SUPPRESSED
+    // (terminator-trimming must NOT carve a clean-looking sub-path out of them).
+    test(r'regression: `${UID}` shell-var path STILL rejected (#826)', () {
+      expect(pathPayloads(r'rm -f /tmp/.ssh_loaded_${UID}_*'), isEmpty);
+    });
+
+    test('regression: glob `~/.ssh/*.pub` STILL rejected (#826)', () {
+      expect(pathPayloads(r'for pub in ~/.ssh/*.pub'), isEmpty);
+    });
+
+    test('regression: command-sub `~/.zshrc.bak.\$(date +%s)` STILL rejected',
+        () {
+      expect(pathPayloads(r'cp ~/.zshrc ~/.zshrc.bak.$(date +%s)'),
+          isNot(contains(r'~/.zshrc.bak.')));
+    });
+
+    test('regression: bracket glob `~/.ssh/id_[rd]sa` STILL rejected (#826)',
+        () {
+      expect(pathPayloads(r'~/.ssh/id_[rd]sa'), isEmpty);
+    });
+
+    test('regression: a glob TERMINATED by `;` is STILL rejected, not trimmed',
+        () {
+      // `/a/b*` is a glob; the trailing `;` must NOT rescue a clean `/a/b*`→`/a/b`
+      // — the reject-class `*` suppresses the whole candidate.
+      expect(pathPayloads('/a/b*; echo'), isEmpty);
+    });
+
+    test('regression: clean paths STILL detect (no over-suppression)', () {
+      expect(pathPayloads('see /etc/hosts here'), contains('/etc/hosts'));
+      expect(pathPayloads('open ~/notes.md now'), contains('~/notes.md'));
+      expect(pathPayloads('edit ../src/x.dart'), contains('../src/x.dart'));
+    });
+
+    test(
+      'a genuinely long path that WRAPS still matches WHOLE (no over-correction)',
+      () {
+        // cols=15. Row 0 is full and soft-wraps; the long absolute path spans
+        // both rows and must join into ONE match — the delimiter-termination fix
+        // must not break legitimate wrap-join.
+        final reader = _FakeCellReader(
+          [
+            '/var/lib/postg', // 14 chars, soft-wraps into row 1
+            'resql/data/base', // continuation
+          ],
+          cols: 15,
+          wraps: [true, false],
+        );
+        final got = scanner
+            .scan(reader, [pathPattern])
+            .where((m) => m.patternId == 'path')
+            .map((m) => '${m.payload}')
+            .toList();
+        expect(got, contains('/var/lib/postgresql/data/base'));
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary
Fixes #874 — the path detector over-matched shell command syntax as one openable file path and dropped quote-wrapped paths entirely. A path token must terminate at a shell separator/quote and yield only the clean prefix.

Matcher-only change in `native/third_party/flterm/lib/src/foundation/structured_text.dart` (`TextPattern.path()` regex + `_validatePath`). No anchor-lifecycle / `terminal_controller_impl` changes — #873 owns that. No URL detection / notification / SFTP changes.

## Root cause
Probing the real scanner output first (not the issue's "huge run" framing): the existing trailing-trim already split the offending line into the two real paths. The genuinely-broken case was QUOTED paths (`"/a/b"`, `'/a/b'`) returning ZERO matches — the leading quote sat in the regex negative lookbehind, blocking the anchor.

## Fix
- Split the #826 shell-metachar set into two roles:
  - TERMINATOR class (`; | & < > = ' "`): bound a path; trim to the clean prefix before the first such char.
  - REJECT class (`$ { } * ? [ ] ( ) ` backtick ` \`): glob / shell-var / command-sub — suppress the whole candidate (preserves #826; no carving a clean sub-path out of a glob).
- Drop quotes from the lookbehind so a quoted path anchors after the leading quote.
- Narrow the #826 swallow group to REJECT-class chars only, so a terminator is not swallowed into the match span — the regex stops at it, ending the span at the clean path (also fixes range over-highlight of an adjacent `|`/`=`).
- `_validatePath`: trim at the first terminator, strip a leading quote, then apply the #826 reject check on the surviving prefix (trim-THEN-reject keeps a glob like `/a/b*;c` suppressed, not carved to `/a/b*`).

## Result
The device-reported line
`/workspace/outl/scripts/top-task 2>&1 > /tmp/tt.md; echo "=== FLAGGED ==="; sed -n '…' /tmp/tt.md | head -15; …`
now yields exactly `{/workspace/outl/scripts/top-task, /tmp/tt.md}` — two distinct real paths, not one giant run.

## Tests (headless, pure matcher)
+17 tests in `structured_text_test.dart` under a new `#874` group:
- offending line → the two real paths (set equality), no whitespace/`;`/`|`/`>` in any payload
- `/tmp/tt.md; echo x` → `/tmp/tt.md`; `/a/b | grep` and `/a/b|grep` → `/a/b`; `/a/b;rm` → `/a/b`
- redirect `cat /etc/hosts > /tmp/out` → both paths; `/a/b && /c/d` → both
- `"/a/b"`, `'/a/b'`, `cat "/etc/ssh/sshd_config"` → quote-stripped paths
- a genuinely long path that WRAPS still matches whole (no over-correction)
- #826 regression guards: `${UID}`, `~/.ssh/*.pub`, `$(date +%s)`, `~/.ssh/id_[rd]sa`, and a glob terminated by `;` all stay rejected

Quoted-path case RED→GREEN verified against pre-fix scanner output (was `[]`, now `/a/b`). Full `scripts/native-fast-gate.sh` green (analyze + all tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)