### PR TITLE
fix(#878): initialize FLN in the UI isolate so notification-tap payloads deliver

### DIFF
--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'diagnostics/connect_trace.dart';
 import 'diagnostics/crash_reporter.dart';
 import 'platform/desktop.dart';
 import 'ssh/ssh_session.dart';
@@ -120,10 +121,31 @@ class _RootRouterState extends ConsumerState<RootRouter> {
     // tap recorded a pending focus in process-death-surviving storage. Consume
     // it once the first frame settles so sessions exist to focus. Deferred to a
     // post-frame callback so provider reads happen after the widget mounts.
+    //
+    // #878: BEFORE that initial consume, register the UI-isolate FLN tap
+    // handler + seed any cold-start launch-details payload
+    // (attentionUiFlnInitProvider). Without the UI-isolate registration a
+    // plain tap delivers to this engine where no handler exists — the payload
+    // was silently dropped (the #857/#870 root cause). Ordering matters: the
+    // launch-details seed must land before consumePending reads the store.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      unawaited(ref.read(attentionFocusRouterProvider).consumePending());
+      unawaited(_initAttentionTapThenConsume());
     });
+  }
+
+  /// #878 boot ordering: UI-isolate FLN init (+ cold-start launch-details
+  /// seed) FIRST, then the initial pending-focus consume. Init failures are
+  /// logged but never block the consume — a tap recorded by the background
+  /// handler must still route on a degraded boot.
+  Future<void> _initAttentionTapThenConsume() async {
+    try {
+      await ref.read(attentionUiFlnInitProvider.future);
+    } catch (e) {
+      clifecycle('ui.attention', 'fln: UI-isolate init failed: $e');
+    }
+    if (!mounted) return;
+    await ref.read(attentionFocusRouterProvider).consumePending();
   }
 
   @override

--- a/native/lib/services/attention_notifier_fln.dart
+++ b/native/lib/services/attention_notifier_fln.dart
@@ -44,6 +44,47 @@ void attentionNotificationTapBackground(NotificationResponse response) {
   );
 }
 
+/// Shared FLN initialization (#878): the same `InitializationSettings` +
+/// HIGH-importance `mobissh_attention` channel creation (idempotent on
+/// Android), used by BOTH registrations so they can't drift:
+///
+///   * the FGS task isolate ([FlnAttentionNotifier._ensureInit]) — needed for
+///     POSTING from the scanner's isolate;
+///   * the UI isolate (`attentionUiFlnInitProvider` in
+///     `state/attention_providers.dart`) — needed for TAP DELIVERY. On Android
+///     a plain tap resumes MainActivity → the UI engine, and the plugin
+///     delivers `onDidReceiveNotificationResponse` only to the isolate that
+///     initialized it in that engine. Before #878 the UI isolate never did, so
+///     every plain-tap payload was silently dropped (the #857/#870 root cause).
+///
+/// [onResponse] is the per-isolate tap callback; the background-ACTION handler
+/// is always the shared top-level [attentionNotificationTapBackground].
+Future<void> initializeAttentionFln(
+  FlutterLocalNotificationsPlugin plugin, {
+  required void Function(NotificationResponse response) onResponse,
+}) async {
+  const initSettings = InitializationSettings(
+    android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+  );
+  await plugin.initialize(
+    initSettings,
+    onDidReceiveNotificationResponse: onResponse,
+    onDidReceiveBackgroundNotificationResponse:
+        attentionNotificationTapBackground,
+  );
+  // Create the HIGH channel explicitly so importance is correct on first post.
+  final android = plugin.resolvePlatformSpecificImplementation<
+      AndroidFlutterLocalNotificationsPlugin>();
+  await android?.createNotificationChannel(
+    const AndroidNotificationChannel(
+      kAttentionChannelId,
+      kAttentionChannelName,
+      description: kAttentionChannelDescription,
+      importance: Importance.high,
+    ),
+  );
+}
+
 /// `flutter_local_notifications`-backed [AttentionNotifier].
 ///
 /// Lazily initializes the plugin + the HIGH-importance `mobissh_attention`
@@ -60,33 +101,22 @@ class FlnAttentionNotifier implements AttentionNotifier {
 
   Future<void> _ensureInit() async {
     if (_initialized) return;
-    const initSettings = InitializationSettings(
-      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
-    );
-    await _plugin.initialize(
-      initSettings,
-      onDidReceiveNotificationResponse: (response) {
-        // Foreground tap (app alive): record pending focus; the UI consumes it
-        // on the next resume. The background variant covers a dead app. #870:
-        // bind the pending-WRITE log to `ctrace` so the write order is captured.
+    // #878: shared init (settings + channel) — see [initializeAttentionFln].
+    // This task-isolate registration is what allows POSTING; tap DELIVERY for
+    // plain taps happens via the UI isolate's registration
+    // (`attentionUiFlnInitProvider`). This isolate's `onResponse` is kept as a
+    // best-effort fallback for any response the platform still hands this
+    // engine (e.g. a tap while the FGS engine is the one resumed).
+    await initializeAttentionFln(
+      _plugin,
+      onResponse: (response) {
+        // #870: bind the pending-WRITE log to `ctrace` so the write order is
+        // captured.
         unawaited(
           PendingFocusBridge(FftKeyValueStore(), log: ctrace)
               .setPendingFromPayload(response.payload),
         );
       },
-      onDidReceiveBackgroundNotificationResponse:
-          attentionNotificationTapBackground,
-    );
-    // Create the HIGH channel explicitly so importance is correct on first post.
-    final android = _plugin.resolvePlatformSpecificImplementation<
-        AndroidFlutterLocalNotificationsPlugin>();
-    await android?.createNotificationChannel(
-      const AndroidNotificationChannel(
-        kAttentionChannelId,
-        kAttentionChannelName,
-        description: kAttentionChannelDescription,
-        importance: Importance.high,
-      ),
     );
     _initialized = true;
   }

--- a/native/lib/services/attention_tap_ui.dart
+++ b/native/lib/services/attention_tap_ui.dart
@@ -1,0 +1,100 @@
+// UI-isolate notification-tap binding (#878).
+//
+// #878 root cause: `FlutterLocalNotificationsPlugin.initialize()` was called
+// ONLY in the FGS task isolate (the posting side). On Android a plain
+// notification tap launches/resumes MainActivity → the UI isolate's engine —
+// and flutter_local_notifications delivers `onDidReceiveNotificationResponse`
+// to the isolate that initialized the plugin IN THAT ENGINE. The UI isolate
+// never initialized it, so the tap (and its payload) was silently dropped and
+// the pending-focus write never happened — the root of the entire #857/#870
+// wrong-host tap saga (those fixes were correct but downstream of a write that
+// never occurred).
+//
+// This class is the PURE, unit-testable half of the fix: the platform wiring
+// (`initializeAttentionFln` + `getNotificationAppLaunchDetails`, see
+// `state/attention_providers.dart`) binds its two entry points to the real
+// plugin callbacks; tests invoke them directly with payloads.
+//
+//   * [handleTap] — warm tap (app process alive): write pending via the bridge,
+//     then IMMEDIATELY consume. The tap IS the resume — when the activity is
+//     already resumed no later lifecycle event will fire, so waiting for one
+//     (the pre-#878 contract) routes nothing.
+//   * [seedColdStart] — process-death tap: the launch-details payload is seeded
+//     as pending BEFORE the boot path's initial `consumePending()` runs, so the
+//     existing cold-start consume (#840) routes it. Seeding does NOT consume —
+//     boot owns the initial consume ordering.
+//
+// Telemetry flows through the injected [log] — production binds `clifecycle`
+// (#766), whose durable 80-line ring survives connect-ring churn and ships in
+// the feedback upload (bare `ctrace` in non-UI isolates is never uploaded).
+// Logs sid/host only — never auth material.
+
+import 'session_attention_notification.dart';
+
+/// Pure seam between the UI-isolate FLN tap callbacks and the pending-focus
+/// pipeline (#878). Injected bridge + consume keep it platform-free.
+class AttentionUiTapBinding {
+  AttentionUiTapBinding({
+    required PendingFocusBridge bridge,
+    required Future<String?> Function() consume,
+    void Function(String where, String msg)? log,
+  })  : _bridge = bridge,
+        _consume = consume,
+        _log = log;
+
+  // Same pattern as attention_focus_router.dart: private fields from public
+  // named params (no private named parameters in Dart).
+  // ignore_for_file: prefer_initializing_formals
+  final PendingFocusBridge _bridge;
+
+  /// The router's `consumePending` (production:
+  /// `ref.read(attentionFocusRouterProvider).consumePending`). Returns the
+  /// focused sessionId or null. Injected so tests assert the immediate-consume
+  /// wiring without Riverpod.
+  final Future<String?> Function() _consume;
+
+  /// Telemetry seam — production binds `clifecycle` so the tap path lands in
+  /// the UPLOADED lifecycle ring (#766). Null in tests that don't assert logs.
+  final void Function(String where, String msg)? _log;
+
+  /// Warm tap (`onDidReceiveNotificationResponse` in the UI isolate): record
+  /// the pending focus, then consume it IMMEDIATELY — the tap already resumed
+  /// the activity, so no later lifecycle event will arrive to trigger the
+  /// resume-path consume. Never throws (a tap must never crash the app).
+  Future<void> handleTap(String? payload) async {
+    final sid = AttentionNotification.parsePayload(payload).sessionId;
+    _log?.call(
+      'ui.attention',
+      'tap: received sid=${sid ?? 'none'}'
+      '${sid == null ? '' : ' host=${hostOfSessionId(sid)}'}',
+    );
+    // Write first (the bridge logs "pending set" + stamps the #870 seq) so even
+    // a failed immediate consume leaves the pending for the next resume.
+    await _bridge.setPendingFromPayload(payload);
+    try {
+      final focused = await _consume();
+      _log?.call(
+        'ui.attention',
+        'tap: immediate consume → ${focused ?? 'none'}',
+      );
+    } catch (e) {
+      _log?.call('ui.attention', 'tap: immediate consume failed: $e');
+    }
+  }
+
+  /// Cold start: seed the launch-details payload as pending so the boot path's
+  /// initial `consumePending()` (#840, RootRouter post-frame) routes it. Does
+  /// NOT consume here — boot owns that ordering. Payload-less → no-op.
+  Future<void> seedColdStart(String? payload) async {
+    final sid = AttentionNotification.parsePayload(payload).sessionId;
+    if (sid == null) {
+      _log?.call('ui.attention', 'cold-start: launch details carried no sid');
+      return;
+    }
+    _log?.call(
+      'ui.attention',
+      'cold-start: seeding pending sid=$sid host=${hostOfSessionId(sid)}',
+    );
+    await _bridge.setPendingFromPayload(payload);
+  }
+}

--- a/native/lib/state/attention_providers.dart
+++ b/native/lib/state/attention_providers.dart
@@ -4,13 +4,18 @@
 // [PendingFocusBridge] (process-death-surviving), `sessionsProvider.setActive`,
 // session existence, and PTY input for the guarded tmux select-window.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../diagnostics/connect_trace.dart';
+import '../platform/desktop.dart';
 import '../services/attention_focus_router.dart';
 import '../services/attention_notifier_fln.dart';
+import '../services/attention_tap_ui.dart';
 import '../services/session_attention_notification.dart';
 import 'sessions.dart';
 
@@ -78,4 +83,49 @@ final attentionFocusRouterProvider = Provider<AttentionFocusRouter>((ref) {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     },
   );
+});
+
+/// UI-isolate FLN registration (#878). MUST run at app boot, BEFORE the boot
+/// path's initial `consumePending()`.
+///
+/// Root cause being fixed: `initialize()` was only ever called in the FGS task
+/// isolate (for posting). A plain notification tap resumes MainActivity → the
+/// UI engine, and the plugin delivers `onDidReceiveNotificationResponse` only
+/// to the isolate that initialized it IN THAT ENGINE — so every tap payload
+/// was dropped and the pending-focus write never happened (the confirmed root
+/// of the #857/#870 wrong-host saga).
+///
+/// This provider:
+///   1. initializes FLN in the UI isolate via the SHARED
+///      [initializeAttentionFln] (same settings + idempotent channel creation
+///      as the task isolate — no copy-paste drift), with a tap handler that
+///      writes pending AND immediately consumes (the tap IS the resume);
+///   2. checks `getNotificationAppLaunchDetails()`: a process-death tap seeds
+///      pending BEFORE the initial consume runs (`main.dart` awaits this
+///      provider's future first).
+///
+/// Telemetry flows through `clifecycle` (#766): its durable 80-line ring ships
+/// in the feedback upload and survives connect-ring churn. Desktop (#577) has
+/// no FLN/FGS machinery → no-op.
+final attentionUiFlnInitProvider = FutureProvider<void>((ref) async {
+  if (ref.watch(isDesktopProvider)) return;
+  final binding = AttentionUiTapBinding(
+    // clifecycle-bound bridge: the pending WRITE line lands in the uploaded
+    // lifecycle ring (the task/background-isolate writes only reach logcat).
+    bridge: PendingFocusBridge(const FftKeyValueStore(), log: clifecycle),
+    consume: () => ref.read(attentionFocusRouterProvider).consumePending(),
+    log: clifecycle,
+  );
+  final plugin = FlutterLocalNotificationsPlugin();
+  await initializeAttentionFln(
+    plugin,
+    onResponse: (response) => unawaited(binding.handleTap(response.payload)),
+  );
+  clifecycle('ui.attention', 'fln: UI-isolate tap handler registered');
+  // Cold start: a tap on a dead process launches the app with the response in
+  // the launch details — seed it as pending so the initial consume routes it.
+  final details = await plugin.getNotificationAppLaunchDetails();
+  if (details?.didNotificationLaunchApp ?? false) {
+    await binding.seedColdStart(details!.notificationResponse?.payload);
+  }
 });

--- a/native/test/services/attention_tap_ui_test.dart
+++ b/native/test/services/attention_tap_ui_test.dart
@@ -1,0 +1,195 @@
+// Unit tests for the UI-isolate notification-tap binding (#878).
+//
+// #878 root cause: `flutter_local_notifications` delivers a plain tap to the
+// isolate that initialized the plugin IN THE LAUNCHED ENGINE — the UI isolate
+// never initialized it, so the tap (and its payload) was silently dropped and
+// the pending-focus write never happened (the root of the #857/#870 wrong-host
+// saga). The fix registers an FLN init in the UI isolate whose tap handler is
+// this pure seam: write pending via the bridge, then IMMEDIATELY consume (the
+// tap IS the resume). Cold start seeds pending from the launch details BEFORE
+// the initial consume.
+//
+// These tests exercise the seam with the real PendingFocusBridge +
+// AttentionFocusRouter over in-memory fakes — no platform channels.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/attention_focus_router.dart';
+import 'package:mobissh/services/attention_tap_ui.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+
+void main() {
+  group('AttentionUiTapBinding.handleTap (warm tap)', () {
+    test('writes pending AND immediately consumes → setActive', () async {
+      final store = MapKeyValueStore();
+      final bridge = PendingFocusBridge(store);
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+      );
+      final binding = AttentionUiTapBinding(
+        bridge: bridge,
+        consume: router.consumePending,
+      );
+
+      await binding.handleTap(jsonEncode({'sessionId': 'h:22:u:111'}));
+
+      // The tap routed without waiting for any later resume/lifecycle event.
+      expect(activated, ['h:22:u:111']);
+      // Consumed one-shot: nothing left pending for the next resume.
+      expect((await bridge.readPending()).sessionId, isNull);
+    });
+
+    test('stale sid nonce → host-fallback still applies', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (id) => id == 'h:22:u:222', // reconnected nonce
+        sendInput: (a, b) {},
+        resolveLiveSessionForHost: (host) =>
+            host == 'h' ? 'h:22:u:222' : null,
+      );
+      final binding = AttentionUiTapBinding(
+        bridge: bridge,
+        consume: router.consumePending,
+      );
+
+      await binding.handleTap(jsonEncode({'sessionId': 'h:22:u:111'}));
+
+      expect(activated, ['h:22:u:222']);
+    });
+
+    test('null payload: no pending write, consume still fires', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      var consumed = 0;
+      final binding = AttentionUiTapBinding(
+        bridge: bridge,
+        consume: () async {
+          consumed++;
+          return null;
+        },
+      );
+
+      await binding.handleTap(null);
+
+      expect(consumed, 1);
+      expect((await bridge.readPending()).sessionId, isNull);
+    });
+
+    test('consume failure is swallowed; pending was still written', () async {
+      final store = MapKeyValueStore();
+      final bridge = PendingFocusBridge(store);
+      final binding = AttentionUiTapBinding(
+        bridge: bridge,
+        consume: () async => throw StateError('router exploded'),
+      );
+
+      // Must not throw — a tap handler crash would break the notification path.
+      await binding.handleTap(jsonEncode({'sessionId': 'h:22:u:111'}));
+
+      // The write happened before the consume attempt, so a later resume's
+      // ordinary consumePending can still route it.
+      expect((await bridge.readPending()).sessionId, 'h:22:u:111');
+    });
+
+    test('telemetry: tap received + immediate-consume outcome logged',
+        () async {
+      final lines = <String>[];
+      final bridge = PendingFocusBridge(
+        MapKeyValueStore(),
+        log: (where, msg) => lines.add('[$where] $msg'),
+      );
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+      );
+      final binding = AttentionUiTapBinding(
+        bridge: bridge,
+        consume: router.consumePending,
+        log: (where, msg) => lines.add('[$where] $msg'),
+      );
+
+      await binding.handleTap(jsonEncode({'sessionId': 'h:22:u:111'}));
+
+      // Tap received (sid/host only — never auth material).
+      expect(lines.any((l) => l.contains('tap') && l.contains('h:22:u:111')),
+          isTrue);
+      // Pending written (bridge's own write log).
+      expect(lines.any((l) => l.contains('pending set')), isTrue);
+      // Immediate-consume outcome.
+      expect(
+        lines.any((l) => l.contains('consume') && l.contains('h:22:u:111')),
+        isTrue,
+      );
+    });
+  });
+
+  group('AttentionUiTapBinding.seedColdStart (launch details)', () {
+    test('seeds pending so the initial consume routes to that host', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (_) => true,
+        sendInput: (a, b) {},
+      );
+      final binding = AttentionUiTapBinding(
+        bridge: bridge,
+        consume: router.consumePending,
+      );
+
+      // Cold start: seed BEFORE the app's initial consume runs.
+      await binding.seedColdStart(jsonEncode({'sessionId': 'h:22:u:111'}));
+      expect(activated, isEmpty); // seeding does NOT consume
+
+      // …then the boot-path initial consume routes it.
+      await router.consumePending();
+      expect(activated, ['h:22:u:111']);
+    });
+
+    test('stale sid nonce at cold start → host-fallback still applies',
+        () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final activated = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: activated.add,
+        sessionExists: (id) => id == 'h:22:u:999',
+        sendInput: (a, b) {},
+        resolveLiveSessionForHost: (host) =>
+            host == 'h' ? 'h:22:u:999' : null,
+      );
+      final binding = AttentionUiTapBinding(
+        bridge: bridge,
+        consume: router.consumePending,
+      );
+
+      await binding.seedColdStart(jsonEncode({'sessionId': 'h:22:u:111'}));
+      await router.consumePending();
+
+      expect(activated, ['h:22:u:999']);
+    });
+
+    test('null / payload-less launch details → no-op', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final binding = AttentionUiTapBinding(
+        bridge: bridge,
+        consume: () async => null,
+      );
+
+      await binding.seedColdStart(null);
+
+      expect((await bridge.readPending()).sessionId, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #878 — notification tap payload DROPPED because flutter_local_notifications was never initialized in the UI isolate (the confirmed root cause of the #857/#870 wrong-host tap saga).

## Root cause
`FlutterLocalNotificationsPlugin.initialize()` ran ONLY in the FGS task isolate (`FlnAttentionNotifier._ensureInit()`, the posting side). On Android a plain tap resumes MainActivity → the UI engine; the plugin delivers `onDidReceiveNotificationResponse` only to the isolate that initialized it in that engine. The UI isolate never did → the response (and payload) was silently dropped, so the pending-focus write never happened (`takePending: first=none/-1 second=none/-1` in the +56 capture).

## Fix
- **`attention_notifier_fln.dart`** — factored the init (same `InitializationSettings` + idempotent HIGH `mobissh_attention` channel creation) into a shared top-level `initializeAttentionFln(plugin, onResponse:)`. The task-isolate `_ensureInit()` registration stays (needed for posting) and now calls the shared code — no copy-paste drift.
- **`attention_tap_ui.dart` (new)** — pure, platform-free `AttentionUiTapBinding` seam:
  - `handleTap(payload)`: writes pending via `PendingFocusBridge` then **immediately** invokes the router's `consumePending()` — the tap IS the resume, no waiting for the next lifecycle event. Write happens first so a failed consume still leaves the pending for the next resume. Never throws.
  - `seedColdStart(payload)`: seeds the launch-details payload as pending; does NOT consume (boot owns the initial consume ordering).
- **`attention_providers.dart`** — `attentionUiFlnInitProvider`: UI-isolate FLN init with the binding's tap handler, then `getNotificationAppLaunchDetails()` → cold-start seed when `didNotificationLaunchApp`. Desktop (#577) no-op.
- **`main.dart`** — RootRouter boot post-frame now awaits the init provider future BEFORE the initial `consumePending()` (cold-start seed must land before the consume reads the store). Init failure is logged and never blocks the consume. Resume-path consume unchanged.
- **Telemetry** — tap received (sid/host), pending written (bridge log), immediate-consume outcome, UI-init registered, cold-start seed: all through `clifecycle` (#766) so they land in the durable 80-line uploaded ring that survives connect-ring churn. Never auth material.

## Not touched
`takePending` seq/grace (#870), routing logic in `attention_focus_router.dart`, scanner, suppression gates (#847/#851/#856), structured-text/terminal, sftp.

## Tests (red→green)
New `test/services/attention_tap_ui_test.dart` (8 tests, confirmed failing before the implementation existed):
- warm tap: pending written + consume fired immediately → router `setActive` (real router over in-memory fakes)
- stale sid nonce → host-fallback still applies (warm AND cold paths)
- null payload tolerant (no write, consume still fires)
- consume failure swallowed; pending preserved for the next resume
- telemetry: tap received + pending set + immediate-consume outcome lines
- cold-start seed → initial consume routes; payload-less launch details no-op

Existing #870 bridge race tests + router tests stay green.

## Gate
`scripts/native-fast-gate.sh` (in worktree): analyze clean, **1254 tests passed**.

Platform-channel init itself isn't unit-testable headless — the FLN calls live behind `initializeAttentionFln` / the provider so the wiring IS tested; compile coverage via the gate. Real-tap validation needs a device/emulator pass (warm tap + cold-start tap), per the device-validation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)