### PR TITLE
fix(#883): prune evicts only on CONFIRMED content change — anchors survive scrollback eviction row shifts

### DIFF
--- a/native/integration_test/selection_copy_after_redraw_test.dart
+++ b/native/integration_test/selection_copy_after_redraw_test.dart
@@ -34,6 +34,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/clipboard.dart' show clipboardChannel;
 import 'package:mobissh/state/sessions.dart';
 import 'package:mobissh/ui/ghostty_terminal_view.dart';
 
@@ -48,10 +49,25 @@ void main() {
     (tester) async {
       FlutterForegroundTask.initCommunicationPort();
 
-      // Capture clipboard writes (the device clipboard is system state; on the
-      // emulator integration harness the platform channel is mocked, so we
-      // intercept Clipboard.setData to read exactly what Copy wrote).
+      // Capture clipboard writes. On-device the app's Copy path writes through
+      // the NATIVE `mobissh/clipboard` MethodChannel (`setText`, #845 labeled
+      // clip) — Flutter's `Clipboard.setData` is only its no-plugin FALLBACK.
+      // Cycle-1 of #883 showed the device telemetry "wrote 129 chars (native)"
+      // while this test's old SystemChannels.platform-only mock observed
+      // nothing: a harness gap, not an app bug. Mock BOTH: the native channel
+      // (the path actually taken on the emulator) and the platform channel
+      // (fallback + the read-back verify's Clipboard.getData).
       String? copied;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        clipboardChannel,
+        (call) async {
+          if (call.method == 'setText') {
+            copied = (call.arguments as Map)['text'] as String?;
+            return true;
+          }
+          return null;
+        },
+      );
       tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
         SystemChannels.platform,
         (call) async {
@@ -65,6 +81,10 @@ void main() {
         },
       );
       addTearDown(() {
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          clipboardChannel,
+          null,
+        );
         tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
           SystemChannels.platform,
           null,

--- a/native/test/terminal/scrollback_eviction_anchor_883_test.dart
+++ b/native/test/terminal/scrollback_eviction_anchor_883_test.dart
@@ -1,0 +1,246 @@
+@Tags(['ffi'])
+library;
+
+// INVARIANT (#883, regression of #873): a live detection anchor (URL/path
+// highlight) must SURVIVE a scrollback EVICTION shift. libghostty evicts
+// history in large page bursts once the buffer hits its cap (observed ≈1139
+// rows in one write at cols=40), which moves EVERY absolute `screen` row down
+// by the evicted count. #873's synchronous `_pruneStaleDetections()` re-read
+// each match's STORED rows — which after the shift address other content (or
+// land beyond the live buffer entirely) — found no same-payload match there,
+// and EVICTED the anchor before the debounced `_rescanDetections` could
+// re-emit corrected coordinates. With the URL more than the bounded window
+// (~200 rows) above the tail viewport, the rescan never re-discovers it: the
+// loss is PERMANENT. On-device this killed #767 ("highlight tracks scroll
+// into scrollback") — the suite-caught `ghostty_url_detection_test.dart`
+// failure.
+//
+// The #883 rule: EVICT ONLY ON CONFIRMED CONTENT CHANGE. The prune trusts the
+// stored coordinates only while the frame they were anchored in still holds
+// (scrollbackRows has not shrunk, no resize). Under a shifted frame it
+// re-locates the same payload at the drop-corrected rows (adopting fresh
+// coordinates) or keeps the match for the debounced rescan to re-anchor from
+// content. The #873 win is intact: an in-place redraw with different readable
+// text (frame unchanged) still evicts synchronously — see
+// redraw_anchor_eviction_873_test.dart, which must stay green alongside this.
+//
+// These tests drive a REAL flterm TerminalController (real libghostty VT
+// parser, ffi-tagged) to the actual page-eviction boundary: fill close to the
+// cap, anchor a URL near the tail, stream until scrollbackRows visibly DROPS
+// (the page eviction), and assert the anchor survives the synchronous prune
+// (the KEY pre-debounce read — red on pre-#883 code) and is re-anchored at
+// the shifted rows once the rescan settles.
+
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Detection re-scan is debounced (~120ms); settle past it before reading.
+  Future<void> settle() =>
+      Future<void>.delayed(const Duration(milliseconds: 250));
+
+  // A short tick that pumps async microtasks/timers but stays WELL UNDER the
+  // ~120ms detection debounce — so state observed here reflects the
+  // SYNCHRONOUS prune, not the debounced rescan.
+  Future<void> tick() => Future<void>.delayed(const Duration(milliseconds: 5));
+
+  Uint8List bytes(String s) => Uint8List.fromList(s.codeUnits);
+
+  const url = 'https://example.com/some/path/page';
+
+  // 37-char filler at cols=40. Deliberately LONGER than the 34-char URL row —
+  // with a 2-column margin past the scanner's `wrapCol - 1` join slack — so
+  // the inferred-wrap-col heuristic keys on the filler shape and never
+  // width-joins the URL row with its neighbour. The only mechanism under test
+  // here is the coordinate shift from scrollback eviction.
+  String filler(int i) => 'f${i.toString().padLeft(5, '0')} ${'x' * 30}';
+
+  // The grid under test: cols=40, rows=6, scrollbackLimit=50. libghostty's
+  // page-eviction trip point for this shape is ≈2270 scrollback rows (the
+  // limit is page/byte-granular, NOT a row count), evicting ≈1140 rows at
+  // once. The fill below stops safely under the trip; the streaming phase
+  // then walks to it and DETECTS the eviction from scrollbackRows shrinking —
+  // nothing is hardcoded beyond "the trip exists before the loop budget runs
+  // out", which is asserted loudly.
+  const fillTo = 2150;
+
+  TerminalController newController() {
+    final controller = TerminalController(
+      config: const TerminalConfig(cols: 40, rows: 6, scrollbackLimit: 50),
+    );
+    controller.registerTextPattern(TextPattern.url());
+    return controller;
+  }
+
+  group('#883 — anchors survive the scrollback page-eviction row shift', () {
+    test(
+      'a URL anchored near the tail SURVIVES the page eviction — the '
+      'synchronous prune must not drop it on shifted coordinates (RED on '
+      'pre-#883: the prune evicted it before the debounced rescan could '
+      'correct, and the bounded rescan never re-found it)',
+      () async {
+        final controller = newController();
+        addTearDown(controller.dispose);
+
+        var lineNo = 0;
+        void writeFiller(int n) {
+          final sb = StringBuffer();
+          for (var i = 0; i < n; i++) {
+            sb.write('${filler(lineNo++)}\r\n');
+          }
+          controller.write(bytes(sb.toString()));
+        }
+
+        // Fill close to (but safely under) the page-eviction trip point.
+        while (controller.scrollbackRows < fillTo) {
+          writeFiller(50);
+          await tick();
+        }
+        controller.write(bytes('$url\r\n'));
+        await settle();
+
+        List<StructuredAnchor> urlAnchors() =>
+            controller.anchors.where((a) => a.payload == url).toList();
+
+        expect(urlAnchors(), hasLength(1),
+            reason: 'precondition: the URL is detected near the tail');
+        final rowsBefore = urlAnchors().first.ranges.first.topRow;
+
+        // Stream until the page eviction lands: scrollbackRows SHRINKS in one
+        // burst. Chunks stay small and ticks stay far under the debounce, so
+        // the synchronous prune is the only detection actor in this loop.
+        var maxSb = controller.scrollbackRows;
+        var evicted = false;
+        for (var chunk = 0; chunk < 40 && !evicted; chunk++) {
+          writeFiller(25);
+          await tick();
+          final sb = controller.scrollbackRows;
+          evicted = sb < maxSb;
+          if (sb > maxSb) maxSb = sb;
+        }
+        expect(evicted, isTrue,
+            reason: 'precondition: the scrollback page eviction must trip '
+                'within the loop budget (scrollbackRows never shrank — '
+                'libghostty page accounting changed?)');
+
+        // THE #883 RED ASSERTION: the eviction shifted every absolute row,
+        // but the URL's content is alive (it sat far below the evicted page)
+        // — the prune must NOT have dropped its anchor. Read BEFORE the
+        // debounce (tick-only): pre-#883 the anchor is already gone here.
+        expect(urlAnchors(), hasLength(1),
+            reason: 'the URL anchor was EVICTED by the synchronous prune on '
+                'eviction-shifted coordinates — a coordinate shift is not a '
+                'content change (#883)');
+
+        // After the debounced rescan settles, the anchor is re-anchored from
+        // content at the SHIFTED rows (the URL stayed within the bounded
+        // window of the tail viewport by construction: it was written ~120
+        // rows above it).
+        await settle();
+        expect(urlAnchors(), hasLength(1),
+            reason: 'the settled rescan must re-anchor the URL from content');
+        final rowsAfter = urlAnchors().first.ranges.first.topRow;
+        expect(rowsAfter, lessThan(rowsBefore),
+            reason: 'the re-anchored rows must reflect the eviction shift '
+                '(absolute rows only ever shift DOWN, toward 0)');
+      },
+    );
+
+    test(
+      'single-line writes at the eviction boundary RE-LOCATE the anchor with '
+      'fresh coordinates immediately (the drop-corrected re-locate path, no '
+      'debounce wait)',
+      () async {
+        final controller = newController();
+        addTearDown(controller.dispose);
+
+        var lineNo = 0;
+        void writeFiller(int n) {
+          final sb = StringBuffer();
+          for (var i = 0; i < n; i++) {
+            sb.write('${filler(lineNo++)}\r\n');
+          }
+          controller.write(bytes(sb.toString()));
+        }
+
+        while (controller.scrollbackRows < fillTo) {
+          writeFiller(50);
+          await tick();
+        }
+        controller.write(bytes('$url\r\n'));
+        await settle();
+
+        List<StructuredAnchor> urlAnchors() =>
+            controller.anchors.where((a) => a.payload == url).toList();
+
+        expect(urlAnchors(), hasLength(1),
+            reason: 'precondition: the URL is detected near the tail');
+        final rowsBefore = urlAnchors().first.ranges.first.topRow;
+
+        // Walk to the eviction ONE LINE AT A TIME. Each pre-eviction prune
+        // re-validates the (trusted) frame and advances the anchor epoch, so
+        // when the eviction lands the observable scrollback drop differs from
+        // the true shift by only the single appended line — well within the
+        // re-locate slack. The prune then finds the same payload at the
+        // drop-corrected rows and adopts the FRESH coordinates synchronously.
+        var maxSb = controller.scrollbackRows;
+        var evicted = false;
+        for (var i = 0; i < 250 && !evicted; i++) {
+          writeFiller(1);
+          await tick();
+          final sb = controller.scrollbackRows;
+          evicted = sb < maxSb;
+          if (sb > maxSb) maxSb = sb;
+        }
+        expect(evicted, isTrue,
+            reason: 'precondition: the page eviction must trip within the '
+                'loop budget');
+
+        // Pre-debounce: anchor present AND already at the shifted rows — the
+        // re-locate updated the stored ranges without waiting for the rescan.
+        expect(urlAnchors(), hasLength(1),
+            reason: 'the anchor must survive the eviction-shift prune (#883)');
+        final rowsAtEviction = urlAnchors().first.ranges.first.topRow;
+        expect(rowsAtEviction, lessThan(rowsBefore),
+            reason: 'the surviving anchor should carry the RE-LOCATED rows '
+                '(eviction shifts absolute rows down) before the rescan');
+      },
+    );
+
+    test(
+      'ESC[3J (scrollback clear) still removes a scrollback-resident anchor '
+      'once the rescan settles — keeping #883 deferral from leaking anchors '
+      'for content that is truly gone',
+      () async {
+        final controller = newController();
+        addTearDown(controller.dispose);
+
+        controller.write(bytes('$url\r\n'));
+        // Push the URL into scrollback (but nowhere near any cap/window).
+        final sb = StringBuffer();
+        for (var i = 0; i < 30; i++) {
+          sb.write('${filler(i)}\r\n');
+        }
+        controller.write(bytes(sb.toString()));
+        await settle();
+        expect(controller.anchors.where((a) => a.payload == url),
+            hasLength(1),
+            reason: 'precondition: detected with the URL in scrollback');
+
+        // Erase the scrollback. The coordinate frame shrinks, so the prune
+        // DEFERS (it cannot confirm anything from shifted coordinates) — but
+        // the debounced rescan re-scans real content and must drop the
+        // anchor: the URL no longer exists anywhere in the buffer.
+        controller.write(bytes('\x1b[3J'));
+        await settle();
+        expect(controller.anchors.where((a) => a.payload == url), isEmpty,
+            reason: 'the scrollback was erased; the settled rescan must drop '
+                'the anchor for good');
+      },
+    );
+  });
+}

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -1121,9 +1121,26 @@ class TerminalControllerImpl extends TerminalController
   @override
   void scrollToTop() {
     if (_activeScreen == .alternate) return;
-    terminal.scrollToTop();
+    // #883: jump the ScrollController FIRST, while the FFI scrollbar still
+    // holds the OLD offset. The render box's `_onScroll` derives its scroll
+    // delta as `targetOffset - scrollbar.offset`; with the old order
+    // (`terminal.scrollToTop()` before `jumpTo(0)`) the FFI offset was
+    // already 0 when the jump landed, so the delta was 0 and `_onScroll`
+    // returned WITHOUT marking the frame dirty. The glyphs never repainted
+    // at the top and `reportPaintedViewportOffset(0)` never fired, leaving
+    // [_paintedViewportOffset] stale at the bottom value indefinitely (no
+    // further output → no other repaint refreshes the frame's offset).
+    // [matchAt]/[highlightAt] — which map viewport→absolute via the PAINTED
+    // offset so hit-test and paint share one geometry source (#863) — then
+    // resolved against a wrong absolute row: a tap (or the #767 acceptance
+    // test) on the URL at the top of scrollback found nothing. Jumping first
+    // gives `_onScroll` the real delta → `scrollViewport` + frame-dirty →
+    // the next paint syncs and reports offset 0. `terminal.scrollToTop()`
+    // remains as the backstop for the detached/headless case (no clients)
+    // and is an idempotent no-op after the jump-driven scroll.
     final controller = _scrollController;
     if (controller != null && controller.hasClients) controller.jumpTo(0);
+    terminal.scrollToTop();
   }
 
   @override

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -142,6 +142,31 @@ class TerminalControllerImpl extends TerminalController
   /// 120ms URL re-detect debounce, now owned by the controller.
   static const int _detectionDebounceMs = 120;
 
+  /// #883: the COORDINATE-FRAME EPOCH of [_detectionMatches] — the
+  /// scrollbackRows/cols/visibleRows observed when the matches' absolute rows
+  /// were last anchored (a successful [_rescanDetections]) or fully
+  /// re-validated ([_pruneStaleDetections] confirming every match in place).
+  ///
+  /// Absolute `screen` rows are APPEND-STABLE: new output never moves stored
+  /// coordinates while scrollback grows below its cap. They are invalidated
+  /// wholesale only when the frame itself moves: a scrollback PAGE EVICTION at
+  /// the cap (libghostty evicts in large page bursts — observed ≈1139 rows at
+  /// once at cols=40 — visible as scrollbackRows SHRINKING), an `ESC[3J`
+  /// scrollback clear (also a shrink), or a resize REFLOW (cols/rows change).
+  /// The prune compares the live frame against this epoch to tell "the cells
+  /// under this match really changed" (evict, #873) from "the coordinates
+  /// drifted out from under a live match" (keep/re-locate, #883).
+  int _detectionFrameScrollback = 0;
+  int _detectionFrameCols = 0;
+  int _detectionFrameRows = 0;
+
+  /// #883: row slack when re-locating a match after an observed scrollback
+  /// shrink. The observable drop (epoch − current scrollbackRows) undershoots
+  /// the true shift by however many rows were APPENDED in the same burst, so a
+  /// little slack catches small same-burst appends; larger bursts simply defer
+  /// to the debounced rescan.
+  static const int _relocateRowSlack = 4;
+
   TerminalControllerImpl({TerminalConfig config = const TerminalConfig()})
     : _config = config,
       _keyEvent = vt.KeyEvent(),
@@ -457,8 +482,17 @@ class TerminalControllerImpl extends TerminalController
   /// match occupies (cheap) and, using the SAME scanner/patterns, keeps the match
   /// only if an equivalent same-payload match still covers those cells — so wrap-
   /// join, normalize (`www.`→`https://`), and OSC-8 grouping all re-validate
-  /// identically to a full scan. A match whose rows fell out of the live buffer
-  /// (evicted / scrolled past) reads zero cells → no re-match → dropped.
+  /// identically to a full scan.
+  ///
+  /// #883: eviction happens ONLY on a CONFIRMED content change — i.e. when the
+  /// coordinate frame the stored rows were anchored in still holds (scrollback
+  /// has not shrunk, no resize). When the frame has SHIFTED (a scrollback page
+  /// eviction at the cap moves ALL absolute rows down in one large burst; an
+  /// `ESC[3J` clear or a resize reflow invalidates them outright), a mismatch
+  /// at the stored rows proves nothing: the #883 regression evicted live
+  /// anchors here, killing #767's "highlight tracks scroll into scrollback".
+  /// Shifted-frame matches are re-located at the drop-corrected rows (ranges
+  /// updated) or kept for the debounced rescan to re-anchor from content.
   ///
   /// Defensive like [_rescanDetections]: any FFI/scan hiccup must never crash the
   /// session, so a failure leaves the existing matches untouched (the debounced
@@ -483,19 +517,61 @@ class TerminalControllerImpl extends TerminalController
         : _textPatterns.values.toList(growable: false);
 
     List<StructuredMatch> survivors;
+    var changed = false;
     try {
       _renderState.update(terminal);
       final cols = _renderState.cols;
       final visibleRows = _renderState.rows;
       if (cols <= 0 || visibleRows <= 0) {
-        survivors = const [];
+        // #883: a degenerate render state (mid-layout/churn) reads nothing —
+        // it cannot CONFIRM a content change, so it must not evict. Leave the
+        // set as-is; the debounced rescan reconciles once dims are real.
+        return;
       } else {
         final scrollback = terminal.scrollbackRows;
         final maxEndAbs = scrollback + visibleRows; // exclusive buffer bound
-        survivors = <StructuredMatch>[
-          for (final m in _detectionMatches)
-            if (_matchStillPresent(m, scanPatterns, cols, maxEndAbs)) m,
-        ];
+        // #883: the stored absolute rows are only meaningful while the
+        // coordinate frame they were anchored in still holds. A scrollback
+        // SHRINK (page eviction at the cap, `ESC[3J` clear) shifts/erases
+        // history rows; a cols/rows change reflows them. In either case a
+        // mismatch at the stored rows proves NOTHING about the content, so
+        // eviction must not key off it (the #883 over-evict).
+        final frameShifted = scrollback < _detectionFrameScrollback ||
+            cols != _detectionFrameCols ||
+            visibleRows != _detectionFrameRows;
+        final drop = _detectionFrameScrollback - scrollback;
+        var allConfirmed = true;
+        survivors = <StructuredMatch>[];
+        for (final m in _detectionMatches) {
+          final v = _revalidatedMatch(
+            m,
+            scanPatterns,
+            cols,
+            maxEndAbs,
+            frameShifted: frameShifted,
+            drop: drop,
+          );
+          if (v == null) {
+            changed = true; // confirmed gone → evict
+            continue;
+          }
+          if (identical(v, m)) {
+            if (frameShifted) allConfirmed = false; // kept on deferral
+          } else {
+            changed = true; // re-located → ranges updated
+          }
+          survivors.add(v);
+        }
+        // Advance the frame epoch only when every surviving match was
+        // CONFIRMED at the current coordinates (trusted re-validation or a
+        // successful re-locate). A deferral leaves the epoch stale so later
+        // prunes keep treating the frame as shifted until the debounced
+        // rescan re-anchors.
+        if (allConfirmed) {
+          _detectionFrameScrollback = scrollback;
+          _detectionFrameCols = cols;
+          _detectionFrameRows = visibleRows;
+        }
       }
     } catch (_) {
       // A read hiccup must not crash or spuriously clear anchors; leave the set
@@ -503,47 +579,103 @@ class TerminalControllerImpl extends TerminalController
       return;
     }
 
-    if (survivors.length == _detectionMatches.length) return; // nothing dropped
+    if (!changed) return; // nothing dropped or moved
     _detectionMatches = survivors;
     highlights = [for (final m in survivors) ...m.ranges];
-    // The anchor set shrank → wake the narrow decoration listener so the
+    // The anchor set shrank/moved → wake the narrow decoration listener so the
     // decorator re-resolves and the orphaned box vanishes immediately.
     _decorationNotifier.notify();
   }
 
-  /// #873: true iff [match] is STILL present in the current cells — i.e. a fresh
-  /// scan over exactly the rows it occupies (clamped to the live buffer) yields a
-  /// same-payload match. Re-uses the production scanner + patterns so re-
-  /// validation matches detection exactly.
-  bool _matchStillPresent(
+  /// #873/#883: re-validate [match] against the current cells and decide
+  /// evict-vs-keep:
+  ///
+  /// - `null` — CONFIRMED gone: the coordinate frame is trusted
+  ///   ([frameShifted] false: scrollback has not shrunk, no resize since the
+  ///   match was anchored — absolute rows are append-stable, so the stored
+  ///   rows still address the same content) and a fresh scan over exactly
+  ///   those rows no longer yields a same-payload match. The row was redrawn
+  ///   in place with different/erased text → evict synchronously (#873).
+  /// - the SAME instance — kept: either the trusted re-scan still found the
+  ///   payload at its stored rows, or the frame HAS shifted and the match
+  ///   could not be cheaply re-located — then the mismatch proves nothing
+  ///   (the #883 over-evict), so KEEP and defer to the debounced
+  ///   [_rescanDetections], which re-anchors from content (or legitimately
+  ///   drops it once it is outside the bounded window).
+  /// - a NEW instance — the frame shifted but the same-payload match was
+  ///   RE-LOCATED at the drop-corrected rows: keep it with the fresh
+  ///   coordinates so anchors/highlights track the eviction shift
+  ///   immediately instead of waiting out the debounce.
+  ///
+  /// Re-uses the production scanner + patterns so re-validation matches
+  /// detection exactly (wrap-join, normalize, OSC-8 grouping).
+  StructuredMatch? _revalidatedMatch(
     StructuredMatch match,
     List<TextPattern> scanPatterns,
     int cols,
-    int maxEndAbs,
-  ) {
-    if (scanPatterns.isEmpty) return false;
+    int maxEndAbs, {
+    required bool frameShifted,
+    required int drop,
+  }) {
+    if (scanPatterns.isEmpty) return null;
     var top = match.ranges.first.topRow;
     var bottom = match.ranges.first.bottomRow;
     for (final r in match.ranges) {
       if (r.topRow < top) top = r.topRow;
       if (r.bottomRow > bottom) bottom = r.bottomRow;
     }
-    // Clamp to the live buffer; a match whose rows fell out of the buffer
-    // (evicted / scrolled past) yields an empty region → no re-match → drop.
-    final startAbs = top < 0 ? 0 : top;
-    final endAbs = (bottom + 1) > maxEndAbs ? maxEndAbs : bottom + 1; // exclusive
-    if (endAbs - startAbs <= 0) return false;
+
+    if (!frameShifted) {
+      // Trusted frame — #873 semantics, unchanged: scan exactly the stored
+      // rows (clamped to the live buffer). Same-payload found → keep; a
+      // readable mismatch, an erased row, or rows truly beyond the live
+      // buffer → confirmed content change → evict.
+      final startAbs = top < 0 ? 0 : top;
+      final endAbs = (bottom + 1) > maxEndAbs ? maxEndAbs : bottom + 1;
+      if (endAbs - startAbs <= 0) return null;
+      final fresh = _scanWindow(startAbs, endAbs, cols, scanPatterns);
+      for (final f in fresh) {
+        if (f.payload == match.payload) return match;
+      }
+      return null;
+    }
+
+    // Shifted frame (#883). If the shift came from a scrollback shrink, the
+    // content moved UP in absolute rows by AT LEAST the observed drop (same-
+    // burst appends make the true shift larger). Try to re-locate the same
+    // payload there; on success adopt the fresh coordinates.
+    if (drop > 0) {
+      var startAbs = top - drop - _relocateRowSlack;
+      if (startAbs < 0) startAbs = 0;
+      var endAbs = bottom + 1 - drop + _relocateRowSlack;
+      if (endAbs > maxEndAbs) endAbs = maxEndAbs;
+      if (endAbs - startAbs > 0) {
+        final fresh = _scanWindow(startAbs, endAbs, cols, scanPatterns);
+        for (final f in fresh) {
+          if (f.payload == match.payload) return f;
+        }
+      }
+    }
+    // Could not confirm presence OR absence under a shifted frame — keep the
+    // match and let the debounced rescan re-anchor (or drop) it from content.
+    return match;
+  }
+
+  /// Scan absolute screen rows [startAbs, [endAbs]) with the production
+  /// scanner/patterns (the prune's bounded re-read).
+  List<StructuredMatch> _scanWindow(
+    int startAbs,
+    int endAbs,
+    int cols,
+    List<TextPattern> scanPatterns,
+  ) {
     final reader = _ScreenCellReader(
       terminal: terminal,
       cols: cols,
       startAbsRow: startAbs,
       endAbsRow: endAbs,
     );
-    final fresh = _detectionScanner.scan(reader, scanPatterns);
-    for (final f in fresh) {
-      if (f.payload == match.payload) return true;
-    }
-    return false;
+    return _detectionScanner.scan(reader, scanPatterns);
   }
 
   /// #767: re-scan the active screen plus a bounded scrollback window for every
@@ -629,6 +761,14 @@ class TerminalControllerImpl extends TerminalController
           endAbsRow: endAbs,
         );
         matches = _detectionScanner.scan(reader, scanPatterns);
+        // #883: a fresh scan emits absolute rows in the CURRENT coordinate
+        // frame — record that frame as the matches' anchor epoch so the
+        // synchronous prune can tell a real in-place content change (frame
+        // unchanged → evict, #873) from coordinate drift after a scrollback
+        // eviction/clear or a resize reflow (frame shifted → keep/re-locate).
+        _detectionFrameScrollback = scrollback;
+        _detectionFrameCols = cols;
+        _detectionFrameRows = visibleRows;
       }
     } catch (_) {
       matches = const [];

--- a/native/third_party/flterm/test/widgets/scroll_to_top_painted_offset_883_test.dart
+++ b/native/third_party/flterm/test/widgets/scroll_to_top_painted_offset_883_test.dart
@@ -1,0 +1,142 @@
+// #883 (cycle 2) — the ON-EMULATOR mechanism behind "matchAt on the URL cell
+// after scroll did not resolve it", pinned headless.
+//
+// `TerminalControllerImpl.scrollToTop()` used to set the FFI scrollbar to 0
+// (`terminal.scrollToTop()`) BEFORE jumping the ScrollController. The render
+// box's `_onScroll` derives its scroll delta as
+// `targetOffset - scrollbar.offset`; with the FFI offset already 0 the delta
+// was 0 and `_onScroll` returned WITHOUT marking the frame dirty. The frame
+// never re-synced, so:
+//   - the glyphs kept showing the BOTTOM of scrollback (stale paint), and
+//   - `reportPaintedViewportOffset(0)` never fired — [paintedViewportOffset]
+//     stayed at the bottom value indefinitely (no further output → nothing
+//     else refreshes the frame's offset).
+// [matchAt]/[highlightAt] map viewport→absolute via the PAINTED offset so
+// hit-test and paint share one geometry source (#863); with the painted
+// offset stale at ~bottom, a tap on the URL now visible at the TOP of
+// scrollback resolved to a wrong absolute row → null. The detection anchor
+// itself was alive the whole time (instrumented on-emulator: anchors carried
+// the URL payload, scrollbar.offset == 0, paintedViewportOffset == 195) —
+// hypothesis (b), not a prune eviction.
+//
+// The fix reorders scrollToTop: jump the ScrollController FIRST (while the
+// FFI scrollbar still holds the old offset) so `_onScroll` sees the real
+// delta → `scrollViewport` + frame-dirty → the next paint syncs and reports
+// offset 0; `terminal.scrollToTop()` stays as the detached/headless backstop.
+//
+// RED on the pre-fix order: paintedViewportOffset stays at the bottom value
+// and matchAt returns null. GREEN with the reorder.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const url = 'https://example.com/some/path/page';
+
+  Widget wrapInApp(TerminalController controller) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 800,
+          height: 480,
+          child: TerminalView(controller: controller),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'programmatic scrollToTop repaints the frame: the painted viewport offset '
+    'reaches 0, the anchor survives the pure viewport scroll, and matchAt '
+    'resolves the URL at the top of scrollback (#883)',
+    (tester) async {
+      final controller = TerminalController();
+      addTearDown(controller.dispose);
+      controller.registerTextPattern(TextPattern.url());
+
+      await tester.pumpWidget(wrapInApp(controller));
+      await tester.pump();
+
+      void write(String s) {
+        controller.write(Uint8List.fromList(utf8.encode(s)));
+      }
+
+      // Print the URL, then push it to the very top of scrollback. Nowhere
+      // near the scrollback cap — no eviction, no row shift: the ONLY
+      // mechanism in play is the pure viewport scroll. Filler lines are
+      // LONGER than the URL row so the scanner's inferred-wrap-col heuristic
+      // never width-joins the URL with its neighbour (same trick as
+      // scrollback_eviction_anchor_883_test.dart).
+      write('$url\r\n');
+      for (var i = 0; i < 200; i++) {
+        write('f${i.toString().padLeft(5, '0')} ${'x' * 30}\r\n');
+      }
+      // Let layout stick-to-bottom, the ~120ms detection debounce, and the
+      // ~140ms scroll-settle timer all run, then paint a settled frame.
+      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump();
+
+      expect(
+        controller.scrollbackRows,
+        greaterThan(0),
+        reason: 'precondition: the output filled scrollback',
+      );
+      expect(
+        controller.anchors.any((a) => a.payload == url),
+        isTrue,
+        reason: 'precondition: the URL is detected in scrollback',
+      );
+      expect(
+        controller.paintedViewportOffset,
+        greaterThan(0),
+        reason: 'precondition: the frame painted at the BOTTOM of scrollback '
+            '(stick-to-bottom), so the painted offset is non-zero',
+      );
+
+      controller.scrollToTop();
+      // One frame for the repaint the scroll MUST trigger, then settle the
+      // detection debounce + scroll-settle timers.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      expect(controller.scrollbar.offset, 0,
+          reason: 'scrollToTop moved the live scrollbar to the top');
+
+      // The anchor must survive a PURE viewport scroll — no content changed,
+      // so the synchronous prune has nothing to evict (hypothesis (a) ruled
+      // out and pinned).
+      expect(
+        controller.anchors.any((a) => a.payload == url),
+        isTrue,
+        reason: 'a pure viewport scroll to top must not evict the anchor',
+      );
+
+      // THE #883 CYCLE-2 RED ASSERTION: the frame must have repainted at the
+      // top — pre-fix the delta-0 early return left the painted offset stale
+      // at the bottom value, so hit-tests resolved a wrong absolute row.
+      expect(
+        controller.paintedViewportOffset,
+        0,
+        reason: 'scrollToTop must repaint the frame so the painted viewport '
+            'offset reaches 0 — a stale painted offset breaks every '
+            'painted-offset hit-test (matchAt/highlightAt, #863)',
+      );
+
+      // And the user-visible behaviour: hit-testing the URL cell (viewport
+      // row = absolute row - offset = absolute row) resolves the match.
+      final range =
+          controller.highlights.firstWhere((r) => r.payload == url);
+      final viewRow = range.startRow - controller.scrollbar.offset;
+      final match = controller.matchAt(row: viewRow, col: range.startCol);
+      expect(
+        match?.payload,
+        url,
+        reason: 'matchAt on the URL cell after scrollToTop must resolve it',
+      );
+    },
+  );
+}

--- a/scripts/gh-ops.sh
+++ b/scripts/gh-ops.sh
@@ -212,6 +212,27 @@ case "$CMD" in
     gh pr merge "$PR_NUM" "$STRATEGY" --delete-branch
     ;;
 
+  pr-edit)
+    # Update a PR's body (and/or title): pr-edit PR_NUM --body-file FILE [--title T]
+    [ $# -ge 1 ] || { echo "Error: pr-edit requires PR number" >&2; exit 1; }
+    PR_NUM="$1"; shift
+    BODY_FILE=""
+    TITLE=""
+    while [[ $# -gt 0 ]]; do
+      case $1 in
+        --body-file) BODY_FILE="$2"; shift 2 ;;
+        --title) TITLE="$2"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+      esac
+    done
+    ARGS=()
+    [ -n "$BODY_FILE" ] && ARGS+=(--body-file "$BODY_FILE")
+    [ -n "$TITLE" ] && ARGS+=(--title "$TITLE")
+    [ ${#ARGS[@]} -ge 1 ] || { echo "Error: pr-edit needs --body-file and/or --title" >&2; exit 1; }
+    echo "Editing PR #${PR_NUM}" >&2
+    gh pr edit "$PR_NUM" "${ARGS[@]}"
+    ;;
+
   pr-close)
     [ $# -ge 1 ] || { echo "Error: pr-close requires PR number" >&2; exit 1; }
     PR_NUM="$1"; shift


### PR DESCRIPTION
Fixes #883 — in-terminal URL/path anchors vanishing from scrollback (prune over-evict) **plus** the cycle-2 on-emulator discovery: stale painted-offset hit-tests after programmatic `scrollToTop`.

## Cycle 1 — prune evicts only on CONFIRMED content change

The #873 synchronous `_pruneStaleDetections()` re-read each match's STORED absolute screen rows and evicted on any mismatch. Absolute rows are append-stable, but libghostty evicts scrollback in large PAGE bursts at the cap (probed ≈1139 rows in one write at cols=40), shifting EVERY absolute row at once — the prune evicted live anchors before the debounced rescan could correct, and with the match > ~200 rows above the tail the bounded rescan never re-found it: permanent loss.

Fix: track the matches' coordinate-frame EPOCH (scrollbackRows + cols + visibleRows at last anchoring). Trusted frame → #873 semantics unchanged (in-place mismatch still evicts synchronously). Shifted frame → a mismatch proves nothing: re-locate the same payload at drop-corrected rows (adopt fresh ranges) or KEEP and defer to the debounced rescan. Degenerate render state defers instead of blanket-clearing.

Headless pin: `native/test/terminal/scrollback_eviction_anchor_883_test.dart` (real libghostty driven to the actual page-eviction boundary; red pre-fix, green with it; ESC[3J case pins that deferral doesn't leak truly-gone anchors).

## Cycle 2 — the remaining acceptance failure was NOT the prune

`ghostty_url_detection_test.dart` still failed at `matchAt` after `scrollToTop()`. One instrumented emulator run discriminated the hypotheses:

```
anchors=[..., url:https://example.com/...wrap@12, ...]
scrollbarOffset=0  paintedOffset=195  isScrolling=false
```

Anchors ALIVE (hypothesis (a) — prune eviction during the scroll — ruled out; the cycle-1 fix held). **Hypothesis (b) confirmed**: `matchAt` maps viewport→absolute via the PAINTED offset (the #863 paint/hit-test unification), and the painted offset was stale at the bottom (195) while the live offset was 0 → absRow 12+195=207 → null.

**Mechanism**: `TerminalControllerImpl.scrollToTop()` zeroed the FFI scrollbar (`terminal.scrollToTop()`) BEFORE jumping the ScrollController. The render box's `_onScroll` derives `delta = targetOffset - scrollbar.offset`; with the FFI offset already 0, delta == 0 → early return WITHOUT `_markFrameDirty()`. `_paintState.viewportOffset` only refreshes on a dirty frame sync, so `reportPaintedViewportOffset(0)` never fired — the painted offset (and the painted glyphs) stayed at the bottom indefinitely with no later event to correct them.

**Fix** (surgical reorder in `terminal_controller_impl.dart`, no #863 offset divergence reintroduced): jump the ScrollController FIRST, while the FFI scrollbar still holds the old offset, so `_onScroll` sees the real delta → `scrollViewport` + frame-dirty → the next paint syncs and reports offset 0. `terminal.scrollToTop()` remains as the detached/headless backstop (idempotent no-op after the jump-driven scroll).

Headless pin (red→green verified by temporarily reverting the order): `native/third_party/flterm/test/widgets/scroll_to_top_painted_offset_883_test.dart` — URL at the top of scrollback, NO eviction (pure viewport scroll), `scrollToTop()`, asserts anchor survival + `paintedViewportOffset == 0` + `matchAt` resolution. Pre-fix order fails exactly like the emulator (painted 169 vs live 0).

**Latent sibling (not changed here)**: `scrollToBottom()` has the same model-first ordering (delta 0 → stale paint when no output follows; the pin-to-bottom button `ghostty_terminal_view.dart:2322` hits it), but it sits on the per-output hot path (`_scrollToBottomOnOutput`) under the stick-to-bottom layout net — left untouched deliberately; recommend a follow-up issue.

## #828 selection_copy_after_redraw — harness gap, fixed in the TEST

On-device, Copy writes via the NATIVE `mobissh/clipboard` MethodChannel (`setText`, the #845 labeled-clip path); `Clipboard.setData` is only its no-plugin fallback. The test mocked only `SystemChannels.platform`, so cycle-1 telemetry showed `[clipboard] wrote 129 chars (native)` while the capture stayed null. The test now mocks BOTH channels (native `setText` + platform fallback/`getData` read-back). App code untouched.

Also adds a `pr-edit` subcommand to `scripts/gh-ops.sh` (PR body/title updates were not wrapped; rules forbid raw `gh`).

## Validation

- **On-emulator**: `integration_test/ghostty_url_detection_test.dart` **GREEN**; `integration_test/selection_copy_after_redraw_test.dart` **GREEN**
- Fork suite: 742 green (741 + new pin); new pin verified RED on pre-fix order
- `scrollback_eviction_anchor_883_test.dart` (3), `redraw_anchor_eviction_873_test.dart` (all 5), `replay_paint_hit_unify_863_test.dart` green
- `scripts/native-fast-gate.sh` (analyze + 1257 unit tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
