### PR TITLE
fix(#885): attention notifications must not outlive their session — death-cancel + dead-host tap reconnect-or-cancel

### DIFF
--- a/native/lib/services/attention_focus_router.dart
+++ b/native/lib/services/attention_focus_router.dart
@@ -16,10 +16,19 @@
 //      BOTH focuses the originating session AND opens the URL. Guarded to
 //      well-formed http(s) only; launch errors are swallowed so a tap never
 //      crashes.
+//   4. DEAD HOST (#885): when the payload's host has NO live session at all
+//      (route='none' — cold start after process death, or the session closed),
+//      the tap must never strand the user on the connect view with the
+//      notification still posted. Instead: RECONNECT the host's profile via the
+//      injected [reconnectHost] seam and focus the new session once it exists;
+//      when reconnect is unwired / resolves nothing (no profile, no creds) /
+//      throws, CANCEL the host's notification via [cancelHostNotification] so
+//      the undeliverable notification doesn't dangle. Either way the decision
+//      is logged (`route=reconnect` / `route=cancelled`).
 //
 // The platform/UI wiring (which sessionId is valid, how to send PTY bytes, how
-// to detect tmux, how to open a URL) is injected so this class is unit-testable
-// without Flutter.
+// to detect tmux, how to open a URL, how to reconnect/cancel) is injected so
+// this class is unit-testable without Flutter.
 
 import 'session_attention_notification.dart';
 import 'tmux_window_select.dart';
@@ -34,6 +43,8 @@ class AttentionFocusRouter {
     bool Function(String sessionId)? isTmux,
     Future<void> Function(String url)? openUrl,
     String? Function(String host)? resolveLiveSessionForHost,
+    Future<String?> Function(String host)? reconnectHost,
+    Future<void> Function(String host)? cancelHostNotification,
     void Function(String where, String msg)? log,
   }) : _bridge = bridge,
        _setActive = setActive,
@@ -42,6 +53,8 @@ class AttentionFocusRouter {
        _isTmux = isTmux,
        _openUrl = openUrl,
        _resolveLiveSessionForHost = resolveLiveSessionForHost,
+       _reconnectHost = reconnectHost,
+       _cancelHostNotification = cancelHostNotification,
        _log = log;
 
   // ignore_for_file: prefer_initializing_formals
@@ -59,6 +72,22 @@ class AttentionFocusRouter {
   /// previously-active, different-host session — the #857 bug). Null/unwired →
   /// no fallback (the router gives up on a stale id, as before).
   final String? Function(String host)? _resolveLiveSessionForHost;
+
+  /// Dead-host RECONNECT seam (#885). Given a HOST with no live session,
+  /// triggers that host's profile reconnect (production: resolve the saved
+  /// profile + vault creds and route through the EXISTING connect flow —
+  /// `sessionsProvider.notifier.addOrActivate` + `proxy.connect`, the same path
+  /// a profile-row tap takes) and resolves to the NEW sessionId once the entry
+  /// exists, or null when the host has no profile / no usable stored creds.
+  /// Null/unwired → the router falls through to [_cancelHostNotification].
+  final Future<String?> Function(String host)? _reconnectHost;
+
+  /// Dead-host CANCEL seam (#885). Cancels the HOST's attention notification
+  /// (host-keyed tag, #847) when the tap cannot deliver: no live session AND
+  /// reconnect is unwired or declined. Without this the undeliverable
+  /// notification dangles, promising attention for a session that is gone.
+  /// Best-effort: errors are swallowed (a tap must never crash).
+  final Future<void> Function(String host)? _cancelHostNotification;
 
   /// URL opener seam (#710), or null when URL-open is unwired (e.g. a test that
   /// only exercises focus routing). Production binds this to
@@ -121,7 +150,10 @@ class AttentionFocusRouter {
       '${sid == null ? 'none' : 'setActive(matched sid=$sid) | $route'}',
     );
 
-    if (sid == null) return null;
+    // #885: a tap whose host has NO live session must never silently strand
+    // the user on the connect view — reconnect the host's profile (preferred)
+    // or cancel the now-undeliverable notification.
+    if (sid == null) return _routeDeadHost(host);
 
     _setActive(sid);
 
@@ -148,6 +180,38 @@ class AttentionFocusRouter {
       }
     }
     return sid;
+  }
+
+  /// Dead-host routing (#885): the pending payload's [host] has no live session
+  /// (route='none'). Try the injected profile-reconnect seam first — when it
+  /// resolves a new sessionId, focus it (the tap delivers after all). Otherwise
+  /// (seam unwired, no profile / no creds, or the reconnect threw) cancel the
+  /// host's notification so it can't dangle and promise attention forever.
+  /// Both outcomes log through the capturable seam (#870) — `route=reconnect` /
+  /// `route=cancelled` — so the next device report shows the decision.
+  Future<String?> _routeDeadHost(String host) async {
+    final reconnect = _reconnectHost;
+    if (reconnect != null) {
+      String? newSid;
+      try {
+        newSid = await reconnect(host);
+      } catch (_) {
+        // Best-effort: a failed reconnect degrades to cancel, never crashes.
+        newSid = null;
+      }
+      if (newSid != null) {
+        _setActive(newSid);
+        _log?.call('ui.attention', 'route=reconnect host=$host sid=$newSid');
+        return newSid;
+      }
+    }
+    try {
+      await _cancelHostNotification?.call(host);
+    } catch (_) {
+      // Best-effort: a failed cancel must not crash the tap.
+    }
+    _log?.call('ui.attention', 'route=cancelled host=$host');
+    return null;
   }
 }
 

--- a/native/lib/services/attention_notifier_fln.dart
+++ b/native/lib/services/attention_notifier_fln.dart
@@ -121,10 +121,6 @@ class FlnAttentionNotifier implements AttentionNotifier {
     _initialized = true;
   }
 
-  /// Stable integer notification id derived from the per-session tag so a repeat
-  /// from the same session REPLACES (same id) rather than stacks.
-  int _idFor(String tag) => tag.hashCode & 0x7fffffff;
-
   @override
   Future<void> post(AttentionNotification n) async {
     await _ensureInit();
@@ -138,7 +134,9 @@ class FlnAttentionNotifier implements AttentionNotifier {
       autoCancel: true,
     );
     await _plugin.show(
-      _idFor(n.tag),
+      // Shared tag→id derivation (#885) so the dead-host tap cancel addresses
+      // the exact id this post used.
+      attentionIdForTag(n.tag),
       n.title,
       n.body,
       NotificationDetails(android: details),
@@ -152,8 +150,8 @@ class FlnAttentionNotifier implements AttentionNotifier {
     await _ensureInit();
     // #847: notifications are keyed per-HOST, so cancel the host's slot (a tap
     // / focus on any session to this host clears the one shared notification).
-    final tag = 'mobissh.attention.${hostOfSessionId(sessionId)}';
-    await _plugin.cancel(_idFor(tag), tag: tag);
+    final tag = attentionTagForHost(hostOfSessionId(sessionId));
+    await _plugin.cancel(attentionIdForTag(tag), tag: tag);
   }
 }
 

--- a/native/lib/services/session_attention_notification.dart
+++ b/native/lib/services/session_attention_notification.dart
@@ -52,6 +52,18 @@ const String kAttentionTitle = 'MobiSSH — Claude needs attention';
 /// rather than stacks (the #847 "two stacked identical alerts" bug).
 const String _tagPrefix = 'mobissh.attention.';
 
+/// The Android notification tag for [host]'s attention slot (#847). Shared by
+/// the builder ([AttentionNotification.build]), the platform poster/canceller
+/// (`FlnAttentionNotifier`), and the dead-host tap cancel (#885) so the key
+/// can never drift between the post and the cancel.
+String attentionTagForHost(String host) => '$_tagPrefix$host';
+
+/// Stable non-negative integer notification id derived from [tag], so a repeat
+/// post for the same host REPLACES (same id+tag) and a cancel addresses the
+/// exact posted notification. Shared for the same no-drift reason as
+/// [attentionTagForHost].
+int attentionIdForTag(String tag) => tag.hashCode & 0x7fffffff;
+
 /// Cross-session attention dedup window (#847). Multiple bells from multiple
 /// sessions to the SAME host within this window collapse to ONE notification —
 /// a single underlying Claude event reaching two PTYs should not double-alert.
@@ -202,7 +214,7 @@ class AttentionNotification {
       // Per-HOST tag (#847): two sessions to the same host collapse to one
       // notification slot (replace, not stack). The tap payload still carries
       // the exact sessionId so focus routing is unchanged.
-      tag: '$_tagPrefix${hostOfSessionId(sessionId)}',
+      tag: attentionTagForHost(hostOfSessionId(sessionId)),
       payload: jsonEncode(payloadMap),
       sourceWindow: win,
       url: url,

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -498,6 +498,15 @@ class SessionHost {
         // context, and a monotonic edge# so a capture reveals double-fires
         // ("cut once"). Telemetry only — drives no behaviour.
         _maybeRecordDisconnect(cmd.sessionId, hosted, prevState, data);
+        // #885: a TERMINAL transition (failed / disconnected — NOT the
+        // transient reconnecting/softDisconnected drop states, whose
+        // auto-reconnect can still revive the session) means this session can
+        // never deliver an attention tap again. Cancel the HOST's notification
+        // unless a sibling session to the same host is still live (the #857
+        // host-fallback can still route the tap there).
+        if (_terminalStates.contains(data.state)) {
+          _cancelAttentionForDeadHost(cmd.sessionId);
+        }
         prevState = data.state;
       }
       // Drop the prior shell the instant the transport leaves `connected`
@@ -554,6 +563,12 @@ class SessionHost {
     final hosted = _sessions.remove(cmd.sessionId);
     if (hosted == null) return;
     unawaited(_teardown(cmd.sessionId, hosted));
+    // #885: a user-closed session is terminal, but `_teardown` cancels the
+    // state subscription BEFORE the controller emits `disconnected`, so the
+    // state listener never sees this death — cancel here instead. The session
+    // is already out of [_sessions], so the sibling-live guard only consults
+    // the survivors.
+    _cancelAttentionForDeadHost(cmd.sessionId);
   }
 
   void _handleInput(SshInputCommand cmd) {
@@ -763,6 +778,52 @@ class SessionHost {
     SshSessionState.failed,
     SshSessionState.disconnected,
   };
+
+  /// TERMINAL session states (#885) — the session is gone for good (a user
+  /// close, an exhausted/aborted reconnect). Deliberately EXCLUDES the
+  /// transient drop states (`softDisconnected`/`reconnecting`): their
+  /// auto-reconnect can still revive the session, so its host's attention
+  /// notification can still deliver and must survive them.
+  static const Set<SshSessionState> _terminalStates = {
+    SshSessionState.failed,
+    SshSessionState.disconnected,
+  };
+
+  /// Cancel [sessionId]'s HOST attention notification once the host can no
+  /// longer deliver a tap (#885): every hosted session to that host is in a
+  /// terminal state (or gone). Skips when ANY sibling session to the same host
+  /// is still non-terminal — the #857 host-fallback can still route the tap to
+  /// it. The notifier's `cancel` is host-keyed (#847), so cancelling by the
+  /// dead session's id clears the host's one shared notification slot.
+  /// Best-effort + fire-and-forget: a cancel failure must never break the
+  /// session pipeline. No-op when no notifier is wired (desktop / unit tests
+  /// without one).
+  void _cancelAttentionForDeadHost(String sessionId) {
+    final notifier = _attentionNotifier;
+    if (notifier == null) return;
+    final host = hostOfSessionId(sessionId);
+    for (final entry in _sessions.entries) {
+      if (entry.key == sessionId) continue;
+      if (hostOfSessionId(entry.key) != host) continue;
+      if (!_terminalStates.contains(entry.value.controller.data.state)) {
+        clifecycle(
+          'attention',
+          'cancel skipped (host $host still has live session ${entry.key}) '
+              'session $sessionId',
+        );
+        return;
+      }
+    }
+    clifecycle(
+      'attention',
+      'cancelled (session terminal, host $host dead) session $sessionId',
+    );
+    unawaited(
+      notifier.cancel(sessionId).catchError((Object e) {
+        clifecycle('attention', 'cancel-error: $e (session $sessionId)');
+      }),
+    );
+  }
 
   /// Classify a drop edge's CAUSE from the (prev→new) transition + controller
   /// context (#838). Pure string label for telemetry; no behaviour depends on
@@ -1319,6 +1380,24 @@ class SessionHost {
     _snapshotTimer = null;
     await _commandSub?.cancel();
     _commandSub = null;
+    // #885: a graceful host dispose (FGS stop) kills every session — no
+    // attention notification can deliver afterwards, so cancel each distinct
+    // host's slot. One representative sessionId per host suffices (the
+    // notifier's cancel is host-keyed, #847). A process death never runs this,
+    // so a cold-start tap still finds its notification → the #885 dead-host
+    // reconnect path composes.
+    final notifier = _attentionNotifier;
+    if (notifier != null) {
+      final seenHosts = <String>{};
+      for (final id in _sessions.keys) {
+        if (!seenHosts.add(hostOfSessionId(id))) continue;
+        unawaited(
+          notifier.cancel(id).catchError((Object e) {
+            clifecycle('attention', 'cancel-error: $e (session $id)');
+          }),
+        );
+      }
+    }
     for (final entry in _sessions.entries) {
       await _teardown(entry.key, entry.value);
     }

--- a/native/lib/state/attention_providers.dart
+++ b/native/lib/state/attention_providers.dart
@@ -5,6 +5,7 @@
 // session existence, and PTY input for the guarded tmux select-window.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -17,6 +18,9 @@ import '../services/attention_focus_router.dart';
 import '../services/attention_notifier_fln.dart';
 import '../services/attention_tap_ui.dart';
 import '../services/session_attention_notification.dart';
+import '../ssh/ssh_connect_params.dart';
+import '../storage/profiles_store.dart';
+import 'profiles_providers.dart';
 import 'sessions.dart';
 
 /// Builds the [AttentionFocusRouter] bound to the live session collection.
@@ -72,6 +76,26 @@ final attentionFocusRouterProvider = Provider<AttentionFocusRouter>((ref) {
       }
       return bestId;
     },
+    // #885: dead-host tap → reconnect the host's PROFILE through the EXISTING
+    // connect flow (the same addOrActivate + proxy.connect path a profile-row
+    // tap takes — see connect_form `_connectFromProfile` and
+    // `SessionsNotifier._reviveFromProfile`). Resolves to the new session's id
+    // once the entry exists so the router can focus it; null when no saved
+    // profile matches the host or it has no usable stored credentials (then
+    // the router cancels the notification instead).
+    reconnectHost: (host) => _reconnectHostFromProfile(ref, host),
+    // #885: dead-host tap with no reconnectable profile → cancel the host's
+    // notification so it can't dangle. Deliberately a BARE plugin cancel (the
+    // shared tag/id helpers guarantee it addresses the posted slot), NOT
+    // `FlnAttentionNotifier.cancel` — its lazy `_ensureInit` would re-run
+    // `plugin.initialize` in this (UI) isolate and clobber the #878
+    // tap-binding registration. By tap time the UI isolate is already
+    // initialized via [attentionUiFlnInitProvider].
+    cancelHostNotification: (host) async {
+      final tag = attentionTagForHost(host);
+      await FlutterLocalNotificationsPlugin()
+          .cancel(attentionIdForTag(tag), tag: tag);
+    },
     // See doc above: a parsed (win N) hint implies the owner's tmux setup.
     isTmux: (_) => true,
     // #710: open an explicitly-signalled URL from the tapped notification in the
@@ -84,6 +108,77 @@ final attentionFocusRouterProvider = Provider<AttentionFocusRouter>((ref) {
     },
   );
 });
+
+/// Dead-host tap reconnect (#885): resolve [host]'s saved profile + vault
+/// credentials and re-connect through the EXISTING connect flow
+/// (`sessionsProvider.notifier.addOrActivate` + `proxy.connect` — the same
+/// path a profile-row / recent-session tap takes, and the same credential
+/// resolution as `SessionsNotifier._reviveFromProfile`). Returns the new
+/// session's id once the entry exists (the router focuses it), or null when no
+/// profile matches the host / it has no usable stored secret — the router then
+/// cancels the dangling notification instead. Best-effort: any failure resolves
+/// null (→ cancel), never throws into the tap.
+Future<String?> _reconnectHostFromProfile(Ref ref, String host) async {
+  try {
+    final profiles = await ref.read(profilesStoreProvider).load();
+    SavedProfile? match;
+    for (final p in profiles) {
+      if (p.host == host) {
+        match = p;
+        break;
+      }
+    }
+    if (match == null) {
+      ctrace('ui.attention', 'reconnectHost: no profile for host=$host');
+      return null;
+    }
+    final secrets = ref.read(secretsStoreProvider);
+    final creds = await loadProfileCredentials(secrets, match);
+    final wantsKey =
+        match.authType == 'key' ||
+        (match.authType == null &&
+            (creds.privateKey != null && creds.privateKey!.isNotEmpty));
+    final SshAuth? auth;
+    if (wantsKey && creds.privateKey != null && creds.privateKey!.isNotEmpty) {
+      auth = SshAuth.key(
+        Uint8List.fromList(utf8.encode(creds.privateKey!)),
+        passphrase: (creds.passphrase == null || creds.passphrase!.isEmpty)
+            ? null
+            : creds.passphrase,
+      );
+    } else if (!wantsKey &&
+        creds.password != null &&
+        creds.password!.isNotEmpty) {
+      auth = SshAuth.password(creds.password!);
+    } else {
+      auth = null;
+    }
+    if (auth == null) {
+      ctrace(
+        'ui.attention',
+        'reconnectHost: no stored creds for host=$host — cannot reconnect',
+      );
+      return null;
+    }
+    final params = SshConnectParams(
+      host: match.host,
+      port: match.port,
+      username: match.username,
+      auth: auth,
+    );
+    // The existing connect flow: addOrActivate dedupes by host:port:user,
+    // starts the keepalive service, creates the per-session proxy + terminal,
+    // and makes the new entry active; the connect is dispatched on its proxy.
+    final entry = ref
+        .read(sessionsProvider.notifier)
+        .addOrActivate(params, title: match.title);
+    unawaited(entry.proxy.connect(params, title: match.title));
+    return entry.id;
+  } catch (e) {
+    ctrace('ui.attention', 'reconnectHost failed for host=$host: $e');
+    return null;
+  }
+}
 
 /// UI-isolate FLN registration (#878). MUST run at app boot, BEFORE the boot
 /// path's initial `consumePending()`.

--- a/native/test/services/attention_focus_router_dead_host_test.dart
+++ b/native/test/services/attention_focus_router_dead_host_test.dart
@@ -1,0 +1,273 @@
+// Dead-host tap routing (#885): an attention notification must not outlive its
+// ability to deliver. When the tapped payload's HOST has NO live session
+// (route='none' — cold start after process death, or the session closed), the
+// router must either:
+//
+//   * RECONNECT: when the injected `reconnectHost` seam is wired and resolves a
+//     new sessionId (a profile exists for the host and the reconnect flow
+//     produced a session entry), focus that new session and log
+//     `route=reconnect host=…`; or
+//   * CANCEL: when the seam is unwired, resolves null (no profile / no creds),
+//     or throws — cancel the host's notification via the injected
+//     `cancelHostNotification` seam (so the dead notification doesn't dangle)
+//     and log `route=cancelled host=…`.
+//
+// Never the pre-#885 behavior: silently return null and strand the user on the
+// connect view with the notification still posted.
+//
+// All platform effects are injected — these tests run without Flutter bindings.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/attention_focus_router.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+
+void main() {
+  group('AttentionFocusRouter dead-host tap (#885)', () {
+    const staleSid = 'fddev:22:me:100'; // payload id; host fddev has no session
+    const newSid = 'fddev:22:me:999'; // the session the reconnect flow creates
+
+    Future<PendingFocusBridge> seededBridge() async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      await bridge.setPendingFromPayload(jsonEncode({'sessionId': staleSid}));
+      return bridge;
+    }
+
+    test(
+      'reconnect seam wired + profile exists → reconnect invoked, new session '
+      'focused, route=reconnect logged, NO cancel',
+      () async {
+        final bridge = await seededBridge();
+        final activated = <String>[];
+        final reconnected = <String>[];
+        final cancelled = <String>[];
+        final logs = <String>[];
+        final router = AttentionFocusRouter(
+          bridge: bridge,
+          setActive: activated.add,
+          sessionExists: (_) => false,
+          sendInput: (a, b) {},
+          resolveLiveSessionForHost: (_) => null,
+          reconnectHost: (host) async {
+            reconnected.add(host);
+            return newSid; // profile resolved + reconnect flow created a session
+          },
+          cancelHostNotification: (host) async => cancelled.add(host),
+          log: (where, msg) => logs.add(msg),
+        );
+
+        final focused = await router.consumePending();
+
+        expect(reconnected, ['fddev'],
+            reason: 'the dead-host tap must trigger the host profile reconnect');
+        expect(focused, newSid);
+        expect(activated, [newSid],
+            reason: 'the tap must focus the reconnected session once it exists');
+        expect(cancelled, isEmpty,
+            reason: 'a successful reconnect keeps delivering — nothing to cancel');
+        expect(logs.any((l) => l.contains('route=reconnect host=fddev')), isTrue,
+            reason: 'route decision must be capturable: $logs');
+      },
+    );
+
+    test(
+      'reconnect seam wired but NO profile (resolves null) → cancel invoked, '
+      'route=cancelled logged, nothing focused',
+      () async {
+        final bridge = await seededBridge();
+        final activated = <String>[];
+        final cancelled = <String>[];
+        final logs = <String>[];
+        final router = AttentionFocusRouter(
+          bridge: bridge,
+          setActive: activated.add,
+          sessionExists: (_) => false,
+          sendInput: (a, b) {},
+          reconnectHost: (_) async => null, // no profile / no usable creds
+          cancelHostNotification: (host) async => cancelled.add(host),
+          log: (where, msg) => logs.add(msg),
+        );
+
+        final focused = await router.consumePending();
+
+        expect(focused, isNull);
+        expect(activated, isEmpty);
+        expect(cancelled, ['fddev'],
+            reason: 'an undeliverable notification must be cancelled, not left '
+                'dangling');
+        expect(logs.any((l) => l.contains('route=cancelled host=fddev')), isTrue,
+            reason: 'route decision must be capturable: $logs');
+      },
+    );
+
+    test('reconnect seam ABSENT → cancel invoked (route=cancelled)', () async {
+      final bridge = await seededBridge();
+      final cancelled = <String>[];
+      final logs = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => false,
+        sendInput: (a, b) {},
+        cancelHostNotification: (host) async => cancelled.add(host),
+        log: (where, msg) => logs.add(msg),
+      );
+
+      expect(await router.consumePending(), isNull);
+      expect(cancelled, ['fddev']);
+      expect(logs.any((l) => l.contains('route=cancelled host=fddev')), isTrue);
+    });
+
+    test('reconnect seam THROWS → falls back to cancel, tap never crashes',
+        () async {
+      final bridge = await seededBridge();
+      final cancelled = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => false,
+        sendInput: (a, b) {},
+        reconnectHost: (_) async => throw StateError('reconnect boom'),
+        cancelHostNotification: (host) async => cancelled.add(host),
+      );
+
+      // Must not throw.
+      expect(await router.consumePending(), isNull);
+      expect(cancelled, ['fddev']);
+    });
+
+    test('cancel seam ABSENT too → still returns null without crashing',
+        () async {
+      final bridge = await seededBridge();
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => false,
+        sendInput: (a, b) {},
+      );
+      expect(await router.consumePending(), isNull);
+    });
+
+    test('cancel seam THROWS → swallowed, tap never crashes', () async {
+      final bridge = await seededBridge();
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => false,
+        sendInput: (a, b) {},
+        cancelHostNotification: (_) async => throw StateError('cancel boom'),
+      );
+      expect(await router.consumePending(), isNull);
+    });
+
+    test(
+      'LIVE session for the payload id → existing routing unchanged: '
+      'setActive(payload sid), reconnect + cancel never invoked',
+      () async {
+        final bridge = await seededBridge();
+        final activated = <String>[];
+        final reconnected = <String>[];
+        final cancelled = <String>[];
+        final router = AttentionFocusRouter(
+          bridge: bridge,
+          setActive: activated.add,
+          sessionExists: (id) => id == staleSid, // payload id IS live
+          sendInput: (a, b) {},
+          reconnectHost: (host) async {
+            reconnected.add(host);
+            return newSid;
+          },
+          cancelHostNotification: (host) async => cancelled.add(host),
+        );
+
+        final focused = await router.consumePending();
+        expect(focused, staleSid);
+        expect(activated, [staleSid]);
+        expect(reconnected, isEmpty,
+            reason: 'a live session routes via setActive — never reconnects');
+        expect(cancelled, isEmpty);
+      },
+    );
+
+    test(
+      'HOST-FALLBACK (#857) still wins over reconnect: stale payload id but the '
+      'host has a live session → setActive(live), no reconnect, no cancel',
+      () async {
+        final bridge = await seededBridge();
+        const liveSid = 'fddev:22:me:500';
+        final activated = <String>[];
+        final reconnected = <String>[];
+        final cancelled = <String>[];
+        final router = AttentionFocusRouter(
+          bridge: bridge,
+          setActive: activated.add,
+          sessionExists: (id) => id == liveSid,
+          sendInput: (a, b) {},
+          resolveLiveSessionForHost: (host) => host == 'fddev' ? liveSid : null,
+          reconnectHost: (host) async {
+            reconnected.add(host);
+            return newSid;
+          },
+          cancelHostNotification: (host) async => cancelled.add(host),
+        );
+
+        final focused = await router.consumePending();
+        expect(focused, liveSid);
+        expect(activated, [liveSid]);
+        expect(reconnected, isEmpty);
+        expect(cancelled, isEmpty);
+      },
+    );
+
+    test(
+      'cold-start seed (#878) composes: a seeded payload for a dead host drives '
+      'the same reconnect path on the boot consume',
+      () async {
+        // Mirrors AttentionUiTapBinding.seedColdStart: the launch-details payload
+        // is written as pending, then the boot path's consumePending routes it.
+        final bridge = PendingFocusBridge(MapKeyValueStore());
+        await bridge.setPendingFromPayload(jsonEncode({'sessionId': staleSid}));
+
+        final activated = <String>[];
+        final reconnected = <String>[];
+        final router = AttentionFocusRouter(
+          bridge: bridge,
+          setActive: activated.add,
+          sessionExists: (_) => false,
+          sendInput: (a, b) {},
+          reconnectHost: (host) async {
+            reconnected.add(host);
+            return newSid;
+          },
+          cancelHostNotification: (_) async {},
+        );
+
+        final focused = await router.consumePending(); // the boot consume
+        expect(reconnected, ['fddev']);
+        expect(focused, newSid);
+        expect(activated, [newSid]);
+      },
+    );
+
+    test('nothing pending → reconnect/cancel never invoked', () async {
+      final bridge = PendingFocusBridge(MapKeyValueStore());
+      final reconnected = <String>[];
+      final cancelled = <String>[];
+      final router = AttentionFocusRouter(
+        bridge: bridge,
+        setActive: (_) {},
+        sessionExists: (_) => false,
+        sendInput: (a, b) {},
+        reconnectHost: (host) async {
+          reconnected.add(host);
+          return null;
+        },
+        cancelHostNotification: (host) async => cancelled.add(host),
+      );
+      expect(await router.consumePending(), isNull);
+      expect(reconnected, isEmpty);
+      expect(cancelled, isEmpty);
+    });
+  });
+}

--- a/native/test/services/session_host_attention_cancel_test.dart
+++ b/native/test/services/session_host_attention_cancel_test.dart
@@ -1,0 +1,211 @@
+// Session-death attention-notification cancel (#885).
+//
+// An attention notification must not outlive its session: when a session
+// reaches a TERMINAL state (failed / disconnected — including the user closing
+// it), the host cancels that HOST's attention notification (host-keyed tag,
+// #847). TRANSIENT drop states (softDisconnected / reconnecting — the
+// auto-reconnect path is still in flight) must NOT cancel: the session can
+// revive and the notification can still deliver. A host with ANOTHER live
+// session must NOT cancel either — the #857 host-fallback can still route the
+// tap to that sibling.
+//
+// Headless via InMemoryGatewayPair + inert controllers the test drives directly
+// (no real socket), with a RecordingAttentionNotifier so no platform channels.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// Inert controller: the test owns connected + the drop; a reconnect attempt
+/// fail-fasts only when the test exhausts it deliberately.
+class _NoConnectController extends SshSessionController {
+  _NoConnectController({super.reconnectDelay});
+
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+class _Harness {
+  _Harness(this.host, this.pair, this.notifier, this.controllers);
+  final SessionHost host;
+  final InMemoryGatewayPair pair;
+  final RecordingAttentionNotifier notifier;
+
+  /// Controllers in creation order (one per connect command).
+  final List<SshSessionController> controllers;
+}
+
+Future<_Harness> _spawn() async {
+  final controllers = <SshSessionController>[];
+  final pair = InMemoryGatewayPair();
+  final notifier = RecordingAttentionNotifier();
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: () {
+      // A LONG reconnect delay so a transient drop parks in `reconnecting`
+      // instead of racing through exhausted attempts to `failed`.
+      final c = _NoConnectController(reconnectDelay: const Duration(hours: 1));
+      controllers.add(c);
+      return c;
+    },
+    snapshotInterval: const Duration(hours: 1),
+    attentionNotifier: notifier,
+    replayWindow: Duration.zero,
+  );
+  return _Harness(host, pair, notifier, controllers);
+}
+
+Future<void> _connect(_Harness h, String sid, {String host = 'h'}) async {
+  h.pair.uiSide.send(
+    SshConnectCommand(
+      sessionId: sid,
+      host: host,
+      port: 22,
+      username: 'u',
+      authJson: const {'type': 'password', 'password': 'p'},
+    ).toJson(),
+  );
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  h.controllers.last.debugSetConnectedForTest(_params);
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+}
+
+void main() {
+  test('connected → failed (terminal) cancels the host notification', () async {
+    const sid = 'h:22:u:1';
+    final h = await _spawn();
+    addTearDown(() async {
+      await h.host.dispose();
+      await h.pair.dispose();
+    });
+    await _connect(h, sid);
+    expect(h.notifier.cancelled, isEmpty);
+
+    // Non-transient transport error → `failed` directly (terminal).
+    h.controllers.single.handleTransportClosed(StateError('fatal'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(h.notifier.cancelled, [sid],
+        reason: 'a terminally-failed session must cancel its host notification');
+  });
+
+  test('user disconnect (SshDisconnectCommand) cancels the host notification',
+      () async {
+    const sid = 'h:22:u:2';
+    final h = await _spawn();
+    addTearDown(() async {
+      await h.host.dispose();
+      await h.pair.dispose();
+    });
+    await _connect(h, sid);
+
+    h.pair.uiSide.send(SshDisconnectCommand(sessionId: sid).toJson());
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(h.notifier.cancelled, [sid],
+        reason: 'a user-closed session must cancel its host notification');
+  });
+
+  test(
+    'TRANSIENT drop (softDisconnected → reconnecting) does NOT cancel',
+    () async {
+      const sid = 'h:22:u:3';
+      final h = await _spawn();
+      addTearDown(() async {
+        await h.host.dispose();
+        await h.pair.dispose();
+      });
+      await _connect(h, sid);
+
+      // Clean transport close from `connected` → softDisconnected + an armed
+      // reconnect (the 1h delay parks it in `reconnecting`).
+      h.controllers.single.handleTransportClosed(null);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(h.controllers.single.data.state, SshSessionState.reconnecting,
+          reason: 'precondition: the drop must park in the transient state');
+      expect(h.notifier.cancelled, isEmpty,
+          reason: 'a transient reconnecting drop can still revive — the '
+              'notification must survive it');
+    },
+  );
+
+  test(
+    'sibling session to the SAME host still live → NO cancel until the last '
+    'one dies',
+    () async {
+      const sidA = 'h:22:u:1';
+      const sidB = 'h:2222:u:2';
+      final h = await _spawn();
+      addTearDown(() async {
+        await h.host.dispose();
+        await h.pair.dispose();
+      });
+      await _connect(h, sidA);
+      await _connect(h, sidB);
+
+      // Kill A terminally — B (same host `h`) is still connected, so the host
+      // can still deliver the tap via the #857 host-fallback. No cancel.
+      h.controllers[0].handleTransportClosed(StateError('fatal'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(h.notifier.cancelled, isEmpty,
+          reason: 'host h still has a live session — keep the notification');
+
+      // Now kill B too — the host is fully dead → cancel.
+      h.controllers[1].handleTransportClosed(StateError('fatal'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(h.notifier.cancelled, [sidB],
+          reason: 'the LAST live session dying must cancel the host slot');
+    },
+  );
+
+  test('a DIFFERENT host dying does not cancel this host', () async {
+    const sidH = 'h:22:u:1';
+    const sidOther = 'other:22:u:1';
+    final h = await _spawn();
+    addTearDown(() async {
+      await h.host.dispose();
+      await h.pair.dispose();
+    });
+    await _connect(h, sidH, host: 'h');
+    await _connect(h, sidOther, host: 'other');
+
+    h.controllers[1].handleTransportClosed(StateError('fatal'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(h.notifier.cancelled, [sidOther],
+        reason: 'only the dead host (`other`) is cancelled — host h keeps its '
+            'notification slot');
+  });
+
+  test('host dispose (graceful FGS stop) cancels every hosted host', () async {
+    const sidA = 'h:22:u:1';
+    const sidB = 'other:22:u:1';
+    final h = await _spawn();
+    addTearDown(() async {
+      await h.pair.dispose();
+    });
+    await _connect(h, sidA, host: 'h');
+    await _connect(h, sidB, host: 'other');
+
+    await h.host.dispose();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    final cancelledHosts =
+        h.notifier.cancelled.map(hostOfSessionId).toSet();
+    expect(cancelledHosts, {'h', 'other'},
+        reason: 'a graceful FGS stop kills every session — no notification can '
+            'deliver, so every host slot is cancelled');
+  });
+}


### PR DESCRIPTION
Fixes #885 — an attention notification must not outlive its ability to deliver: cancel on session death, and a tap whose host has no live session reconnects the host's profile (preferred) or cancels + logs — never a silent strand on the connect view.

## Seam 1 — session-death cancel (task isolate, `session_host.dart`)

The task isolate posts notifications and owns the session state machine, so it also cancels:

- **Terminal transition edge** (`failed` / `disconnected`) in the controller state listener → `_cancelAttentionForDeadHost`. Transient drop states (`softDisconnected` / `reconnecting`) deliberately do NOT cancel — auto-reconnect can revive the session and the notification can still deliver.
- **User close** (`_handleDisconnect`) — teardown cancels the state subscription before the controller emits `disconnected`, so the listener never sees that death; the disconnect handler cancels explicitly.
- **Graceful FGS stop** (`dispose()`) — every session dies, so every distinct host slot is cancelled. Process death never runs dispose, so a cold-start tap still finds its notification → composes with the reconnect path below.
- **Sibling-live guard**: a host with ANOTHER non-terminal session keeps its notification — the #857 host-fallback can still route the tap there.

## Seam 2 — dead-host tap: reconnect-or-cancel (`attention_focus_router.dart`)

The route='none' path now takes two injected seams (router stays pure / unit-testable, all platform effects injected):

- `reconnectHost(host) → Future<String?>`: production resolves the host's saved profile + vault creds (same resolution as `_reviveFromProfile` / connect_form `_connectFromProfile`) and routes through the EXISTING connect flow — `sessionsNotifier.addOrActivate` + `proxy.connect` — returning the new session id once the entry exists. The router then focuses it and logs `route=reconnect host=…`.
- `cancelHostNotification(host)`: when reconnect is unwired / resolves null (no profile, no usable creds) / throws → cancel the host's notification and log `route=cancelled host=…`, so the undeliverable notification never dangles.
- Cold-start seed (#878 `getNotificationAppLaunchDetails`) composes: the seeded payload drives the same reconnect-or-cancel on the boot consume. No changes to `attention_tap_ui.dart` needed — warm tap + cold seed both funnel through `consumePending`.

Wiring note: the UI-isolate cancel is a **bare** `FlutterLocalNotificationsPlugin().cancel` via new shared `attentionTagForHost`/`attentionIdForTag` helpers (FlnAttentionNotifier refactored onto them, no key drift) — deliberately NOT `FlnAttentionNotifier.cancel`, whose lazy `_ensureInit` would re-run `plugin.initialize` in the UI isolate and clobber the #878 tap-binding registration.

## Tests (red→green)

- `attention_focus_router_dead_host_test.dart` (10): reconnect seam wired+resolves → reconnect invoked + new session focused + `route=reconnect` logged + no cancel; seam null/absent/throws → cancel + `route=cancelled`; cancel seam absent/throws → tap never crashes; live-session and #857 host-fallback routing unchanged (reconnect/cancel never invoked); cold-start seed composes; nothing-pending → no calls.
- `session_host_attention_cancel_test.dart` (6): connected→failed cancels; user disconnect cancels; transient reconnecting does NOT cancel; same-host sibling live → no cancel until the last dies; different host dying doesn't cancel this host; dispose cancels every hosted host.
- Existing attention suites (#878 tap binding, #870 bridge/telemetry, #857 fallback, #847 suppression) stay green.

## Gate

`scripts/native-fast-gate.sh` (worktree): analyze clean, 1273 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)