### PR TITLE
fix(#887): new output marks the glyph render box needs-paint — terminal text no longer invisible

### DIFF
--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -560,7 +560,18 @@ class TerminalRenderBox extends RenderBox {
     if (_paintState.rows == 0 || _performingLayout) return;
 
     if (_terminal.scrollbackRows != _lastScrollbackRows) {
-      _needsFrameSync = true;
+      // #887: scrollback grew (the steady-state case: a full shell streaming
+      // output pushes rows into history). `performLayout` only re-marks the
+      // frame dirty when the GRID size changed (`gridChanged ||
+      // atlasReconfigured`) — for plain output the grid is unchanged, so a
+      // bare `markNeedsLayout()` recomputes scroll extents but NEVER adds this
+      // box to the needs-PAINT set (markNeedsLayout does not imply
+      // markNeedsPaint in Flutter). The new glyph rows then stayed unpainted —
+      // only the independently-driven decoration layer (`_decorationNotifier`)
+      // repainted — until an unrelated event (route push / scroll / keystroke)
+      // forced a frame. `_markFrameDirty()` sets `_needsFrameSync` AND calls
+      // markNeedsPaint, so the glyphs repaint in lockstep with the new output.
+      _markFrameDirty();
       markNeedsLayout();
       return;
     }

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
+import 'package:flutter/scheduler.dart' show SchedulerBinding, SchedulerPhase;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:libghostty/libghostty.dart' as vt;
@@ -112,6 +113,21 @@ class TerminalControllerImpl extends TerminalController
   /// not on every one of the ~15 redraw notifies/sec a streaming TUI scroll
   /// emits. Exposed via [decorationListenable].
   final _DecorationNotifier _decorationNotifier = _DecorationNotifier();
+
+  /// #887: set while a [_onTerminalChanged] notify that arrived MID-FRAME has
+  /// already scheduled its deferred side-effects to the next post-frame
+  /// callback. libghostty's [Terminal.resize] — invoked synchronously from
+  /// [TerminalRenderBox.performLayout] when the grid is re-sized (SFTP browser
+  /// opens, keyboard inset changes the layout) — fires the terminal listener
+  /// DURING the layout/paint phase. Running the prune's `highlights=` notify
+  /// (→ the widget's `_updateTextInputGeometry` reading `RenderBox.size`) or
+  /// `_decorationNotifier.notify()` (→ an `AnimatedBuilder`/`setState`) then is
+  /// illegal ("RenderBox.size accessed beyond the scope…" / "Build scheduled
+  /// during frame"). When mid-frame we DEFER those effects to the next
+  /// post-frame callback; this flag coalesces a burst of mid-frame notifies in
+  /// the same frame into a single deferral. The normal (non-layout) notify path
+  /// stays synchronous so #873 eviction remains immediate when it is safe.
+  bool _deferredFrameWorkScheduled = false;
 
   FocusNode? _focusNode;
   TerminalSelection? _selection;
@@ -1556,19 +1572,66 @@ class TerminalControllerImpl extends TerminalController
       changed = true;
     }
 
+    // #767: a notify means the cells may have changed (output streamed) or the
+    // viewport scrolled; re-scan registered structured-text patterns on a
+    // debounce so the highlights track new content. No-op when none registered.
+    // This only (re)arms a Timer — safe to run mid-frame (it fires outside it).
+    _scheduleDetectionRescan();
+
+    // #887: the remaining work emits notifications that REBUILD or read layout
+    // geometry — `_scrollToBottomOnOutput` (scroll controller notify), the
+    // prune/synchronous rescan (`highlights=` general notify +
+    // `_decorationNotifier.notify()`), and the `changed` notify. When this
+    // terminal notify arrived DURING a frame's layout/paint phase (libghostty's
+    // `Terminal.resize` fired synchronously from `performLayout`), running them
+    // now throws "RenderBox.size accessed beyond the scope…" /
+    // "Build scheduled during frame". Defer to the next post-frame callback in
+    // that case; run synchronously otherwise so #873 eviction stays immediate.
+    _runOrDeferFrameWork(leftAlternateScreen, changed);
+  }
+
+  /// #887: the notify-producing tail of [_onTerminalChanged]. Runs synchronously
+  /// when it is safe to schedule rebuilds / read render geometry, and is
+  /// otherwise deferred (whole) to one post-frame callback. See
+  /// [_deferredFrameWorkScheduled].
+  void _runOrDeferFrameWork(bool leftAlternateScreen, bool changed) {
+    final phase = SchedulerBinding.instance.schedulerPhase;
+    final midFrame = phase == SchedulerPhase.persistentCallbacks ||
+        phase == SchedulerPhase.midFrameMicrotasks;
+    if (!midFrame) {
+      _applyFrameWork(leftAlternateScreen, changed);
+      return;
+    }
+    // Mid-frame: coalesce this and any further mid-frame notifies in the SAME
+    // frame into one post-frame pass. `leftAlternateScreen`/`changed` need not
+    // be carried — the deferred pass re-reads the live terminal state (the
+    // prune/rescan read cells directly) and always notifies, which is the
+    // superset of what an individual mid-frame notify would have done.
+    if (_deferredFrameWorkScheduled) return;
+    _deferredFrameWorkScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _deferredFrameWorkScheduled = false;
+      if (_disposed) return;
+      // Re-derive leftAlternateScreen would require remembering it; the
+      // post-frame pass simply runs the full detection reconcile + notify.
+      // Force a synchronous rescan so a vim-exit that happened mid-frame still
+      // re-anchors immediately on the next frame (parity with the inline path).
+      _applyFrameWork(true, true);
+    });
+  }
+
+  /// #887: the deferrable side-effects extracted from [_onTerminalChanged].
+  void _applyFrameWork(bool leftAlternateScreen, bool changed) {
+    if (_disposed) return;
     _scrollToBottomOnOutput();
     // #873: a redraw may have rewritten the cells UNDER a live anchor (tmux/app
     // repaints a row, or content scrolled past the bounded window). DISCOVERY of
-    // new matches stays debounced below, but EVICTION of a now-stale anchor must
-    // be immediate — synchronously re-validate the live anchors against the
+    // new matches stays debounced (above), but EVICTION of a now-stale anchor
+    // must be immediate — synchronously re-validate the live anchors against the
     // current cells and drop any whose run no longer carries the matched text, so
     // no orphaned highlight box lingers through the debounce window. No-op when no
     // anchors are live or no pattern is registered.
     _pruneStaleDetections();
-    // #767: a notify means the cells may have changed (output streamed) or the
-    // viewport scrolled; re-scan registered structured-text patterns on a
-    // debounce so the highlights track new content. No-op when none registered.
-    _scheduleDetectionRescan();
     // #824: returning to the shell (alternate->primary) must resume detection
     // immediately, not on the next stray notify — re-scan synchronously so the
     // shell's URLs/paths re-anchor the moment vim exits.

--- a/native/third_party/flterm/test/widgets/new_output_glyph_repaint_887_test.dart
+++ b/native/third_party/flterm/test/widgets/new_output_glyph_repaint_887_test.dart
@@ -1,0 +1,113 @@
+// #887 (P0, device 0.1.10+58) — terminal TEXT invisible: only the
+// structured-text HIGHLIGHT decoration paints on new output until a forced
+// repaint (route push / scroll / keystroke) makes the glyphs appear.
+//
+// MECHANISM (pinned here headless):
+// The render box's `_onTerminalChanged` handles a terminal notify two ways:
+//   - scrollback length UNCHANGED (screen not full) -> `_markFrameDirty()`
+//     (which calls `markNeedsPaint`) -> glyphs repaint. Fine.
+//   - scrollback length GREW (the screen was full and output pushed rows into
+//     history — the common steady-state case) -> it set `_needsFrameSync=true`
+//     and called ONLY `markNeedsLayout()`, then returned.
+// `markNeedsLayout()` does NOT imply `markNeedsPaint()` in Flutter: the box is
+// added to the needs-LAYOUT set, not the needs-PAINT set. `performLayout` then
+// runs but only calls `_markFrameDirty()` when the GRID size changed
+// (`gridChanged || atlasReconfigured`); for plain streamed output the grid is
+// unchanged, so the box is never marked needs-paint. The new glyph rows stay
+// unpainted (the `_needsFrameSync` flag just waits) until an UNRELATED event
+// forces a paint. Meanwhile the decoration layer repaints independently via the
+// controller's `_decorationNotifier`, so the #777 path underline/glyph shows on
+// the new rows while the path TEXT itself is blank — exactly the screenshot.
+//
+// RED on the pre-fix code: after output that grows scrollback, the render box
+// is NOT marked needs-paint. GREEN with the fix: the scrollback-grew branch
+// also marks the glyph render box needs-paint.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget wrapInApp(TerminalController controller) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 800,
+          height: 480,
+          child: TerminalView(controller: controller),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'new output that grows scrollback marks the glyph render box needs-paint '
+    'without a forced repaint (#887)',
+    (tester) async {
+      final controller = TerminalController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(wrapInApp(controller));
+      await tester.pump();
+
+      void write(String s) {
+        controller.write(Uint8List.fromList(utf8.encode(s)));
+      }
+
+      // Fill the screen and overflow it so the terminal accumulates scrollback
+      // history (the steady state when you've been typing in a shell). Pump a
+      // settled frame so the painted offset / scrollback bookkeeping catches up
+      // and the render box is clean (debugNeedsPaint == false) before the line
+      // under test.
+      for (var i = 0; i < 60; i++) {
+        write('line ${i.toString().padLeft(4, '0')}\r\n');
+      }
+      await tester.pump();
+      await tester.pump();
+
+      final renderBox = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+
+      expect(
+        controller.scrollbackRows,
+        greaterThan(0),
+        reason: 'precondition: output overflowed the screen into scrollback',
+      );
+      expect(
+        renderBox.debugNeedsPaint,
+        isFalse,
+        reason: 'precondition: the frame painted and settled before new output',
+      );
+
+      // ONE more line — pushes another row into scrollback (scrollback length
+      // grows), the SAME notify path as a freshly-printed prompt line in a
+      // full shell. NO scroll, NO keystroke, NO route push afterward.
+      final scrollbackBefore = controller.scrollbackRows;
+      write('fresh output line that must be painted\r\n');
+      expect(
+        controller.scrollbackRows,
+        greaterThan(scrollbackBefore),
+        reason: 'precondition: the new output grew the scrollback length, '
+            'taking the markNeedsLayout branch in _onTerminalChanged',
+      );
+
+      // THE #887 ASSERTION: the terminal notify fired synchronously inside
+      // `write`, running the render box's `_onTerminalChanged`. The glyph
+      // render box MUST be marked needs-paint so the new row repaints on the
+      // next frame — WITHOUT any forced repaint. Pre-fix this is false (only
+      // needs-layout was set), so the glyphs stayed blank until an unrelated
+      // event forced a paint.
+      expect(
+        renderBox.debugNeedsPaint,
+        isTrue,
+        reason: 'new output must mark the glyph render box needs-paint; the '
+            'decoration notify must never be the sole repaint trigger (#887)',
+      );
+    },
+  );
+}

--- a/native/third_party/flterm/test/widgets/prune_during_layout_defers_notify_887_test.dart
+++ b/native/third_party/flterm/test/widgets/prune_during_layout_defers_notify_887_test.dart
@@ -1,0 +1,193 @@
+@Tags(['ffi'])
+library;
+
+// #887 cycle 2 — REGRESSION pin: the controller's per-redraw detection prune /
+// `_onTerminalChanged` tail must NOT run its rebuild/geometry side-effects
+// synchronously when the terminal notify arrives DURING a frame's layout/paint
+// phase.
+//
+// MECHANISM (reproduced on emulator in sftp_browse_smoke_test, pinned here
+// headless): libghostty's `Terminal.resize` is invoked synchronously from
+// `TerminalRenderBox.performLayout` when the grid is re-sized (the SFTP browser
+// opens / the keyboard inset changes the layout). That resize fires the
+// terminal listener mid-frame -> `TerminalControllerImpl._onTerminalChanged`,
+// whose notify-producing tail is illegal during layout/paint:
+//   1. the controller's general `notifyListeners()` (via `highlights=` in the
+//      prune, or the `changed` notify) -> `_TerminalViewState._onController
+//      Changed` -> `_updateTextInputGeometry` reads `RenderBox.size`
+//      (`getTransformTo`) + a `setState` -> "RenderBox.size accessed beyond the
+//      scope of resize, layout…" / "Build scheduled during frame".
+//   2. `_DecorationNotifier.notify()` -> a decorator `AnimatedBuilder`/setState
+//      rebuild scheduled mid-frame -> "Build scheduled during frame".
+//
+// The fix: when `SchedulerBinding.schedulerPhase` is mid-frame
+// (`persistentCallbacks`/`midFrameMicrotasks`) `_onTerminalChanged` DEFERS that
+// whole tail to a post-frame callback. The synchronous path is kept for the
+// normal (non-layout) notify so #873 eviction stays immediate when safe.
+//
+// This test asserts the GUARD as a binding-portable INVARIANT: it records the
+// scheduler phase at every controller notify AND every decoration notify, then
+// forces a real grid resize from `performLayout` (with a live URL anchor) and
+// requires that NEITHER notify ever lands while a frame is mid-layout/paint
+// (`persistentCallbacks`/`midFrameMicrotasks`). With the fix any such notify is
+// deferred to `idle` (post-frame).
+//
+// AUTHORITATIVE RED BASELINE: the device-class repro is the on-emulator
+// `integration_test/sftp_browse_smoke_test.dart`, where opening the SFTP
+// browser resizes the grid WHILE shell output is streaming — that timing
+// coincidence makes `_onTerminalChanged` emit its `changed`/decoration notify
+// mid-layout and throws "Build scheduled during frame" / "RenderBox.size
+// accessed beyond the scope…". It was GREEN on +58, RED on the #887 cycle-1
+// branch, and GREEN again with this guard. `AutomatedTestWidgetsFlutterBinding`
+// fires the resize notify but a PURE resize never sets the prune `changed` flag
+// (#883 keeps shifted-frame matches rather than dropping them) so it cannot
+// stage the streaming-output coincidence deterministically — hence the emulator
+// suite, not this headless test, is the regression gate. This test still guards
+// the invariant against any future binding/path that DOES emit mid-frame.
+
+import 'dart:typed_data';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'a terminal notify arriving mid-layout (grid resize from performLayout) '
+    'defers its general + decoration notify out of the layout/paint phase (#887)',
+    (tester) async {
+      final controller = TerminalController();
+      addTearDown(controller.dispose);
+
+      // A live structured-text anchor so the prune has a non-empty match set to
+      // operate on and the decoration/highlight side-effects are reachable.
+      controller.registerTextPattern(TextPattern.url());
+
+      // Record the scheduler phase at EVERY notify. A notify that fires while a
+      // frame is mid-layout/paint (`persistentCallbacks`/`midFrameMicrotasks`)
+      // is the #887 hazard — that is exactly when reading RenderBox.size or
+      // scheduling a build throws.
+      final controllerNotifyPhases = <SchedulerPhase>[];
+      final decorationNotifyPhases = <SchedulerPhase>[];
+      controller.addListener(
+        () => controllerNotifyPhases
+            .add(SchedulerBinding.instance.schedulerPhase),
+      );
+      controller.decorationListenable.addListener(
+        () => decorationNotifyPhases
+            .add(SchedulerBinding.instance.schedulerPhase),
+      );
+
+      // Drive a REAL TerminalView whose constraints we can change, so a pump
+      // re-runs `performLayout` -> grid resize -> `Terminal.resize` ->
+      // synchronous terminal notify mid-frame (the exact device trigger).
+      var width = 800.0;
+      var height = 480.0;
+      late StateSetter setOuter;
+      Widget app() {
+        return MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                setOuter = setState;
+                return Center(
+                  child: SizedBox(
+                    width: width,
+                    height: height,
+                    child: TerminalView(controller: controller),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(app());
+      await tester.pump();
+
+      // Print a long URL near the right edge so SHRINKING the width re-wraps it
+      // across a different column boundary — that reflow moves/drops the match
+      // in the prune (`changed`), exercising the prune's `highlights=` general
+      // notify + `_decorationNotifier.notify()` (the throwing side-effects). Let
+      // the detection debounce (~120ms) settle so a live anchor exists first.
+      controller.write(
+        Uint8List.fromList(
+          'open https://example.com/some/fairly/long/path/segment/here now\r\n'
+              .codeUnits,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(
+        controller.highlights,
+        isNotEmpty,
+        reason: 'precondition: a live URL anchor exists for the prune to act on',
+      );
+
+      // Clear the phases captured during normal (non-layout) operation; we only
+      // care about notifies provoked by the resize-during-layout below.
+      controllerNotifyPhases.clear();
+      decorationNotifyPhases.clear();
+
+      // Shrink BOTH dimensions substantially -> the TerminalView gets new
+      // constraints -> `performLayout` re-derives fewer grid cols AND rows ->
+      // `Terminal.resize` fires the terminal listener SYNCHRONOUSLY mid-frame
+      // (the exact device trigger). The narrower grid re-wraps the URL, so the
+      // prune relocates/drops the match and runs its `highlights=`/decoration
+      // notify — the side-effects that throw if not deferred.
+      setOuter(() {
+        width = 320.0;
+        height = 160.0;
+      });
+      await tester.pump();
+
+      // A notify scheduled mid-layout/paint also surfaces a framework assertion;
+      // capture it as a second signal.
+      final resizeException = tester.takeException();
+
+      // Drain the deferred post-frame work + the (re)armed detection debounce so
+      // no FakeTimer is left pending at test end and the reconcile completes.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      bool midFrame(SchedulerPhase p) =>
+          p == SchedulerPhase.persistentCallbacks ||
+          p == SchedulerPhase.midFrameMicrotasks;
+
+      // THE #887 ASSERTIONS: no notify (general or decoration) provoked by the
+      // resize fired during the layout/paint phase. Pre-fix the resize notify
+      // lands at `persistentCallbacks`; post-fix it is deferred to `idle`.
+      expect(
+        controllerNotifyPhases.where(midFrame),
+        isEmpty,
+        reason: 'the controller general notify (highlights=/changed) must be '
+            'deferred out of the layout/paint phase when _onTerminalChanged '
+            'fires from performLayout (#887). Phases: $controllerNotifyPhases',
+      );
+      expect(
+        decorationNotifyPhases.where(midFrame),
+        isEmpty,
+        reason: 'the decoration notify must be deferred out of the layout/paint '
+            'phase when _onTerminalChanged fires from performLayout (#887). '
+            'Phases: $decorationNotifyPhases',
+      );
+      expect(
+        resizeException,
+        isNull,
+        reason: 'no "Build scheduled during frame" / "RenderBox.size beyond the '
+            'scope" assertion from the resize frame (#887). Got: '
+            '$resizeException',
+      );
+
+      // The reconcile still happens — the anchor survives the resize reflow
+      // rather than being silently dropped or left un-notified.
+      expect(
+        controller.highlights,
+        isNotEmpty,
+        reason: 'the URL anchor is re-anchored after the resize reflow, not lost',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## #887 — terminal text invisible until forced repaint

P0 daily-driver regression (0.1.10+58): freshly-printed terminal lines were invisible — only the #777 structured-text decoration painted — until a forced full repaint made the glyphs appear.

### Cycle 1 (commit c2b5325)
`TerminalRenderBox._onTerminalChanged`'s scrollback-grew branch called only `markNeedsLayout()` (which does not imply `markNeedsPaint()`), so streamed glyph rows were never scheduled to paint. Fix: that branch now calls `_markFrameDirty()` before `markNeedsLayout()`. Greened the glyph-repaint headless test and all on-emulator paint tests.

### Cycle 2 — prune-during-layout notify deferral (this update)

Cycle 1 greened the paint tests but the full on-emulator integration suite surfaced a **regression** in `integration_test/sftp_browse_smoke_test.dart` (GREEN on +58, RED on the cycle-1 branch).

**Mechanism (reproduced RED on emulator-5554):** when the SFTP browser opens / the keyboard inset changes the layout, `TerminalRenderBox.performLayout` (terminal_renderer.dart:423) re-sizes the libghostty grid via `Terminal.resize`, which **synchronously fires the terminal listener mid-frame** → `TerminalControllerImpl._onTerminalChanged` → its notify tail:
- `_pruneStaleDetections`/`highlights=` → the controller's general `notifyListeners()` → `_TerminalViewState._updateTextInputGeometry` reads `RenderBox.size`/`getTransformTo` → **"RenderBox.size accessed beyond the scope of resize, layout…"**.
- `_DecorationNotifier.notify()` → an `AnimatedBuilder`/setState rebuild → **"Build scheduled during frame"**.

**#887-introduced or latent?** **Latent.** The prune calling `highlights=`/`notify()` synchronously during a frame was always unsafe — `_onTerminalChanged` had no scheduler-phase guard. The codebase already guards the twin SCROLL path (`reportPaintedViewportOffset`, which fires during paint, defers its `_decorationNotifier.notify()` post-frame). Cycle 1's `_markFrameDirty()` only increased layout/paint churn enough to make the `Terminal.resize`-from-`performLayout` collision (coinciding with streaming output that sets `changed`) observable.

**The guard:** `_onTerminalChanged` now splits its notify-producing tail into `_applyFrameWork` and routes it through `_runOrDeferFrameWork`. When `SchedulerBinding.instance.schedulerPhase` is `persistentCallbacks`/`midFrameMicrotasks` (mid-frame), the whole tail (scroll-to-bottom, prune, leftAlternate-screen rescan, `changed` notify) is deferred to one coalesced `addPostFrameCallback`; otherwise it runs synchronously so #873 eviction stays immediate. The debounced `_scheduleDetectionRescan` (Timer-only, fires outside the frame) stays inline. No #883/#863/#803 painted-offset divergence reintroduced (prune/rescan internals untouched); the cycle-1 glyph-repaint fix (render-box layer) is untouched.

### Validation (all on emulator-5554 unless noted)
- `sftp_browse_smoke_test.dart` — **RED pre-fix** (Build-scheduled + RenderBox.size-out-of-scope), **GREEN post-fix** (both sub-tests, no exceptions). Authoritative regression gate.
- `ghostty_url_detection_test.dart`, `selection_copy_after_redraw_test.dart`, `terminal_layout_fill_test.dart` — STAY GREEN.
- `new_output_glyph_repaint_887_test.dart` (cycle 1) + full flterm fork suite (#873/#863/#812/#883 controller logic) + native fast gate (analyze clean, 1273 unit/widget) — STAY GREEN.
- New headless `prune_during_layout_defers_notify_887_test.dart` — GREEN; asserts no controller/decoration notify lands mid-frame on a layout-driven resize. Binding-portable invariant pin (does not go RED in `AutomatedTestWidgetsFlutterBinding` — a pure synthetic resize never sets the prune `changed` flag per #883, so it can't stage the streaming-output coincidence the device hits; the emulator suite is the regression gate).

Closes #887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
