### PR TITLE
feat(#888): Part A — in-terminal detection settings + wiring (URLs/paths toggle)

### DIFF
--- a/native/integration_test/detection_toggle_test.dart
+++ b/native/integration_test/detection_toggle_test.dart
@@ -1,0 +1,159 @@
+// On-emulator DETECTION TOGGLE gate (#888 Part A).
+//
+// #888 Part A makes in-terminal structured-text detection toggleable: the
+// Ghostty view reads the GLOBAL detectionSettingsProvider when registering
+// flterm TextPatterns, and re-applies LIVE (clearTextPatterns + re-register)
+// when the settings change. URL detection OFF ⇒ neither the osc8 nor the url
+// pattern is registered ⇒ a printed URL produces NO `url` anchor (zero scan,
+// zero decoration). Turning it back ON re-scans the current cells.
+//
+// This is the device-class assertion a headless unit test cannot make: it
+// drives a REAL flterm controller over a live PTY and reads its anchors, and it
+// exercises the build() ref.listen live-re-apply path. Reuses the #767
+// detection harness (debugControllers + connect helpers). ONE connect (no
+// double-connect flake): connect once, then flip the global toggle through the
+// notifier and watch the anchors clear / return.
+//
+// The ghostty backend is the DEFAULT (#727), so no backend override is needed.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/detection_toggle_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const url = 'https://example.com/some/longish/path/that/may/wrap';
+
+  testWidgets(
+    'URL detection toggle gates the url anchor (ON→OFF→ON), live (#888)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      // Default detection settings (all-true) — the notifier hydrates the
+      // all-true default with no stored value on a fresh app data dir.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 80; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller for session');
+
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      bool hasUrlAnchor() => controller!.anchors.any(
+            (a) => a.patternId == 'url' && a.payload == url,
+          );
+
+      // --- Detection ON (default): a printed URL is anchored. ---
+      entry.proxy.sendInput(
+        Uint8List.fromList(utf8.encode('echo MARKER888 $url\n')),
+      );
+      for (var i = 0; i < 40 && !hasUrlAnchor(); i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(
+        hasUrlAnchor(),
+        isTrue,
+        reason: 'with detection ON the printed URL was not anchored',
+      );
+
+      // --- Flip URL detection OFF: live re-apply clears the url anchor. ---
+      await container.read(detectionSettingsProvider.notifier).setUrl(false);
+      // Pump build() so the ref.listen fires (clearTextPatterns + re-register),
+      // then let the controller's scan settle on the empty pattern set.
+      for (var i = 0; i < 20 && hasUrlAnchor(); i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      // Re-print the URL to give the (now-absent) url pattern every chance to
+      // (incorrectly) anchor it, then assert it does NOT.
+      entry.proxy.sendInput(
+        Uint8List.fromList(utf8.encode('echo MARKER888B $url\n')),
+      );
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      expect(
+        hasUrlAnchor(),
+        isFalse,
+        reason:
+            'with URL detection OFF the url pattern must NOT be registered, so '
+            'no url anchor exists (#888 Part A live re-apply)',
+      );
+
+      // --- Flip URL detection back ON: live re-apply re-scans + re-anchors. ---
+      await container.read(detectionSettingsProvider.notifier).setUrl(true);
+      for (var i = 0; i < 40 && !hasUrlAnchor(); i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      expect(
+        hasUrlAnchor(),
+        isTrue,
+        reason:
+            'turning URL detection back ON did not re-scan the cells and '
+            're-anchor the URL (#888 live re-apply)',
+      );
+    },
+  );
+}

--- a/native/lib/state/detection_providers.dart
+++ b/native/lib/state/detection_providers.dart
@@ -1,0 +1,194 @@
+// In-terminal structured-text DETECTION settings (#888 Part A).
+//
+// Controls whether (and what kind of) structured-text detection runs over the
+// terminal's own cells. Detection is a GHOSTTY-backend affordance: the flterm
+// controller registers `TextPattern`s (osc8 + url + path) and maintains anchors
+// across scroll / wrap / eviction (#767, #778). When a type is OFF, that pattern
+// is simply NOT registered — the scan/decoration machinery already no-ops on an
+// empty pattern set, so OFF means zero scan + zero decoration.
+//
+// Scope is GLOBAL (a viewer-affordance preference, user-uniform — per
+// feedback_feature_scoping; it is NOT host/session/profile-specific). The
+// persisted value is a single SCHEMA-VERSIONED JSON string (NOT a bumped key —
+// code-style rule): the version lives INSIDE the value so the shape can grow
+// (e.g. a per-profile override, commit-hash / issue-ref types) without a key
+// bump. Hydrate is field-by-field with a per-field default fallback so a
+// missing / wrong-version / corrupt value never crashes and never silently
+// disables detection.
+//
+// Defaults are ALL TRUE (master + url + path) so the setting is purely additive:
+// shipping it changes nothing for an existing user (no regression).
+//
+// Mirrors the `terminal_backend.dart` / `ComposeBarVisibleNotifier` notifier
+// idiom: synchronous default in `super()` so the first build is stable, an
+// injectable `Future<SharedPreferences>?` for tests, and best-effort
+// hydrate/persist that never throws when prefs are unavailable (widget tests
+// without bindings).
+
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// SharedPreferences key holding the versioned JSON detection settings.
+/// One value, NOT a bumped key — the schema version lives inside the JSON.
+const String detectionSettingsPrefKey = 'mobissh.detection.settings';
+
+/// Current persisted-value schema version. Bump only the in-value `v` when the
+/// JSON shape changes; never the key.
+const int detectionSettingsSchemaVersion = 1;
+
+/// Immutable detection settings.
+///
+/// [enabled] is the master switch. [url] gates BOTH the OSC-8 hyperlink source
+/// and the regex URL pattern (they are one user-facing type). [path] gates the
+/// absolute-file-path pattern. All default TRUE = no regression.
+class DetectionSettings {
+  const DetectionSettings({
+    this.schemaVersion = detectionSettingsSchemaVersion,
+    this.enabled = true,
+    this.url = true,
+    this.path = true,
+  });
+
+  /// The schema version this instance was built from (defaults to current).
+  final int schemaVersion;
+
+  /// Master switch — when false, NO detection patterns are registered.
+  final bool enabled;
+
+  /// Detect URLs (covers both OSC-8 hyperlinks and plain-text URLs).
+  final bool url;
+
+  /// Detect absolute file paths.
+  final bool path;
+
+  /// Whether the URL patterns should be registered (master AND url).
+  bool get detectUrls => enabled && url;
+
+  /// Whether the path pattern should be registered (master AND path).
+  bool get detectPaths => enabled && path;
+
+  DetectionSettings copyWith({bool? enabled, bool? url, bool? path}) {
+    return DetectionSettings(
+      schemaVersion: detectionSettingsSchemaVersion,
+      enabled: enabled ?? this.enabled,
+      url: url ?? this.url,
+      path: path ?? this.path,
+    );
+  }
+
+  /// Serialize to the persisted JSON shape: `{"v":1,"enabled":..,"url":..,"path":..}`.
+  String toJsonString() => jsonEncode(<String, dynamic>{
+    'v': detectionSettingsSchemaVersion,
+    'enabled': enabled,
+    'url': url,
+    'path': path,
+  });
+
+  /// Parse a stored JSON string, FIELD-BY-FIELD with a per-field default
+  /// fallback. A null / non-JSON / non-object / wrong-version / corrupt value
+  /// (or any non-bool field) falls back to the default for that field — it never
+  /// throws and never returns "all off". Returns the all-true default for any
+  /// input that can't be decoded at all.
+  static DetectionSettings fromJsonString(String? raw) {
+    if (raw == null) return const DetectionSettings();
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return const DetectionSettings();
+      bool field(String key, bool fallback) {
+        final v = decoded[key];
+        return v is bool ? v : fallback;
+      }
+
+      // The version is informational here (the shape is back-compatible field
+      // reads), but we record it so a future migration can branch on it.
+      final v = decoded['v'];
+      const def = DetectionSettings();
+      return DetectionSettings(
+        schemaVersion: v is int ? v : detectionSettingsSchemaVersion,
+        enabled: field('enabled', def.enabled),
+        url: field('url', def.url),
+        path: field('path', def.path),
+      );
+    } catch (_) {
+      // Corrupt / non-JSON value → safe all-true default (no silent disable).
+      return const DetectionSettings();
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is DetectionSettings &&
+      other.schemaVersion == schemaVersion &&
+      other.enabled == enabled &&
+      other.url == url &&
+      other.path == path;
+
+  @override
+  int get hashCode => Object.hash(schemaVersion, enabled, url, path);
+
+  @override
+  String toString() =>
+      'DetectionSettings(v:$schemaVersion, enabled:$enabled, url:$url, path:$path)';
+}
+
+/// Persisted GLOBAL detection settings (#888 Part A). Synchronous default
+/// (all-true) while prefs hydrate so the terminal registers patterns
+/// immediately on first build; a stored value re-applies on hydrate.
+class DetectionSettingsNotifier extends StateNotifier<DetectionSettings> {
+  DetectionSettingsNotifier({Future<SharedPreferences>? prefs})
+    : _prefs = prefs ?? SharedPreferences.getInstance(),
+      super(const DetectionSettings()) {
+    _hydrate();
+  }
+
+  final Future<SharedPreferences> _prefs;
+
+  Future<void> _hydrate() async {
+    try {
+      final prefs = await _prefs;
+      final stored = prefs.getString(detectionSettingsPrefKey);
+      if (stored != null) {
+        final parsed = DetectionSettings.fromJsonString(stored);
+        if (parsed != state) state = parsed;
+      }
+    } catch (_) {
+      // best-effort; keep the all-true default if prefs unavailable (tests).
+    }
+  }
+
+  Future<void> _persist() async {
+    try {
+      final prefs = await _prefs;
+      await prefs.setString(detectionSettingsPrefKey, state.toJsonString());
+    } catch (_) {
+      // best-effort persistence
+    }
+  }
+
+  /// Toggle the master switch (when false, NO patterns are registered).
+  Future<void> setEnabled(bool value) async {
+    state = state.copyWith(enabled: value);
+    await _persist();
+  }
+
+  /// Toggle URL detection (osc8 + url patterns).
+  Future<void> setUrl(bool value) async {
+    state = state.copyWith(url: value);
+    await _persist();
+  }
+
+  /// Toggle file-path detection.
+  Future<void> setPath(bool value) async {
+    state = state.copyWith(path: value);
+    await _persist();
+  }
+}
+
+/// Global detection-settings provider. Read at terminal pattern-registration
+/// time and `ref.listen`-ed for live re-apply (clear + re-register).
+final detectionSettingsProvider =
+    StateNotifierProvider<DetectionSettingsNotifier, DetectionSettings>((ref) {
+      return DetectionSettingsNotifier();
+    });

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -177,6 +177,7 @@ import '../services/clipboard.dart';
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../state/ctrl_modifier_provider.dart';
+import '../state/detection_providers.dart';
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
@@ -2068,25 +2069,38 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// draws the affordance instead. The bubble colour comes from the decorator
   /// layer ([_lastHighlightColor]); this registration is theme-independent.
   void _registerUrlPattern(TerminalController controller) {
-    // #767 Slice B: register the OSC-8 hyperlink source as the PRIMARY, exact
-    // URL source ALONGSIDE the regex `url` pattern. The scanner runs both and
-    // an OSC-8 match WINS over an overlapping regex one (the partial first-row
-    // `https://…` over a hyperlink's visible text is suppressed), so a
-    // hyperlinked URL yields ONE exact anchor spanning all its wrapped rows. A
-    // plain-text URL (no OSC-8) still falls to the regex pattern unchanged.
-    // #864: register both URL sources with the EMPTY highlight style (no fill,
-    // no underline) so the bubble decorator is the SINGLE affordance — the app
-    // never co-renders an underline that reads redundant with the chip.
-    controller.registerTextPattern(
-      TextPattern.osc8(id: _kOsc8PatternId, style: kGhosttyUrlHighlightStyle),
-    );
-    controller.registerTextPattern(
-      TextPattern.url(id: _kUrlPatternId, style: kGhosttyUrlHighlightStyle),
-    );
-    // #778 paths Slice 1: also detect absolute file paths. A `path` anchor gets
-    // its own decorator (folder glyph + dotted underline) and routes a tap to
-    // the SFTP explorer; `://` contexts are rejected so a URL stays a URL.
-    controller.registerTextPattern(TextPattern.path(id: _kPathPatternId));
+    // #888 Part A: detection is gated on the GLOBAL detection settings. Read
+    // them HERE so registration reflects the current toggles; a live change
+    // re-runs this (after clearTextPatterns) via the build() ref.listen below.
+    // Each NOT-registered pattern means zero scan + zero decoration for that
+    // type (the controller no-ops on an empty pattern set). Master OFF →
+    // register nothing.
+    final detection = ref.read(detectionSettingsProvider);
+    if (detection.detectUrls) {
+      // #767 Slice B: register the OSC-8 hyperlink source as the PRIMARY, exact
+      // URL source ALONGSIDE the regex `url` pattern. The scanner runs both and
+      // an OSC-8 match WINS over an overlapping regex one (the partial first-row
+      // `https://…` over a hyperlink's visible text is suppressed), so a
+      // hyperlinked URL yields ONE exact anchor spanning all its wrapped rows. A
+      // plain-text URL (no OSC-8) still falls to the regex pattern unchanged.
+      // The URL toggle gates BOTH sources (one user-facing "URLs" type).
+      // #864: register both URL sources with the EMPTY highlight style (no fill,
+      // no underline) so the bubble decorator is the SINGLE affordance — the app
+      // never co-renders an underline that reads redundant with the chip.
+      controller.registerTextPattern(
+        TextPattern.osc8(id: _kOsc8PatternId, style: kGhosttyUrlHighlightStyle),
+      );
+      controller.registerTextPattern(
+        TextPattern.url(id: _kUrlPatternId, style: kGhosttyUrlHighlightStyle),
+      );
+    }
+    if (detection.detectPaths) {
+      // #778 paths Slice 1: also detect absolute file paths. A `path` anchor
+      // gets its own decorator (folder glyph + dotted underline) and routes a
+      // tap to the SFTP explorer; `://` contexts are rejected so a URL stays a
+      // URL.
+      controller.registerTextPattern(TextPattern.path(id: _kPathPatternId));
+    }
   }
 
   /// #712: mirror whether a selection is active into [_hasSelection], rebuilding
@@ -2813,6 +2827,18 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // INCOMING view re-attaches focus and re-shows the keyboard iff it was up.
     ref.listen<String?>(activeSessionIdProvider, (prev, next) {
       _onActiveSessionChanged(prev, next);
+    });
+    // #888 Part A: LIVE re-apply of the detection toggles. When the global
+    // detection settings change, clear the registered patterns (drops anchors +
+    // highlights cleanly) and re-run registration against the new settings — so
+    // turning URL/path detection off removes existing decorations immediately,
+    // and turning it back on re-scans the current cells. No restart needed.
+    ref.listen<DetectionSettings>(detectionSettingsProvider, (prev, next) {
+      if (prev == next) return;
+      final c = _controller;
+      if (c == null) return;
+      c.clearTextPatterns();
+      _registerUrlPattern(c);
     });
     final controller = _controller;
     if (controller == null) {

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/battery_optimization.dart';
+import '../state/detection_providers.dart';
 import '../state/keepalive_providers.dart';
 import '../state/terminal_backend.dart';
 import '../state/ui_prefs_providers.dart';
@@ -20,6 +21,7 @@ class SettingsPanel extends ConsumerWidget {
     final keepalive = ref.watch(keepaliveEnabledProvider);
     final fontSize = ref.watch(fontSizeProvider);
     final backend = ref.watch(terminalBackendProvider);
+    final detection = ref.watch(detectionSettingsProvider);
     return ExpansionTile(
       key: const ValueKey('settings-section'),
       leading: const Icon(Icons.settings_outlined),
@@ -110,6 +112,43 @@ class SettingsPanel extends ConsumerWidget {
             onSelectionChanged: (sel) =>
                 ref.read(terminalBackendProvider.notifier).set(sel.first),
           ),
+        ),
+        // #888 Part A: in-terminal structured-text DETECTION. Master switch +
+        // per-type toggles (URLs, file paths). When a type is off, the flterm
+        // controller never registers that pattern (no scan, no decoration);
+        // changes re-apply LIVE. Detection is a Ghostty-engine affordance —
+        // xterm has no structured detection. Monochrome outlined icons only.
+        SwitchListTile(
+          key: const ValueKey('detection-master-toggle'),
+          secondary: const Icon(Icons.search_outlined),
+          title: const Text('Detect links & paths in terminal'),
+          subtitle: const Text(
+            'Find URLs and file paths in terminal output and make them '
+            'tappable. Applies to the Ghostty engine.',
+          ),
+          value: detection.enabled,
+          onChanged: (v) =>
+              ref.read(detectionSettingsProvider.notifier).setEnabled(v),
+        ),
+        SwitchListTile(
+          key: const ValueKey('detection-url-toggle'),
+          secondary: const Icon(Icons.link_outlined),
+          title: const Text('URLs'),
+          subtitle: const Text('Detect and tap http/https links.'),
+          value: detection.url,
+          onChanged: detection.enabled
+              ? (v) => ref.read(detectionSettingsProvider.notifier).setUrl(v)
+              : null,
+        ),
+        SwitchListTile(
+          key: const ValueKey('detection-path-toggle'),
+          secondary: const Icon(Icons.folder_outlined),
+          title: const Text('File paths'),
+          subtitle: const Text('Detect absolute paths and open them in files.'),
+          value: detection.path,
+          onChanged: detection.enabled
+              ? (v) => ref.read(detectionSettingsProvider.notifier).setPath(v)
+              : null,
         ),
       ],
     );

--- a/native/test/state/detection_providers_test.dart
+++ b/native/test/state/detection_providers_test.dart
@@ -1,0 +1,177 @@
+// Unit tests for the #888 Part A in-terminal detection settings.
+//
+// Locks the versioned-JSON persistence contract: default ALL TRUE (no
+// regression), hydrate a stored value, a corrupt / wrong-shape value falling
+// back FIELD-BY-FIELD to defaults (a stale pref must never crash or silently
+// disable detection), and a set+persist round-trip writing the versioned shape.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _settle() async {
+  // Let the StateNotifier _hydrate Future resolve.
+  await Future<void>.delayed(const Duration(milliseconds: 10));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('DetectionSettings', () {
+    test('defaults are all true (no regression)', () {
+      const s = DetectionSettings();
+      expect(s.enabled, isTrue);
+      expect(s.url, isTrue);
+      expect(s.path, isTrue);
+      expect(s.schemaVersion, detectionSettingsSchemaVersion);
+      expect(s.detectUrls, isTrue);
+      expect(s.detectPaths, isTrue);
+    });
+
+    test('master off gates both url and path registration', () {
+      const s = DetectionSettings(enabled: false, url: true, path: true);
+      expect(s.detectUrls, isFalse);
+      expect(s.detectPaths, isFalse);
+    });
+
+    test('per-type off gates only that type', () {
+      const noUrl = DetectionSettings(url: false);
+      expect(noUrl.detectUrls, isFalse);
+      expect(noUrl.detectPaths, isTrue);
+      const noPath = DetectionSettings(path: false);
+      expect(noPath.detectUrls, isTrue);
+      expect(noPath.detectPaths, isFalse);
+    });
+
+    test('toJsonString emits the versioned shape', () {
+      const s = DetectionSettings(enabled: true, url: false, path: true);
+      final decoded = jsonDecode(s.toJsonString()) as Map<String, dynamic>;
+      expect(decoded['v'], detectionSettingsSchemaVersion);
+      expect(decoded['enabled'], true);
+      expect(decoded['url'], false);
+      expect(decoded['path'], true);
+    });
+
+    test('fromJsonString round-trips a serialized value', () {
+      const s = DetectionSettings(enabled: false, url: false, path: true);
+      final back = DetectionSettings.fromJsonString(s.toJsonString());
+      expect(back, s);
+    });
+
+    group('fromJsonString fallback', () {
+      test('null → all-true default', () {
+        expect(DetectionSettings.fromJsonString(null), const DetectionSettings());
+      });
+
+      test('non-JSON garbage → all-true default', () {
+        expect(
+          DetectionSettings.fromJsonString('not json {{{'),
+          const DetectionSettings(),
+        );
+      });
+
+      test('JSON that is not an object → all-true default', () {
+        expect(
+          DetectionSettings.fromJsonString('[1,2,3]'),
+          const DetectionSettings(),
+        );
+      });
+
+      test('missing fields fall back to default per-field (not all-off)', () {
+        // Only `enabled:false` present — url/path must default TRUE, not false.
+        final s = DetectionSettings.fromJsonString('{"v":1,"enabled":false}');
+        expect(s.enabled, isFalse);
+        expect(s.url, isTrue);
+        expect(s.path, isTrue);
+      });
+
+      test('non-bool field values fall back to default per-field', () {
+        final s = DetectionSettings.fromJsonString(
+          '{"v":1,"enabled":"yes","url":1,"path":false}',
+        );
+        expect(s.enabled, isTrue); // "yes" not a bool → default true
+        expect(s.url, isTrue); // 1 not a bool → default true
+        expect(s.path, isFalse); // valid bool honored
+      });
+
+      test('unknown/wrong version still reads back-compatible fields', () {
+        final s = DetectionSettings.fromJsonString(
+          '{"v":99,"enabled":false,"url":false,"path":false}',
+        );
+        expect(s.enabled, isFalse);
+        expect(s.url, isFalse);
+        expect(s.path, isFalse);
+        expect(s.schemaVersion, 99);
+      });
+    });
+  });
+
+  group('DetectionSettingsNotifier', () {
+    test('defaults to all-true with no stored value', () async {
+      final n = DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n.state, const DetectionSettings());
+      expect(n.state.detectUrls, isTrue);
+      expect(n.state.detectPaths, isTrue);
+    });
+
+    test('hydrates a stored versioned value', () async {
+      SharedPreferences.setMockInitialValues({
+        detectionSettingsPrefKey:
+            '{"v":1,"enabled":true,"url":false,"path":true}',
+      });
+      final n = DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n.state.enabled, isTrue);
+      expect(n.state.url, isFalse);
+      expect(n.state.path, isTrue);
+    });
+
+    test('hydrate with a corrupt stored value keeps the all-true default',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        detectionSettingsPrefKey: 'corrupt {{{',
+      });
+      final n = DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n.state, const DetectionSettings());
+    });
+
+    test('setEnabled updates state and persists the versioned shape', () async {
+      final n = DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      await n.setEnabled(false);
+      expect(n.state.enabled, isFalse);
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(detectionSettingsPrefKey);
+      expect(raw, isNotNull);
+      final decoded = jsonDecode(raw!) as Map<String, dynamic>;
+      expect(decoded['v'], detectionSettingsSchemaVersion);
+      expect(decoded['enabled'], false);
+    });
+
+    test('setUrl / setPath persist independently (round-trip)', () async {
+      final n = DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      await n.setUrl(false);
+      await n.setPath(false);
+      expect(n.state.url, isFalse);
+      expect(n.state.path, isFalse);
+      expect(n.state.enabled, isTrue);
+
+      // A fresh notifier reading the persisted value sees the same state.
+      final n2 =
+          DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n2.state.url, isFalse);
+      expect(n2.state.path, isFalse);
+      expect(n2.state.enabled, isTrue);
+    });
+  });
+}

--- a/native/test/widget/appearance_settings_widget_test.dart
+++ b/native/test/widget/appearance_settings_widget_test.dart
@@ -34,7 +34,13 @@ void main() {
     ) async {
       await tester.pumpWidget(
         const ProviderScope(
-          child: MaterialApp(home: Scaffold(body: SettingsPanel())),
+          child: MaterialApp(
+            // Mirror production (settings_screen.dart) — the grown panel (#888
+            // Detection group) overflows a bare bounded Scaffold body.
+            home: Scaffold(
+              body: SingleChildScrollView(child: SettingsPanel()),
+            ),
+          ),
         ),
       );
       await _pumpFrames(tester);
@@ -55,7 +61,11 @@ void main() {
 
       await tester.pumpWidget(
         const ProviderScope(
-          child: MaterialApp(home: Scaffold(body: SettingsPanel())),
+          child: MaterialApp(
+            home: Scaffold(
+              body: SingleChildScrollView(child: SettingsPanel()),
+            ),
+          ),
         ),
       );
       await _pumpFrames(tester);
@@ -76,7 +86,11 @@ void main() {
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
-          child: const MaterialApp(home: Scaffold(body: SettingsPanel())),
+          child: const MaterialApp(
+            home: Scaffold(
+              body: SingleChildScrollView(child: SettingsPanel()),
+            ),
+          ),
         ),
       );
       await _pumpFrames(tester);

--- a/native/test/widget/keepalive_toggle_widget_test.dart
+++ b/native/test/widget/keepalive_toggle_widget_test.dart
@@ -11,7 +11,12 @@ Future<void> pumpSettings(WidgetTester tester) async {
   await tester.pumpWidget(
     const ProviderScope(
       child: MaterialApp(
-        home: Scaffold(body: SettingsPanel()),
+        // Mirror production (settings_screen.dart): the panel lives in a
+        // SingleChildScrollView. Mounting it bare in a bounded Scaffold body
+        // overflows now that the panel has grown (the Detection group, #888).
+        home: Scaffold(
+          body: SingleChildScrollView(child: SettingsPanel()),
+        ),
       ),
     ),
   );


### PR DESCRIPTION
## #888 (Part A: detection settings + wiring)

Implements **Part A** of #888: a global, schema-versioned URL/text **detection
settings** provider that gates the Ghostty terminal's structured-text pattern
registration, with live re-apply. **Part B (Settings/Diagnostics screen
consolidation + IA) is deferred** to a follow-up after this and #887 land — no
`main.dart` nav changes, no diagnostics-screen deletion here.

### What changed
- **`native/lib/state/detection_providers.dart` (new)** — immutable
  `DetectionSettings {schemaVersion, enabled, url, path}`, defaults **ALL TRUE**
  (no regression). `DetectionSettingsNotifier` mirrors the
  `terminal_backend.dart` idiom (injectable prefs, synchronous default in
  `super()`, best-effort `_hydrate()`/persist). GLOBAL scope.
- **Persistence**: ONE versioned JSON value under key
  `mobissh.detection.settings` = `{"v":1,"enabled":true,"url":true,"path":true}`
  — version lives **inside the value** (no key bump, per code-style). Hydrate is
  field-by-field with a per-field default fallback; missing / wrong-`v` / corrupt
  / non-JSON → safe all-true default (never crashes, never silently disables).
- **`ghostty_terminal_view.dart`** — `_registerUrlPattern` reads the settings:
  master OFF registers nothing; URL OFF skips **both** osc8 + url patterns; path
  OFF skips path. **Live re-apply**: a `build()` `ref.listen(detectionSettingsProvider)`
  calls `controller.clearTextPatterns()` then re-runs `_registerUrlPattern` on
  change — so toggling removes/restores decorations immediately, no restart.
- **`settings_panel.dart`** — Detection group: master `SwitchListTile`
  "Detect links & paths in terminal" + child "URLs" + "File paths" (children
  disabled/greyed when master off). Monochrome Material outlined icons
  (`search_outlined` / `link_outlined` / `folder_outlined`), no emoji. Subtext
  notes it applies to the Ghostty engine.

### Tests (red→green)
- **Unit** (`native/test/state/detection_providers_test.dart`, 16 tests):
  default all-true, hydrate, corrupt-JSON / non-object / wrong-version fallback,
  per-field fallback, set+persist round-trip (injected fake prefs).
- **Integration** (`native/integration_test/detection_toggle_test.dart`, on
  emulator-5554): connect once, then **ON→OFF→ON** — a printed URL is anchored
  with detection ON, the `url` anchor **clears** when URL detection is toggled
  OFF (proves live re-apply + zero scan), and **returns** when re-enabled. Run:
  `scripts/native-connect-test.sh integration_test/detection_toggle_test.dart`.
- **Harness fix**: the Detection group grew `SettingsPanel`, overflowing 3
  existing widget tests that mounted it bare in a bounded `Scaffold` body. Fixed
  by mounting in a `SingleChildScrollView`, mirroring production
  `settings_screen.dart`.
- Fast gate green (`scripts/native-fast-gate.sh`: analyze + unit/widget).

### #887 overlap
Touches only the registration **seam** (the widget layer) plus the controller's
public `registerTextPattern` / `clearTextPatterns` API — **NOT** #887's
paint/notify path in `terminal_controller_impl.dart`. No edits to that file. If
#887 changes the register/clear signatures, the re-apply path rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)