### PR TITLE
fix(#893): route extensionless text files (SSH config, dotfiles, Dockerfile) to viewer + binary guard

### DIFF
--- a/native/lib/services/text_file_detect.dart
+++ b/native/lib/services/text_file_detect.dart
@@ -30,6 +30,41 @@ bool hasTextExtension(String name) {
   return _textExtensions.contains(ext);
 }
 
+/// Well-known filenames that carry no extension but are conventionally plain
+/// text/config. Compared case-insensitively against the full name. Mirrors the
+/// PWA's content-class fall-through for extensionless text (#893).
+const Set<String> _extensionlessTextNames = {
+  'config',
+  'dockerfile',
+  'makefile',
+  'rakefile',
+  'gemfile',
+  'procfile',
+  'license',
+  'readme',
+  'authorized_keys',
+  'known_hosts',
+  'hosts',
+};
+
+/// True when [name] has no real extension yet is conventionally text:
+///   (a) a bare dotfile — leading dot, no inner dot (`.bashrc`, `.gitconfig`,
+///       `.vimrc`). Files like `.tmux.conf` already match by their `.conf`
+///       extension, so this only covers the no-extension case (PWA `isDotfile`).
+///   (b) a well-known extensionless name (`config`, `Dockerfile`, `LICENSE`,
+///       `known_hosts`, …), case-insensitive.
+/// A bare `config` arriving as the basename of `~/.ssh/config` is the motivating
+/// case (#893).
+bool isExtensionlessTextName(String name) {
+  if (name.isEmpty) return false;
+  // (a) bare dotfile: leading dot and no further dot.
+  if (name.startsWith('.') && name.indexOf('.', 1) == -1) return true;
+  // (b) well-known extensionless names (must genuinely have no extension).
+  final dot = name.lastIndexOf('.');
+  if (dot > 0 && dot != name.length - 1) return false;
+  return _extensionlessTextNames.contains(name.toLowerCase());
+}
+
 /// True when [mime] denotes textual content: any `text/*`, or a known textual
 /// `application/*` type (json, xml, javascript, etc.). MIME parameters
 /// (`; charset=…`) are ignored. Null / empty / binary types are false.
@@ -49,11 +84,16 @@ bool isTextMime(String? mime) {
   return textApps.contains(base);
 }
 
-/// True when [entry] is a regular file that looks like text, by extension or by
-/// an explicit [mime]. Directories are never text.
+/// True when [entry] is a regular file that looks like text, by a known
+/// extension, a well-known extensionless name / bare dotfile, or an explicit
+/// text [mime]. Directories are never text. This single classifier drives the
+/// view router (and, once SFTP write lands, the edit gate) — matching the PWA's
+/// single `getPreviewType()` (#893).
 bool isTextEntry(SftpEntry entry, {String? mime}) {
   if (entry.isDirectory) return false;
-  return hasTextExtension(entry.name) || isTextMime(mime);
+  return hasTextExtension(entry.name) ||
+      isExtensionlessTextName(entry.name) ||
+      isTextMime(mime);
 }
 
 /// Markdown extensions (lowercase, no leading dot). A subset of

--- a/native/lib/services/text_file_fetcher.dart
+++ b/native/lib/services/text_file_fetcher.dart
@@ -21,9 +21,55 @@ import '../ssh/ssh_session_proxy.dart';
 import '../state/sessions.dart';
 import 'session_messages.dart';
 
+/// User-facing message surfaced when the fetched content looks binary. The
+/// viewer's existing error path renders this so the user is told to download
+/// rather than shown mojibake (#893).
+const String binaryFileMessage = 'Binary file — download instead';
+
+/// Thrown by the fetcher when [isBinaryContent] flags the downloaded bytes as
+/// binary. Carries the user-facing [binaryFileMessage].
+class BinaryFileException implements Exception {
+  const BinaryFileException();
+
+  @override
+  String toString() => binaryFileMessage;
+}
+
+/// True when [bytes] look like binary (not human-readable text). Examines only
+/// the leading [sampleBytes] (first ~64 KB) so it stays cheap on large files:
+///   - any NUL byte (`0x00`) in the sample → binary (NUL never appears in text);
+///   - otherwise, if more than [threshold] (default ~30%) of the sampled bytes
+///     are non-printable, treat as binary.
+/// Printable = tab/newline/carriage-return, or any byte >= 0x20 that is not the
+/// DEL control (0x7F). Bytes >= 0x80 are allowed as potential UTF-8 multibyte
+/// continuation/lead bytes, so valid UTF-8 text is not misclassified. An empty
+/// buffer is text.
+bool isBinaryContent(
+  Uint8List bytes, {
+  int sampleBytes = 64 * 1024,
+  double threshold = 0.30,
+}) {
+  if (bytes.isEmpty) return false;
+  final limit = bytes.length < sampleBytes ? bytes.length : sampleBytes;
+  var nonPrintable = 0;
+  for (var i = 0; i < limit; i++) {
+    final b = bytes[i];
+    if (b == 0x00) return true; // NUL — definitive binary marker.
+    final isPrintable =
+        b == 0x09 || // tab
+        b == 0x0A || // LF
+        b == 0x0D || // CR
+        (b >= 0x20 && b != 0x7F) || // printable ASCII (excl. DEL)
+        b >= 0x80; // possible UTF-8 multibyte byte
+    if (!isPrintable) nonPrintable++;
+  }
+  return nonPrintable > limit * threshold;
+}
+
 /// Fetches the text content of [entry] (a remote text/code file) and returns it
 /// decoded as a String. [maxBytes] caps the in-memory buffer so a huge file
-/// can't exhaust memory. [onProgress] reports received / total bytes.
+/// can't exhaust memory. [onProgress] reports received / total bytes. Throws a
+/// [BinaryFileException] if the content looks binary.
 abstract class TextFileFetcher {
   Future<String> fetch(
     String sessionId,
@@ -81,7 +127,12 @@ class ProxyTextFileFetcher implements TextFileFetcher {
           for (final offset in (byOffset.keys.toList()..sort())) {
             buffer.add(byOffset[offset]!);
           }
-          completer.complete(utf8.decode(buffer.takeBytes(), allowMalformed: true));
+          final assembled = buffer.takeBytes();
+          if (isBinaryContent(assembled)) {
+            completer.completeError(const BinaryFileException());
+            return;
+          }
+          completer.complete(utf8.decode(assembled, allowMalformed: true));
         case SftpErrorEvent():
           if (event.requestId != requestId) return;
           if (!completer.isCompleted) {

--- a/native/test/services/text_file_detect_test.dart
+++ b/native/test/services/text_file_detect_test.dart
@@ -66,6 +66,50 @@ void main() {
     });
   });
 
+  group('isExtensionlessTextName', () {
+    test('matches bare dotfiles (leading dot, no inner dot)', () {
+      for (final n in ['.bashrc', '.zshrc', '.gitconfig', '.vimrc', '.profile']) {
+        expect(isExtensionlessTextName(n), isTrue, reason: n);
+      }
+    });
+
+    test('matches well-known extensionless names, case-insensitive', () {
+      for (final n in [
+        'config',
+        'Dockerfile',
+        'dockerfile',
+        'Makefile',
+        'Rakefile',
+        'Gemfile',
+        'Procfile',
+        'LICENSE',
+        'license',
+        'README',
+        'authorized_keys',
+        'known_hosts',
+        'hosts',
+      ]) {
+        expect(isExtensionlessTextName(n), isTrue, reason: n);
+      }
+    });
+
+    test('does not match files with a real extension', () {
+      for (final n in ['photo.png', 'archive.tar.gz', 'app.bin', 'a.txt']) {
+        expect(isExtensionlessTextName(n), isFalse, reason: n);
+      }
+    });
+
+    test('does not match dotfiles with an inner dot (handled by extension)', () {
+      expect(isExtensionlessTextName('.tmux.conf'), isFalse);
+      expect(isExtensionlessTextName('.env.local'), isFalse);
+    });
+
+    test('does not match unknown bare names', () {
+      expect(isExtensionlessTextName('photo'), isFalse);
+      expect(isExtensionlessTextName('binaryblob'), isFalse);
+    });
+  });
+
   group('isTextEntry', () {
     test('true for a text-extension file', () {
       expect(isTextEntry(file('a.txt')), isTrue);
@@ -73,6 +117,15 @@ void main() {
 
     test('true for a text MIME even without a text extension', () {
       expect(isTextEntry(file('blob'), mime: 'text/plain'), isTrue);
+    });
+
+    test('true for extensionless well-known text names', () {
+      // .ssh/config arrives as basename `config`.
+      expect(isTextEntry(file('config')), isTrue);
+      expect(isTextEntry(file('Dockerfile')), isTrue);
+      expect(isTextEntry(file('.bashrc')), isTrue);
+      expect(isTextEntry(file('LICENSE')), isTrue);
+      expect(isTextEntry(file('known_hosts')), isTrue);
     });
 
     test('false for directories', () {
@@ -88,6 +141,20 @@ void main() {
     test('false for binary files', () {
       expect(isTextEntry(file('app.bin')), isFalse);
       expect(isTextEntry(file('doc.pdf')), isFalse);
+      expect(isTextEntry(file('photo.png')), isFalse);
+      expect(isTextEntry(file('archive.tar.gz')), isFalse);
+    });
+  });
+
+  group('isMarkdownEntry stays distinct (ordered first in registry)', () {
+    test('markdown extension is markdown', () {
+      expect(isMarkdownEntry(file('README.md')), isTrue);
+      expect(isMarkdownEntry(file('notes.markdown')), isTrue);
+    });
+
+    test('non-markdown text is not markdown', () {
+      expect(isMarkdownEntry(file('config')), isFalse);
+      expect(isMarkdownEntry(file('a.txt')), isFalse);
     });
   });
 }

--- a/native/test/services/text_file_fetcher_test.dart
+++ b/native/test/services/text_file_fetcher_test.dart
@@ -1,0 +1,58 @@
+// Binary-guard unit tests for the text fetcher (#893).
+//
+// The fetcher decodes downloaded bytes as lossy UTF-8 for the read-only text
+// viewer. Before rendering it must reject binary content (NUL byte or a high
+// proportion of non-printable bytes in the leading sample) so the viewer
+// surfaces a "download instead" state rather than mojibake. `isBinaryContent`
+// is a pure helper so this is trivially unit-testable, emulator-free.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/text_file_fetcher.dart';
+
+void main() {
+  group('isBinaryContent', () {
+    test('detects a NUL byte as binary', () {
+      final bytes = Uint8List.fromList([0x48, 0x69, 0x00, 0x21]); // "Hi\0!"
+      expect(isBinaryContent(bytes), isTrue);
+    });
+
+    test('detects mostly-non-printable buffer as binary', () {
+      // 0x80..0x8F are non-printable control/high bytes (not valid lone UTF-8
+      // printables); a buffer dominated by them is binary.
+      final bytes = Uint8List.fromList(
+        List<int>.generate(100, (i) => 0x01 + (i % 7)),
+      );
+      expect(isBinaryContent(bytes), isTrue);
+    });
+
+    test('accepts normal ASCII/UTF-8 text', () {
+      final bytes = Uint8List.fromList(
+        utf8.encode('Host example\n  User me\n  Port 22\n'),
+      );
+      expect(isBinaryContent(bytes), isFalse);
+    });
+
+    test('accepts UTF-8 with multibyte characters and common whitespace', () {
+      final bytes = Uint8List.fromList(
+        utf8.encode('café ☕\tline2\r\nrésumé naïve\n'),
+      );
+      expect(isBinaryContent(bytes), isFalse);
+    });
+
+    test('treats an empty buffer as text (not binary)', () {
+      expect(isBinaryContent(Uint8List(0)), isFalse);
+    });
+
+    test('tolerates a small fraction of non-printable bytes in text', () {
+      // Mostly printable ASCII with a couple of stray control bytes (< 30%).
+      final list = <int>[];
+      for (var i = 0; i < 100; i++) {
+        list.add(i % 25 == 0 ? 0x07 : 0x41 + (i % 26));
+      }
+      expect(isBinaryContent(Uint8List.fromList(list)), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #893 — native file-type detection missed extensionless text files (bare `config`, the basename of `~/.ssh/config`, `Dockerfile`, dotfiles), so they never routed to the in-app text viewer. Also adds the binary guard native should have (the PWA blindly renders binary as `<pre>`).

## Changes
- `native/lib/services/text_file_detect.dart`
  - New `isExtensionlessTextName(name)`:
    - bare dotfiles — leading dot, no inner dot (`.bashrc`, `.zshrc`, `.gitconfig`, `.vimrc`), parity with the PWA `isDotfile()`
    - well-known extensionless names (case-insensitive): `config`, `Dockerfile`, `Makefile`, `Rakefile`, `Gemfile`, `Procfile`, `LICENSE`, `README`, `authorized_keys`, `known_hosts`, `hosts`
  - Widened the single classifier: `isTextEntry = hasTextExtension || isExtensionlessTextName || isTextMime` (text/* mime with no extension still routes to text). This one function drives the view router and the future edit gate, matching the PWA's single `getPreviewType()`.
  - `isMarkdownEntry` unchanged → still ordered first in `file_viewer_registry.dart`.
- `native/lib/services/text_file_fetcher.dart`
  - New pure `isBinaryContent(Uint8List, {sampleBytes=64KB, threshold=0.30})`: a NUL byte in the leading sample → binary; otherwise >30% non-printable bytes → binary. Bytes `>= 0x80` are allowed (UTF-8 multibyte) so valid UTF-8 (accents, emoji) is not misclassified.
  - New `BinaryFileException` (message: `Binary file — download instead`). The download-done path rejects binary content via the viewer's existing error path instead of rendering mojibake.

## Tests (unit, RED→GREEN, emulator-free under fast gate)
- Detection table: `config`, `Dockerfile`, `.bashrc`, `LICENSE`, `known_hosts` → text; `photo.png`, `archive.tar.gz` → not text; no-extension + `text/plain` mime → text; `README.md` stays markdown, `config` is not markdown.
- Fetcher: NUL byte / mostly-non-printable → binary; normal ASCII + multibyte UTF-8 / empty buffer → not binary; <30% control bytes in text → not binary.

## Verification
`scripts/native-fast-gate.sh` PASSED — `flutter analyze` clean, all tests pass.

## Scope
Surgical: `text_file_detect.dart` + `text_file_fetcher.dart` + their tests only. No viewer-UI, SFTP write, in-terminal detection, or profile/browser changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)