### PR TITLE
feat(native): SSH profile default path — file-browser starting dir (#891)

### DIFF
--- a/native/integration_test/profile_default_path_test.dart
+++ b/native/integration_test/profile_default_path_test.dart
@@ -1,0 +1,294 @@
+// On-emulator SFTP DEFAULT-PATH smoke (#891).
+//
+// A saved profile carries an optional `defaultPath` (the file-browser starting
+// directory). When set, opening the file browser for that session must land at
+// `defaultPath`, NOT the SFTP home — crucial for VPS/seedbox hosts (Whatbox)
+// where the home dir isn't where you work. When unset, the browser opens at the
+// SFTP home (the `~` realpath), the unchanged behaviour.
+//
+// Headless widget tests feed a fake gateway and never touch a real sshd, so a
+// task-side SFTP regression (e.g. defaultPath not expanded/resolved) only shows
+// on the emulator. This test runs the REAL app against test-sshd: it saves a
+// profile with `defaultPath=/tmp` through the editor, connects, opens the file
+// browser via the session-menu "Files" affordance (the SAME entry point #891
+// wires — openFileBrowserForSession), and asserts the first listing IS `/tmp`.
+// A second case connects WITHOUT a defaultPath and asserts the browser opens at
+// the resolved home (not `/`).
+//
+// Network: scripts/native-connect-test.sh sets up
+//   emulator 127.0.0.1:2222 → (adb reverse → socat) → test-sshd:22
+// Credentials: testuser/testpass (see CLAUDE.md → Test SSH).
+//
+// NOTE: written as the RED baseline; the orchestrator runs this on-device — the
+// develop agent does NOT run integration_test on the busy emulator.
+
+@Tags(['integration'])
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+
+/// Pump in 500ms slices until [test] is true or [maxSlices] elapse, accepting a
+/// host-key trust prompt ("Trust + connect") whenever it surfaces.
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+/// Reach the terminal screen for a freshly-submitted connect.
+Future<bool> _reachTerminal(WidgetTester tester) {
+  return _pumpUntil(
+    tester,
+    () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+  );
+}
+
+/// Assert real LOGIN (not just widget mount): a typed marker echoes back.
+Future<void> _assertShellAlive(
+  WidgetTester tester,
+  SessionEntry entry, {
+  required String marker,
+}) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  addTearDown(sub.cancel);
+  await tester.pump(const Duration(milliseconds: 200));
+  entry.proxy.sendInput(Uint8List.fromList(utf8.encode('echo $marker\n')));
+  final sawMarker = await _pumpUntil(
+    tester,
+    () => utf8.decode(out, allowMalformed: true).contains(marker),
+    maxSlices: 40,
+  );
+  expect(sawMarker, isTrue, reason: 'typed command never echoed — dead shell');
+}
+
+/// Open the session menu reliably (#782) and tap the per-row "Files" affordance
+/// so the browser opens via the REAL #891 entry point (openFileBrowserForSession
+/// → resolves the profile's defaultPath). Returns once the menu overlay shows.
+Future<void> _openSessionMenu(WidgetTester tester) async {
+  await tester.testTextInput.receiveAction(TextInputAction.done);
+  await tester.pump(const Duration(milliseconds: 200));
+  final trigger = find.byKey(const Key('session-bar-open-menu'));
+  await tester.ensureVisible(trigger);
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.tap(trigger, warnIfMissed: false);
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('session-menu-new')).evaluate().isNotEmpty,
+    maxSlices: 20,
+  );
+}
+
+/// Tap the Files button for [sessionId]'s row in the open session menu, then
+/// wait for the browser listing to render. This is the #891 entry point.
+Future<void> _openFilesForSession(
+  WidgetTester tester,
+  String sessionId,
+) async {
+  final files = find.byKey(Key('session-menu-files-$sessionId'));
+  await tester.ensureVisible(files);
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.tap(files);
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('file-browser-list')).evaluate().isNotEmpty,
+    maxSlices: 60,
+  );
+}
+
+/// Fill + save-and-connect an ad-hoc password profile that ALSO sets the
+/// editor's optional default-directory field (#891), so the saved profile
+/// carries [defaultPath]. Mirrors [adhocPasswordConnect] but adds the new field.
+Future<void> _connectWithDefaultPath(
+  WidgetTester tester, {
+  required String host,
+  required String port,
+  required String user,
+  required String pass,
+  required String defaultPath,
+}) async {
+  await openNewConnectionEditor(tester);
+  await tester.enterText(find.byKey(const Key('profile-editor-host')), host);
+  await tester.enterText(find.byKey(const Key('profile-editor-port')), port);
+  await tester.enterText(
+    find.byKey(const Key('profile-editor-username')),
+    user,
+  );
+  await tester.enterText(
+    find.byKey(const Key('profile-editor-password')),
+    pass,
+  );
+  final pathField = find.byKey(const Key('profile-editor-default-path'));
+  await tester.ensureVisible(pathField);
+  await tester.enterText(pathField, defaultPath);
+  await tester.pump();
+  final submit = find.byKey(const Key('connect-submit'));
+  await tester.ensureVisible(submit);
+  await tester.pump();
+  await tester.tap(submit);
+}
+
+Future<void> _disconnectAll(
+  WidgetTester tester,
+  ProviderContainer container,
+) async {
+  final notifier = container.read(sessionsProvider.notifier);
+  final ids = container
+      .read(sessionsProvider)
+      .entries
+      .map((e) => e.id)
+      .toList(growable: false);
+  for (final id in ids) {
+    notifier.close(id);
+  }
+  await _pumpUntil(
+    tester,
+    () => container.read(sessionsProvider).entries.isEmpty,
+    maxSlices: 20,
+  );
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 200));
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'profile defaultPath=/tmp → file browser opens at /tmp, not home (#891)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Connect via a SAVED profile carrying defaultPath=/tmp.
+      await _connectWithDefaultPath(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+        defaultPath: '/tmp',
+      );
+      expect(
+        await _reachTerminal(tester),
+        isTrue,
+        reason: 'never reached the terminal screen',
+      );
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      await _assertShellAlive(tester, entry!, marker: 'MOBISSH_SHELL_OK_891');
+
+      // Open Files via the session menu (the #891 entry point) and assert the
+      // FIRST listing is /tmp — the profile's default dir, not the SFTP home.
+      await _openSessionMenu(tester);
+      await _openFilesForSession(tester, entry.id);
+      expect(
+        find.byKey(const Key('file-browser-list')),
+        findsOneWidget,
+        reason: 'browser listing never rendered',
+      );
+      expect(
+        find.text('/tmp'),
+        findsOneWidget,
+        reason: 'browser did not open at the profile defaultPath (/tmp)',
+      );
+
+      await _disconnectAll(tester, container);
+    },
+  );
+
+  testWidgets(
+    'empty defaultPath → file browser opens at the SFTP home, not "/" (#891)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Connect WITHOUT a defaultPath (the unchanged behaviour).
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      expect(await _reachTerminal(tester), isTrue, reason: 'no terminal');
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      await _assertShellAlive(tester, entry!, marker: 'MOBISSH_HOME_OK_891');
+
+      await _openSessionMenu(tester);
+      await _openFilesForSession(tester, entry.id);
+      expect(
+        find.byKey(const Key('file-browser-list')),
+        findsOneWidget,
+        reason: 'browser listing never rendered',
+      );
+      // With no defaultPath the browser opens at the SFTP home: the path bar
+      // shows the `~` home sentinel (resolved server-side to the realpath home
+      // for the listing) and NOT the root `/`. The home listing rendering at
+      // all (above) proves `~` resolved to a real directory, not an error.
+      expect(
+        find.byKey(const Key('file-browser-path')),
+        findsOneWidget,
+        reason: 'path bar missing',
+      );
+      expect(
+        find.text('~'),
+        findsOneWidget,
+        reason: 'empty defaultPath should open at the home (~), not "/"',
+      );
+      expect(
+        find.text('/'),
+        findsNothing,
+        reason: 'empty defaultPath should open at home, not the root "/"',
+      );
+
+      await _disconnectAll(tester, container);
+    },
+  );
+}

--- a/native/lib/storage/profiles_store.dart
+++ b/native/lib/storage/profiles_store.dart
@@ -38,6 +38,7 @@ class SavedProfile {
     this.vaultId,
     this.keyVaultId,
     this.initialCommand,
+    this.defaultPath = '',
   });
 
   final String title;
@@ -78,6 +79,19 @@ class SavedProfile {
 
   /// Optional command to send after auth — preserved verbatim from the PWA.
   final String? initialCommand;
+
+  /// Optional file-browser starting directory (#891). Empty string = current
+  /// behaviour (open at the SFTP home). Crucial for VPS/seedbox hosts (Whatbox)
+  /// where the SFTP home is NOT where you work — you want to land in e.g.
+  /// `/files` or `~/downloads`. Per-PROFILE (a property of the host), seeded
+  /// into the file browser's initial listing on open and resolved through the
+  /// SFTP `_resolve()` chokepoint (#867 — `~`/relative expand against the
+  /// session home; absolute passes through; invalid → friendly empty-state).
+  ///
+  /// Stored as a plain string; an absent field on an OLD profile JSON reads
+  /// back as '' (migration via [_coerceDefaultPath] — no key bump, per
+  /// .claude/rules code-style), so legacy profiles keep their current behaviour.
+  final String defaultPath;
 
   /// Identity key for dedupe / lookup. Matches the PWA's behavior of treating
   /// (host:port:username) as the unique constraint.
@@ -124,6 +138,16 @@ class SavedProfile {
     return null;
   }
 
+  /// Validate a raw stored default path (#891). Returns the trimmed string when
+  /// it's a non-empty String; anything else (null, absent on an OLD profile,
+  /// non-String) yields '' so legacy profiles + corrupt values fall back to the
+  /// SFTP-home behaviour (corrupt-resilience per .claude/rules — no crash, no
+  /// key bump). This IS the schema migration for the absent-field case.
+  static String _coerceDefaultPath(Object? raw) {
+    if (raw is String) return raw.trim();
+    return '';
+  }
+
   Map<String, dynamic> toJson() {
     final out = <String, dynamic>{
       'title': title,
@@ -141,6 +165,9 @@ class SavedProfile {
     if (initialCommand != null && initialCommand!.isNotEmpty) {
       out['initialCommand'] = initialCommand;
     }
+    // #891: omit when empty so old profiles + default-empty ones stay byte-for-
+    // byte identical (absent field is the migration signal, not a key bump).
+    if (defaultPath.isNotEmpty) out['defaultPath'] = defaultPath;
     return out;
   }
 
@@ -206,6 +233,8 @@ class SavedProfile {
       initialCommand = initialCommandRaw;
     }
 
+    final String defaultPath = _coerceDefaultPath(json['defaultPath']);
+
     return SavedProfile(
       title: title,
       host: hostRaw,
@@ -219,6 +248,7 @@ class SavedProfile {
       vaultId: vaultId,
       keyVaultId: keyVaultId,
       initialCommand: initialCommand,
+      defaultPath: defaultPath,
     );
   }
 
@@ -229,6 +259,7 @@ class SavedProfile {
     double? fontSize,
     String? fontFamily,
     String? theme,
+    String? defaultPath,
   }) {
     return SavedProfile(
       title: title ?? this.title,
@@ -243,6 +274,7 @@ class SavedProfile {
       vaultId: vaultId ?? this.vaultId,
       keyVaultId: keyVaultId ?? this.keyVaultId,
       initialCommand: initialCommand,
+      defaultPath: defaultPath ?? this.defaultPath,
     );
   }
 
@@ -529,6 +561,7 @@ class ProfilesStore {
             vaultId: profile.vaultId,
             keyVaultId: profile.keyVaultId,
             initialCommand: profile.initialCommand,
+            defaultPath: profile.defaultPath,
           );
           updated++;
           continue;

--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -20,6 +20,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/session_messages.dart';
 import '../services/sftp_download.dart';
 import '../ssh/ssh_session_proxy.dart';
+import '../state/profiles_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import 'file_viewer_registry.dart';
@@ -91,6 +92,60 @@ Future<void> openFileBrowser(
       builder: (_) =>
           FileBrowserScreen(sessionId: sessionId, initialPath: initialPath),
     ),
+  );
+}
+
+/// Resolve a saved profile's [defaultPath] (#891) to the browser's initial
+/// listing path. A non-empty path opens the browser THERE; an empty one falls
+/// back to `'~'` (the SFTP home), which the SFTP layer's `_resolve()`/
+/// [expandTilde] (#867) turns into the session's realpath home. `~`/relative
+/// paths and absolutes pass straight through to the same resolver, and an
+/// invalid path surfaces as the browser's friendly empty-state — never a crash.
+String resolveBrowserInitialPath(String defaultPath) {
+  final trimmed = defaultPath.trim();
+  return trimmed.isEmpty ? '~' : trimmed;
+}
+
+/// Open the file browser for [sessionId] starting at its saved profile's
+/// `defaultPath` (#891), falling back to the SFTP home when unset. Looks the
+/// profile up by the session's `host:port:username` identity via
+/// [profilesStoreProvider]; an ad-hoc (never-saved) session simply has no match
+/// and opens at home. This is the entry point the session menu + terminal "Files"
+/// affordances use — the absolute-tap path (#778) still calls [openFileBrowser]
+/// with an explicit `initialPath` and is unaffected.
+Future<void> openFileBrowserForSession(
+  BuildContext context,
+  WidgetRef ref,
+  String sessionId,
+) async {
+  var defaultPath = '';
+  // Find the session's identity (host:port:username) so we can match a profile.
+  String? profileKey;
+  for (final e in ref.read(sessionsProvider).entries) {
+    if (e.id == sessionId) {
+      profileKey = e.profileKey;
+      break;
+    }
+  }
+  if (profileKey != null) {
+    try {
+      final profiles = await ref.read(profilesStoreProvider).load();
+      for (final p in profiles) {
+        if (p.identityKey == profileKey) {
+          defaultPath = p.defaultPath;
+          break;
+        }
+      }
+    } catch (_) {
+      // Profile lookup failure degrades to home — never block opening the
+      // browser on a storage hiccup.
+    }
+  }
+  if (!context.mounted) return;
+  await openFileBrowser(
+    context,
+    sessionId,
+    initialPath: resolveBrowserInitialPath(defaultPath),
   );
 }
 

--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -98,6 +98,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
   late final TextEditingController _portCtrl;
   late final TextEditingController _userCtrl;
   late final TextEditingController _initialCommandCtrl;
+  late final TextEditingController _defaultPathCtrl;
   late final TextEditingController _colorCtrl;
 
   /// Selected theme = a PWA `ThemeName` key from [terminalPalettes] (#613). The
@@ -126,6 +127,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
     _portCtrl = TextEditingController(text: p.port.toString());
     _userCtrl = TextEditingController(text: p.username);
     _initialCommandCtrl = TextEditingController(text: p.initialCommand ?? '');
+    _defaultPathCtrl = TextEditingController(text: p.defaultPath);
     _colorCtrl = TextEditingController(text: p.color ?? '');
     // Seed the picker from the profile's stored theme key when it maps to a
     // known palette; otherwise fall back to the default palette's key.
@@ -152,6 +154,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
     _portCtrl.dispose();
     _userCtrl.dispose();
     _initialCommandCtrl.dispose();
+    _defaultPathCtrl.dispose();
     _colorCtrl.dispose();
     _passwordCtrl.dispose();
     _keyCtrl.dispose();
@@ -251,6 +254,8 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
         vaultId: vaultId,
         keyVaultId: keyVaultId,
         initialCommand: _emptyToNull(_initialCommandCtrl.text),
+        // #891: optional file-browser starting dir. Trim; empty = SFTP home.
+        defaultPath: _defaultPathCtrl.text.trim(),
       );
 
       await store.upsert(updated, previousIdentityKey: _originalIdentityKey);
@@ -427,6 +432,21 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
                 decoration: const InputDecoration(
                   labelText: 'Initial command (optional)',
                   hintText: 'e.g. tmux attach || tmux',
+                ),
+                autocorrect: false,
+                enableSuggestions: false,
+              ),
+              const SizedBox(height: 12),
+              // #891: optional file-browser starting directory. Empty = SFTP
+              // home (current behaviour). Crucial for VPS/seedbox hosts where
+              // the home dir isn't where you work (e.g. `/files`).
+              TextField(
+                key: const Key('profile-editor-default-path'),
+                controller: _defaultPathCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Default directory (optional)',
+                  hintText: 'e.g. /files or ~/downloads',
+                  prefixIcon: Icon(Icons.folder_outlined),
                 ),
                 autocorrect: false,
                 enableSuggestions: false,

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -746,12 +746,15 @@ class _SessionRow extends ConsumerWidget {
             icon: const Icon(Icons.folder_outlined),
             // Open the file browser for THIS row's session id (its live SSH
             // connection drives SFTP). Close the menu first so the browser
-            // route isn't covered by the overlay.
+            // route isn't covered by the overlay. #891: open at the profile's
+            // default directory (else SFTP home) via openFileBrowserForSession.
             onPressed: () {
               final sessionId = entry.id;
               final navigator = Navigator.of(context);
               onClose();
-              openFileBrowser(navigator.context, sessionId);
+              unawaited(
+                openFileBrowserForSession(navigator.context, ref, sessionId),
+              );
             },
           ),
           if (sessionCanReconnect(state))

--- a/native/test/profile_default_path_test.dart
+++ b/native/test/profile_default_path_test.dart
@@ -1,0 +1,197 @@
+// #891 — SSH profile default path (file-browser starting directory).
+//
+// A new OPTIONAL `defaultPath` on the profile model + the browser initial-path
+// resolution helper. Covers:
+//   - toJson omits an empty defaultPath (no key bump; absent field = migration)
+//   - toJson includes a non-empty defaultPath
+//   - round-trip through the store preserves defaultPath
+//   - OLD profile JSON WITHOUT the field migrates to '' (no crash)
+//   - a non-String stored value coerces to '' (corrupt-resilience)
+//   - copyWith carries / overrides defaultPath
+//   - resolveBrowserInitialPath: empty -> '~' (home); `~`/relative/absolute
+//     pass through; surrounding whitespace trimmed
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('SavedProfile.defaultPath (#891)', () {
+    test('defaults to empty string', () {
+      final p = SavedProfile(title: 't', host: 'h', port: 22, username: 'u');
+      expect(p.defaultPath, '');
+    });
+
+    test('toJson omits an empty defaultPath', () {
+      final p = SavedProfile(title: 't', host: 'h', port: 22, username: 'u');
+      expect(p.toJson().containsKey('defaultPath'), isFalse);
+    });
+
+    test('toJson includes a non-empty defaultPath', () {
+      final p = SavedProfile(
+        title: 't',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        defaultPath: '/files',
+      );
+      expect(p.toJson()['defaultPath'], '/files');
+    });
+
+    test('fromJson reads a stored defaultPath', () {
+      final p = SavedProfile.fromJson(<String, dynamic>{
+        'title': 't',
+        'host': 'h',
+        'port': 22,
+        'username': 'u',
+        'defaultPath': '~/downloads',
+      });
+      expect(p.defaultPath, '~/downloads');
+    });
+
+    test('OLD profile JSON without defaultPath migrates to "" (no crash)', () {
+      // A pre-#891 profile blob: no defaultPath key at all.
+      final p = SavedProfile.fromJson(<String, dynamic>{
+        'title': 'legacy',
+        'host': 'old.host',
+        'port': 2222,
+        'username': 'u',
+        'theme': 'nord',
+      });
+      expect(p.defaultPath, '');
+    });
+
+    test('a non-String stored defaultPath coerces to ""', () {
+      final p = SavedProfile.fromJson(<String, dynamic>{
+        'title': 't',
+        'host': 'h',
+        'port': 22,
+        'username': 'u',
+        'defaultPath': 42,
+      });
+      expect(p.defaultPath, '');
+    });
+
+    test('fromJson trims surrounding whitespace on defaultPath', () {
+      final p = SavedProfile.fromJson(<String, dynamic>{
+        'title': 't',
+        'host': 'h',
+        'port': 22,
+        'username': 'u',
+        'defaultPath': '  /files  ',
+      });
+      expect(p.defaultPath, '/files');
+    });
+
+    test('copyWith carries defaultPath through unchanged', () {
+      final p = SavedProfile(
+        title: 't',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        defaultPath: '/files',
+      );
+      expect(p.copyWith(theme: 'nord').defaultPath, '/files');
+    });
+
+    test('copyWith overrides defaultPath when supplied', () {
+      final p = SavedProfile(
+        title: 't',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        defaultPath: '/files',
+      );
+      expect(p.copyWith(defaultPath: '/other').defaultPath, '/other');
+    });
+  });
+
+  group('ProfilesStore round-trip (#891)', () {
+    test('save -> load preserves a non-empty defaultPath', () async {
+      final store = ProfilesStore();
+      final p = SavedProfile(
+        title: 'whatbox',
+        host: 'box.example',
+        port: 22,
+        username: 'me',
+        defaultPath: '/files',
+      );
+      await store.save(<SavedProfile>[p]);
+
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      expect(loaded.single.defaultPath, '/files');
+    });
+
+    test('save -> load yields "" for a profile saved without defaultPath',
+        () async {
+      final store = ProfilesStore();
+      final p = SavedProfile(
+        title: 't',
+        host: 'h',
+        port: 22,
+        username: 'u',
+      );
+      await store.save(<SavedProfile>[p]);
+
+      final loaded = await store.load();
+      expect(loaded.single.defaultPath, '');
+    });
+
+    test('upsert preserves defaultPath across an in-place update', () async {
+      final store = ProfilesStore();
+      final p = SavedProfile(
+        title: 't',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        defaultPath: '/files',
+      );
+      await store.upsert(p);
+      // Re-save with the same identity but a new default path.
+      await store.upsert(p.copyWith(defaultPath: '/data'));
+
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      expect(loaded.single.defaultPath, '/data');
+    });
+  });
+
+  group('resolveBrowserInitialPath (#891)', () {
+    test('an empty defaultPath resolves to "~" (SFTP home)', () {
+      expect(resolveBrowserInitialPath(''), '~');
+    });
+
+    test('a whitespace-only defaultPath resolves to "~"', () {
+      expect(resolveBrowserInitialPath('   '), '~');
+    });
+
+    test('an absolute defaultPath passes through', () {
+      expect(resolveBrowserInitialPath('/files'), '/files');
+    });
+
+    test('a "~"-prefixed defaultPath passes through', () {
+      expect(resolveBrowserInitialPath('~/downloads'), '~/downloads');
+    });
+
+    test('a bare "~" passes through', () {
+      expect(resolveBrowserInitialPath('~'), '~');
+    });
+
+    test('a relative defaultPath passes through', () {
+      expect(resolveBrowserInitialPath('downloads'), 'downloads');
+    });
+
+    test('surrounding whitespace is trimmed', () {
+      expect(resolveBrowserInitialPath('  /files  '), '/files');
+    });
+  });
+}


### PR DESCRIPTION
Closes #891.

## What
Optional per-profile **default path** (file-browser starting directory). When set, opening the file browser for a session lands at `defaultPath` instead of the SFTP home — crucial for VPS/seedbox hosts (Whatbox) where the home dir isn't where you work (e.g. `/files`, `~/downloads`).

## How
- **Model** (`profiles_store.dart`): `SavedProfile.defaultPath` (String, default `''`).
  - `toJson` omits it when empty — an **absent field IS the migration** (no key bump, per code-style rule). Old profile JSON without the field loads with `''`.
  - `fromJson` coerces a non-String/absent value to `''` (corrupt-resilient, no crash) and trims.
  - `copyWith` + the import upsert carry it.
- **Editor** (`profile_editor.dart`): "Default directory (optional)" field with monochrome folder icon and hint `/files or ~/downloads`.
- **Browser seam** (`file_browser_screen.dart`) — kept minimal:
  - `resolveBrowserInitialPath(defaultPath)` → the path when set, else `'~'` (home sentinel).
  - `openFileBrowserForSession(context, ref, sessionId)` looks the profile up by the session's `host:port:username` identity and opens at the resolved path. The session-menu **Files** affordance uses it.
  - The `#778` absolute-tap path and `openFileBrowser(initialPath:)` default `/` are **unchanged** (existing widget tests + tap-to-open unaffected).
  - `~` / relative / absolute all flow through the existing **#867** `expandTilde` `_resolve()` chokepoint; an invalid path surfaces the friendly empty-state, never a crash. **Per-PROFILE** scope.

## Seams
- **New field:** `SavedProfile.defaultPath`.
- **Migration:** absent JSON field → `''` via `_coerceDefaultPath` (no key bump).
- **Browser initial-path seam:** `openFileBrowserForSession` → `resolveBrowserInitialPath` → `openFileBrowser(initialPath:)` → host `_resolve`/`expandTilde` (#867).

## Tests
- **Unit (fast gate, green):** model round-trip; OLD-JSON-without-field migrates to `''`; non-String coercion; copyWith; store round-trip + upsert; `resolveBrowserInitialPath` (empty→`~`, `~`/relative/absolute passthrough, whitespace trim). 19 tests, all passing under `scripts/native-fast-gate.sh`.
- **Integration (written as the RED baseline; NOT run here):** `integration_test/profile_default_path_test.dart` — `defaultPath=/tmp` opens the browser at `/tmp`; empty opens at the SFTP home (`~`), not `/`.

> NOTE: the integration test was authored as the red baseline only. **The orchestrator runs it on the emulator/device** — the develop agent did not run `integration_test` (emulator busy). Gated with `scripts/native-fast-gate.sh` (green).

## Scope guard
profile model/store + editor + provider lookup + session-menu Files call site + browser helper + tests. Did NOT touch terminal paint (#887), detection (#890/#893), settings IA (#888B), SFTP write (#892), or viewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)