### PR TITLE
fix(#898): tmux window switch repaints — glyph dirty-mark unconditional, not dropped mid-layout

### DIFF
--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -551,32 +551,39 @@ class TerminalRenderBox extends RenderBox {
     _markFrameDirty();
   }
 
-  // Handles terminal change notifications.
-  //
-  // When scrollback length changes, a layout pass is needed because scroll
-  // extents must be recalculated. For normal output (same scrollback
-  // length), only a repaint is needed.
+  // Handles terminal change notifications. See the inline #887/#898 notes for
+  // why the glyph dirty-mark is unconditional and why only `markNeedsLayout` is
+  // gated on `_performingLayout`.
   void _onTerminalChanged() {
-    if (_paintState.rows == 0 || _performingLayout) return;
+    if (_paintState.rows == 0) return;
 
-    if (_terminal.scrollbackRows != _lastScrollbackRows) {
-      // #887: scrollback grew (the steady-state case: a full shell streaming
-      // output pushes rows into history). `performLayout` only re-marks the
-      // frame dirty when the GRID size changed (`gridChanged ||
-      // atlasReconfigured`) — for plain output the grid is unchanged, so a
-      // bare `markNeedsLayout()` recomputes scroll extents but NEVER adds this
-      // box to the needs-PAINT set (markNeedsLayout does not imply
-      // markNeedsPaint in Flutter). The new glyph rows then stayed unpainted —
-      // only the independently-driven decoration layer (`_decorationNotifier`)
-      // repainted — until an unrelated event (route push / scroll / keystroke)
-      // forced a frame. `_markFrameDirty()` sets `_needsFrameSync` AND calls
-      // markNeedsPaint, so the glyphs repaint in lockstep with the new output.
-      _markFrameDirty();
-      markNeedsLayout();
-      return;
-    }
+    final scrollbackChanged = _terminal.scrollbackRows != _lastScrollbackRows;
 
+    // #898: the GLYPH dirty-mark is UNCONDITIONAL — ANY content change marks
+    // this box needs-paint AND `_needsFrameSync` (so the next paint re-snapshots
+    // the cells). We deliberately do NOT enumerate triggers (scrollback-grew /
+    // size-change / in-place alt-screen redraw): the rendered grid is gated on
+    // `_needsFrameSync` + the needs-PAINT set, so a notify that does not mark
+    // BOTH leaves the glyphs stale until an unrelated frame forces a paint. That
+    // was the #887 class (the scrollback-grew branch only re-laid out) and the
+    // #898 class — a tmux window switch is an IN-PLACE alt-screen redraw (no
+    // scrollback growth, no grid resize); when its notify fired while this box
+    // was mid-`performLayout` the old `if (_performingLayout) return;` guard
+    // DROPPED it entirely, so the new window's glyphs never repainted (the
+    // intermittent stale display).
+    //
+    // `markNeedsPaint()` is SAFE while `_performingLayout` is true: layout runs
+    // BEFORE paint in the frame pipeline, so setting the needs-paint flag here
+    // simply schedules this box's paint for the SAME frame — it is not dropped.
+    // (libghostty fires this listener synchronously from `performLayout` via
+    // `Terminal.resize` / `_syncScrollLayout`'s viewport scroll.) Always do it.
     _markFrameDirty();
+
+    // `markNeedsLayout()` is the ONLY part that is illegal during layout (it
+    // throws "called during layout"), and it is redundant then anyway — we are
+    // already in a layout pass that will recompute scroll extents. So request a
+    // follow-up layout for a scrollback-length change ONLY when not mid-layout.
+    if (scrollbackChanged && !_performingLayout) markNeedsLayout();
   }
 
   // Maintains scroll position and content dimensions.

--- a/native/third_party/flterm/test/widgets/alt_screen_inplace_repaint_898_test.dart
+++ b/native/third_party/flterm/test/widgets/alt_screen_inplace_repaint_898_test.dart
@@ -1,0 +1,273 @@
+@Tags(['ffi'])
+library;
+
+// #898 (P0, device 0.1.10+60, intermittent) — a tmux window switch leaves the
+// rendered glyph grid STALE: the cursor moves but the cells don't repaint to
+// show the new window's content. The input is a CORRECT SGR-1006 status-bar
+// mouse click (not #881's cursor-key fallback); tmux switches the window
+// server-side and the server redraws — output comes back — but the glyph grid
+// intermittently does not repaint.
+//
+// CONFIRMED MECHANISM: a tmux window switch is an IN-PLACE ALT-SCREEN full
+// redraw — scrollback does NOT grow, the grid size does NOT change.
+// `TerminalRenderBox._onTerminalChanged` marks the glyph render box needs-paint
+// (`_markFrameDirty`, which also sets `_needsFrameSync` so the next paint
+// re-snapshots the cells) for that case — UNLESS the notify arrives while the
+// box is mid-`performLayout`. libghostty fires the terminal listener
+// SYNCHRONOUSLY from inside `performLayout` (via `Terminal.resize` and
+// `_syncScrollLayout`'s viewport scroll). The pre-fix guard
+// `if (_paintState.rows == 0 || _performingLayout) return;` DROPPED that notify
+// entirely, so `_needsFrameSync` was never set and the new window's glyphs never
+// re-synced — only the cursor (read live each paint) moved. An unrelated later
+// frame eventually forced a re-sync, which is why it was intermittent.
+//
+// THE FIX: the glyph dirty-mark is now UNCONDITIONAL on any content change.
+// `markNeedsPaint()` is SAFE during `performLayout` (layout runs before paint,
+// so the flag is honoured this same frame); only `markNeedsLayout()` is illegal
+// then, and it is redundant mid-layout, so it is skipped in that window. The box
+// therefore re-syncs and repaints for an in-place redraw whether the notify
+// lands at idle OR during a layout pass.
+//
+// HEADLESS COVERAGE vs DEVICE GATE: the two tests below pin the contract
+// headless — (1) an idle in-place redraw marks needs-paint, and (2) an in-place
+// redraw whose notify fires DURING `performLayout` does not throw and the frame
+// re-syncs/settles (the mid-layout safety the fix must preserve, mirroring the
+// #887 cycle-2 prune pin). The AUTHORITATIVE red→green for the intermittent race
+// is the on-emulator tmux window-switch confirm the orchestrator runs (a
+// status-bar SGR mouse click updates the rendered grid to the new window's
+// content), exactly as `prune_during_layout_defers_notify_887_test` defers its
+// timing-coincidence baseline to the emulator suite.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
+import 'package:flterm/src/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+void main() {
+  void writeUtf8(Terminal terminal, String s) {
+    terminal.write(Uint8List.fromList(utf8.encode(s)));
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // (1) The steady (idle) in-place redraw: a tmux window switch rewrites the
+  // same alt-screen rows in place — no scrollback growth, no grid resize — and
+  // MUST mark the glyph render box needs-paint. Guards the unconditional-marking
+  // contract on the in-place trigger (the #887/#898 class).
+
+  testWidgets(
+    'an in-place alt-screen redraw at idle (no scrollback growth, no size '
+    'change) marks the glyph render box needs-paint (#898)',
+    (tester) async {
+      final controller = TerminalController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 800,
+                height: 480,
+                child: TerminalView(controller: controller),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      void write(String s) =>
+          controller.write(Uint8List.fromList(utf8.encode(s)));
+
+      write('\x1b[?1049h\x1b[2J\x1b[H');
+      for (var r = 1; r <= 20; r++) {
+        write('\x1b[$r;1Hwindow A row ${r.toString().padLeft(2, '0')} content');
+      }
+      await tester.pump();
+      await tester.pump();
+
+      final renderBox = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      expect(
+        controller.activeScreen,
+        TerminalScreen.alternate,
+        reason: 'precondition: on the alternate screen (tmux/full-screen app)',
+      );
+      expect(
+        renderBox.debugNeedsPaint,
+        isFalse,
+        reason: 'precondition: the frame painted and settled before the switch',
+      );
+      final scrollbackBefore = controller.scrollbackRows;
+
+      // tmux switches the window: the SAME alt-screen rows are rewritten IN
+      // PLACE with the new window's content. No scrollback growth, no resize.
+      for (var r = 1; r <= 20; r++) {
+        write('\x1b[$r;1Hwindow B row ${r.toString().padLeft(2, '0')} content');
+      }
+      expect(
+        controller.scrollbackRows,
+        scrollbackBefore,
+        reason: 'precondition: an in-place alt-screen redraw does NOT grow '
+            'scrollback (it takes the in-place branch of _onTerminalChanged)',
+      );
+      expect(
+        renderBox.debugNeedsPaint,
+        isTrue,
+        reason: 'an in-place alt-screen redraw (tmux window switch) must mark '
+            'the glyph render box needs-paint (#898)',
+      );
+    },
+  );
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // (2) Mid-layout safety: a content-change notify that fires WHILE the box is
+  // inside `performLayout` (the device race — libghostty fires the listener
+  // synchronously from layout) must mark needs-paint WITHOUT throwing
+  // "markNeedsLayout called during layout", and the frame must re-sync and
+  // settle (the new in-place content repaints, the box ends clean — not stuck
+  // dirty and not stale). We drive a raw `TerminalRenderer` and write the
+  // in-place redraw from its `onResize` hook, which fires synchronously from
+  // inside `TerminalRenderBox.performLayout` (`_performingLayout == true`).
+
+  testWidgets(
+    'a content-change notify firing DURING performLayout re-syncs and settles '
+    'without throwing (the in-place redraw racing a layout pass) (#898)',
+    (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+      final terminal = Terminal(cols: 80, rows: 24);
+      addTearDown(terminal.dispose);
+
+      writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
+      for (var r = 1; r <= 20; r++) {
+        writeUtf8(terminal,
+            '\x1b[$r;1Hwindow A row ${r.toString().padLeft(2, '0')} content');
+      }
+
+      final cache = TerminalRenderCache();
+      addTearDown(cache.dispose);
+
+      // The onResize hook fires from INSIDE `performLayout`. When armed, write an
+      // in-place alt-screen redraw there — its `_onTerminalChanged` fires while
+      // `_performingLayout` is true, the exact #898 race. Pre-fix the guard
+      // dropped it (silent); the fix marks needs-paint mid-layout, which must NOT
+      // throw and must end in a settled repaint.
+      var armed = false;
+      var ranInLayoutRedraw = false;
+      void onResize(int cols, int rows) {
+        if (!armed) return;
+        armed = false;
+        ranInLayoutRedraw = true;
+        for (var r = 1; r <= 20; r++) {
+          writeUtf8(terminal,
+              '\x1b[$r;1Hwindow B row ${r.toString().padLeft(2, '0')} new');
+        }
+      }
+
+      var width = 640.0;
+      late StateSetter setOuter;
+      Widget app() {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: StatefulBuilder(
+            builder: (context, setState) {
+              setOuter = setState;
+              return Align(
+                alignment: Alignment.topLeft,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: width, maxHeight: 384),
+                  child: TerminalRenderer(
+                    terminal: terminal,
+                    theme: TerminalTheme.dark(),
+                    metrics: metrics,
+                    offset: ViewportOffset.zero(),
+                    renderCache: cache,
+                    renderObserver: _TestRenderObserver(),
+                    onResize: onResize,
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      }
+
+      await tester.pumpWidget(app());
+      await tester.pump();
+
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      expect(
+        box.debugNeedsPaint,
+        isFalse,
+        reason: 'precondition: settled, clean frame before the layout-race redraw',
+      );
+
+      // Arm and shrink the width: `performLayout` runs, `onResize` fires
+      // mid-layout, and the in-place redraw's notify lands while
+      // `_performingLayout` is true.
+      armed = true;
+      setOuter(() {
+        width = 560.0;
+      });
+      await tester.pump();
+
+      expect(
+        ranInLayoutRedraw,
+        isTrue,
+        reason: 'precondition: the in-place redraw ran from onResize (mid-layout)',
+      );
+      // The fix marks needs-paint mid-layout via `markNeedsPaint` (safe — layout
+      // precedes paint), NOT `markNeedsLayout` (which would throw during layout).
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'marking the glyph box dirty mid-layout must not throw '
+            '"markNeedsLayout called during layout" (#898)',
+      );
+
+      // The in-layout redraw re-syncs and the frame settles: pumping leaves the
+      // box clean (the new window content was painted) — not stuck dirty, not
+      // stale.
+      await tester.pump();
+      expect(
+        box.debugNeedsPaint,
+        isFalse,
+        reason: 'the in-layout in-place redraw re-syncs and the frame settles '
+            'into a real repaint (#898)',
+      );
+    },
+  );
+}
+
+class _TestRenderObserver implements TerminalRenderObserver {
+  @override
+  TerminalSelection? get selection => null;
+
+  @override
+  bool get hasFocus => true;
+
+  @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
+  void reportPaintedViewportOffset(int offset) {}
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+}


### PR DESCRIPTION
Fixes #898.

## Confirmed mechanism (b)
A tmux window switch is an **in-place alt-screen full redraw** — no scrollback growth, no grid resize. The render-box listener `TerminalRenderBox._onTerminalChanged` (`native/third_party/flterm/lib/src/rendering/terminal_renderer.dart`) early-returned on:

```dart
if (_paintState.rows == 0 || _performingLayout) return;
```

libghostty fires the terminal listener **synchronously from inside this box's own `performLayout`** (via `Terminal.resize` on a grid change and `_syncScrollLayout`'s viewport scroll). When the redraw notify raced a layout pass, the `_performingLayout` guard **dropped it entirely** — `_needsFrameSync` was never set, so the next paint (driven by the live cursor read each frame) did not re-snapshot the cells. The glyph grid stayed at the old window until an unrelated frame forced a re-sync. That race is the intermittency.

This is the #887 paint-dirty class on a new trigger, and a regression from the +59 #887 cycle-2 work at the render-box layer. It is **mechanism (b)**, not (a): the controller's cycle-2 deferral (`_runOrDeferFrameWork`) correctly handles its own side-effects — the gap was the separate render-box listener dropping the glyph dirty-mark.

## The dirty-marking change
The glyph dirty-mark is now **unconditional** on any content change — always `_markFrameDirty()` (sets `_needsFrameSync` + `markNeedsPaint`). `markNeedsPaint()` is **safe during `performLayout`** (layout precedes paint, so the flag is honoured the same frame — not dropped). Only `markNeedsLayout()` is illegal mid-layout (it throws) and is redundant then, so it is gated:

```dart
_markFrameDirty();
if (scrollbackChanged && !_performingLayout) markNeedsLayout();
```

No trigger enumeration. No deferral machinery — a post-frame deferral was tried and **rejected**: it left the box needs-paint after settle and broke the golden suite's `!debugNeedsPaint` capture assertion.

## Why intermittent
The drop only occurred when an in-place redraw notify coincided with a layout/paint frame (`_performingLayout` true). Most redraws land at idle and already marked needs-paint via the in-place branch; only the ones racing a layout went stale — hence intermittent.

## Tests (headless)
`native/third_party/flterm/test/widgets/alt_screen_inplace_repaint_898_test.dart`:
- an idle in-place alt-screen redraw marks the glyph render box needs-paint (contract);
- a content-change notify firing **during `performLayout`** re-syncs and settles **without throwing** "markNeedsLayout called during layout" (the mid-layout safety the fix must preserve).

The exact mid-layout race cannot be staged as a deterministic headless RED (the only in-layout write hook, `onResize`, fires on a grid change that pre-dirties the box), mirroring `prune_during_layout_defers_notify_887_test` deferring its baseline to the emulator suite.

## Orchestrator action required
Run the **on-device tmux window-switch confirm**: a status-bar SGR mouse click must update the rendered grid to the new window's content (assert glyph content changed, not just the cursor).

## Gates
- flterm full fork suite: **746 passed** (incl. #887 `new_output_glyph_repaint` + `prune_during_layout_defers_notify`, #883 `scroll_to_top_painted_offset`, golden + emoji golden).
- native fast gate: analyze clean, **1330 tests passed**.
- Preserved #883 (no painted-offset divergence), #812 (hide-on-scroll), cycle-2 mid-layout safety (controller layer untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)