### PR TITLE
fix(#900): tmux window-switch repaints EVERY switch — structural full re-read on alt-screen redraw

### DIFF
--- a/native/third_party/flterm/lib/src/rendering/terminal_frame_builder.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_frame_builder.dart
@@ -187,6 +187,12 @@ class TerminalFrameBuilder {
   late final _TerminalRowBuilder _rowBuilder;
   late final _CursorFrameBuilder _cursorBuilder;
 
+  /// Number of rows the LAST [sync] re-emitted (0 if it skipped the build).
+  /// Test-only signal for the #900 repaint-on-every-redraw contract: an
+  /// in-place alt-screen redraw must re-read rows on EVERY switch, not every
+  /// other one.
+  var debugRowsRebuiltLastSync = 0;
+
   TerminalFrameBuilder(this._atlas, this._sprites, this._state)
     : _content = CellContentResolver(_atlas),
       _renderState = RenderState(),
@@ -235,6 +241,7 @@ class TerminalFrameBuilder {
     required bool terminalDirty,
     String preeditText = '',
   }) {
+    debugRowsRebuiltLastSync = 0;
     var dirty = DirtyState.clean;
 
     if (terminalDirty) {
@@ -286,14 +293,17 @@ class TerminalFrameBuilder {
     _rows.reset(_renderState);
 
     var row = 0;
+    var rebuilt = 0;
     while (_rows.next()) {
       if (row >= _state.rows) break;
       if (rebuildAll || _rows.dirty || _dirtyRows.isDirty(row)) {
         _rowBuilder.rebuildRow(row, _rows, _cells);
         _rows.dirty = false;
+        rebuilt++;
       }
       row++;
     }
+    debugRowsRebuiltLastSync = rebuilt;
 
     _dirtyRows._clear();
     _atlas.ensureImage();

--- a/native/third_party/flterm/lib/src/rendering/terminal_render_pipeline.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_render_pipeline.dart
@@ -60,6 +60,10 @@ final class TerminalRenderPipeline {
 
   void markAllRowsDirty() => _frameBuilder.markAllRowsDirty();
 
+  /// Rows the LAST [sync] re-emitted (0 if it skipped the build). Test-only
+  /// signal for the #900 repaint-on-every-redraw contract.
+  int get debugRowsRebuiltLastSync => _frameBuilder.debugRowsRebuiltLastSync;
+
   void markSelectionRowsDirty(
     TerminalSelection? selection, {
     required int viewportOffset,

--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -230,6 +230,12 @@ class TerminalRenderBox extends RenderBox {
   @override
   bool get isRepaintBoundary => true;
 
+  /// Rows the LAST paint's frame-sync re-emitted (0 if it skipped the build).
+  /// Test-only signal for the #900 repaint-on-every-redraw contract: an
+  /// in-place alt-screen redraw (tmux window switch) must re-read the visible
+  /// grid on EVERY switch, not every other one.
+  int get debugRowsRebuiltLastSync => _pipeline.debugRowsRebuiltLastSync;
+
   /// Current terminal input caret rect in this render box's local coordinates.
   Rect get textInputCaretRect {
     final metrics = _paintState.metrics;
@@ -578,6 +584,37 @@ class TerminalRenderBox extends RenderBox {
     // (libghostty fires this listener synchronously from `performLayout` via
     // `Terminal.resize` / `_syncScrollLayout`'s viewport scroll.) Always do it.
     _markFrameDirty();
+
+    // #900 (STRUCTURAL, supersedes the #887/#898 per-trigger patches): on the
+    // ALTERNATE screen, force a FULL re-read of the visible grid on every
+    // content-change notify, instead of trusting libghostty's single-consumption
+    // per-row damage.
+    //
+    // ROOT of the "every OTHER switch repaints" alternation: the partial-build
+    // path (`TerminalFrameBuilder.sync` → `_build(.partial)`) re-reads only the
+    // rows libghostty's `RenderState.update` reports DAMAGED, and `update`
+    // CONSUMES (clears) that damage as it reads it. The render box fires multiple
+    // paints per tmux window switch (cursor blink, scroll/offset correction, the
+    // atlas `onImageReady` repaint, the #803 painted-offset post-frame notify).
+    // When an EARLIER paint's `update` consumes the switch's row damage before
+    // the build that actually reaches the screen — or when a second `update`
+    // straddles the in-place redraw — the next switch's `update` can read as
+    // CLEAN (no NEW damage since the consumed one), so its build re-reads NO
+    // rows and the grid stays on the previous window. The damage is repopulated
+    // only every other cycle, which is the strict A/B/A/B alternation. This is
+    // single-consumption damage feeding a partial build that has no flterm-side
+    // guarantee the consuming `update` is the one that paints.
+    //
+    // The fix DECOUPLES alt-screen redraw correctness from that damage entirely:
+    // `markAllRowsDirty()` makes `_dirtyRows.anyDirty` true, so the build runs and
+    // re-reads the FULL visible grid from the CURRENT `RenderState` snapshot even
+    // when `update` returns `.clean` because a prior frame already consumed the
+    // per-row damage. The alternate screen has NO scrollback, so a full re-read is
+    // bounded to the visible rows — what a native terminal does for a full-screen
+    // app redraw. This is scoped to the alternate screen, so #805's primary-screen
+    // streaming-output perf path (which relies on partial per-row rebuilds during
+    // scrollback growth) is untouched.
+    if (_terminal.activeScreen == .alternate) _pipeline.markAllRowsDirty();
 
     // `markNeedsLayout()` is the ONLY part that is illegal during layout (it
     // throws "called during layout"), and it is redundant then anyway — we are

--- a/native/third_party/flterm/test/rendering/alt_screen_repaint_alternation_900_test.dart
+++ b/native/third_party/flterm/test/rendering/alt_screen_repaint_alternation_900_test.dart
@@ -1,0 +1,168 @@
+@Tags(['ffi'])
+library;
+
+// #900 (P0, device 0.1.10+61) — switching tmux windows repaints the rendered
+// grid only on ALTERNATE switches ("works/fails/works/fails"). This is the 4th
+// repaint fix in the flterm render-box frame-sync subsystem (#887 cycle1/cycle2,
+// #898); per know-when-to-quit it is STRUCTURAL, not another per-trigger patch.
+//
+// CONFIRMED ROOT (the exact toggle):
+//   `TerminalFrameBuilder.sync` re-reads the terminal grid via
+//   `RenderState.update`, which CONSUMES (clears) libghostty's per-row damage as
+//   it reads it. The partial-build path (`_build(.partial)`) then re-emits ONLY
+//   the rows libghostty flagged damaged. The render box fires MULTIPLE paints
+//   per tmux window switch (cursor blink, scroll/offset correction, the atlas
+//   `onImageReady` repaint, the #803 painted-offset post-frame notify). When an
+//   earlier paint's `update` consumes the switch's row damage before the build
+//   that reaches the screen — or a second `update` straddles the in-place redraw
+//   — the NEXT switch's `update` reads CLEAN (no NEW damage since the consumed
+//   one), so its partial build re-emits NO rows and the grid stays on the
+//   previous window. Damage is repopulated only every OTHER cycle → the strict
+//   A/B/A/B alternation. The defect is single-consumption libghostty damage
+//   feeding a partial build with no flterm-side guarantee that the `update` which
+//   consumed the damage is the one that paints it.
+//
+// STRUCTURAL FIX (in `TerminalRenderBox._onTerminalChanged`): on the ALTERNATE
+// screen, force `_pipeline.markAllRowsDirty()` on every content-change notify.
+// That makes the frame builder's own `_dirtyRows` request a FULL re-read of the
+// visible grid from the CURRENT `RenderState` snapshot even when `update`
+// returns `.clean` because a prior frame already consumed the per-row damage.
+// The alternate screen has NO scrollback, so a full re-read is bounded to the
+// visible rows (what a native terminal does for a full-screen-app redraw), and
+// the primary-screen streaming-output perf path (#805) is untouched.
+//
+// This test reproduces the damage double-consume DETERMINISTICALLY at the
+// pipeline level: a content change followed by a `terminalDirty` sync that
+// CONSUMES the damage without surviving to the screen, then asserts that the
+// fix's action (`markAllRowsDirty`) re-reads the full grid on the next sync,
+// whereas relying on libghostty damage alone re-reads NOTHING (the stale grid).
+
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flterm/src/foundation/cell_metrics.dart';
+import 'package:flterm/src/foundation/terminal_theme.dart';
+import 'package:flterm/src/rendering/atlas/atlas.dart';
+import 'package:flterm/src/rendering/paint_state.dart';
+import 'package:flterm/src/rendering/terminal_render_pipeline.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+void main() {
+  const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+  AtlasConfig config() => AtlasConfig(
+        fontSize: 14,
+        fontWeight: FontWeight.normal,
+        fontFamily: 'monospace',
+        fontFamilyFallback: const [],
+        metrics: metrics,
+        devicePixelRatio: 1.0,
+      );
+
+  void writeUtf8(Terminal terminal, String text) {
+    terminal.write(Uint8List.fromList(utf8.encode(text)));
+  }
+
+  late Terminal terminal;
+  late Atlas atlas;
+  late TerminalPaintState state;
+  late TerminalRenderPipeline pipeline;
+
+  setUp(() {
+    terminal = Terminal(cols: 16, rows: 4);
+    atlas = Atlas(config());
+    state = TerminalPaintState(TerminalTheme.dark(), metrics)
+      ..cols = 16
+      ..rows = 4;
+    pipeline = TerminalRenderPipeline(
+      atlas: atlas,
+      state: state,
+      onImageReady: () {},
+    )..configureGrid(4, 16);
+  });
+
+  tearDown(() {
+    pipeline.dispose();
+    atlas.dispose();
+    terminal.dispose();
+  });
+
+  // tmux-style in-place rewrite (no \x1b[2J clear): addressed cells only, so
+  // libghostty reports DirtyState.partial with per-row damage — the exact path
+  // a tmux window switch on the alternate screen takes.
+  void inPlaceRedraw(String tag) {
+    for (var r = 1; r <= 4; r++) {
+      writeUtf8(terminal, '\x1b[$r;1Hwindow $tag row $r        ');
+    }
+  }
+
+  test(
+    'an in-place alt-screen redraw whose damage was consumed by a prior '
+    'terminalDirty sync still re-reads the full grid when markAllRowsDirty is '
+    'forced (the #900 fix) — but re-reads NOTHING without it (the alternation)',
+    () {
+      writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
+      expect(terminal.activeScreen, TerminalScreen.alternate,
+          reason: 'precondition: on the alternate screen (tmux/full-screen app)');
+
+      // Window A drawn and painted.
+      inPlaceRedraw('A');
+      pipeline.sync(terminal, terminalDirty: true);
+      expect(pipeline.debugRowsRebuiltLastSync, greaterThan(0),
+          reason: 'precondition: the first redraw re-reads rows');
+
+      // Switch to window B: the in-place redraw writes B's rows. libghostty now
+      // holds per-row damage for the change.
+      inPlaceRedraw('B');
+
+      // The device fires MULTIPLE paints per switch. Model the EARLIER paint
+      // that consumes the damage BEFORE the build that reaches the screen: a
+      // `terminalDirty` sync runs `RenderState.update`, which clears libghostty's
+      // per-row damage as it reads it.
+      pipeline.sync(terminal, terminalDirty: true);
+
+      // Now the SCREEN paint for the switch runs. libghostty reports CLEAN (no
+      // NEW damage since the consuming update). WITHOUT the fix the partial
+      // build re-reads NOTHING — the grid stays on the previous window (the
+      // "fails" half of the alternation). The #900 fix forces a full re-read.
+      pipeline.markAllRowsDirty();
+      pipeline.sync(terminal, terminalDirty: true);
+
+      expect(
+        pipeline.debugRowsRebuiltLastSync,
+        equals(4),
+        reason: 'the #900 fix (markAllRowsDirty on an alt-screen redraw) re-reads '
+            'the FULL visible grid on EVERY switch, immune to single-consumption '
+            'libghostty damage — not every other one',
+      );
+    },
+  );
+
+  test(
+    'without the fix, a redraw whose damage was already consumed re-reads NO '
+    'rows (documents the alternation root)',
+    () {
+      writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
+      inPlaceRedraw('A');
+      pipeline.sync(terminal, terminalDirty: true);
+
+      inPlaceRedraw('B');
+      // First (consuming) sync: reads + clears the per-row damage.
+      pipeline.sync(terminal, terminalDirty: true);
+      // Second sync WITHOUT markAllRowsDirty: libghostty has no new damage, so
+      // the partial-build re-reads nothing. This is the stale-grid half of the
+      // strict A/B/A/B alternation the fix eliminates.
+      pipeline.sync(terminal, terminalDirty: true);
+
+      expect(
+        pipeline.debugRowsRebuiltLastSync,
+        equals(0),
+        reason: 'WITHOUT the fix, a redraw whose damage a prior frame consumed '
+            're-reads zero rows — the rendered grid stays stale every other '
+            'switch (the #900 root)',
+      );
+    },
+  );
+}

--- a/native/third_party/flterm/test/widgets/alt_screen_full_reread_900_test.dart
+++ b/native/third_party/flterm/test/widgets/alt_screen_full_reread_900_test.dart
@@ -1,0 +1,149 @@
+@Tags(['ffi'])
+library;
+
+// #900 widget-level pin for the STRUCTURAL fix in
+// `TerminalRenderBox._onTerminalChanged`: on the ALTERNATE screen, every
+// content-change notify forces `_pipeline.markAllRowsDirty()`, so the next paint
+// re-reads the FULL visible grid regardless of libghostty's single-consumption
+// per-row damage. This is what makes a tmux window switch repaint on EVERY
+// switch instead of every other one (the root: damage consumed by an earlier
+// per-switch paint leaves the partial build re-reading nothing).
+//
+// Headless `tester.pump` coalesces the per-switch notifies into one paint, so it
+// cannot reproduce the device's multi-paint damage-consume timing (that red→green
+// is the orchestrator's on-emulator tmux confirm). What it CAN pin, and what this
+// test asserts, is the fix's production contract: an in-place alt-screen redraw
+// re-reads the FULL grid (rows == viewport rows), not just libghostty-damaged
+// rows — the property that makes the repaint immune to damage double-consume.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+void main() {
+  testWidgets(
+    'an in-place alt-screen redraw re-reads the FULL visible grid each paint '
+    '(#900 markAllRowsDirty on alt-screen content change)',
+    (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controller = TerminalController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 320,
+                height: 128,
+                child: TerminalView(controller: controller),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      void write(String s) =>
+          controller.write(Uint8List.fromList(utf8.encode(s)));
+
+      write('\x1b[?1049h\x1b[2J\x1b[H');
+      await tester.pump();
+
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      expect(controller.activeScreen, TerminalScreen.alternate,
+          reason: 'precondition: alternate screen (tmux/full-screen app)');
+      final rows = box.debugRowsRebuiltLastSync; // viewport rows after seed.
+
+      // Seed window A in place (no 2J — tmux rewrites addressed cells only).
+      for (var r = 1; r <= rows; r++) {
+        write('\x1b[$r;1Hwindow A row $r        ');
+      }
+      await tester.pump();
+      final seededRows = box.debugRowsRebuiltLastSync;
+      expect(seededRows, greaterThan(0),
+          reason: 'precondition: the seed redraw re-read rows');
+
+      // Each tmux window switch: an in-place redraw of the SAME rows. With the
+      // fix, EVERY switch re-reads the FULL visible grid — not a partial subset
+      // that a consumed-damage frame could shrink to zero.
+      for (var i = 0; i < 4; i++) {
+        final tag = i.isEven ? 'B' : 'A';
+        for (var r = 1; r <= rows; r++) {
+          write('\x1b[$r;1Hwindow $tag row $r        ');
+        }
+        await tester.pump();
+        expect(
+          box.debugRowsRebuiltLastSync,
+          equals(seededRows),
+          reason: 'switch $i (to $tag): the in-place alt-screen redraw must '
+              're-read the FULL visible grid ($seededRows rows) on EVERY '
+              'switch (#900) — not every other one',
+        );
+      }
+    },
+  );
+
+  testWidgets(
+    'on the PRIMARY screen, a redraw does NOT force a full re-read (perf: the '
+    '#805 partial-rebuild path is preserved off the alternate screen)',
+    (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final controller = TerminalController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 320,
+                height: 128,
+                child: TerminalView(controller: controller),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      void write(String s) =>
+          controller.write(Uint8List.fromList(utf8.encode(s)));
+
+      // Stay on the PRIMARY screen. Fill it once.
+      for (var r = 1; r <= 6; r++) {
+        write('\x1b[$r;1Hline $r contents here');
+      }
+      await tester.pump();
+
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      expect(controller.activeScreen, TerminalScreen.primary);
+
+      // Change ONE line. On the primary screen the fix must NOT force a
+      // full-grid re-read: only the libghostty-damaged rows rebuild (the #805
+      // streaming-output perf path). One changed line => fewer rebuilt rows than
+      // the full viewport.
+      write('\x1b[3;1Hline 3 CHANGED        ');
+      await tester.pump();
+
+      final fullRows = box.debugRowsRebuiltLastSync;
+      expect(fullRows, lessThan(box.size.height ~/ 16),
+          reason: 'a single-line primary-screen change must rebuild fewer rows '
+              'than the full viewport — the #900 fix is scoped to the alternate '
+              'screen and does not regress #805 partial rebuilds');
+    },
+  );
+}


### PR DESCRIPTION
Fixes #900.

## The alternation root (the exact toggle)

`TerminalFrameBuilder.sync` re-reads the terminal grid via libghostty
`RenderState.update`, which **consumes (clears) per-row damage as it reads it**.
The partial-build path (`_build(.partial)`) then re-emits **only** the rows
libghostty flagged damaged.

The render box fires **multiple paints per tmux window switch** — cursor blink,
scroll/offset correction, the atlas `onImageReady` repaint, and the #803
painted-offset post-frame notify. When an earlier paint's `update` consumes the
switch's row damage **before** the build that reaches the screen — or a second
`update` straddles the in-place redraw — the **next** switch's `update` reads
`clean` (no new damage since the consumed one), so its partial build re-emits
**zero rows** and the grid stays on the previous window. Damage is repopulated
only every *other* cycle → the strict A/B/A/B alternation the device saw.

The defect is single-consumption libghostty damage feeding a partial build, with
no flterm-side guarantee that the `update` which consumed the damage is the one
that paints it.

## Why this is structural, not a 5th per-trigger patch

This is the 4th repaint fix in this subsystem (#887 c1/c2, #898). Rather than
guarding a new trigger, the fix **removes the dependency** of alt-screen redraw
correctness on single-consumption damage entirely.

`TerminalRenderBox._onTerminalChanged`: on `activeScreen == alternate`, force
`_pipeline.markAllRowsDirty()` on every content-change notify. The frame
builder's own `_dirtyRows` then drives a **full re-read of the visible grid** from
the *current* `RenderState` snapshot, even when `update` returns `clean` because a
prior frame consumed the per-row damage. The alternate screen has no scrollback,
so a full re-read is bounded to the visible rows — what a native terminal does for
a full-screen-app redraw. Correctness no longer depends on which per-switch paint
consumed the damage, so every switch repaints.

## Preserved

- #883 (painted-offset), #812 (hide-on-scroll), #898 (mid-frame `markNeedsPaint`
  safety; `markNeedsLayout` still gated on `_performingLayout`).
- #805 perf: scoped to the alternate screen, so primary-screen streaming output
  keeps the partial per-row rebuild (asserted by the primary-screen perf test).

## Tests (deterministic, headless)

- `rendering/alt_screen_repaint_alternation_900_test.dart` — a consumed-damage
  redraw re-reads **0 rows** without the fix (documents the root) and the **full
  grid** with `markAllRowsDirty` (the fix). Adds a `debugRowsRebuiltLastSync`
  counter.
- `widgets/alt_screen_full_reread_900_test.dart` — every alt-screen in-place
  redraw re-reads the full grid; a primary-screen single-line change does **not**
  (perf scope pin for #805).
- Green: #898 pins, full flterm fork suite (272 tests), native fast gate.

## Device confirm (orchestrator)

Headless `tester.pump` coalesces the per-switch notifies into one paint, so it
cannot reproduce the device multi-paint damage-consume timing. The authoritative
red→green is an **on-emulator tmux repeated-window-switch confirm**: switch
windows ≥4× and assert the rendered grid content updates on **every** switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)