### PR TITLE
fix(#903): coalesce flterm resize storm to the final settled size

### DIFF
--- a/native/integration_test/resize_storm_bounded_test.dart
+++ b/native/integration_test/resize_storm_bounded_test.dart
@@ -34,6 +34,14 @@ import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+// The rendered-grid read below resolves cells through libghostty's GridRef the
+// SAME way the flterm fork's `_ScreenCellReader` does. flterm re-exports the
+// widget types (TerminalController) but NOT the low-level grid API, so this
+// reads from libghostty directly — a transitive dep pulled in via flterm and
+// present in pubspec.lock.
+// ignore: depend_on_referenced_packages
+import 'package:libghostty/libghostty.dart'
+    show CellWidth, GridRef, PointTag, RenderState, Terminal;
 
 import 'package:mobissh/main.dart' show MobisshApp;
 import 'package:mobissh/state/sessions.dart';
@@ -51,7 +59,10 @@ void main() {
 
       // #727 made ghostty the DEFAULT backend; do NOT override it — this is a
       // ghostty-path bug (flterm's per-frame onResize), so run on flterm.
-      await tester.pumpWidget(const MobisshApp());
+      // MobisshApp is a Riverpod ConsumerWidget — it MUST be wrapped in a
+      // ProviderScope or it throws "No ProviderScope found" at boot (the
+      // canonical pattern, cf. connect_smoke_test.dart).
+      await tester.pumpWidget(const ProviderScope(child: MobisshApp()));
       await tester.pump(const Duration(seconds: 1));
 
       await adhocPasswordConnect(
@@ -176,9 +187,17 @@ void main() {
       // The grid must still track the active window: switch to window 1 and
       // confirm its marker renders (the coalescer must not have starved the
       // terminal of the resizes it legitimately needs).
-      entry.proxy.sendInput(
-        Uint8List.fromList('tmux select-window -t t:1\n'.codeUnits),
-      );
+      //
+      // Switch via tmux's PREFIX KEY (C-b then '1'), NOT by typing
+      // `tmux select-window …` at the shell: with tmux mouse mode on, the swipe
+      // interaction above left DA/CPR query RESPONSES interleaving the PTY input
+      // stream, which corrupted a typed shell command (observed:
+      // `-bash: 62ctmux: command not found`). The prefix key is a single control
+      // byte consumed by the tmux CLIENT directly — it switches the window
+      // regardless of what the foreground shell line contains.
+      entry.proxy.sendInput(Uint8List.fromList(<int>[0x02])); // C-b (prefix)
+      await tester.pump(const Duration(milliseconds: 300));
+      entry.proxy.sendInput(Uint8List.fromList('1'.codeUnits)); // window 1
       for (var i = 0; i < 20; i++) {
         await tester.pump(const Duration(milliseconds: 300));
       }
@@ -206,21 +225,46 @@ SessionEntry activeSession(WidgetTester tester) {
 }
 
 /// Read the flterm controller's visible viewport as plain text so the test can
-/// assert which tmux window is rendered. The controller's grid-read surface
-/// differs from xterm's, so this is defensive: on any shape mismatch it falls
-/// back to `toString` and still yields a diagnostic.
+/// assert which tmux window is rendered.
+///
+/// The controller is flterm's `TerminalControllerImpl`, NOT xterm — it has no
+/// `buffer.lines` / `viewHeight`. Its rendered cells live in the underlying
+/// libghostty [Terminal], read via [GridRef] exactly the way the fork's
+/// `_ScreenCellReader` (terminal_controller_impl.dart) reads them. We read the
+/// VISIBLE viewport ([PointTag.viewport]: row 0 = top visible row), one cell at
+/// a time, disposing each short-lived [GridRef] immediately (a ref is only valid
+/// until the next terminal op). [RenderState] supplies the live cols/rows. A
+/// wide-character spacer tail carries no glyph of its own (the head cell holds
+/// it), so it reads as blank to keep columns aligned — mirroring the reader.
 String _visibleGridText(Object controller) {
+  // `terminal` is the impl's public field; reach it via dynamic since the
+  // flterm `TerminalController` interface doesn't surface it.
+  final Terminal term = (controller as dynamic).terminal as Terminal;
+  final rs = RenderState()..update(term);
   try {
-    final dynamic c = controller;
-    final term = c.terminal;
-    final buffer = term.buffer;
+    final rows = rs.rows;
+    final cols = rs.cols;
+    if (rows <= 0 || cols <= 0) return '<empty grid: ${rows}x$cols>';
     final sb = StringBuffer();
-    final int height = term.viewHeight as int;
-    for (var y = 0; y < height; y++) {
-      sb.writeln(buffer.lines[buffer.height - height + y].toString());
+    for (var row = 0; row < rows; row++) {
+      for (var col = 0; col < cols; col++) {
+        final ref = GridRef.at(
+          term,
+          col: col,
+          row: row,
+          pointTag: PointTag.viewport,
+        );
+        try {
+          if (ref.wide == CellWidth.spacerTail) continue;
+          sb.write(ref.content);
+        } finally {
+          ref.dispose();
+        }
+      }
+      sb.writeln();
     }
     return sb.toString();
-  } catch (_) {
-    return controller.toString();
+  } finally {
+    rs.dispose();
   }
 }

--- a/native/integration_test/resize_storm_bounded_test.dart
+++ b/native/integration_test/resize_storm_bounded_test.dart
@@ -1,0 +1,226 @@
+// On-emulator RESIZE-STORM bound (#903) — the ROOT of the repaint-fail saga.
+//
+// Device bug (0.1.10+62, tmux-state-trace, SINGLE client): the app emitted a
+// RESIZE STORM. A keyboard show/hide animated the viewport inset over many
+// frames; flterm fired `onResize` for each, and the ghostty path sent EVERY
+// distinct height straight to the PTY (`58x44→43→42→38→37→35→34` in one second).
+// A window switch showed the same shape as a transient `34→36→34` reflow blip.
+// Each resize regridded the terminal mid-interaction and raced the redraw → the
+// stale/blank repaint the #887/#898/#900 paint patches were chasing at the wrong
+// layer. The proxy's #848 IDENTICAL-dims no-op guard didn't help — every
+// animation frame is a DISTINCT height.
+//
+// The fix (#903) coalesces flterm's `onResize` burst into a SINGLE settled PTY
+// resize ([GhosttyResizeCoalescer]): intermediate frames only reset the settle
+// timer; only the FINAL stable size is sent, and a transient that returns to the
+// base emits nothing. The #666/#702 forced resync still flushes immediately.
+//
+// This test connects to tmux with ≥2 windows, then toggles the keyboard and
+// switches windows several times, asserting the number of PTY resizes ACTUALLY
+// sent (the coalescer's `sendCount`) is BOUNDED — a handful (one per settled
+// size), NOT one-per-animation-frame — AND that the rendered grid updates to each
+// new window (content tracks the switch). RED on pre-#903 main (the storm: the
+// resize count balloons), GREEN after.
+//
+// The owner re-validates on device with `scripts/tmux-state-trace.sh watch`
+// armed: a keyboard toggle + window switches log only a FEW `client-resized`
+// events (final sizes), not a cascade.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'keyboard toggle + window switches send a BOUNDED number of PTY resizes',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      // #727 made ghostty the DEFAULT backend; do NOT override it — this is a
+      // ghostty-path bug (flterm's per-frame onResize), so run on flterm.
+      await tester.pumpWidget(const MobisshApp());
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      // Reach the terminal screen, accepting the host-key prompt if shown.
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = activeSession(tester);
+      final sessionId = entry.id;
+
+      // Wait for the shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // Start tmux with TWO windows so a window switch has somewhere to go.
+      // Window 0 prints AAAA, window 1 prints BBBB so a grid read can tell them
+      // apart after a switch.
+      entry.proxy.sendInput(
+        Uint8List.fromList(
+          'tmux kill-server 2>/dev/null; '
+                  'tmux new -s t -n w0 \\; '
+                  'send-keys "clear; echo AAAA_WINDOW_ZERO" Enter \\; '
+                  'new-window -n w1 \\; '
+                  'send-keys "clear; echo BBBB_WINDOW_ONE" Enter \\; '
+                  'select-window -t t:0\n'
+              .codeUnits,
+        ),
+      );
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (entry.terminal.isUsingAltBuffer) break;
+      }
+
+      // The coalescer is the seam that proves the storm is tamed: `sendCount` is
+      // every PTY resize ACTUALLY sent. Snapshot it AFTER connect/tmux settle so
+      // the connect-time #666/#702 resync burst isn't counted against the
+      // interaction we're measuring.
+      final coalescer =
+          GhosttyTerminalView.debugResizeCoalescers[sessionId];
+      expect(
+        coalescer,
+        isNotNull,
+        reason: 'no coalescer registered for the active ghostty session',
+      );
+      // Let any connect-time resync burst finish settling.
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      final baselineSends = coalescer!.sendCount;
+
+      // ── Interaction: toggle the keyboard and switch windows several times. ──
+      // Each keyboard show/hide animates the inset over MANY frames; each window
+      // switch is a horizontal swipe (→ tmux next/previous-window) that also
+      // reflows the layout transiently. Pre-#903 this drove dozens of resizes;
+      // post-#903 each settled size is ONE resize (most are net-zero blips → 0).
+      final router = find.byType(GhosttyPointerGestureRouter);
+      expect(router, findsWidgets);
+      final center = tester.getCenter(router.first);
+
+      for (var round = 0; round < 4; round++) {
+        // Raise the keyboard (tap focuses + shows the IME → inset animation).
+        await tester.tap(router.first);
+        for (var i = 0; i < 6; i++) {
+          await tester.pump(const Duration(milliseconds: 120));
+        }
+        // Swipe RIGHT → next-window, then LEFT → previous-window.
+        await tester.dragFrom(center, const Offset(140, 0));
+        await tester.pump(const Duration(milliseconds: 120));
+        await tester.dragFrom(center, const Offset(-140, 0));
+        await tester.pump(const Duration(milliseconds: 120));
+        // Dismiss the keyboard (another inset animation the other way).
+        await SystemChannels.textInput.invokeMethod('TextInput.hide');
+        for (var i = 0; i < 6; i++) {
+          await tester.pump(const Duration(milliseconds: 120));
+        }
+      }
+      // Let the final size settle past the coalescer window.
+      for (var i = 0; i < 6; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+
+      final delta = coalescer.sendCount - baselineSends;
+      debugPrint('CTRACE903 resize sends during interaction: $delta');
+
+      // BOUNDED: 4 rounds × (keyboard up + down) = 8 genuine settled sizes at
+      // most; the window-switch blips coalesce to net-zero. A storm (pre-#903)
+      // would be DOZENS (per-animation-frame). Allow generous headroom for
+      // real settled transitions while still failing the storm by a wide margin.
+      expect(
+        delta,
+        lessThanOrEqualTo(12),
+        reason:
+            'resize storm NOT tamed — $delta PTY resizes for 4 keyboard '
+            'toggles + window switches (expected a handful of settled sizes, '
+            'not one-per-animation-frame)',
+      );
+
+      // The grid must still track the active window: switch to window 1 and
+      // confirm its marker renders (the coalescer must not have starved the
+      // terminal of the resizes it legitimately needs).
+      entry.proxy.sendInput(
+        Uint8List.fromList('tmux select-window -t t:1\n'.codeUnits),
+      );
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      final controller =
+          GhosttyTerminalView.debugControllers[sessionId];
+      expect(controller, isNotNull, reason: 'no flterm controller for session');
+      final visible = _visibleGridText(controller!);
+      debugPrint('CTRACE903 grid after switch to w1:\n$visible');
+      expect(
+        visible.contains('BBBB_WINDOW_ONE'),
+        isTrue,
+        reason: 'grid did not update to window 1 — content stale after switch',
+      );
+    },
+  );
+}
+
+/// The active session entry (typed accessor so the test reads cleanly).
+SessionEntry activeSession(WidgetTester tester) {
+  final ctx = tester.element(find.byType(MobisshApp));
+  final container = ProviderScope.containerOf(ctx);
+  final entry = container.read(sessionsProvider).active;
+  expect(entry, isNotNull, reason: 'no active session after connect');
+  return entry!;
+}
+
+/// Read the flterm controller's visible viewport as plain text so the test can
+/// assert which tmux window is rendered. The controller's grid-read surface
+/// differs from xterm's, so this is defensive: on any shape mismatch it falls
+/// back to `toString` and still yields a diagnostic.
+String _visibleGridText(Object controller) {
+  try {
+    final dynamic c = controller;
+    final term = c.terminal;
+    final buffer = term.buffer;
+    final sb = StringBuffer();
+    final int height = term.viewHeight as int;
+    for (var y = 0; y < height; y++) {
+      sb.writeln(buffer.lines[buffer.height - height + y].toString());
+    }
+    return sb.toString();
+  } catch (_) {
+    return controller.toString();
+  }
+}

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -401,6 +401,133 @@ bool ghosttyShouldResyncResize({
 /// no-op (no stray resize).
 const List<int> kGhosttyResyncBurstMs = [120, 350, 700, 1200];
 
+/// #903 — the settle window that coalesces a keyboard-animation / layout-reflow
+/// burst of `controller.onResize` events into a SINGLE PTY resize at the FINAL
+/// stable size.
+///
+/// Root cause (tmux-state-trace, SINGLE client): flterm fires `onResize` for
+/// EVERY layout change, and the ghostty path sent each straight to the PTY. A
+/// soft-keyboard show/hide animates the viewport inset over many frames — flterm
+/// recomputes its grid each frame, so one keyboard toggle logged a cascade
+/// (`44→43→42→38→37→35→34` in a second). The proxy's #848 no-op guard only drops
+/// IDENTICAL dims; each animation frame is a DISTINCT height, so every one
+/// reached tmux → regrid → repaint race. A window switch shows the same shape as
+/// a transient `34→36→34` reflow blip.
+///
+/// 120ms (the xterm #848 `kMetricsSettleDelay`) is too SHORT — the keyboard
+/// animation spans longer, so intermediate frames still slip past it. This window
+/// must OUTLAST the soft-keyboard show/hide animation (~100–300ms on Android) so
+/// the resize fires once the inset stops moving, off the FINAL chrome-correct
+/// viewport. Long enough to span the animation; short enough that a real
+/// rotation/resize re-syncs promptly.
+const Duration kGhosttyResizeSettle = Duration(milliseconds: 250);
+
+/// #903 — coalesces a burst of grid sizes into ONE settled PTY resize.
+///
+/// Pure (no FFI / no widget / no provider) → unit-testable headless. flterm
+/// can't render headless, so the storm fix lives in this testable seam rather
+/// than inside the widget's `onResize` closure.
+///
+/// Wire-up: `controller.onResize` calls [submit] with each live grid; once the
+/// size has been STABLE for [settle] the coalescer calls [onSettled] ONCE with the
+/// final dims. Intermediate animation-frame sizes never reach [onSettled]. A
+/// transient excursion that returns to the start (the window-switch `34→36→34`
+/// blip) coalesces to the original size — and because that equals what was last
+/// submitted-as-settled, [skipIfUnchanged] drops it so no spurious resize fires.
+///
+/// The #666/#702 forced resync must NOT be debounced (it re-pushes the CURRENT
+/// size the instant the shell exists). It calls [flushNow] to send immediately,
+/// cancelling any pending debounce.
+class GhosttyResizeCoalescer {
+  GhosttyResizeCoalescer({
+    required this.onSettled,
+    this.settle = kGhosttyResizeSettle,
+    Timer Function(Duration, void Function())? scheduleTimer,
+  }) :
+       // Injectable for headless tests (a fake scheduler fires synchronously);
+       // production uses a real `Timer`.
+       _scheduleTimer = scheduleTimer ?? Timer.new;
+
+  /// Called with the FINAL settled (cols, rows) once the size stops changing
+  /// for [settle]. In the widget this is `_sendResize` (which records the #719
+  /// last-sent grid + writes the PTY).
+  final void Function(int cols, int rows) onSettled;
+
+  /// The settle window the resize must stay stable for before [onSettled] fires.
+  final Duration settle;
+
+  final Timer Function(Duration, void Function()) _scheduleTimer;
+
+  Timer? _timer;
+  int? _pendingCols;
+  int? _pendingRows;
+
+  /// The dims the coalescer last EMITTED via [onSettled] (so an excursion that
+  /// returns to the last settled size emits nothing). Null until the first emit.
+  int? _lastEmittedCols;
+  int? _lastEmittedRows;
+
+  /// Test/telemetry: how many times [onSettled] was actually invoked. A keyboard
+  /// toggle's N animation frames must increment this by AT MOST one.
+  int sendCount = 0;
+
+  /// The last dims submitted (the live grid the gesture map mirrors), regardless
+  /// of whether they've settled yet. Null until the first [submit].
+  int? get pendingCols => _pendingCols;
+  int? get pendingRows => _pendingRows;
+
+  /// Record a new live grid. Resets the settle timer; the resize is sent only
+  /// once the size stops changing for [settle].
+  void submit(int cols, int rows) {
+    _pendingCols = cols;
+    _pendingRows = rows;
+    _timer?.cancel();
+    _timer = _scheduleTimer(settle, _fire);
+  }
+
+  void _fire() {
+    _timer = null;
+    final cols = _pendingCols;
+    final rows = _pendingRows;
+    if (cols == null || rows == null) return;
+    // The settled size equals the last one we emitted (e.g. a `34→36→34`
+    // excursion that returned to 34) → nothing changed, emit nothing. This
+    // mirrors the proxy's #848 no-op guard but at the coalescing seam, so the
+    // transient never even reaches the gateway.
+    if (cols == _lastEmittedCols && rows == _lastEmittedRows) return;
+    _lastEmittedCols = cols;
+    _lastEmittedRows = rows;
+    sendCount += 1;
+    onSettled(cols, rows);
+  }
+
+  /// Send the CURRENT size to the PTY immediately, bypassing the debounce.
+  /// Used by the #666/#702 forced resync (re-pushes the same dims the instant
+  /// the shell exists). Cancels any pending debounce and resets the
+  /// last-emitted gate so the forced send always lands. Falls back to the
+  /// supplied [cols]/[rows] when nothing has been submitted yet.
+  void flushNow(int cols, int rows) {
+    _timer?.cancel();
+    _timer = null;
+    _pendingCols = cols;
+    _pendingRows = rows;
+    // A FORCED resync deliberately re-sends even an unchanged size (the #666
+    // re-push of the same dims once the shell exists), so it always lands —
+    // the dedup gate is set to the just-sent size for the NEXT debounce. The
+    // proxy still owns the #666 one-shot force-bypass of ITS no-op guard.
+    _lastEmittedCols = cols;
+    _lastEmittedRows = rows;
+    sendCount += 1;
+    onSettled(cols, rows);
+  }
+
+  /// Cancel any pending debounce (dispose / teardown). Does NOT emit.
+  void cancel() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}
+
 /// Whether an app-lifecycle transition warrants a Ghostty resume re-fit +
 /// refresh (#704).
 ///
@@ -1737,6 +1864,15 @@ class GhosttyTerminalView extends ConsumerStatefulWidget {
   static final Map<String, TerminalController> debugControllers =
       <String, TerminalController>{};
 
+  /// #903: the live resize coalescer per sessionId, exposed for the on-emulator
+  /// integration test so it can read `sendCount` — the number of PTY resizes
+  /// ACTUALLY sent — and assert a keyboard-toggle / window-switch burst stays
+  /// BOUNDED (one per settled size), not a per-animation-frame storm. Set in
+  /// initState, cleared on dispose. Test-only — no production code reads it.
+  @visibleForTesting
+  static final Map<String, GhosttyResizeCoalescer> debugResizeCoalescers =
+      <String, GhosttyResizeCoalescer>{};
+
   @override
   ConsumerState<GhosttyTerminalView> createState() =>
       _GhosttyTerminalViewState();
@@ -1873,6 +2009,14 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// so dispose cancels them and a gone widget is never re-synced.
   final List<Timer> _resyncTimers = <Timer>[];
 
+  /// #903: coalesces flterm's per-layout-change `onResize` burst (a keyboard
+  /// animation's per-frame regrids, the window-switch reflow blip) into a SINGLE
+  /// settled PTY resize. Initialised in [initState] so its [onSettled] callback is
+  /// the same single `_sendResize` seam (which records the #719 last-sent grid).
+  /// The #666/#702 forced resync calls [GhosttyResizeCoalescer.flushNow] to
+  /// bypass the debounce. Cancelled on dispose.
+  late final GhosttyResizeCoalescer _resizeCoalescer;
+
   /// #704: the lifecycle state seen on the previous `ref.listen` tick, so
   /// [ghosttyShouldRefreshOnLifecycle] can detect a transition INTO `resumed`
   /// (and not double-fire on a `resumed → resumed` repeat). Null until the
@@ -1913,6 +2057,16 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       return;
     }
     _proxy = proxy;
+    // #903: the coalescer's send seam is `_sendResize` (which records the #719
+    // last-sent grid + writes the PTY). Created before `controller.onResize` is
+    // wired so the first resize is debounced too.
+    _resizeCoalescer = GhosttyResizeCoalescer(
+      onSettled: _sendResize,
+    );
+    // #903 (test-only): expose the coalescer so the emulator integration test
+    // can read `sendCount` and assert the resize count is BOUNDED.
+    GhosttyTerminalView.debugResizeCoalescers[widget.sessionId] =
+        _resizeCoalescer;
     try {
       final controller = TerminalController();
       // Keystrokes (controller.onOutput) -> SSH stdin. Gate on a LIVE session,
@@ -1934,15 +2088,24 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // pixel sizes default to 0 (the task isolate only needs cols/rows). Also
       // mirror (cols, rows) so the #692 gesture router can map touch -> cell.
       controller.onResize = (cols, rows) {
-        // Mirror the live grid (for the touch->cell map) AND send the resize
-        // through the single [_sendResize] helper so the rows tmux is told about
-        // can never diverge from what the window-switch wheel targets (#719).
+        // Mirror the live grid SYNCHRONOUSLY (the touch->cell map + gesture
+        // router read `_cols`/`_rows` every gesture, so they must track flterm's
+        // real grid the instant it changes — only the PTY SEND is debounced).
         _cols = cols;
         _rows = rows;
         // #790: record the live viewport grid so the replay harness can lay out
         // the captured byte stream at the SAME cols×rows the bug occurred at.
         _byteRecorder.recordGrid(cols, rows);
-        _sendResize(cols, rows);
+        // #903: COALESCE the PTY resize. flterm fires `onResize` for EVERY
+        // layout change — a soft-keyboard show/hide animates the inset over many
+        // frames (per-frame regrid → the `44→43→…→34` storm) and a window switch
+        // reflows ~2 rows transiently (`34→36→34`). Sending each straight to the
+        // PTY made tmux regrid mid-interaction and race every redraw (the repaint
+        // fail #887/#898/#900 were chasing). The coalescer debounces to the FINAL
+        // settled size: intermediate frames never reach tmux, and a transient
+        // that returns to the start emits nothing. The #719 last-sent grid is
+        // still recorded by `_sendResize` (the coalescer's send seam).
+        _resizeCoalescer.submit(cols, rows);
         // #767: a resize changes the cell ranges, but the URL re-detect now lives
         // INSIDE the terminal — the controller re-scans on its own notify cycle,
         // so the host no longer schedules detection here.
@@ -2216,7 +2379,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       );
       return;
     }
-    _sendResize(_cols, _rows);
+    // #903: a forced resync must NOT be debounced — it re-pushes the CURRENT
+    // size the instant the shell exists (#666/#702), so flush immediately and
+    // cancel any pending coalesce. The proxy still owns the #666 one-shot
+    // force-bypass of its no-op guard.
+    _resizeCoalescer.flushNow(_cols, _rows);
     gtrace('ghostty-resync $trigger: cols=$_cols rows=$_rows');
   }
 
@@ -2787,6 +2954,13 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       t.cancel();
     }
     _resyncTimers.clear();
+    // #903: drop any pending coalesced resize so a gone widget never resizes,
+    // and drop the test-only handle if it's still ours.
+    _resizeCoalescer.cancel();
+    if (GhosttyTerminalView.debugResizeCoalescers[widget.sessionId] ==
+        _resizeCoalescer) {
+      GhosttyTerminalView.debugResizeCoalescers.remove(widget.sessionId);
+    }
     _outputSub?.cancel();
     // #767 (test-only): drop the debug controller handle if it's still ours.
     if (GhosttyTerminalView.debugControllers[widget.sessionId] == _controller) {

--- a/native/test/ui/ghostty_resize_coalesce_test.dart
+++ b/native/test/ui/ghostty_resize_coalesce_test.dart
@@ -1,0 +1,223 @@
+// #903 — the ROOT of the terminal repaint-fail saga: the ghostty path sent a
+// PTY resize for EVERY flterm `onResize`, and flterm fires `onResize` for every
+// LAYOUT CHANGE. A soft-keyboard show/hide animates the viewport inset over many
+// frames (per-frame regrid → the `44→43→42→38→37→35→34` storm the tmux-state-
+// trace caught), and a window switch reflows ~2 rows transiently (`34→36→34`).
+// Each distinct size slipped past the proxy's #848 IDENTICAL-dims no-op guard,
+// reached tmux, and raced every redraw — the stale/blank repaint #887/#898/#900
+// were chasing at the paint layer.
+//
+// The fix coalesces the burst: [GhosttyResizeCoalescer] debounces `submit` so a
+// PTY resize fires ONCE the size has been STABLE for a settle window that
+// outlasts the keyboard animation, sending only the FINAL settled size. A
+// transient excursion that returns to the start emits nothing (the window-switch
+// blip). The #666/#702 forced resync bypasses the debounce via `flushNow`.
+//
+// flterm/libghostty can't render headless (native .so), so these drive the PURE
+// coalescer directly with a fake scheduler — the storm-vs-bounded behaviour is
+// asserted deterministically, with no Timer flakiness. The real on-device
+// bounded resize count + repaint is the emulator integration test (red baseline)
+// + the owner's `scripts/tmux-state-trace.sh` device validation.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+void main() {
+  // A controllable scheduler: each `submit` registers a pending callback; the
+  // PREVIOUS pending callback is cancelled (debounce). `settle()` fires the one
+  // surviving callback, modelling "the size stopped changing for the window".
+  late List<int> sentCols;
+  late List<int> sentRows;
+  late void Function()? pending;
+  late int liveTimers;
+
+  Timer fakeScheduler(Duration _, void Function() cb) {
+    pending = cb;
+    liveTimers += 1;
+    return _FakeTimer(() {
+      // A debounce-cancel of THIS timer: if it's still the pending one, drop it.
+      if (identical(pending, cb)) pending = null;
+      liveTimers -= 1;
+    });
+  }
+
+  void settle() {
+    final cb = pending;
+    pending = null;
+    if (cb != null) {
+      liveTimers -= 1;
+      cb();
+    }
+  }
+
+  GhosttyResizeCoalescer build() => GhosttyResizeCoalescer(
+    onSettled: (c, r) {
+      sentCols.add(c);
+      sentRows.add(r);
+    },
+    scheduleTimer: fakeScheduler,
+  );
+
+  setUp(() {
+    sentCols = <int>[];
+    sentRows = <int>[];
+    pending = null;
+    liveTimers = 0;
+  });
+
+  group('#903 keyboard-animation storm coalesces to the FINAL size', () {
+    test(
+      'a 7-frame keyboard-hide cascade sends ONE resize at the final size',
+      () {
+        final c = build();
+        // The exact device-trace shape: a single keyboard-hide animation logged
+        // 58×44→43→42→38→37→35→34 in one second. Pre-fix EVERY distinct height
+        // reached tmux (7 resizes → 7 regrids racing the redraw). Coalesced, the
+        // intermediate frames only RESET the settle timer; only 34 (the final,
+        // chrome-correct viewport) is sent.
+        for (final rows in [44, 43, 42, 38, 37, 35, 34]) {
+          c.submit(58, rows);
+        }
+        // Mid-animation: nothing has settled yet, so NOTHING has reached the PTY.
+        expect(sentRows, isEmpty, reason: 'no PTY resize mid-animation');
+        // The inset stops moving → the single surviving debounce fires.
+        settle();
+        expect(c.sendCount, 1, reason: 'exactly ONE resize for the whole burst');
+        expect(sentCols, [58]);
+        expect(sentRows, [34], reason: 'the FINAL settled size, not a frame');
+      },
+    );
+
+    test('each new frame CANCELS the prior pending debounce (no leak)', () {
+      final c = build();
+      c.submit(58, 44);
+      c.submit(58, 38);
+      c.submit(58, 34);
+      // Three submits, but only ONE timer should be live (each cancels the last).
+      expect(liveTimers, 1, reason: 'debounce keeps a single pending timer');
+      settle();
+      expect(c.sendCount, 1);
+      expect(sentRows, [34]);
+    });
+  });
+
+  group('#903 window-switch blip (transient that returns to base) emits nothing',
+      () {
+    test('34→36→34 around a window switch coalesces to NO resize', () {
+      final c = build();
+      // Establish the settled baseline (34) — one real resize.
+      c.submit(58, 34);
+      settle();
+      expect(sentRows, [34]);
+      expect(c.sendCount, 1);
+      // The window-switch reflow blip: grows 2 rows then returns to 34.
+      c.submit(58, 36);
+      c.submit(58, 34);
+      settle();
+      // The settled size equals the last EMITTED size → no spurious resize. The
+      // local grid never tells tmux to regrid for a remote window switch.
+      expect(c.sendCount, 1, reason: 'the net-zero blip must emit nothing');
+      expect(sentRows, [34], reason: 'still only the original resize');
+    });
+
+    test('a real size change after a blip DOES send (blip is not sticky)', () {
+      final c = build();
+      c.submit(58, 34);
+      settle();
+      // blip
+      c.submit(58, 36);
+      c.submit(58, 34);
+      settle();
+      // a genuine keyboard open afterwards
+      c.submit(58, 44);
+      settle();
+      expect(c.sendCount, 2, reason: 'baseline + the genuine 44, not the blip');
+      expect(sentRows, [34, 44]);
+    });
+  });
+
+  group('#903 forced resync (#666/#702) bypasses the debounce', () {
+    test('flushNow sends IMMEDIATELY without waiting for settle', () {
+      final c = build();
+      c.flushNow(58, 34);
+      // No settle() call — the forced resync must have sent already.
+      expect(c.sendCount, 1, reason: 'forced resync is not debounced');
+      expect(sentCols, [58]);
+      expect(sentRows, [34]);
+    });
+
+    test('flushNow cancels a pending debounce (no double-send)', () {
+      final c = build();
+      c.submit(58, 40); // a debounce is pending
+      expect(liveTimers, 1);
+      c.flushNow(58, 34); // forced resync wins + cancels the pending debounce
+      expect(c.sendCount, 1);
+      expect(sentRows, [34]);
+      // The previously-pending debounce must NOT fire a second resize.
+      settle();
+      expect(c.sendCount, 1, reason: 'flushNow cancelled the pending debounce');
+    });
+
+    test(
+      'flushNow re-sends the SAME size (the #666 resync re-pushes identical)',
+      () {
+        final c = build();
+        c.submit(58, 34);
+        settle();
+        expect(c.sendCount, 1);
+        // The #666 resync deliberately re-pushes the SAME size once the shell
+        // exists — the coalescer must NOT swallow it as a no-op (the proxy owns
+        // the one-shot force-bypass of ITS guard).
+        c.flushNow(58, 34);
+        expect(c.sendCount, 2, reason: 'forced resync re-sends identical dims');
+        expect(sentRows, [34, 34]);
+      },
+    );
+  });
+
+  group('#903 settle window outlasts the xterm 120ms', () {
+    test('kGhosttyResizeSettle is longer than the xterm metrics settle', () {
+      // The #848 xterm `kMetricsSettleDelay` (120ms) was too SHORT — the
+      // keyboard animation spans longer, so frames slipped past it (the storm).
+      // This window must outlast the soft-keyboard show/hide animation.
+      expect(
+        kGhosttyResizeSettle.inMilliseconds,
+        greaterThan(120),
+        reason: 'must outlast the 120ms xterm window that let the storm pass',
+      );
+    });
+  });
+
+  group('#903 cancel drops a pending resize (dispose safety)', () {
+    test('cancel() prevents a settled send', () {
+      final c = build();
+      c.submit(58, 34);
+      c.cancel();
+      settle(); // nothing pending after cancel
+      expect(c.sendCount, 0, reason: 'a cancelled debounce never sends');
+      expect(sentRows, isEmpty);
+    });
+  });
+}
+
+class _FakeTimer implements Timer {
+  _FakeTimer(this._onCancel);
+  final void Function() _onCancel;
+  bool _active = true;
+
+  @override
+  void cancel() {
+    if (_active) {
+      _active = false;
+      _onCancel();
+    }
+  }
+
+  @override
+  bool get isActive => _active;
+
+  @override
+  int get tick => 0;
+}


### PR DESCRIPTION
## Summary

ROOT fix for the terminal repaint-fail saga (closes #903). After 5 render-box paint patches (#887/#898/#900) the daily-driver symptom persisted; the `scripts/tmux-state-trace.sh` lens proved the real cause is a RESIZE STORM the app emits, regridding the terminal mid-interaction and racing every redraw.

## Confirmed cause

- The active backend is **ghostty/flterm** (`GhosttyTerminalView`). flterm's `controller.onResize(cols,rows)` fires once per **layout change**, and the ghostty path sent **each one straight to the PTY** with no debounce.
- The xterm-side #848 `didChangeMetrics` settle (120ms) does **not** cover ghostty: `terminal_screen.dart`'s `_buildGhosttyBody` skips the xterm-only fit machinery, and `_explicitFit` is a no-op without an xterm `TerminalViewState`.
- A soft-keyboard show/hide animates the viewport inset over many frames → flterm recomputes its grid each frame → `58x44→43→42→38→37→35→34` in one second. The proxy's #848 no-op guard only drops **identical** dims, so every distinct animation-frame height passed through.

### The per-window-switch blip (`34→36→34`)

The window-switch code path emits **only an SGR wheel report** — it does NOT locally resize. The `+2/-2` blip is a **transient layout reflow** on the swipe / trailing tap (keyboard inset jitter; the closing tap fires `hideKeyboard()`+`showKeyboard()`). Rather than scatter a guard into the gesture handler, the coalescer's net-zero dedup suppresses it structurally: any transient that returns to the base size emits nothing, so a remote window switch never tells tmux to regrid.

## Fix

A pure, headless-testable `GhosttyResizeCoalescer` sits between `controller.onResize` and `_sendResize`:

1. **Coalesce to the final settled size.** `submit(cols,rows)` debounces; the PTY resize fires once the size has been stable for `kGhosttyResizeSettle` = **250ms** — chosen to **outlast the soft-keyboard show/hide animation** (~100–300ms on Android); the xterm 120ms window was too short per the trace. Intermediate animation-frame sizes never reach the PTY.
2. **Kill the net-zero blip.** A settled size equal to the last emitted size emits nothing — the `34→36→34` excursion collapses to `34` and is dropped at the coalescing seam.
3. **Keep #666/#702 resync.** `_forceResizeResync` calls `flushNow` to send immediately, bypassing the debounce and re-sending identical dims (the proxy still owns its one-shot force-bypass).
4. `_cols`/`_rows` still mirror synchronously on every `onResize` (the gesture map / window-switch wheel need the live grid); only the PTY **send** is debounced. The #719 last-sent grid is still recorded by `_sendResize` (the coalescer's send seam).

## Tests

- **`native/test/ui/ghostty_resize_coalesce_test.dart`** (fast gate, RED→GREEN): pure coalescer unit tests driven by a fake scheduler — a 7-frame keyboard cascade sends **one** resize at the final size; a net-zero window-switch blip emits **nothing**; a genuine change after a blip does send; `flushNow` bypasses the debounce and re-sends identical dims; settle window > 120ms; `cancel()` drops a pending send.
- **`native/integration_test/resize_storm_bounded_test.dart`** (emulator, written as the **red baseline** — not run here): connects to tmux with 2 windows, toggles the keyboard + switches windows several times, asserts the coalescer's `sendCount` delta is **bounded** (a handful of settled sizes, not one-per-animation-frame) and the rendered grid tracks the active window. The orchestrator runs it on-emulator and validates with `scripts/tmux-state-trace.sh` on device.

## Validation

- `scripts/native-fast-gate.sh`: **green** (analyze clean + 1339 unit/widget tests pass).
- #848 / #666 / #702 / #719 / #723 + #887/#898/#900 paint pins + fork suite stay green.

The render-box paint code (#900 et al.) is untouched — that symptom should resolve once resizes stop storming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)