### PR TITLE
feat(native): tmux control-mode Part C — atomic command delivery + real window gestures (#911)

### DIFF
--- a/native/integration_test/cc_gestures_test.dart
+++ b/native/integration_test/cc_gestures_test.dart
@@ -1,0 +1,188 @@
+// On-emulator tmux control-mode (`-CC`) GESTURE parity — Part C (#911, epic #906).
+//
+// The deterministic repro that the wrong-row "swipe did nothing / taps sometimes
+// work" window-switch bug (#903/#905) is DISSOLVED by control mode. With
+// `tmuxControlMode` flipped ON, MobiSSH enters `tmux -CC` automatically (Part B),
+// and window switching is driven by REAL tmux control commands over the channel —
+// `next-window` / `previous-window` (swipe) and `select-window -t @<id>` (status
+// tap) — NOT a synthesised SGR wheel at a guessed status row. The authoritative
+// active window is read back from `%session-window-changed` (Part B repaints the
+// grid on it). This test asserts, end-to-end over real SSH→tmux(-CC)→host→flterm:
+//
+//   1. With ≥3 windows, a swipe (next-window/previous-window via the control
+//      channel) SWITCHES the active window AND repaints the grid to it.
+//   2. A status-bar tap (select-window via the control channel) switches to the
+//      tapped window AND repaints.
+//   3. Run the switch sequence REPEATEDLY (the old failure was intermittent) — it
+//      must be DETERMINISTICALLY green: every step lands on the expected window.
+//
+// There is NO dependence on a guessed status row: the swipe issues a real
+// next/previous command and the tap maps the column to a window from the parsed
+// window list — geometry is never guessed.
+//
+// The orchestrator runs this FLAG-ON; the shipped build keeps the flag OFF.
+//
+// Run: scripts/native-connect-test.sh integration_test/cc_gestures_test.dart
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/session_messages.dart' show TmuxWindowGesture;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late bool prevFlag;
+  setUp(() => prevFlag = setTmuxControlModeForTest(true));
+  tearDown(() => setTmuxControlModeForTest(prevFlag));
+
+  testWidgets(
+    '-CC gestures: real next/previous/select-window switch + repaint, '
+    'deterministic over repeated switches (#911)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+
+      // Everything the host forwards to the grid (the demuxed ACTIVE window's
+      // bytes). When the active window switches, Part B repaints, so a fresh
+      // marker echoed in the NEW active window appears here.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      String rendered() => utf8.decode(out, allowMalformed: true);
+
+      // A control command delivered ATOMICALLY (Part C Step 1): one envelope, one
+      // framed line — a multi-token command survives the gateway intact.
+      void ctl(String command) => entry.proxy.sendControlCommand(command);
+
+      Future<bool> waitFor(String marker, {int ticks = 40}) async {
+        for (var i = 0; i < ticks; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+          if (rendered().contains(marker)) return true;
+        }
+        return false;
+      }
+
+      // Wait for the initial control-mode paint.
+      var painted = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (out.isNotEmpty) {
+          painted = true;
+          break;
+        }
+      }
+      expect(painted, isTrue,
+          reason: 'control-mode grid received ZERO bytes — %output never demuxed');
+
+      // Build a session with THREE windows (0,1,2). Window 0 already exists.
+      ctl('new-window -t :1 -n cc_w1');
+      ctl('new-window -t :2 -n cc_w2');
+      // Give each window a UNIQUE, identifiable marker via send-keys so its
+      // %output carries it when that window is active + repainting. The simple
+      // `echo WORD` form survives the (now-atomic) command path.
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // 1) SWIPE-style switch via REAL previous-window: from window 2 step back to
+      //    window 1 and confirm the grid repaints to window 1's content.
+      out.clear();
+      entry.proxy.sendTmuxGesture(TmuxWindowGesture.previousWindow);
+      ctl('send-keys -t :1 "echo CC_GEST_W1_AAA" Enter');
+      expect(await waitFor('CC_GEST_W1_AAA'), isTrue,
+          reason: 'previous-window (swipe) did not repaint to window 1');
+
+      // 2) SWIPE-style switch via REAL next-window: window 1 → window 2.
+      out.clear();
+      entry.proxy.sendTmuxGesture(TmuxWindowGesture.nextWindow);
+      ctl('send-keys -t :2 "echo CC_GEST_W2_BBB" Enter');
+      expect(await waitFor('CC_GEST_W2_BBB'), isTrue,
+          reason: 'next-window (swipe) did not repaint to window 2');
+
+      // 3) STATUS-TAP switch via REAL select-window: tap the LEFT third of the
+      //    status line → window 0. The host maps the column to the window from the
+      //    parsed window list — no guessed status row.
+      out.clear();
+      entry.proxy.sendTmuxGesture(
+        TmuxWindowGesture.tapStatusCol,
+        statusCol: 3,
+        statusCols: 90,
+      );
+      ctl('send-keys -t :0 "echo CC_GEST_W0_CCC" Enter');
+      expect(await waitFor('CC_GEST_W0_CCC'), isTrue,
+          reason: 'status-tap select-window did not repaint to window 0');
+
+      // 4) DETERMINISM: run the switch sequence REPEATEDLY (the old bug was
+      //    intermittent). Each cycle: select-window 1, 2, 0 and confirm a fresh
+      //    per-cycle marker repaints in each. Every cycle must be green.
+      for (var cycle = 0; cycle < 3; cycle++) {
+        for (final w in [1, 2, 0]) {
+          out.clear();
+          entry.proxy.sendTmuxGesture(
+            TmuxWindowGesture.tapStatusCol,
+            // 3 windows over 90 cols: window 0 ~ col 3, window 1 ~ col 45,
+            // window 2 ~ col 85. Map the target window to its segment.
+            statusCol: w == 0 ? 3 : (w == 1 ? 45 : 85),
+            statusCols: 90,
+          );
+          final marker = 'CC_GEST_CYCLE_${cycle}_W$w';
+          ctl('send-keys -t :$w "echo $marker" Enter');
+          expect(await waitFor(marker), isTrue,
+              reason: 'cycle $cycle: switch to window $w did not repaint '
+                  '(intermittent failure — must be deterministic). '
+                  'Saw: ${rendered()}');
+        }
+      }
+
+      // Still connected after the whole gesture storm (the channel survived).
+      expect(find.byKey(const Key('session-menu-button')), findsOneWidget,
+          reason: 'session torn down during the gesture sequence');
+
+      debugPrint('CC_GESTURES: real next/previous/select-window switching is '
+          'deterministic across ${3 * 3} repeated switches');
+    },
+  );
+}

--- a/native/integration_test/cc_gestures_test.dart
+++ b/native/integration_test/cc_gestures_test.dart
@@ -120,27 +120,45 @@ void main() {
           reason: 'control-mode grid received ZERO bytes — %output never demuxed');
 
       // Build a session with THREE windows (0,1,2). Window 0 already exists.
+      // tmux makes the newly-created window active, so after this the active
+      // window is window 2 (the last created). Settle so the channel processes
+      // both %window-add + %session-window-changed before the first gesture.
       ctl('new-window -t :1 -n cc_w1');
       ctl('new-window -t :2 -n cc_w2');
-      // Give each window a UNIQUE, identifiable marker via send-keys so its
-      // %output carries it when that window is active + repainting. The simple
-      // `echo WORD` form survives the (now-atomic) command path.
-      await tester.pump(const Duration(milliseconds: 500));
+      for (var i = 0; i < 6; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+
+      // Settle after a gesture BEFORE echoing the target window's marker: the
+      // gesture (a `previous-window` / `next-window` / `select-window` control
+      // command) and the marker `send-keys` are SEPARATE async IPC envelopes. If
+      // the marker echoes before the channel has processed the authoritative
+      // `%session-window-changed`, the target window's %output is filtered out as
+      // non-active and lost. Pumping between them lets the switch settle first.
+      Future<void> settle() async {
+        for (var i = 0; i < 4; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+        }
+      }
 
       // 1) SWIPE-style switch via REAL previous-window: from window 2 step back to
       //    window 1 and confirm the grid repaints to window 1's content.
       out.clear();
       entry.proxy.sendTmuxGesture(TmuxWindowGesture.previousWindow);
+      await settle();
       ctl('send-keys -t :1 "echo CC_GEST_W1_AAA" Enter');
       expect(await waitFor('CC_GEST_W1_AAA'), isTrue,
-          reason: 'previous-window (swipe) did not repaint to window 1');
+          reason: 'previous-window (swipe) did not repaint to window 1. '
+              'Saw: ${rendered()}');
 
       // 2) SWIPE-style switch via REAL next-window: window 1 → window 2.
       out.clear();
       entry.proxy.sendTmuxGesture(TmuxWindowGesture.nextWindow);
+      await settle();
       ctl('send-keys -t :2 "echo CC_GEST_W2_BBB" Enter');
       expect(await waitFor('CC_GEST_W2_BBB'), isTrue,
-          reason: 'next-window (swipe) did not repaint to window 2');
+          reason: 'next-window (swipe) did not repaint to window 2. '
+              'Saw: ${rendered()}');
 
       // 3) STATUS-TAP switch via REAL select-window: tap the LEFT third of the
       //    status line → window 0. The host maps the column to the window from the
@@ -151,9 +169,11 @@ void main() {
         statusCol: 3,
         statusCols: 90,
       );
+      await settle();
       ctl('send-keys -t :0 "echo CC_GEST_W0_CCC" Enter');
       expect(await waitFor('CC_GEST_W0_CCC'), isTrue,
-          reason: 'status-tap select-window did not repaint to window 0');
+          reason: 'status-tap select-window did not repaint to window 0. '
+              'Saw: ${rendered()}');
 
       // 4) DETERMINISM: run the switch sequence REPEATEDLY (the old bug was
       //    intermittent). Each cycle: select-window 1, 2, 0 and confirm a fresh
@@ -168,6 +188,7 @@ void main() {
             statusCol: w == 0 ? 3 : (w == 1 ? 45 : 85),
             statusCols: 90,
           );
+          await settle();
           final marker = 'CC_GEST_CYCLE_${cycle}_W$w';
           ctl('send-keys -t :$w "echo $marker" Enter');
           expect(await waitFor(marker), isTrue,

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -326,6 +326,59 @@ class SessionHost {
         _handleSftpDownload(cmd);
       case SftpUploadCommand():
         _handleSftpUpload(cmd);
+      case SshControlCommand():
+        _handleControlCommand(cmd);
+      case SshTmuxGestureCommand():
+        _handleTmuxGesture(cmd);
+    }
+  }
+
+  /// #911 Part C Step 1: write a FULL `-CC` control-command line ATOMICALLY.
+  ///
+  /// The whole line is framed by [TmuxControlChannel.controlCommand] (exactly one
+  /// trailing newline) and written in a SINGLE `transport.send`, so a multi-token
+  /// command (`select-window -t @1`) can't fragment across the gateway and have
+  /// its tail land in the pane shell (the Part B failure). A no-op unless control
+  /// mode is ON for this session (`tmuxChannel != null`) — the scrape path never
+  /// issues control commands, so the flag-OFF default is provably untouched.
+  void _handleControlCommand(SshControlCommand cmd) {
+    final hosted = _sessions[cmd.sessionId];
+    if (hosted == null) return;
+    if (hosted.tmuxChannel == null) return; // flag OFF — ignore.
+    try {
+      hosted.shell?.send(TmuxControlChannel.controlCommand(cmd.command));
+    } catch (_) {
+      // Channel closed mid-command; the next connect re-syncs.
+    }
+  }
+
+  /// #911 Part C Step 2: resolve a high-level window gesture to a real tmux
+  /// control command using the channel's AUTHORITATIVE ordered window list, then
+  /// deliver it atomically. Keeping the index lookup here (task-side) means the UI
+  /// never holds the window list and a status-bar tap maps with NO pixel guessing
+  /// — the wrong-row bug this part dissolves. A no-op unless control mode is ON.
+  void _handleTmuxGesture(SshTmuxGestureCommand cmd) {
+    final hosted = _sessions[cmd.sessionId];
+    if (hosted == null) return;
+    final tmux = hosted.tmuxChannel;
+    if (tmux == null) return; // flag OFF — ignore.
+    final String? line;
+    switch (cmd.gesture) {
+      case TmuxWindowGesture.nextWindow:
+        line = TmuxControlChannel.nextWindowCommand;
+      case TmuxWindowGesture.previousWindow:
+        line = TmuxControlChannel.previousWindowCommand;
+      case TmuxWindowGesture.tapStatusCol:
+        line = tmux.selectWindowCommandForStatusCol(
+          cmd.statusCol,
+          cmd.statusCols,
+        );
+    }
+    if (line == null) return; // no window known yet — nothing to target.
+    try {
+      hosted.shell?.send(TmuxControlChannel.controlCommand(line));
+    } catch (_) {
+      // Channel closed; reconnect re-syncs.
     }
   }
 

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -534,6 +534,16 @@ class SessionHost {
       }
       return;
     }
+    // #911: apply the UI-isolate's desired control-mode state to THIS (task)
+    // isolate's global before the shell opens. `tmuxControlMode` is a per-isolate
+    // global, and the host runs in the foreground-task isolate — a flag flipped
+    // in the UI isolate (settings toggle / emulator parity tests) otherwise never
+    // reaches `_ensureShell`, so `tmux -CC` is never entered and control commands
+    // are dropped. The connect command carries the bit across the gateway.
+    tmuxControlMode = cmd.controlMode;
+    ctrace('task.host',
+        'connect sid=${cmd.sessionId} controlMode=${cmd.controlMode}');
+
     final controller = _factory();
     final hosted = _HostedSession(controller: controller);
     _sessions[cmd.sessionId] = hosted;

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -66,6 +66,37 @@ enum SshTaskCommandKind {
   /// carried inline; the task opens the resolved path write|create|truncate and
   /// writes them, then replies with a terminal [SftpUploadDoneEvent].
   sftpUpload,
+
+  // --- tmux control mode (#911, Part C) ---
+
+  /// UI → task: a FULL tmux `-CC` control-command LINE, delivered ATOMICALLY
+  /// (#911). The host writes it as ONE framed `transport.send` with a single
+  /// trailing newline (`TmuxControlChannel.controlCommand`) so a multi-token
+  /// command (`select-window -t @1`) can't fragment across the gateway and hit
+  /// the pane shell. Only acts when the control-mode flag is ON (the host has a
+  /// `tmuxChannel`); a no-op otherwise. NEVER used by the scrape (flag-OFF) path.
+  controlCommand,
+
+  /// UI → task: a high-level tmux WINDOW gesture (#911) — `nextWindow`,
+  /// `previousWindow`, or a status-bar TAP at a column. The host resolves it
+  /// against the channel's authoritative ordered window list and issues the
+  /// matching `next-window` / `previous-window` / `select-window -t @<id>` via the
+  /// atomic control-command path. Keeping the index lookup TASK-SIDE means the UI
+  /// never needs the window list and a status tap maps with no pixel guessing.
+  tmuxGesture,
+}
+
+/// The kind of tmux window gesture an [SshTmuxGestureCommand] carries (#911).
+enum TmuxWindowGesture {
+  /// Horizontal swipe RIGHT → `next-window`.
+  nextWindow,
+
+  /// Horizontal swipe LEFT → `previous-window`.
+  previousWindow,
+
+  /// Tap a status-bar window name → `select-window -t @<id>` for the window whose
+  /// status segment the tap column fell in.
+  tapStatusCol,
 }
 
 /// Envelope kind discriminator for task → UI events.
@@ -252,6 +283,23 @@ sealed class SshTaskCommand {
           requestId: json['requestId'] as String,
           path: json['path'] as String,
           bytes: Uint8List.fromList(base64Decode(json['bytes'] as String)),
+        );
+      case SshTaskCommandKind.controlCommand:
+        return SshControlCommand(
+          sessionId: sessionId,
+          command: json['command'] as String,
+        );
+      case SshTaskCommandKind.tmuxGesture:
+        final gestureRaw = json['gesture'] as String;
+        return SshTmuxGestureCommand(
+          sessionId: sessionId,
+          gesture: TmuxWindowGesture.values.firstWhere(
+            (g) => g.name == gestureRaw,
+            orElse: () => throw FormatException(
+                'SshTmuxGestureCommand: unknown gesture "$gestureRaw"'),
+          ),
+          statusCol: (json['statusCol'] as int?) ?? 0,
+          statusCols: (json['statusCols'] as int?) ?? 0,
         );
     }
   }
@@ -572,6 +620,66 @@ class SshSetActiveCommand extends SshTaskCommand {
     if (activeSessionId != null) 'activeSessionId': activeSessionId,
     if (activeHost != null) 'activeHost': activeHost,
   };
+}
+
+/// UI → task: a FULL tmux `-CC` control-command line, delivered ATOMICALLY
+/// (#911, Part C Step 1). The host writes [command] as ONE framed
+/// `transport.send` terminated with a single newline, so a multi-token command
+/// survives the UI→isolate gateway intact (Part B found a fragmented command's
+/// tail hit the pane shell). [command] carries NO trailing newline — the host's
+/// `TmuxControlChannel.controlCommand` adds exactly one. Per-session.
+class SshControlCommand extends SshTaskCommand {
+  const SshControlCommand({required String sessionId, required this.command})
+      : super(sessionId);
+
+  /// The complete `-CC` command line (no trailing newline), e.g.
+  /// `select-window -t @1` or `next-window`.
+  final String command;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.controlCommand;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'command': command,
+      };
+}
+
+/// UI → task: a high-level tmux WINDOW gesture (#911, Part C Step 2). The host
+/// resolves it against the channel's authoritative ordered window list and
+/// issues the right control command atomically. [statusCol]/[statusCols] carry
+/// the 1-based tap column + the status-line width for [TmuxWindowGesture.
+/// tapStatusCol] (ignored for next/previous). Per-session.
+class SshTmuxGestureCommand extends SshTaskCommand {
+  const SshTmuxGestureCommand({
+    required String sessionId,
+    required this.gesture,
+    this.statusCol = 0,
+    this.statusCols = 0,
+  }) : super(sessionId);
+
+  final TmuxWindowGesture gesture;
+
+  /// 1-based tap column over the status line (only for [TmuxWindowGesture.
+  /// tapStatusCol]).
+  final int statusCol;
+
+  /// The status-line width in columns at tap time (only for tapStatusCol).
+  final int statusCols;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.tmuxGesture;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'gesture': gesture.name,
+        'statusCol': statusCol,
+        'statusCols': statusCols,
+      };
 }
 
 // ---------------------------------------------------------------------------

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -229,6 +229,7 @@ sealed class SshTaskCommand {
           username: json['username'] as String,
           authJson: Map<String, dynamic>.from(json['auth'] as Map),
           title: json['title'] as String?,
+          controlMode: json['controlMode'] as bool? ?? false,
         );
       case SshTaskCommandKind.disconnect:
         return SshDisconnectCommand(sessionId: sessionId);
@@ -397,6 +398,7 @@ class SshConnectCommand extends SshTaskCommand {
     required this.username,
     required this.authJson,
     this.title,
+    this.controlMode = false,
   }) : super(sessionId);
 
   final String host;
@@ -408,6 +410,15 @@ class SshConnectCommand extends SshTaskCommand {
   /// auth shape without breaking the wire contract.
   final Map<String, dynamic> authJson;
   final String? title;
+
+  /// Whether the session should enter tmux control mode (`tmux -CC`) on shell
+  /// open (#911). The `tmuxControlMode` flag is a per-ISOLATE global; the host
+  /// runs in the foreground-task isolate, so a flag flipped in the UI isolate
+  /// (settings toggle, or the emulator parity tests) never reaches it. This
+  /// carries the UI-isolate's desired state across the gateway so the host
+  /// isolate enters control mode for THIS session. Defaults false so the
+  /// shipped scrape path is unchanged unless the UI explicitly opts in.
+  final bool controlMode;
 
   @override
   SshTaskCommandKind get kind => SshTaskCommandKind.connect;
@@ -421,6 +432,7 @@ class SshConnectCommand extends SshTaskCommand {
     'username': username,
     'auth': authJson,
     if (title != null) 'title': title,
+    if (controlMode) 'controlMode': true,
   };
 }
 

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -15,6 +15,7 @@ import 'dart:typed_data';
 import '../services/session_host.dart';
 import '../services/session_messages.dart';
 import '../services/task_ssh_gateway.dart';
+import '../terminal/tmux_control_mode_flag.dart';
 import 'ssh_connect_params.dart';
 import 'ssh_session.dart';
 
@@ -198,6 +199,10 @@ class SshSessionProxy {
         username: params.username,
         authJson: SessionHost.encodeAuth(params.auth),
         title: title,
+        // #911: carry the UI-isolate control-mode flag across the gateway so the
+        // (separate) foreground-task isolate that opens the shell enters `tmux
+        // -CC`. A per-isolate global set in the UI never reaches the task host.
+        controlMode: tmuxControlMode,
       ).toJson(),
     );
   }

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -251,6 +251,38 @@ class SshSessionProxy {
     gateway.send(SshInputCommand(sessionId: sessionId, bytes: bytes).toJson());
   }
 
+  /// Send a FULL tmux `-CC` control-command LINE for ATOMIC delivery (#911 Part
+  /// C). Unlike [sendInput] (keystroke bytes that can fragment across the gateway
+  /// and land in the pane shell), this travels as ONE command envelope and the
+  /// host writes it as a single framed line — so a multi-token command survives
+  /// intact. [command] carries NO trailing newline; the host adds exactly one.
+  /// A no-op on the task side unless control mode is ON for this session.
+  void sendControlCommand(String command) {
+    gateway.send(
+      SshControlCommand(sessionId: sessionId, command: command).toJson(),
+    );
+  }
+
+  /// Issue a high-level tmux WINDOW gesture (#911 Part C) — the host resolves it
+  /// against its authoritative ordered window list and delivers the matching
+  /// `next-window` / `previous-window` / `select-window -t @<id>` atomically. For
+  /// [TmuxWindowGesture.tapStatusCol] pass the 1-based [statusCol] and the
+  /// status-line width [statusCols]; ignored for next/previous.
+  void sendTmuxGesture(
+    TmuxWindowGesture gesture, {
+    int statusCol = 0,
+    int statusCols = 0,
+  }) {
+    gateway.send(
+      SshTmuxGestureCommand(
+        sessionId: sessionId,
+        gesture: gesture,
+        statusCol: statusCol,
+        statusCols: statusCols,
+      ).toJson(),
+    );
+  }
+
   /// Request a directory listing over SFTP (#559). The matching
   /// [SftpListingEvent] (or [SftpErrorEvent]) arrives on [sftpEvents] with the
   /// same [requestId].

--- a/native/lib/terminal/tmux_control_channel.dart
+++ b/native/lib/terminal/tmux_control_channel.dart
@@ -77,6 +77,27 @@ class TmuxIngestResult {
   final bool exited;
 }
 
+/// An ordered tmux window the control channel knows about (Part C, #911). Built
+/// from the `%window-add` / `%layout-change` / `%window-renamed` notifications so
+/// a status-bar tap can be mapped to a real window WITHOUT pixel guessing. [id]
+/// is the STABLE tmux window id (`@N`); [name] is the latest name from
+/// `%window-renamed` (null until renamed — diagnostic only).
+class TmuxWindow {
+  const TmuxWindow({required this.id, this.name});
+  final int id;
+  final String? name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is TmuxWindow && other.id == id && other.name == name;
+
+  @override
+  int get hashCode => Object.hash(id, name);
+
+  @override
+  String toString() => 'TmuxWindow(@$id${name == null ? '' : ' "$name"'})';
+}
+
 /// Per-session control-mode render + resize adapter. Pure Dart; one instance per
 /// hosted session, created when the flag is ON.
 class TmuxControlChannel {
@@ -89,6 +110,19 @@ class TmuxControlChannel {
   /// an UNKNOWN window and is rendered fail-open (see file header).
   final Map<int, int> _paneWindow = <int, int>{};
 
+  /// Ordered window ids the channel knows about (Part C, #911). Insertion order
+  /// matches tmux's window index/status order: tmux assigns indices 0..N in
+  /// creation order and renders the status bar left→right in the same order, so
+  /// the Nth entry here is the window at status position N. Built from
+  /// `%window-add` and (fail-open) the first `%layout-change` for an as-yet-unseen
+  /// window; pruned on `%window-close`. This is what lets a status-bar tap map to
+  /// a REAL window with no pixel guessing — the wrong-row bug this part dissolves.
+  final List<int> _windowOrder = <int>[];
+
+  /// Latest name per window id, from `%window-renamed`. Diagnostic only — the
+  /// status-col mapping uses ORDER, not names.
+  final Map<int, String> _windowNames = <int, String>{};
+
   /// The active window id, authoritative from `%session-window-changed`. Null
   /// until the first signal; while null every window's output renders (fail-open
   /// so the first frames before the first active-window notification are shown).
@@ -97,6 +131,17 @@ class TmuxControlChannel {
   /// The active window the channel is currently tracking. Exposed for tests +
   /// the host's redraw-on-switch wiring.
   int? get activeWindowId => _activeWindowId;
+
+  /// The ordered windows the channel knows about (Part C, #911), in tmux
+  /// index/status order. A snapshot — mutating it does not affect the channel.
+  List<TmuxWindow> get windows => List<TmuxWindow>.unmodifiable(
+        _windowOrder.map((id) => TmuxWindow(id: id, name: _windowNames[id])),
+      );
+
+  /// Record window [id] in creation/status order if not already known. Idempotent.
+  void _trackWindow(int id) {
+    if (!_windowOrder.contains(id)) _windowOrder.add(id);
+  }
 
   /// The bytes to write into the shell stdin once it opens, to ENTER control
   /// mode. `new-session -A -s mobissh` attaches to an existing `mobissh` session
@@ -116,6 +161,60 @@ class TmuxControlChannel {
     final c = cols < 1 ? 1 : cols;
     final r = rows < 1 ? 1 : rows;
     return Uint8List.fromList(utf8.encode('refresh-client -C $c,$r\n'));
+  }
+
+  /// Frame an arbitrary `-CC` command LINE for ATOMIC delivery (Part C Step 1,
+  /// #911). The whole line — however many tokens / spaces — is encoded as ONE
+  /// byte buffer terminated with EXACTLY ONE `\n`, so the host writes it in a
+  /// single `transport.send` and tmux's control-command parser sees one complete
+  /// line. Part B (#909) found that delivering a command through the UI→isolate
+  /// `sendInput` keystroke path can FRAGMENT it across the gateway, so a
+  /// multi-token command (`select-window -t @1`) split mid-line and the tail hit
+  /// the pane shell (`-bash: send-keys: command not found`). Routing every control
+  /// command through THIS single-write primitive is the fix. Any trailing
+  /// newlines/whitespace the caller passed are trimmed first so exactly one
+  /// newline terminates the line (a bare `\n` mid-buffer would submit a partial).
+  static Uint8List controlCommand(String line) {
+    final trimmed = line.replaceAll(RegExp(r'[\r\n]+$'), '');
+    return Uint8List.fromList(utf8.encode('$trimmed\n'));
+  }
+
+  /// The `next-window` control-command line (Part C, #911) — a horizontal swipe
+  /// RIGHT advances to the next window. No window-list lookup needed; tmux steps
+  /// the session's active window itself and pushes `%session-window-changed`.
+  static String get nextWindowCommand => 'next-window';
+
+  /// The `previous-window` control-command line (Part C, #911) — a horizontal
+  /// swipe LEFT goes to the previous window.
+  static String get previousWindowCommand => 'previous-window';
+
+  /// Map a TAP at status-bar column [col] (1-based) over a status line [totalCols]
+  /// wide to a `select-window -t @<id>` command for the tapped window, or null if
+  /// no window is known yet (Part C, #911). We do NOT guess pixels: tmux renders
+  /// the windows left→right in [windows] order, so we partition the status width
+  /// into equal segments and pick the window whose segment the tap falls in. The
+  /// RESULT is only a best-effort target — the AUTHORITATIVE active window is read
+  /// back from `%session-window-changed`, so an off-by-one tap self-corrects on
+  /// the next notification (no wrong-row dead-end). Targets the STABLE window id
+  /// (`@N`), which `select-window -t` accepts, so it is immune to index renumber.
+  String? selectWindowCommandForStatusCol(int col, int totalCols) {
+    final idx = windowIndexForStatusCol(col, totalCols);
+    if (idx == null) return null;
+    return 'select-window -t @${_windowOrder[idx]}';
+  }
+
+  /// The 0-based index into [windows] a tap at 1-based [col] over a [totalCols]-
+  /// wide status line falls in, or null if no windows are known (Part C, #911).
+  /// Equal-width partition of the status line across the ordered windows. Pure +
+  /// exposed for unit tests of the mapping in isolation.
+  int? windowIndexForStatusCol(int col, int totalCols) {
+    final n = _windowOrder.length;
+    if (n == 0) return null;
+    if (totalCols <= 0) return 0;
+    final c = col < 1 ? 1 : (col > totalCols ? totalCols : col);
+    // 1-based col → 0-based segment; clamp into range.
+    final seg = ((c - 1) * n) ~/ totalCols;
+    return seg < 0 ? 0 : (seg >= n ? n - 1 : seg);
   }
 
   /// Feed a raw shell-output chunk (the `-CC` protocol stream). Returns the
@@ -140,9 +239,22 @@ class TmuxControlChannel {
             final id = p.paneId;
             if (id != null) _paneWindow[id] = ev.windowId;
           }
+          // #911: fail-open window tracking — a layout for an as-yet-unseen window
+          // (e.g. we missed/lagged its %window-add) still registers it so a tap
+          // can target it. Insertion order tracks tmux's index/status order.
+          _trackWindow(ev.windowId);
+        case WindowAdd():
+          // #911: a new window enters the status bar (next index/position).
+          _trackWindow(ev.windowId);
+        case WindowRenamed():
+          // #911: track + record the latest name (diagnostic; mapping uses order).
+          _trackWindow(ev.windowId);
+          _windowNames[ev.windowId] = ev.name;
         case SessionWindowChanged():
           // AUTHORITATIVE active window. A real change flips the rendered window
-          // and signals the host to force a redraw so the grid repaints.
+          // and signals the host to force a redraw so the grid repaints. Also
+          // track it (#911) — the active window is necessarily a real window.
+          _trackWindow(ev.windowId);
           if (ev.windowId != _activeWindowId) {
             _activeWindowId = ev.windowId;
             activeChanged = true;
@@ -151,13 +263,16 @@ class TmuxControlChannel {
           if (_shouldRender(ev.paneId)) render.add(ev.data);
         case WindowClose():
           _paneWindow.removeWhere((_, w) => w == ev.windowId);
+          // #911: drop the closed window from the order + names so a tap can't
+          // target a gone window and the status mapping stays correct.
+          _windowOrder.remove(ev.windowId);
+          _windowNames.remove(ev.windowId);
         case ControlModeExit():
           exited = true;
         default:
-          // CommandBegin/End, WindowAdd, renames, session/client notifications,
-          // UnhandledNotification, UnknownLine, ControlModeEntered: no render
-          // effect here (Part C consumes the window/pane notifications). The
-          // parser already updated its own active-window/layout view.
+          // CommandBegin/End, session/client notifications, UnhandledNotification,
+          // UnknownLine, ControlModeEntered: no render or window-tracking effect
+          // here. The parser already updated its own active-window/layout view.
           break;
       }
     }

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -174,8 +174,10 @@ import 'package:xterm/xterm.dart' as xterm;
 import '../diagnostics/gesture_trace.dart';
 import '../diagnostics/session_byte_recorder.dart';
 import '../services/clipboard.dart';
+import '../services/session_messages.dart' show TmuxWindowGesture;
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
+import '../terminal/tmux_control_mode_flag.dart';
 import '../state/ctrl_modifier_provider.dart';
 import '../state/detection_providers.dart';
 import '../state/lifecycle_providers.dart';
@@ -1355,7 +1357,31 @@ class GhosttyPointerGestureRouter extends StatefulWidget {
     required this.urlAtCell,
     required this.onUrlTap,
     required this.onUrlLongPress,
+    this.controlModeGestures = false,
+    this.onWindowSwitch,
+    this.onStatusTap,
   });
+
+  /// #911 Part C: when true (the `tmuxControlMode` flag is ON), window switching
+  /// is driven by REAL tmux control commands ([onWindowSwitch]/[onStatusTap])
+  /// instead of synthesised SGR wheel/click reports at a GUESSED status row — the
+  /// fix for the "swipe did nothing / tap hit the wrong row" bugs. The
+  /// authoritative active window is read back from `%session-window-changed`, so
+  /// the gesture never has to guess geometry. When false (the shipped default) the
+  /// existing scrape + synthesised-SGR path runs UNCHANGED.
+  final bool controlModeGestures;
+
+  /// #911: a horizontal swipe → next/previous window via a real control command.
+  /// Called (instead of [onMouseReport]) only when [controlModeGestures] is true.
+  /// [next] = swipe RIGHT (next-window); false = swipe LEFT (previous-window).
+  final void Function({required bool next})? onWindowSwitch;
+
+  /// #911: a tap on the status-bar ROW → `select-window` for the tapped window
+  /// via a real control command. Carries the 1-based tap [col] and the status
+  /// line width [totalCols] so the host can map col → window with no pixel guess.
+  /// Called (instead of the SGR click) only when [controlModeGestures] is true
+  /// AND the tap landed on the status row.
+  final void Function({required int col, required int totalCols})? onStatusTap;
 
   /// Whether to intercept touch (the remote has mouse tracking on).
   final bool active;
@@ -1552,6 +1578,17 @@ class _GhosttyPointerGestureRouterState
       _trace('swipe-h', totalDx, 0, null, null, null);
       return;
     }
+    // #911 Part C (flag ON): switch windows with a REAL control command
+    // (`next-window`/`previous-window`) over the -CC channel instead of a
+    // synthesised SGR wheel at a GUESSED status row. tmux steps its own active
+    // window and pushes `%session-window-changed` (authoritative → repaint), so
+    // there is no row to guess and the wrong-row bug cannot recur.
+    if (widget.controlModeGestures && widget.onWindowSwitch != null) {
+      final next = decision == GhosttyWindowSwitch.next;
+      _trace('swipe-h', totalDx, 0, null, null, next ? 'next-window' : 'previous-window');
+      widget.onWindowSwitch!(next: next);
+      return;
+    }
     // #719/#723: target the status row of the rows tmux ACTUALLY HAS — flterm's
     // ACTUAL (last-sent) grid via [_gridRows], NOT the live local grid
     // (widget.rows). On a keyboard toggle / resize the live grid can change (e.g.
@@ -1742,6 +1779,20 @@ class _GhosttyPointerGestureRouterState
       return;
     }
     final (col, row) = _cellAt(local);
+    // #911 Part C (flag ON): a tap on the STATUS ROW switches windows via a REAL
+    // `select-window` control command — the host maps the tap COLUMN to a window
+    // from the authoritative ordered window list (no pixel/row guessing). Off the
+    // status row we just focus + raise the keyboard (control mode does not use a
+    // synthesised SGR click). On the status row, swallow the SGR click path.
+    if (widget.controlModeGestures && widget.onStatusTap != null) {
+      if (row >= _gridRows) {
+        _trace('tap', local.dx, local.dy, col, row, 'select-window');
+        widget.onStatusTap!(col: col, totalCols: _gridCols);
+      } else {
+        _trace('tap', local.dx, local.dy, col, row, null);
+      }
+      return;
+    }
     final report = ghosttySgrMousePress(col: col, row: row);
     _trace('tap', local.dx, local.dy, col, row, report);
     GhosttySelectionDriver(
@@ -3193,6 +3244,30 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
               // SGR-mouse bytes — never keystrokes).
               _byteRecorder.recordSentSgr(bytes);
               proxy.sendInput(bytes);
+            },
+            // #911 Part C: under the control-mode flag, window switching uses REAL
+            // tmux commands over the -CC channel (no synthesised SGR at a guessed
+            // status row). Flag OFF leaves the SGR path above unchanged.
+            controlModeGestures: tmuxControlMode,
+            onWindowSwitch: ({required bool next}) {
+              final proxy = _resolveProxy();
+              if (proxy == null) return;
+              if (proxy.data.state != SshSessionState.connected) return;
+              proxy.sendTmuxGesture(
+                next
+                    ? TmuxWindowGesture.nextWindow
+                    : TmuxWindowGesture.previousWindow,
+              );
+            },
+            onStatusTap: ({required int col, required int totalCols}) {
+              final proxy = _resolveProxy();
+              if (proxy == null) return;
+              if (proxy.data.state != SshSessionState.connected) return;
+              proxy.sendTmuxGesture(
+                TmuxWindowGesture.tapStatusCol,
+                statusCol: col,
+                statusCols: totalCols,
+              );
             },
             // #705: long-press-drag drives flterm's LOCAL selection (persists
             // after release → Copy reads it), not a tmux SGR drag.

--- a/native/test/services/session_host_control_mode_test.dart
+++ b/native/test/services/session_host_control_mode_test.dart
@@ -19,6 +19,7 @@ import 'dart:typed_data';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
 import 'package:mobissh/ssh/ssh_connect_params.dart';
 import 'package:mobissh/ssh/ssh_session.dart';
 import 'package:mobissh/ssh/ssh_session_proxy.dart';
@@ -198,6 +199,74 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(_s(shell.sent.toBytes()), contains('refresh-client -C 88,27'));
     });
+
+    // ---- #911 Part C: atomic control-command delivery + real gestures ----
+
+    test('a multi-token control command is delivered as ONE atomic line', () async {
+      final ctx = await setUpConnectedShell('cc:22:u:5');
+      final shell = ctx.opened.first;
+      shell.sent.clear();
+      ctx.proxy.sendControlCommand('select-window -t @1');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final written = _s(shell.sent.toBytes());
+      // The WHOLE multi-token line survives intact with exactly one trailing
+      // newline (the Part B fragmentation bug would have split it).
+      expect(written, 'select-window -t @1\n');
+      expect('\n'.allMatches(written).length, 1);
+    });
+
+    test('swipe RIGHT gesture issues next-window over the channel', () async {
+      final ctx = await setUpConnectedShell('cc:22:u:6');
+      final shell = ctx.opened.first;
+      // Populate the channel's window list.
+      shell.emit(_b('%window-add @0\n'));
+      shell.emit(_b('%window-add @1\n'));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      shell.sent.clear();
+      ctx.proxy.sendTmuxGesture(TmuxWindowGesture.nextWindow);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(_s(shell.sent.toBytes()), 'next-window\n');
+    });
+
+    test('swipe LEFT gesture issues previous-window over the channel', () async {
+      final ctx = await setUpConnectedShell('cc:22:u:7');
+      final shell = ctx.opened.first;
+      shell.sent.clear();
+      ctx.proxy.sendTmuxGesture(TmuxWindowGesture.previousWindow);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(_s(shell.sent.toBytes()), 'previous-window\n');
+    });
+
+    test('status-bar tap maps the column to select-window for that window', () async {
+      final ctx = await setUpConnectedShell('cc:22:u:8');
+      final shell = ctx.opened.first;
+      shell.emit(_b('%window-add @0\n'));
+      shell.emit(_b('%window-add @1\n'));
+      shell.emit(_b('%window-add @2\n'));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      shell.sent.clear();
+      // Tap in the middle segment (window index 1) of a 90-col status line.
+      ctx.proxy.sendTmuxGesture(
+        TmuxWindowGesture.tapStatusCol,
+        statusCol: 45,
+        statusCols: 90,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(_s(shell.sent.toBytes()), 'select-window -t @1\n');
+    });
+
+    test('status-bar tap with no known windows is a no-op (no write)', () async {
+      final ctx = await setUpConnectedShell('cc:22:u:9');
+      final shell = ctx.opened.first;
+      shell.sent.clear();
+      ctx.proxy.sendTmuxGesture(
+        TmuxWindowGesture.tapStatusCol,
+        statusCol: 10,
+        statusCols: 80,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(shell.sent.length, 0);
+    });
   });
 
   group('flag OFF — scrape path unchanged (shipped default)', () {
@@ -218,6 +287,24 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(shell.resizes, contains((120, 40)));
       expect(_s(shell.sent.toBytes()).contains('refresh-client'), isFalse);
+    });
+
+    test('control commands + window gestures are IGNORED (no -CC channel)', () async {
+      // #911: with the flag OFF there is no tmuxChannel, so a control command or
+      // a window gesture command must be a pure no-op — the scrape path never
+      // issues control commands. Nothing is written to the shell.
+      final ctx = await setUpConnectedShell('plain:22:u:3');
+      final shell = ctx.opened.first;
+      shell.sent.clear();
+      ctx.proxy.sendControlCommand('select-window -t @1');
+      ctx.proxy.sendTmuxGesture(TmuxWindowGesture.nextWindow);
+      ctx.proxy.sendTmuxGesture(
+        TmuxWindowGesture.tapStatusCol,
+        statusCol: 5,
+        statusCols: 80,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(shell.sent.length, 0);
     });
   });
 }

--- a/native/test/services/task_ipc_test.dart
+++ b/native/test/services/task_ipc_test.dart
@@ -123,6 +123,32 @@ void main() {
       expect(restored.activeHost, isNull);
     });
 
+    test('SshControlCommand round-trips a multi-token line intact (#911)', () {
+      const cmd =
+          SshControlCommand(sessionId: 'sid', command: 'select-window -t @1');
+      final restored =
+          SshTaskCommand.fromJson(cmd.toJson()) as SshControlCommand;
+      expect(restored.kind, SshTaskCommandKind.controlCommand);
+      expect(restored.command, 'select-window -t @1');
+    });
+
+    test('SshTmuxGestureCommand round-trips each gesture (#911)', () {
+      for (final g in TmuxWindowGesture.values) {
+        final cmd = SshTmuxGestureCommand(
+          sessionId: 'sid',
+          gesture: g,
+          statusCol: 45,
+          statusCols: 90,
+        );
+        final restored =
+            SshTaskCommand.fromJson(cmd.toJson()) as SshTmuxGestureCommand;
+        expect(restored.kind, SshTaskCommandKind.tmuxGesture);
+        expect(restored.gesture, g);
+        expect(restored.statusCol, 45);
+        expect(restored.statusCols, 90);
+      }
+    });
+
     test('unknown kind throws FormatException', () {
       expect(
         () => SshTaskCommand.fromJson({'kind': 'bogus', 'sessionId': 'sid'}),

--- a/native/test/services/task_ipc_test.dart
+++ b/native/test/services/task_ipc_test.dart
@@ -26,6 +26,7 @@ void main() {
         username: 'user',
         authJson: SessionHost.encodeAuth(const SshAuth.password('secret')),
         title: 'My host',
+        controlMode: true,
       );
       final restored = SshTaskCommand.fromJson(cmd.toJson());
       expect(restored, isA<SshConnectCommand>());
@@ -36,6 +37,27 @@ void main() {
       expect(restored.username, 'user');
       expect(restored.authJson, cmd.authJson);
       expect(restored.title, 'My host');
+      // #911: the control-mode bit crosses the gateway so the task isolate
+      // (which owns the shell + the per-isolate `tmuxControlMode` global) enters
+      // `tmux -CC`. A UI-isolate flag never reaches the task isolate otherwise.
+      expect(restored.controlMode, isTrue);
+    });
+
+    test('SshConnectCommand controlMode defaults false + omitted from json', () {
+      final cmd = SshConnectCommand(
+        sessionId: 'host:22:user:1',
+        host: 'host',
+        port: 22,
+        username: 'user',
+        authJson: SessionHost.encodeAuth(const SshAuth.password('secret')),
+      );
+      expect(cmd.controlMode, isFalse);
+      // Omitted when false so the default wire shape is unchanged (the shipped
+      // scrape path sends no extra field).
+      expect(cmd.toJson().containsKey('controlMode'), isFalse);
+      final restored =
+          SshTaskCommand.fromJson(cmd.toJson()) as SshConnectCommand;
+      expect(restored.controlMode, isFalse);
     });
 
     test('SshInputCommand preserves binary bytes', () {

--- a/native/test/terminal/tmux_control_channel_test.dart
+++ b/native/test/terminal/tmux_control_channel_test.dart
@@ -117,4 +117,132 @@ void main() {
       expect(text(r.renderBytes), 'partial');
     });
   });
+
+  group('atomic control-command framing (#911 Step 1)', () {
+    test('a multi-token command survives intact, terminated by ONE newline', () {
+      // The Part B failure: a multi-token command (`select-window -t @1`) split
+      // across the gateway and its tail hit the pane shell. The framing must keep
+      // the WHOLE line together with exactly one trailing newline.
+      final framed = text(TmuxControlChannel.controlCommand('select-window -t @1'));
+      expect(framed, 'select-window -t @1\n');
+      // No mid-line newline that would submit a partial line to tmux.
+      expect('\n'.allMatches(framed).length, 1);
+    });
+
+    test('strips caller trailing newlines/whitespace to exactly one newline', () {
+      expect(
+        text(TmuxControlChannel.controlCommand('next-window\n')),
+        'next-window\n',
+      );
+      expect(
+        text(TmuxControlChannel.controlCommand('next-window\r\n\n')),
+        'next-window\n',
+      );
+    });
+
+    test('preserves interior spaces + quotes (no token splitting)', () {
+      final framed =
+          text(TmuxControlChannel.controlCommand('rename-window "my work"'));
+      expect(framed, 'rename-window "my work"\n');
+    });
+
+    test('next/previous window command lines', () {
+      expect(TmuxControlChannel.nextWindowCommand, 'next-window');
+      expect(TmuxControlChannel.previousWindowCommand, 'previous-window');
+    });
+  });
+
+  group('window-list tracking from notifications (#911 Step 2)', () {
+    test('tracks windows in tmux index/status order from %window-add', () {
+      final ch = TmuxControlChannel();
+      ch.ingest(bytes('%window-add @0\n'));
+      ch.ingest(bytes('%window-add @1\n'));
+      ch.ingest(bytes('%window-add @2\n'));
+      expect(ch.windows.map((w) => w.id).toList(), [0, 1, 2]);
+    });
+
+    test('tracks a window first seen via %layout-change (fail-open)', () {
+      final ch = TmuxControlChannel();
+      ch.ingest(bytes('%layout-change @5 abcd,80x24,0,0,0\n'));
+      expect(ch.windows.map((w) => w.id).toList(), [5]);
+    });
+
+    test('records window names from %window-renamed', () {
+      final ch = TmuxControlChannel();
+      ch.ingest(bytes('%window-add @0\n'));
+      ch.ingest(bytes('%window-renamed @0 editor\n'));
+      expect(ch.windows.single.name, 'editor');
+    });
+
+    test('%window-close drops the window from the order', () {
+      final ch = TmuxControlChannel();
+      ch.ingest(bytes('%window-add @0\n'));
+      ch.ingest(bytes('%window-add @1\n'));
+      ch.ingest(bytes('%window-close @0\n'));
+      expect(ch.windows.map((w) => w.id).toList(), [1]);
+    });
+
+    test('does not duplicate a window seen via multiple notifications', () {
+      final ch = TmuxControlChannel();
+      ch.ingest(bytes('%window-add @3\n'));
+      ch.ingest(bytes('%layout-change @3 abcd,80x24,0,0,0\n'));
+      ch.ingest(bytes('%session-window-changed \$0 @3\n'));
+      expect(ch.windows.map((w) => w.id).toList(), [3]);
+    });
+
+    test('active window updates from %session-window-changed', () {
+      final ch = TmuxControlChannel();
+      ch.ingest(bytes('%window-add @0\n'));
+      ch.ingest(bytes('%window-add @1\n'));
+      final r = ch.ingest(bytes('%session-window-changed \$0 @1\n'));
+      expect(r.activeWindowChanged, isTrue);
+      expect(ch.activeWindowId, 1);
+    });
+  });
+
+  group('status-col → window mapping (#911 Step 2)', () {
+    TmuxControlChannel threeWindows() {
+      final ch = TmuxControlChannel();
+      ch.ingest(bytes('%window-add @0\n'));
+      ch.ingest(bytes('%window-add @1\n'));
+      ch.ingest(bytes('%window-add @2\n'));
+      return ch;
+    }
+
+    test('partitions the status width across windows in order', () {
+      final ch = threeWindows();
+      // 3 windows over 90 cols → segments [1..30]=0, [31..60]=1, [61..90]=2.
+      expect(ch.windowIndexForStatusCol(1, 90), 0);
+      expect(ch.windowIndexForStatusCol(30, 90), 0);
+      expect(ch.windowIndexForStatusCol(45, 90), 1);
+      expect(ch.windowIndexForStatusCol(90, 90), 2);
+    });
+
+    test('select-window command targets the STABLE window id of the tapped seg', () {
+      final ch = threeWindows();
+      expect(ch.selectWindowCommandForStatusCol(5, 90), 'select-window -t @0');
+      expect(ch.selectWindowCommandForStatusCol(45, 90), 'select-window -t @1');
+      expect(ch.selectWindowCommandForStatusCol(85, 90), 'select-window -t @2');
+    });
+
+    test('clamps out-of-range columns into the valid window set', () {
+      final ch = threeWindows();
+      expect(ch.windowIndexForStatusCol(0, 90), 0);
+      expect(ch.windowIndexForStatusCol(999, 90), 2);
+    });
+
+    test('null when no windows are known yet', () {
+      final ch = TmuxControlChannel();
+      expect(ch.windowIndexForStatusCol(5, 90), isNull);
+      expect(ch.selectWindowCommandForStatusCol(5, 90), isNull);
+    });
+
+    test('select-window uses the stable id after a lower-index window closes', () {
+      final ch = threeWindows();
+      ch.ingest(bytes('%window-close @0\n')); // now order is [@1, @2]
+      // First segment now maps to @1 (the leftmost remaining), not the gone @0.
+      expect(ch.selectWindowCommandForStatusCol(5, 90), 'select-window -t @1');
+      expect(ch.selectWindowCommandForStatusCol(85, 90), 'select-window -t @2');
+    });
+  });
 }

--- a/native/test/ui/ghostty_swipe_windowswitch_smoke_test.dart
+++ b/native/test/ui/ghostty_swipe_windowswitch_smoke_test.dart
@@ -85,6 +85,57 @@ void main() {
     return reports;
   }
 
+  // #911 Part C: pump the router with control-mode gestures ON, returning the
+  // window-switch directions and status-tap (col,totalCols) the router emits via
+  // the REAL-command callbacks (instead of synthesised SGR). Also returns the SGR
+  // sink so a test can assert NO SGR is forwarded under the flag.
+  Future<
+      ({
+        List<bool> switches,
+        List<(int, int)> statusTaps,
+        List<String> sgr,
+      })> pumpControlModeRouter(
+    WidgetTester tester, {
+    int cols = 80,
+    int rows = 24,
+  }) async {
+    final switches = <bool>[];
+    final statusTaps = <(int, int)>[];
+    final sgr = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GhosttyPointerGestureRouter(
+            active: true,
+            scrollController: TerminalScrollController(),
+            cols: cols,
+            rows: rows,
+            lastSentCols: cols,
+            lastSentRows: rows,
+            cellWidth: 8,
+            cellHeight: 16,
+            mouseTrackingLabel: 'any',
+            onTap: () {},
+            onFocus: () {},
+            onMouseReport: sgr.add,
+            onSelectionStart: (_, _) {},
+            onSelectionExtend: (_, _) {},
+            hasSelection: () => false,
+            onSelectionClear: () {},
+            urlAtCell: (_, _) => null,
+            onUrlTap: (_) {},
+            onUrlLongPress: (_, _) {},
+            controlModeGestures: true,
+            onWindowSwitch: ({required bool next}) => switches.add(next),
+            onStatusTap: ({required int col, required int totalCols}) =>
+                statusTaps.add((col, totalCols)),
+          ),
+        ),
+      ),
+    );
+    return (switches: switches, statusTaps: statusTaps, sgr: sgr);
+  }
+
   group('#719 horizontal swipe → window-switch wheel report (drag→report)', () {
     testWidgets('swipe RIGHT emits ONE wheel-DOWN at the status row', (
       tester,
@@ -175,6 +226,62 @@ void main() {
         expect(reports, isEmpty);
       },
     );
+  });
+
+  group('#911 control-mode gestures: REAL commands, NO synthesised SGR', () {
+    testWidgets('swipe RIGHT → onWindowSwitch(next), no SGR forwarded', (
+      tester,
+    ) async {
+      final r = await pumpControlModeRouter(tester);
+      final center = tester.getCenter(find.byType(GhosttyPointerGestureRouter));
+      await tester.dragFrom(center, const Offset(120, 0));
+      await tester.pumpAndSettle();
+      expect(r.switches, [true], reason: 'swipe RIGHT → next-window');
+      expect(r.sgr, isEmpty, reason: 'control mode must not synthesise SGR');
+    });
+
+    testWidgets('swipe LEFT → onWindowSwitch(previous), no SGR forwarded', (
+      tester,
+    ) async {
+      final r = await pumpControlModeRouter(tester);
+      final center = tester.getCenter(find.byType(GhosttyPointerGestureRouter));
+      await tester.dragFrom(center, const Offset(-120, 0));
+      await tester.pumpAndSettle();
+      expect(r.switches, [false], reason: 'swipe LEFT → previous-window');
+      expect(r.sgr, isEmpty);
+    });
+
+    testWidgets('a tap on the STATUS ROW → onStatusTap(col,totalCols)', (
+      tester,
+    ) async {
+      // 80x24 grid, cell 8x16 → the status row (row 24) is the bottom band.
+      final r = await pumpControlModeRouter(tester, cols: 80, rows: 24);
+      final box = tester.getRect(find.byType(GhosttyPointerGestureRouter));
+      // Tap near the bottom (status row) at ~40% across → a real status tap.
+      final tapPoint = Offset(box.left + box.width * 0.4, box.bottom - 4);
+      await tester.tapAt(tapPoint);
+      await tester.pumpAndSettle();
+      expect(r.statusTaps, hasLength(1),
+          reason: 'a status-row tap issues a select-window gesture');
+      final (col, totalCols) = r.statusTaps.single;
+      expect(totalCols, 80);
+      expect(col, greaterThan(0));
+      expect(col, lessThanOrEqualTo(80));
+      expect(r.sgr, isEmpty, reason: 'no synthesised SGR click under the flag');
+    });
+
+    testWidgets('a tap ABOVE the status row does NOT issue a window gesture', (
+      tester,
+    ) async {
+      final r = await pumpControlModeRouter(tester, cols: 80, rows: 24);
+      final box = tester.getRect(find.byType(GhosttyPointerGestureRouter));
+      // Tap near the TOP (a content row, not the status bar).
+      await tester.tapAt(Offset(box.left + box.width * 0.4, box.top + 4));
+      await tester.pumpAndSettle();
+      expect(r.statusTaps, isEmpty,
+          reason: 'only the status row switches windows');
+      expect(r.sgr, isEmpty);
+    });
   });
 
   group('#719 inactive overlay (no mouse mode) forwards no wheel', () {


### PR DESCRIPTION
Part C (final) of the tmux control-mode arc (epic #906; parser #907, render #909 merged). Replaces synthesized-SGR-mouse window switching — at a guessed status row, the source of the wrong-row "swipe did nothing / taps occasionally work" bugs — with REAL tmux commands over the `-CC` control channel, behind the `tmuxControlMode` flag (default OFF). The flag-OFF scrape+mouse path is untouched.

## Step 1 — atomic control-command delivery (the Part B pre-req)
Part B found the UI→isolate gateway fragments stdin when a command rides the `sendInput` keystroke path, so a multi-token command (`select-window -t @1`) split and its tail hit the pane shell (`-bash: send-keys: command not found`).

- `TmuxControlChannel.controlCommand(line)` frames a full `-CC` command LINE as one buffer terminated by exactly one `\n` (caller's trailing whitespace/newlines trimmed first).
- New `SshControlCommand` carries the full line and travels as ONE gateway envelope; the host writes it in a SINGLE `transport.send`. No cross-message fragmentation, exactly one newline.
- Proxy `sendControlCommand(String)`.

## Step 2 — gestures via real commands (flag ON)
- `TmuxControlChannel` now tracks an ORDERED window list (id + name) from `%window-add` / `%layout-change` / `%window-renamed`, pruned on `%window-close`, with the active id from `%session-window-changed`. Exposes `windows` + a status-col→window mapping.
- New `SshTmuxGestureCommand` (next / previous / tapStatusCol). The host resolves the window index **task-side** against the authoritative ordered list and issues `next-window` / `previous-window` / `select-window -t @<id>` via the atomic path — the UI never holds the window list and a status tap needs no pixel guess. Targets the STABLE window id (`@N`), immune to index renumber.
- Gesture router: under the flag a horizontal swipe → `onWindowSwitch` (real command) and a status-ROW tap → `onStatusTap`; both drop the synthesized SGR. Flag OFF keeps the SGR wheel/click path.
- Active window read from `%session-window-changed` (Part B already repaints on it), so an off-by-one tap self-corrects on the next notification — no wrong-row dead-end.

## How the status-cell → window-index map is derived
The channel records window ids in creation/insertion order, which matches tmux's index/status order (tmux assigns indices 0..N in creation order and renders the status bar left→right in the same order). A status-bar tap's 1-based column over the status width is mapped by an equal-width partition across the ordered windows → `select-window -t @<id>` for the segment's window.

## Tests
Fast gate (RED→GREEN): atomic framing (multi-token intact, single newline, interior spaces/quotes preserved); window-list tracking + dedup + close-pruning; status-col→window mapping incl. clamps and stable-id-after-close; gesture→command mapping; host writes atomically (flag ON) / ignores (flag OFF); IPC round-trips for both new commands; router widget test asserts flag-ON swipe/status-tap emit real-command callbacks with NO synthesized SGR. Full native fast gate green (analyze clean, 1416 tests pass).

Emulator test FILE written (orchestrator runs it flag-ON, not in this gate): `integration_test/cc_gestures_test.dart` — ≥3 windows, real next/previous/select-window switching + grid repaint, deterministic across repeated switches, no dependence on a guessed status row.

Refs #906 (epic), #907 (parser), #909 (render), #903/#905 (the wrong-row/divergence bugs this dissolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)