### PR TITLE
feat(#913): tmux control-mode Part D — settings toggle (default OFF) + attach-or-create entry

### DIFF
--- a/native/integration_test/cc_setting_test.dart
+++ b/native/integration_test/cc_setting_test.dart
@@ -1,0 +1,151 @@
+// On-emulator rollout test for the #913 tmux-control-mode SETTING (Part D).
+//
+// cc_render (#909) forces control mode ON with the TEST HOOK
+// (`setTmuxControlModeForTest`). This test proves the SHIPPED ROLLOUT path: with
+// the persisted user SETTING enabled (TmuxControlModeNotifier — the real Settings
+// toggle source) and NO test-hook flip, a fresh connect to test-sshd (which has
+// NO pre-existing tmux session) engages control mode via the attach-OR-create
+// entry command (`tmux -CC new-session -A -s mobissh`) and the active window's
+// %output renders to the grid. Reuses the cc_render render assertions.
+//
+// The orchestrator runs this. The shipped DEFAULT keeps the setting OFF, so the
+// scrape path is unchanged unless the owner opts in here.
+//
+// Run: scripts/native-connect-test.sh integration_test/cc_setting_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/tmux_control_mode_setting.dart';
+import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    // Start from a clean prefs store with the setting EXPLICITLY enabled — the
+    // rollout path the owner takes in Settings. Crucially we do NOT call
+    // setTmuxControlModeForTest: control mode must engage purely from the
+    // persisted setting driving the per-isolate global.
+    SharedPreferences.setMockInitialValues({tmuxControlModePrefKey: true});
+    // Ensure the global is OFF before the notifier hydrates, so the assertion
+    // below proves the SETTING (not a stale flag) flipped it.
+    setTmuxControlModeForTest(false);
+  });
+
+  tearDown(() {
+    setTmuxControlModeForTest(false);
+  });
+
+  testWidgets(
+    'setting ON → fresh connect engages control mode (new-session -A) + renders '
+    '(#913)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // Read the notifier so it hydrates the stored `true` and syncs the global.
+      final notifier = container.read(tmuxControlModeProvider.notifier);
+      for (var i = 0; i < 20 && container.read(tmuxControlModeProvider) != true;
+          i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(container.read(tmuxControlModeProvider), isTrue,
+          reason: 'persisted setting did not hydrate to ON');
+      expect(tmuxControlMode, isTrue,
+          reason: 'the notifier must sync the per-isolate global from the '
+              'persisted setting so connect carries controlMode');
+      // Belt-and-suspenders: a programmatic enable is idempotent.
+      await notifier.set(true);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      String rendered() => utf8.decode(out, allowMalformed: true);
+      void send(String s) =>
+          entry.proxy.sendInput(Uint8List.fromList(utf8.encode(s)));
+
+      // The host entered `tmux -CC new-session -A -s mobissh` automatically
+      // (test-sshd has NO pre-existing tmux, so -A CREATED the session — a bare
+      // attach would have failed "no sessions"). Wait for the initial window
+      // paint: bytes only reach the grid if the control stream parsed + demuxed.
+      var painted = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (out.isNotEmpty) {
+          painted = true;
+          break;
+        }
+      }
+      expect(painted, isTrue,
+          reason: 'control-mode grid received ZERO bytes — the SETTING did not '
+              'engage control mode, or new-session -A failed on a tmux-less host');
+
+      // Render a unique marker in the active window and confirm it paints — the
+      // same render assertion cc_render uses, proving the demux works end-to-end.
+      const marker = 'CC_SETTING_MARKER_913';
+      var sawMarker = false;
+      for (var attempt = 0; attempt < 6 && !sawMarker; attempt++) {
+        send('send-keys -t :0 "echo $marker" Enter\n');
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+          if (rendered().contains(marker)) {
+            sawMarker = true;
+            break;
+          }
+        }
+      }
+      expect(sawMarker, isTrue,
+          reason: 'active window content did not render via control mode driven '
+              'by the persisted SETTING. Saw: ${rendered()}');
+      debugPrint(
+        'CC_SETTING: persisted setting ON → control mode engaged on a '
+        'tmux-less host via new-session -A; grid rendered the active window',
+      );
+    },
+  );
+}

--- a/native/lib/state/tmux_control_mode_setting.dart
+++ b/native/lib/state/tmux_control_mode_setting.dart
@@ -1,0 +1,99 @@
+// Persisted user setting for tmux control mode (`tmux -CC`) — Part D (#913).
+//
+// The control-mode arc (epic #906) is shipped flag-gated OFF: the parser (#907),
+// render path (#909) and gestures (#911) all gate on the per-isolate
+// `tmuxControlMode` global (tmux_control_mode_flag.dart), which defaults false so
+// the proven screen-scrape path is the shipped default. A global default-ON flip
+// would force `tmux -CC` on EVERY connect — breaking the test suite and any
+// non-tmux host — so the rollout is a per-user OPT-IN instead.
+//
+// This is that opt-in: a persisted boolean (default false) the owner enables in
+// Settings to validate control mode on real multi-window tmux. It follows the
+// `terminal_backend.dart` / `ComposeBarVisibleNotifier` idiom: injectable prefs,
+// synchronous default, best-effort hydrate/persist that never crashes when prefs
+// are unavailable (widget tests without bindings), schema-tolerant `getBool`
+// (a stale/corrupt non-bool value falls back to the default).
+//
+// HOW IT REACHES THE TASK ISOLATE: `SshSessionProxy.connect` (UI isolate) reads
+// the per-isolate `tmuxControlMode` global at connect time and carries it across
+// the gateway as `SshConnectCommand.controlMode` (Part C). This notifier keeps
+// that global in sync with the PERSISTED value — it writes `tmuxControlMode` on
+// hydrate and on every `set` — so the proxy's single connect-time read yields the
+// user's saved choice. Centralising the read in the proxy (one site) avoids
+// threading a flag through all three connect call sites, and preserves the
+// gateway carrier contract. `setTmuxControlModeForTest` still flips the global
+// directly, so the cc_render/cc_gestures integration tests force control mode ON
+// regardless of this setting. Like the terminal-engine selector, the change takes
+// effect on the NEXT connect / session (no live hot-swap).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../terminal/tmux_control_mode_flag.dart';
+
+/// SharedPreferences key for the tmux-control-mode opt-in (#913). No key bumps —
+/// schema tolerance lives in the value (see [_hydrate]), per code-style rules.
+const String tmuxControlModePrefKey = 'mobissh.ui.tmuxControlMode';
+
+/// Default OFF (#913). Control mode is experimental and forces `tmux -CC`, which
+/// only works on hosts that have tmux — the owner opts in explicitly.
+const bool tmuxControlModeDefault = false;
+
+/// Persisted user opt-in for tmux control mode (#913). Synchronous default while
+/// prefs hydrate so the first paint / a connect before hydrate is stable and OFF.
+///
+/// Keeps the per-isolate [tmuxControlMode] global in sync (writes it on hydrate +
+/// set) so [SshSessionProxy.connect]'s connect-time global read carries the saved
+/// choice across the gateway as `SshConnectCommand.controlMode`.
+class TmuxControlModeNotifier extends StateNotifier<bool> {
+  TmuxControlModeNotifier({Future<SharedPreferences>? prefs})
+    : _prefs = prefs ?? SharedPreferences.getInstance(),
+      super(tmuxControlModeDefault) {
+    // Mirror the synchronous default into the global up front so a connect that
+    // races hydrate sees a defined (OFF) value, never a stale prior-session one.
+    tmuxControlMode = tmuxControlModeDefault;
+    _hydrate();
+  }
+
+  final Future<SharedPreferences> _prefs;
+
+  Future<void> _hydrate() async {
+    try {
+      final prefs = await _prefs;
+      // `getBool` returns null for a missing OR non-bool (corrupt/legacy) value,
+      // so a stale schema falls back to the default — no crash, no key bump.
+      final stored = prefs.getBool(tmuxControlModePrefKey);
+      if (stored != null && stored != state) {
+        state = stored;
+      }
+      // Sync the global to the resolved value (default or stored) so the proxy's
+      // connect-time read reflects the persisted setting.
+      tmuxControlMode = state;
+    } catch (_) {
+      // best-effort; keep default if prefs unavailable (tests). The constructor
+      // already seeded the global with the default.
+    }
+  }
+
+  /// Enable/disable control mode and persist it (best-effort). Updates the
+  /// per-isolate global immediately so the NEXT connect carries it; takes effect
+  /// on a new session / restart (does not hot-swap a live session — mirrors the
+  /// terminal-engine selector).
+  Future<void> set(bool value) async {
+    state = value;
+    tmuxControlMode = value;
+    try {
+      final prefs = await _prefs;
+      await prefs.setBool(tmuxControlModePrefKey, value);
+    } catch (_) {
+      // best-effort persistence
+    }
+  }
+}
+
+/// Persisted global tmux-control-mode opt-in (#913, default OFF). Watch it on the
+/// connect surface so it hydrates (and syncs the global) before the first connect.
+final tmuxControlModeProvider =
+    StateNotifierProvider<TmuxControlModeNotifier, bool>((ref) {
+      return TmuxControlModeNotifier();
+    });

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -34,6 +34,7 @@ import '../state/connection_providers.dart';
 import '../state/profiles_providers.dart';
 import '../state/recent_sessions.dart';
 import '../state/sessions.dart';
+import '../state/tmux_control_mode_setting.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
 import 'host_key_dialog.dart';
@@ -321,6 +322,12 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
         entry,
         title: title ?? '${params.username}@${params.host}:${params.port}',
       );
+      // #913: read the persisted tmux-control-mode opt-in at connect time. The
+      // notifier keeps the per-isolate `tmuxControlMode` global in sync with this
+      // value; reading the provider here also guarantees it's constructed (and
+      // hydrated) before `proxy.connect` reads that global to populate
+      // `SshConnectCommand.controlMode`. Default OFF → scrape path unchanged.
+      ref.read(tmuxControlModeProvider);
       await entry.proxy.connect(params);
       // Once we've proven network reachability, fire-and-forget a crash upload
       // sweep. Tailscale being down at boot is the common case.

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -11,6 +11,7 @@ import '../services/battery_optimization.dart';
 import '../state/detection_providers.dart';
 import '../state/keepalive_providers.dart';
 import '../state/terminal_backend.dart';
+import '../state/tmux_control_mode_setting.dart';
 import '../state/ui_prefs_providers.dart';
 
 class SettingsPanel extends ConsumerWidget {
@@ -21,6 +22,7 @@ class SettingsPanel extends ConsumerWidget {
     final keepalive = ref.watch(keepaliveEnabledProvider);
     final fontSize = ref.watch(fontSizeProvider);
     final backend = ref.watch(terminalBackendProvider);
+    final controlMode = ref.watch(tmuxControlModeProvider);
     final detection = ref.watch(detectionSettingsProvider);
     return ExpansionTile(
       key: const ValueKey('settings-section'),
@@ -112,6 +114,24 @@ class SettingsPanel extends ConsumerWidget {
             onSelectionChanged: (sel) =>
                 ref.read(terminalBackendProvider.notifier).set(sel.first),
           ),
+        ),
+        // #913 Part D: tmux control-mode (`tmux -CC`) opt-in. Default OFF — the
+        // proven screen-scrape path stays the default; enabling this drives
+        // `SshConnectCommand.controlMode` so NEW sessions enter control mode for
+        // authoritative window/size + real switch gestures. Read at connect time
+        // (restart-to-apply, like the engine selector). Monochrome outlined icon.
+        SwitchListTile(
+          key: const ValueKey('tmux-control-mode-toggle'),
+          secondary: const Icon(Icons.cable_outlined),
+          title: const Text('Terminal: tmux control mode (experimental)'),
+          subtitle: const Text(
+            'Drive tmux via control mode (-CC): authoritative windows/size + '
+            'real switch gestures. Requires tmux on the host. Applies to new '
+            'sessions / after a restart.',
+          ),
+          value: controlMode,
+          onChanged: (v) =>
+              ref.read(tmuxControlModeProvider.notifier).set(v),
         ),
         // #888 Part A: in-terminal structured-text DETECTION. Master switch +
         // per-type toggles (URLs, file paths). When a type is off, the flterm

--- a/native/test/ssh/proxy_control_mode_setting_test.dart
+++ b/native/test/ssh/proxy_control_mode_setting_test.dart
@@ -1,0 +1,142 @@
+// #913 Part D: the persisted tmux-control-mode SETTING drives the wire field.
+//
+// The UI proxy's `connect()` reads the per-isolate `tmuxControlMode` global at
+// connect time and carries it across the gateway as `SshConnectCommand.controlMode`
+// (Part C, #911). Part D makes the persisted SETTING the authoritative source for
+// that global (TmuxControlModeNotifier writes it on hydrate + set). These tests
+// drive the notifier (the real settings surface) and assert the proxy's connect
+// command carries the resulting bit: setting ON → `controlMode:true` on the wire;
+// setting OFF → the field is OMITTED (the shipped scrape wire shape is unchanged).
+//
+// Runs against an `InMemoryGatewayPair` (the same harness as proxy_resize_dedupe):
+// the proxy pushes a connect command onto the UI→task channel which we observe on
+// the task side and inspect for the `controlMode` key.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/state/tmux_control_mode_setting.dart';
+import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Map<String, dynamic>? _connectCmd(List<Map<String, dynamic>> seen) {
+  for (final p in seen) {
+    if (p['kind'] == SshTaskCommandKind.connect.name) return p;
+  }
+  return null;
+}
+
+const _params = SshConnectParams(
+  host: 'host',
+  port: 22,
+  username: 'user',
+  auth: SshAuth.password('secret'),
+);
+
+Future<void> _settleHydrate() =>
+    Future<void>.delayed(const Duration(milliseconds: 10));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late InMemoryGatewayPair pair;
+  late List<Map<String, dynamic>> seen;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    setTmuxControlModeForTest(false);
+    pair = InMemoryGatewayPair();
+    seen = <Map<String, dynamic>>[];
+    pair.taskSide.incoming.listen(seen.add);
+  });
+
+  tearDown(() async {
+    setTmuxControlModeForTest(false);
+    await pair.dispose();
+  });
+
+  Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+  test(
+    'setting OFF (default): connect omits controlMode (scrape wire unchanged)',
+    () async {
+      final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+      addTearDown(n.dispose);
+      await _settleHydrate();
+      expect(n.state, isFalse);
+
+      final proxy = SshSessionProxy(sessionId: 's1', gateway: pair.uiSide);
+      addTearDown(proxy.dispose);
+      await proxy.connect(_params);
+      await settle();
+
+      final cmd = _connectCmd(seen);
+      expect(cmd, isNotNull);
+      expect(
+        cmd!.containsKey('controlMode'),
+        isFalse,
+        reason: 'setting OFF must leave the wire shape unchanged — no extra '
+            'field, the shipped scrape path',
+      );
+    },
+  );
+
+  test('setting ON: connect carries controlMode:true on the wire', () async {
+    final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+    addTearDown(n.dispose);
+    await _settleHydrate();
+    // The owner enables the opt-in in Settings.
+    await n.set(true);
+    expect(tmuxControlMode, isTrue);
+
+    final proxy = SshSessionProxy(sessionId: 's1', gateway: pair.uiSide);
+    addTearDown(proxy.dispose);
+    await proxy.connect(_params);
+    await settle();
+
+    final cmd = _connectCmd(seen);
+    expect(cmd, isNotNull);
+    expect(
+      cmd!['controlMode'],
+      isTrue,
+      reason: 'enabling the persisted setting must make the next connect carry '
+          'control mode across the gateway',
+    );
+
+    // Round-trips back into a typed command with the bit set.
+    final restored = SshTaskCommand.fromJson(cmd) as SshConnectCommand;
+    expect(restored.controlMode, isTrue);
+  });
+
+  test('hydrated-ON setting drives connect with no explicit set()', () async {
+    SharedPreferences.setMockInitialValues({tmuxControlModePrefKey: true});
+    final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+    addTearDown(n.dispose);
+    await _settleHydrate();
+    expect(tmuxControlMode, isTrue);
+
+    final proxy = SshSessionProxy(sessionId: 's1', gateway: pair.uiSide);
+    addTearDown(proxy.dispose);
+    await proxy.connect(_params);
+    await settle();
+
+    expect(_connectCmd(seen)!['controlMode'], isTrue);
+  });
+
+  test('toggling OFF after ON reverts the wire to omitted', () async {
+    final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+    addTearDown(n.dispose);
+    await _settleHydrate();
+    await n.set(true);
+    await n.set(false);
+
+    final proxy = SshSessionProxy(sessionId: 's2', gateway: pair.uiSide);
+    addTearDown(proxy.dispose);
+    await proxy.connect(_params);
+    await settle();
+
+    expect(_connectCmd(seen)!.containsKey('controlMode'), isFalse);
+  });
+}

--- a/native/test/state/tmux_control_mode_setting_test.dart
+++ b/native/test/state/tmux_control_mode_setting_test.dart
@@ -1,0 +1,94 @@
+// Unit tests for the #913 persisted tmux-control-mode opt-in (Part D, epic #906).
+//
+// Locks the persisted-bool contract: default OFF, hydrate a stored true, set +
+// persist, and a corrupt/non-bool stored value falling back to the default (a
+// stale pref must never crash). Also asserts the notifier keeps the per-isolate
+// `tmuxControlMode` global in sync (hydrate + set) — that global is what the
+// proxy reads at connect time to populate `SshConnectCommand.controlMode`.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/tmux_control_mode_setting.dart';
+import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _settle() async {
+  // Let the StateNotifier _hydrate Future resolve.
+  await Future<void>.delayed(const Duration(milliseconds: 10));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    // Reset the per-isolate global so one test's ON state can't leak into the
+    // next (the shipped default — and every other suite — assumes OFF).
+    setTmuxControlModeForTest(false);
+  });
+
+  tearDown(() {
+    setTmuxControlModeForTest(false);
+  });
+
+  group('TmuxControlModeNotifier', () {
+    test('defaults OFF with no stored value', () async {
+      expect(tmuxControlModeDefault, isFalse);
+      final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n.state, isFalse);
+      // The global is seeded to the default immediately + after hydrate.
+      expect(tmuxControlMode, isFalse);
+    });
+
+    test('hydrates a stored true value + syncs the global', () async {
+      SharedPreferences.setMockInitialValues({
+        tmuxControlModePrefKey: true,
+      });
+      final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n.state, isTrue);
+      expect(
+        tmuxControlMode,
+        isTrue,
+        reason: 'hydrate must sync the global so the connect-time read carries '
+            'the persisted ON choice',
+      );
+    });
+
+    test('hydrate with a corrupt (non-bool) stored value keeps the default OFF',
+        () async {
+      // A legacy/garbage non-bool value: getBool returns null → default.
+      SharedPreferences.setMockInitialValues({
+        tmuxControlModePrefKey: 'yes',
+      });
+      final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n.state, isFalse);
+      expect(tmuxControlMode, isFalse);
+    });
+
+    test('set(true) updates state, persists, and flips the global', () async {
+      final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      await n.set(true);
+      expect(n.state, isTrue);
+      expect(tmuxControlMode, isTrue);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(tmuxControlModePrefKey), isTrue);
+    });
+
+    test('set(false) persists OFF and clears the global', () async {
+      SharedPreferences.setMockInitialValues({
+        tmuxControlModePrefKey: true,
+      });
+      final n = TmuxControlModeNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n.state, isTrue);
+      await n.set(false);
+      expect(n.state, isFalse);
+      expect(tmuxControlMode, isFalse);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(tmuxControlModePrefKey), isFalse);
+    });
+  });
+}

--- a/native/test/terminal/tmux_control_channel_test.dart
+++ b/native/test/terminal/tmux_control_channel_test.dart
@@ -19,6 +19,22 @@ void main() {
       expect(cmd, endsWith('\n'));
     });
 
+    test('entryCommand is attach-OR-create (#913) — never a bare attach', () {
+      // `new-session -A -s mobissh` attaches to an existing `mobissh` session if
+      // present, else CREATES it. A bare `attach` fails with "no sessions" on a
+      // host with no running tmux (e.g. a fresh test-sshd), so the rollout entry
+      // MUST be attach-or-create. Lock the exact string.
+      expect(
+        text(TmuxControlChannel.entryCommand),
+        'tmux -CC new-session -A -s mobissh\n',
+      );
+      expect(
+        text(TmuxControlChannel.entryCommand),
+        isNot(contains('attach')),
+        reason: 'a bare `attach` fails "no sessions" on a host without tmux',
+      );
+    });
+
     test('resizeCommand is the refresh-client -C single resize primitive', () {
       expect(
         text(TmuxControlChannel.resizeCommand(120, 40)),


### PR DESCRIPTION
## tmux control-mode Part D — settings toggle (default OFF) + attach-or-create entry

Part D (rollout) of the tmux control-mode arc (epic #906; parser #907 + render #909 + gestures #911, all merged flag-gated OFF). Exposes control mode behind a **persisted user setting (default OFF)** so the owner enables it on device. No global default-ON flip — that would force `tmux -CC` on every connect, breaking the suite + non-tmux hosts.

### What changed
- **Persisted setting** `TmuxControlModeNotifier` (`native/lib/state/tmux_control_mode_setting.dart`) — terminal_backend.dart idiom: injectable prefs, synchronous OFF default, best-effort hydrate/persist, schema-tolerant `getBool` fallback (corrupt → default), no key bump. Key `mobissh.ui.tmuxControlMode`.
- **Wire → connect:** the notifier keeps the per-isolate `tmuxControlMode` global in sync (hydrate + set). `SshSessionProxy.connect` already reads that global into `SshConnectCommand.controlMode` (Part C), so the persisted setting is the authoritative source feeding the wire field — one read, in the proxy. `connect_form` reads the provider at connect time to guarantee hydrate. Restart-of-session to apply (documented, like the engine selector).
- **Settings UI:** SwitchListTile near the Terminal engine selector — "Terminal: tmux control mode (experimental)", monochrome `Icons.cable_outlined`, subtext "Drive tmux via control mode (-CC): authoritative windows/size + real switch gestures. Requires tmux on the host."
- **Attach-or-create entry:** already `tmux -CC new-session -A -s mobissh` (attach if exists, else create — never a bare attach that fails "no sessions" on a tmux-less host). Added a unit assertion to lock the exact string.
- **`setTmuxControlModeForTest` unchanged** — cc_render / cc_gestures force control mode ON regardless of the setting.

### Tests
- Unit (fast gate, all green — 1427 tests): setting persists / default-OFF / corrupt-fallback + global sync; connect with setting ON sends `controlMode:true`, OFF omits it (scrape wire shape unchanged); attach-or-create entry string asserted.
- Emulator (written, orchestrator runs): `cc_setting_test.dart` — setting ON → fresh connect to test-sshd (no pre-existing tmux) engages control mode via `new-session -A` + renders, reusing cc_render assertions.

### Default OFF
Full existing suite unchanged + green; the shipped scrape path is byte-for-byte identical unless the owner opts in.

Refs #913 #906 #907 #909 #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)