### PR TITLE
fix(#918): force-repaint robustness layer (tap-Debug-fixes-it mitigation)

### DIFF
--- a/native/integration_test/force_repaint_robustness_918_test.dart
+++ b/native/integration_test/force_repaint_robustness_918_test.dart
@@ -1,0 +1,165 @@
+// #918 — force-repaint robustness layer, on the SCRAPE path (control-mode flag
+// OFF, the shipped default). The "tap Debug fixes it" symptom: the rendered grid
+// doesn't repaint until the user taps the Debug overlay (forcing a full Flutter
+// frame). This test asserts, end-to-end over the real SSH→host→flterm chain on the
+// DEFAULT backend (ghostty/flterm), that the layer self-heals the display:
+//
+//   1. INPUT-DRIVEN: a user input (a tap routed through the gesture router) leaves
+//      the flterm render box NEEDS-PAINT — i.e. the input forced a re-snapshot, the
+//      same full repaint the Debug overlay used to be needed for.
+//   2. OUTPUT SETTLE TICK ("backend clock"): an output burst forces a frame WITHIN
+//      the tick window — the render box's forced-repaint count advances shortly
+//      after fresh PTY bytes arrive, even with no further input.
+//   3. PERF GUARD (#805): when idle (no input, no output) the settle tick does NOT
+//      free-run — the forced-repaint count holds steady and the tick is disarmed.
+//
+// The shipped build keeps the control-mode flag OFF; this test runs on that default
+// scrape path, so it covers the robustness layer as users get it.
+//
+// Run: scripts/native-connect-test.sh integration_test/force_repaint_robustness_918_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' show TerminalRenderBox, TerminalRenderer;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart'
+    show GhosttyPointerGestureRouter;
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // `TerminalRenderBox` is a RenderObject (not a Widget), so it's reached via the
+  // `TerminalRenderer` LeafRenderObjectWidget's render object.
+  TerminalRenderBox? findRenderBox(WidgetTester tester) {
+    final renderers = find.byType(TerminalRenderer);
+    if (renderers.evaluate().isEmpty) return null;
+    final obj = tester.renderObject(renderers.first);
+    return obj is TerminalRenderBox ? obj : null;
+  }
+
+  testWidgets(
+    'scrape path: input forces a re-snapshot, an output burst forces a frame, '
+    'idle does not free-run (#918)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+      void send(String s) =>
+          entry.proxy.sendInput(Uint8List.fromList(utf8.encode(s)));
+
+      // Let the shell prompt paint so the flterm render box is laid out.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out, isNotEmpty, reason: 'shell never produced output');
+
+      final box = findRenderBox(tester);
+      expect(box, isNotNull,
+          reason: 'flterm TerminalRenderBox not found — wrong backend? (ghostty '
+              'is the default)');
+
+      // Let any startup output settle so we measure from a QUIET baseline.
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+
+      // 1) INPUT-DRIVEN: a tap (routed through the gesture router → onTap →
+      //    _forceTerminalRepaint) must leave the render box needs-paint, i.e. the
+      //    forced-repaint count advances on input.
+      final forcedBeforeTap = box!.debugForceRepaintCount;
+      await tester.tap(find.byType(GhosttyPointerGestureRouter).first,
+          warnIfMissed: false);
+      await tester.pump();
+      expect(box.debugForceRepaintCount, greaterThan(forcedBeforeTap),
+          reason: 'a tap did not force a re-snapshot (input-driven repaint) — the '
+              'view would stay stale until a Debug-overlay tap');
+
+      // 2) OUTPUT SETTLE TICK: fresh PTY output must force a frame WITHIN the tick
+      //    window (~80ms) even with NO further input.
+      for (var i = 0; i < 4; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      final forcedBeforeOutput = box.debugForceRepaintCount;
+      send('echo FORCE_REPAINT_918\n');
+      // Wait for the bytes to arrive + the settle window to elapse.
+      var ticked = false;
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+        if (box.debugForceRepaintCount > forcedBeforeOutput) {
+          ticked = true;
+          break;
+        }
+      }
+      expect(ticked, isTrue,
+          reason: 'an output burst did not force a frame via the settle tick — '
+              'the backend-clock half of the robustness layer');
+
+      // 3) PERF GUARD (#805): with no input and no output, the tick must NOT
+      //    free-run. Let everything settle, then idle for many frames and assert
+      //    the forced count holds steady and the tick is disarmed.
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      final forcedAtIdleStart = box.debugForceRepaintCount;
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(box.debugForceRepaintCount, forcedAtIdleStart,
+          reason: 'the settle tick free-ran while idle — regresses the #805 '
+              'battery guard (idle must be zero repaints)');
+      expect(box.debugOutputTickArmed, isFalse,
+          reason: 'the output tick stayed armed while idle (free-run risk)');
+
+      debugPrint(
+        'FORCE_REPAINT_918 scrape path: input-driven OK, output tick OK, '
+        'idle steady at ${box.debugForceRepaintCount} forced repaints',
+      );
+    },
+  );
+}

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -1971,6 +1971,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// painter use — without re-reading the per-session font providers off-build.
   Size _lastCellSize = Size.zero;
 
+  /// #918: a key on the flterm [TerminalView] so [_forceTerminalRepaint] can locate
+  /// the internal [TerminalRenderBox] via the render tree and force a full repaint
+  /// after dispatching user input (the input-driven half of the robustness layer).
+  final GlobalKey _terminalViewKey = GlobalKey();
+
   /// #755/#767: the session theme's selection colour, captured in [build] from
   /// the live palette. #767 Slice B: it colours the URL BUBBLE decorator (a
   /// rounded outline, not a fill), recomputed each build so cycling the session
@@ -2134,6 +2139,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         // so this is the seam that reveals "swipe → wheel events → tmux scrolled".
         _byteRecorder.recordSentSgr(sent);
         proxy.sendInput(sent);
+        // #918: force a full re-snapshot + repaint after dispatching this input
+        // (soft-keyboard key, IME commit, paste, keybar key — all flow through
+        // controller.onOutput). The UI self-heals on every keystroke even if the
+        // damage/frame path dropped the redraw. Coalesced to once per frame.
+        _forceTerminalRepaint();
       };
       // Grid resize -> PTY resize. flterm reports (cols, rows); the proxy's
       // pixel sizes default to 0 (the task isolate only needs cols/rows). Also
@@ -2583,6 +2593,43 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     //    focus is currently held; never raises the keyboard (the keyboard is down
     //    on resume, so `_onFocusChanged` re-attaches the input but does NOT show).
     _forceRepaintOnResume();
+  }
+
+  /// #918: force the flterm render box to re-snapshot + repaint the FULL visible
+  /// grid — the SAME full repaint a route-push / Debug-overlay triggers — after
+  /// dispatching ANY user input to the PTY (key / tap / gesture / paste / keybar).
+  ///
+  /// The UI then self-heals on every interaction: if the normal libghostty
+  /// damage/frame-sync path dropped a redraw (the "tap Debug fixes it" symptom), the
+  /// next input forces it. This is a brute-force SAFETY NET on top of the #900
+  /// damage-consume correctness fix — it does NOT replace it.
+  ///
+  /// The host widget owns only the [TerminalController]; the [TerminalRenderBox] is
+  /// an internal leaf of flterm's [TerminalView]. We locate it via the keyed
+  /// TerminalView's render object and call [TerminalRenderBox.forceRepaint], which
+  /// COALESCES to at most one bounded grid re-read per frame, so dispatching several
+  /// inputs in one frame forces only once.
+  void _forceTerminalRepaint() {
+    final box = _findTerminalRenderBox();
+    box?.forceRepaint();
+  }
+
+  /// #918: walk the render subtree under the keyed [TerminalView] to the
+  /// [TerminalRenderBox] leaf. Returns null before the first layout (no render
+  /// object yet) or if the box can't be found — the caller no-ops.
+  TerminalRenderBox? _findTerminalRenderBox() {
+    final renderObject = _terminalViewKey.currentContext?.findRenderObject();
+    if (renderObject == null) return null;
+    return _searchRenderBox(renderObject);
+  }
+
+  TerminalRenderBox? _searchRenderBox(RenderObject node) {
+    if (node is TerminalRenderBox) return node;
+    TerminalRenderBox? found;
+    node.visitChildren((child) {
+      found ??= _searchRenderBox(child);
+    });
+    return found;
   }
 
   /// #720: force flterm to repaint on resume even when focus was RETAINED.
@@ -3125,6 +3172,8 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       children: [
         Positioned.fill(
           child: TerminalView(
+            // #918: keyed so _forceTerminalRepaint can locate the render box.
+            key: _terminalViewKey,
             controller: controller,
             autofocus: false,
             theme: theme,
@@ -3231,6 +3280,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
                 controller.hideKeyboard();
                 controller.showKeyboard();
               });
+              // #918: a tap is user input — force the full repaint so the view
+              // self-heals on tap (the same gesture the Debug overlay used to need).
+              _forceTerminalRepaint();
             },
             // Long-press-start focuses without raising the keyboard (selection).
             onFocus: controller.requestFocus,
@@ -3244,6 +3296,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
               // SGR-mouse bytes — never keystrokes).
               _byteRecorder.recordSentSgr(bytes);
               proxy.sendInput(bytes);
+              // #918: a synthesised mouse report (tap-click / wheel / selection
+              // drag) is user input — force the full repaint.
+              _forceTerminalRepaint();
             },
             // #911 Part C: under the control-mode flag, window switching uses REAL
             // tmux commands over the -CC channel (no synthesised SGR at a guessed
@@ -3258,6 +3313,10 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
                     ? TmuxWindowGesture.nextWindow
                     : TmuxWindowGesture.previousWindow,
               );
+              // #918: a window-switch swipe is user input — force the full repaint
+              // so the switched window's grid re-reads on EVERY swipe (the historic
+              // "works/fails/works" alternation the Debug tap masked).
+              _forceTerminalRepaint();
             },
             onStatusTap: ({required int col, required int totalCols}) {
               final proxy = _resolveProxy();
@@ -3268,6 +3327,8 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
                 statusCol: col,
                 statusCols: totalCols,
               );
+              // #918: a status-row tap (tmux window select) is user input.
+              _forceTerminalRepaint();
             },
             // #705: long-press-drag drives flterm's LOCAL selection (persists
             // after release → Copy reads it), not a tmux SGR drag.

--- a/native/third_party/flterm/lib/flterm.dart
+++ b/native/third_party/flterm/lib/flterm.dart
@@ -53,6 +53,11 @@ export 'src/foundation/terminal_theme.dart'
         HyperlinkTheme,
         SelectionTheme,
         TerminalTheme;
+// #918: expose the render box so the host widget can force a full repaint
+// (`forceRepaint()`) after dispatching user input — the input-driven half of the
+// force-repaint robustness layer.
+export 'src/rendering/terminal_renderer.dart'
+    show TerminalRenderBox, TerminalRenderer;
 export 'src/widgets/terminal_controller.dart' show TerminalController;
 export 'src/widgets/terminal_scope.dart' show TerminalScope;
 export 'src/widgets/terminal_scroll_controller.dart'

--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:libghostty/libghostty.dart';
@@ -176,6 +178,33 @@ class TerminalRenderBox extends RenderBox {
   var _lastScrollbackRows = 0;
   var _preeditText = '';
 
+  // #918 force-repaint robustness layer (the "tap Debug fixes it" mitigation).
+  //
+  // INPUT-DRIVEN: [forceRepaint] re-reads the FULL visible grid (markAllRowsDirty
+  // + frame-dirty) — the SAME full repaint a route-push / Debug-overlay triggers —
+  // coalesced to AT MOST ONCE per frame: a force sets `_forceCoalesced`, and the
+  // next paint's `_syncFrameState` clears it, so N forces within one frame collapse
+  // to one re-snapshot. This is a SAFETY NET on top of the #900 damage-consume fix.
+  //
+  // OUTPUT SETTLE TICK ("backend clock"): a PTY-output burst arms a one-shot timer
+  // ([_outputSettleTimer]) that fires ONCE ~60ms after the burst and forces a frame,
+  // covering non-user-initiated output the normal damage/frame path dropped. It MUST
+  // NOT free-run when idle (no input, no output) — that regresses the #805 battery
+  // perf guard — so it arms ONLY on a content-change notify and disarms after one fire.
+  var _forceCoalesced = false;
+  var _debugForceRepaintCount = 0;
+  Timer? _outputSettleTimer;
+
+  /// The settle window between the LAST output byte and the forced frame. Long
+  /// enough to coalesce a streaming burst into one tick, short enough to self-heal
+  /// promptly. Bounded; the alternate/visible grid re-read is cheap.
+  static const Duration kOutputSettle = Duration(milliseconds: 80);
+
+  /// Injectable settle-timer factory (test seam). Production schedules a real
+  /// [Timer]; headless tests inject a fake so the tick fires deterministically and
+  /// the #805 idle-no-fire perf guard is assertable.
+  Timer Function(Duration, void Function()) _scheduleSettleTimer = Timer.new;
+
   final TerminalPaintState _paintState;
   late final TerminalRenderPipeline _pipeline;
 
@@ -235,6 +264,45 @@ class TerminalRenderBox extends RenderBox {
   /// in-place alt-screen redraw (tmux window switch) must re-read the visible
   /// grid on EVERY switch, not every other one.
   int get debugRowsRebuiltLastSync => _pipeline.debugRowsRebuiltLastSync;
+
+  /// #918 (test seam): how many times [forceRepaint] actually triggered a forced
+  /// re-snapshot. Coalescing means N forces within one frame increment this once.
+  int get debugForceRepaintCount => _debugForceRepaintCount;
+
+  /// #918 (test seam): whether the output settle tick is currently armed (a timer
+  /// is pending). The #805 perf guard asserts this is FALSE when idle.
+  bool get debugOutputTickArmed => _outputSettleTimer != null;
+
+  /// #918 (test seam): inject the settle-timer factory so headless tests fire the
+  /// output tick deterministically and assert the idle-no-fire perf guard.
+  void debugSetOutputSettleTickFactory(
+    Timer Function(Duration, void Function()) factory,
+  ) {
+    _scheduleSettleTimer = factory;
+  }
+
+  /// #918 INPUT-DRIVEN force-repaint — re-read the FULL visible grid and repaint,
+  /// the SAME full repaint a route-push / Debug-overlay triggers.
+  ///
+  /// Called by the widget layer after dispatching ANY user input to the PTY (key,
+  /// tap, gesture, paste, keybar) so the UI self-heals on every interaction even if
+  /// the normal libghostty damage/frame-sync path dropped the redraw (#900 is the
+  /// correctness fix; this is the brute-force net on top). `markAllRowsDirty` makes
+  /// the next sync's frame build re-read every visible row from the CURRENT snapshot
+  /// even when libghostty reports clean (a prior frame consumed the per-row damage);
+  /// `_markFrameDirty` sets `_needsFrameSync` + `markNeedsPaint`.
+  ///
+  /// COALESCED to once per frame: multiple inputs landing within a single frame set
+  /// the flag once, and the next paint clears it — so we never force more than one
+  /// bounded grid re-read per frame.
+  void forceRepaint() {
+    if (_paintState.rows == 0) return;
+    if (_forceCoalesced) return;
+    _forceCoalesced = true;
+    _debugForceRepaintCount += 1;
+    _pipeline.markAllRowsDirty();
+    _markFrameDirty();
+  }
 
   /// Current terminal input caret rect in this render box's local coordinates.
   Rect get textInputCaretRect {
@@ -367,6 +435,10 @@ class TerminalRenderBox extends RenderBox {
 
   @override
   void detach() {
+    // #918: a detached box must not keep a pending settle tick alive (no free-run
+    // off-screen).
+    _outputSettleTimer?.cancel();
+    _outputSettleTimer = null;
     _offset.removeListener(_onScroll);
     _renderObserver.removeListener(_onRenderObserverChanged);
     _terminal.removeListener(_onTerminalChanged);
@@ -375,6 +447,8 @@ class TerminalRenderBox extends RenderBox {
 
   @override
   void dispose() {
+    _outputSettleTimer?.cancel();
+    _outputSettleTimer = null;
     _paintState.rows = 0;
     _paintState.cols = 0;
     _pipeline.dispose();
@@ -500,6 +574,23 @@ class TerminalRenderBox extends RenderBox {
     markNeedsPaint();
   }
 
+  /// #918: arm the one-shot output settle tick. Cancels any pending timer and
+  /// reschedules, so a streaming burst of notifies coalesces into a SINGLE forced
+  /// frame fired once the output quiets for [kOutputSettle]. Disarms on fire. Called
+  /// ONLY from `_onTerminalChanged`, so an idle terminal never arms it (#805 guard).
+  void _armOutputSettleTick() {
+    _outputSettleTimer?.cancel();
+    _outputSettleTimer = _scheduleSettleTimer(kOutputSettle, _onOutputSettled);
+  }
+
+  /// #918: the output settle tick fired — force ONE full frame and disarm. The
+  /// `markAllRowsDirty` re-reads the visible grid so the latest snapshot reaches the
+  /// screen even when libghostty's damage was consumed by a prior frame.
+  void _onOutputSettled() {
+    _outputSettleTimer = null;
+    forceRepaint();
+  }
+
   void _onRenderObserverChanged() {
     final previousSelection = _paintState.selection;
     final newSelection = _renderObserver.selection;
@@ -616,6 +707,15 @@ class TerminalRenderBox extends RenderBox {
     // scrollback growth) is untouched.
     if (_terminal.activeScreen == .alternate) _pipeline.markAllRowsDirty();
 
+    // #918 OUTPUT SETTLE TICK: a content-change notify is driven by PTY output (or
+    // a local edit). Arm a one-shot timer that forces ONE full frame ~80ms after the
+    // burst quiets, guaranteeing the snapshot reaches the screen even if the normal
+    // damage/frame path dropped it. Re-arming on each notify coalesces a streaming
+    // burst into a single trailing tick. It fires ONCE then disarms (see `_fire`),
+    // and is armed ONLY from this notify — so when idle (no output, no input) it
+    // never schedules or fires: zero repaints (the #805 battery perf guard).
+    _armOutputSettleTick();
+
     // `markNeedsLayout()` is the ONLY part that is illegal during layout (it
     // throws "called during layout"), and it is redundant then anyway — we are
     // already in a layout pass that will recompute scroll extents. So request a
@@ -668,6 +768,9 @@ class TerminalRenderBox extends RenderBox {
 
     final terminalDirty = _needsFrameSync;
     _needsFrameSync = false;
+    // #918: this frame consumed any coalesced force-repaint; a fresh input after
+    // this paint may force again (once per frame).
+    _forceCoalesced = false;
     _pipeline.sync(
       _terminal,
       terminalDirty: terminalDirty,

--- a/native/third_party/flterm/test/rendering/force_repaint_robustness_918_test.dart
+++ b/native/third_party/flterm/test/rendering/force_repaint_robustness_918_test.dart
@@ -1,0 +1,248 @@
+@Tags(['ffi'])
+library;
+
+// #918 — force-repaint robustness layer (the "tap Debug fixes it" mitigation).
+//
+// The recurring symptom: the rendered grid doesn't repaint until the user taps the
+// Debug overlay, which forces a full Flutter frame + grid re-snapshot. The fix layers
+// a SAFETY NET on top of the #900 damage-consume fix:
+//
+//   1. INPUT-DRIVEN: `TerminalRenderBox.forceRepaint()` re-reads the FULL visible grid
+//      (markAllRowsDirty + frame-dirty) — the SAME full repaint a Debug-overlay / route
+//      push triggers — coalesced to AT MOST ONCE per frame.
+//   2. OUTPUT SETTLE TICK ("backend clock"): a PTY-output burst arms a one-shot timer
+//      that fires ONCE ~60ms after the burst and forces a frame, even if the normal
+//      damage/frame path dropped it. It MUST NOT free-run when idle (no input, no
+//      output) — that regresses the #805 battery perf guard. Idle = zero forced frames.
+//
+// These tests drive the render box directly (a real `TerminalRenderBox` is mounted via
+// `TerminalRenderer`, the same harness as terminal_renderer_test.dart) with an INJECTED
+// settle-timer factory so the tick is deterministic headless.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+import 'helpers/font_loader.dart';
+
+void main() {
+  setUpAll(loadBundledFonts);
+
+  const cols = 16;
+  const rows = 4;
+  const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+  TerminalRenderCache createRenderCache() {
+    final cache = TerminalRenderCache();
+    addTearDown(cache.dispose);
+    return cache;
+  }
+
+  void writeUtf8(Terminal terminal, String text) {
+    terminal.write(Uint8List.fromList(utf8.encode(text)));
+  }
+
+  Widget wrap(Terminal terminal, {TerminalRenderCache? renderCache}) {
+    renderCache ??= createRenderCache();
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Align(
+        alignment: Alignment.topLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: cols * metrics.cellWidth,
+            maxHeight: rows * metrics.cellHeight,
+          ),
+          child: TerminalRenderer(
+            terminal: terminal,
+            theme: TerminalTheme.dark(),
+            metrics: metrics,
+            offset: ViewportOffset.zero(),
+            renderCache: renderCache,
+            renderObserver: _TestRenderObserver(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  late Terminal terminal;
+
+  setUp(() => terminal = Terminal(cols: cols, rows: rows));
+  tearDown(() => terminal.dispose());
+
+  group('TerminalRenderBox.forceRepaint (#918 input-driven)', () {
+    testWidgets(
+      'forceRepaint re-reads the FULL visible grid on the next sync, immune to '
+      'consumed libghostty damage (the Debug-tap full repaint)',
+      (tester) async {
+        await tester.pumpWidget(wrap(terminal));
+        final box = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+
+        // Draw + paint window A.
+        writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
+        for (var r = 1; r <= rows; r++) {
+          writeUtf8(terminal, '\x1b[$r;1Hwindow A row $r       ');
+        }
+        await tester.pump();
+
+        // In-place redraw to window B, then a paint that CONSUMES the damage
+        // (cursor blink / offset correction) before forceRepaint runs.
+        for (var r = 1; r <= rows; r++) {
+          writeUtf8(terminal, '\x1b[$r;1Hwindow B row $r       ');
+        }
+        await tester.pump();
+
+        // forceRepaint must re-read EVERY visible row on the next sync, even if a
+        // prior paint already consumed the per-row damage.
+        box.forceRepaint();
+        await tester.pump();
+
+        expect(
+          box.debugRowsRebuiltLastSync,
+          rows,
+          reason: 'forceRepaint re-reads the full visible grid (markAllRowsDirty)',
+        );
+      },
+    );
+
+    testWidgets(
+      'forceRepaint coalesces: many calls within one frame trigger at most one '
+      'forced re-snapshot (bounded — never more than once per frame)',
+      (tester) async {
+        await tester.pumpWidget(wrap(terminal));
+        final box = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        final before = box.debugForceRepaintCount;
+
+        // Five inputs land within the SAME frame.
+        for (var i = 0; i < 5; i++) {
+          box.forceRepaint();
+        }
+        await tester.pump();
+
+        expect(
+          box.debugForceRepaintCount - before,
+          1,
+          reason: 'multiple forceRepaint calls in one frame coalesce to one',
+        );
+      },
+    );
+  });
+
+  group('TerminalRenderBox output settle tick (#918 backend clock)', () {
+    testWidgets(
+      'a PTY-output burst ARMS the one-shot settle tick; firing it forces a full '
+      'frame re-read',
+      (tester) async {
+        final scheduled = <void Function()>[];
+        await tester.pumpWidget(wrap(terminal));
+        // Let any mount-time settle tick (the initial grid populate) elapse with
+        // the real timer, so we assert on a QUIET baseline.
+        await tester.pump(const Duration(milliseconds: 200));
+        final box = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        box.debugSetOutputSettleTickFactory(
+          (_, cb) {
+            scheduled.add(cb);
+            // A no-op timer captured for the box's `_outputSettleTimer` handle;
+            // cancel it immediately so it never lands as a pending timer at
+            // teardown — the test fires `cb` itself to model the window elapsing.
+            return Timer(const Duration(days: 1), () {})..cancel();
+          },
+        );
+
+        expect(box.debugOutputTickArmed, isFalse,
+            reason: 'idle (settled) before any new output: tick not armed');
+
+        // Output burst.
+        writeUtf8(terminal, 'streaming output line\r\n');
+        await tester.pump();
+
+        expect(box.debugOutputTickArmed, isTrue,
+            reason: 'output arms the settle tick');
+        expect(scheduled, isNotEmpty,
+            reason: 'a timer was scheduled by the output burst');
+
+        final forcedBefore = box.debugForceRepaintCount;
+        // Fire the settle timer (simulating the ~60ms window elapsing).
+        for (final cb in scheduled) {
+          cb();
+        }
+        await tester.pump();
+
+        expect(box.debugForceRepaintCount, greaterThan(forcedBefore),
+            reason: 'the settle tick forces a frame');
+        expect(box.debugOutputTickArmed, isFalse,
+            reason: 'the tick fires ONCE then disarms (no free-run)');
+      },
+    );
+
+    testWidgets(
+      'PERF GUARD (#805): when idle (no input, no output) the settle tick NEVER '
+      'arms or fires — zero forced repaints',
+      (tester) async {
+        final scheduled = <void Function()>[];
+        await tester.pumpWidget(wrap(terminal));
+        // Let the mount-time settle tick (initial grid populate) elapse with the
+        // real timer, so we measure a QUIET baseline.
+        await tester.pump(const Duration(milliseconds: 200));
+        final box = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        box.debugSetOutputSettleTickFactory(
+          (_, cb) {
+            scheduled.add(cb);
+            return Timer(const Duration(days: 1), () {})..cancel();
+          },
+        );
+
+        final forcedBefore = box.debugForceRepaintCount;
+
+        // Idle: several frames with NO output and NO input.
+        for (var i = 0; i < 10; i++) {
+          await tester.pump(const Duration(milliseconds: 16));
+        }
+
+        expect(box.debugOutputTickArmed, isFalse,
+            reason: 'idle never arms the tick');
+        expect(scheduled, isEmpty,
+            reason: 'idle schedules no settle timer (no free-run)');
+        expect(box.debugForceRepaintCount, forcedBefore,
+            reason: 'idle produces zero forced repaints (#805 battery guard)');
+      },
+    );
+  });
+}
+
+class _TestRenderObserver implements TerminalRenderObserver {
+  @override
+  TerminalSelection? get selection => null;
+
+  @override
+  bool get hasFocus => true;
+
+  @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
+  void reportPaintedViewportOffset(int offset) {}
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+}


### PR DESCRIPTION
## #918 — force-repaint robustness layer (the "tap Debug fixes it" mitigation)

The terminal sometimes didn't repaint until the user tapped the Debug overlay (which route-pushes and forces a full Flutter frame + grid re-snapshot, masking the libghostty single-consumption damage gap #900). This layers a SAFETY NET on top of the #900 correctness fix so the UI self-heals on every interaction.

### What changed
**Render box** (`native/third_party/flterm/lib/src/rendering/terminal_renderer.dart`):
- public `TerminalRenderBox.forceRepaint()` — `markAllRowsDirty` + frame-dirty (the SAME full re-snapshot a route-push / Debug-overlay triggers), COALESCED to at most once per frame.
- output settle tick ("backend clock") — a one-shot timer armed in `_onTerminalChanged`; fires once ~80ms after an output burst quiets, forces a frame, then disarms. Armed ONLY on a content-change notify, so an idle terminal never schedules or fires it (the #805 battery perf guard: idle = zero repaints).
- injectable settle-timer factory + debug seams; cancel the tick on detach/dispose.

**Widget** (`native/lib/ui/ghostty_terminal_view.dart`):
- after dispatching ANY user input to the PTY (key/IME/paste via `controller.onOutput`, tap, mouse-report, window-switch swipe, status-tap), force the render box to re-snapshot + repaint. The widget holds only the controller, so it locates the internal `TerminalRenderBox` via a GlobalKey on `TerminalView` + a `visitChildren` walk.

**flterm barrel** (`flterm.dart`): export `TerminalRenderBox`/`TerminalRenderer` so the host widget can reach the render box.

This is a brute-force mitigation, NOT a fix of the #900 damage-consume correctness — the existing damage/frame-sync path is left intact. Ships independent of the tmux control-mode arc (flag OFF by default).

### Tests (TDD red→green)
- **flterm unit** (`test/rendering/force_repaint_robustness_918_test.dart`): forceRepaint re-reads the full grid immune to consumed damage; coalesces once/frame; output tick arms/fires-once/disarms; **PERF GUARD** idle never arms/fires (#805).
- **emulator integration** (`integration_test/force_repaint_robustness_918_test.dart`, scrape path / control-mode flag OFF): a tap forces a re-snapshot, an output burst forces a frame within the tick window, and idle holds steady (no free-run).

### Validation
- Emulator integration test PASSED on `emulator-5554` (`input-driven OK, output tick OK, idle steady at 6 forced repaints`).
- Native fast gate green (analyze + 1436 unit/widget tests).
- Full flterm rendering suite green (126 tests incl. the #900 alternation test).

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)