### PR TITLE
fix(#921): detection ON froze primary-screen repaint

### DIFF
--- a/native/integration_test/detection_repaint_921_test.dart
+++ b/native/integration_test/detection_repaint_921_test.dart
@@ -1,0 +1,187 @@
+// #921 — with detect-URLs ON the terminal does NOT repaint on the PRIMARY
+// screen; with detection OFF it paints. tmux control mode is OFF and irrelevant.
+//
+// ROOT (same single-consumption libghostty damage as #900, now on the PRIMARY
+// screen): detection ON registers a second libghostty `RenderState` consumer and
+// drives an EXTRA content notify per output change, so the render box's frame
+// builder syncs the SAME handle twice for one change — the first sync consumes
+// the per-row damage, the second reads CLEAN and its partial build re-emits NO
+// rows, freezing the grid. The #900 fix's full-re-read gate was alternate-screen
+// only, so the primary screen had no guard. FIX (#921): force a full visible-grid
+// re-read on the primary screen too, but ONLY while detection is active
+// (`TerminalRenderBox.detectionActive`), wired from the URL/path pattern
+// registration. #805 streaming perf (detection OFF) is untouched.
+//
+// This is the device-class assertion a headless test cannot make: it drives the
+// REAL SSH→host→flterm chain on the DEFAULT scrape path (control-mode flag OFF),
+// detection ON, and asserts that FRESH PTY output with NO user input repaints the
+// visible grid (the render box re-reads rows). It also keeps the #805 idle
+// no-free-run guard. Reuses the #918 render-box access + connect helpers.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/detection_repaint_921_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' show TerminalRenderBox, TerminalRenderer;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // `TerminalRenderBox` is a RenderObject (not a Widget), so it's reached via the
+  // `TerminalRenderer` LeafRenderObjectWidget's render object.
+  TerminalRenderBox? findRenderBox(WidgetTester tester) {
+    final renderers = find.byType(TerminalRenderer);
+    if (renderers.evaluate().isEmpty) return null;
+    final obj = tester.renderObject(renderers.first);
+    return obj is TerminalRenderBox ? obj : null;
+  }
+
+  testWidgets(
+    'scrape path, detection ON: fresh output with NO user input repaints the '
+    'primary-screen grid; idle does not free-run (#921)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      // Default detection settings (all-true) — detection ON, the exact #921
+      // failing condition.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Make sure detection (URLs) is ON for this run regardless of any stored
+      // setting from a prior run on the same data dir.
+      await container.read(detectionSettingsProvider.notifier).setUrl(true);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 80; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+      void send(String s) =>
+          entry.proxy.sendInput(Uint8List.fromList(utf8.encode(s)));
+
+      // Let the shell prompt paint so the flterm render box is laid out.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out, isNotEmpty, reason: 'shell never produced output');
+
+      final box = findRenderBox(tester);
+      expect(box, isNotNull,
+          reason: 'flterm TerminalRenderBox not found — wrong backend? (ghostty '
+              'is the default)');
+
+      // The fix wires detectionActive from the URL/path pattern registration.
+      // Give the post-frame wiring a few frames to apply, then assert it is ON.
+      for (var i = 0; i < 20 && !box!.detectionActive; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(box!.detectionActive, isTrue,
+          reason: 'detectionActive was never wired onto the render box with URL '
+              'detection ON — the #921 primary-screen full-re-read guard would '
+              'never engage');
+
+      // Let startup output settle so we measure from a QUIET baseline.
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+
+      // CORE #921 ASSERTION: fresh PTY output with NO user input must repaint the
+      // visible grid even with detection ON (the competing detection sync would
+      // otherwise consume the damage and freeze the grid). The render box must
+      // re-read rows within the settle window after the bytes arrive.
+      var repainted = false;
+      send('echo DETECT_REPAINT_921\n');
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+        if (box.debugRowsRebuiltLastSync > 0) {
+          repainted = true;
+          break;
+        }
+      }
+      expect(repainted, isTrue,
+          reason: 'with detection ON, fresh output with no user input did NOT '
+              'repaint the primary-screen grid (the #921 paint freeze) — the '
+              'render box re-read zero rows after new PTY bytes');
+
+      // Stream several more lines (no user input) and confirm the grid keeps
+      // repainting — the device repro is streaming output / window churn.
+      for (var n = 0; n < 4; n++) {
+        send('printf "stream line %d https://example.com/p%d\\n" $n $n\n');
+        var sawRebuild = false;
+        for (var i = 0; i < 20; i++) {
+          await tester.pump(const Duration(milliseconds: 100));
+          if (box.debugRowsRebuiltLastSync > 0) {
+            sawRebuild = true;
+            break;
+          }
+        }
+        expect(sawRebuild, isTrue,
+            reason: 'streaming output line $n with detection ON did not repaint '
+                'the grid (#921)');
+      }
+
+      // PERF GUARD (#805): with no input and no output, the full re-read must NOT
+      // free-run. Let everything settle, then idle and assert the output tick is
+      // disarmed (the primary full-re-read fires only on a content notify).
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(box.debugOutputTickArmed, isFalse,
+          reason: 'the output tick stayed armed while idle — the #921 primary '
+              'full-re-read must fire only on a content notify, never free-run '
+              '(the #805 battery guard)');
+
+      debugPrint(
+        'DETECT_REPAINT_921 scrape path: detectionActive ON, fresh-output '
+        'repaint OK, streaming repaint OK, idle tick disarmed',
+      );
+    },
+  );
+}

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -2325,6 +2325,16 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // URL.
       controller.registerTextPattern(TextPattern.path(id: _kPathPatternId));
     }
+    // #921: tell the render box whether detection is now active. Active means the
+    // controller's detection RenderState handle competes to consume the shared
+    // terminal damage, so the PRIMARY screen must force a full re-read on content
+    // change to keep repainting. Deferred to a post-frame callback so the keyed
+    // render box exists (this runs from initState-time registration before first
+    // layout, where the box lookup would no-op).
+    final detectionActive = detection.detectUrls || detection.detectPaths;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _applyDetectionActive(detectionActive);
+    });
   }
 
   /// #712: mirror whether a selection is active into [_hasSelection], rebuilding
@@ -2612,6 +2622,22 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   void _forceTerminalRepaint() {
     final box = _findTerminalRenderBox();
     box?.forceRepaint();
+  }
+
+  /// #921: mirror whether structured-text DETECTION is active onto the flterm
+  /// render box. When detection is active a SECOND libghostty `RenderState`
+  /// handle (the controller's, registered BEFORE the render box) consumes the
+  /// shared terminal's per-row damage on the same synchronous notify, starving
+  /// the render box's partial build so the PRIMARY screen stops repainting (the
+  /// detection-ON paint freeze). Setting [TerminalRenderBox.detectionActive]
+  /// makes the primary screen force a full visible-grid re-read on each content
+  /// change (the same decoupling the #900 fix uses for the alternate screen), so
+  /// the paint is immune to that consume. Reached via the same #918 keyed
+  /// render-box lookup; no-ops before first layout (the next registration after
+  /// layout re-applies it).
+  void _applyDetectionActive(bool active) {
+    final box = _findTerminalRenderBox();
+    box?.detectionActive = active;
   }
 
   /// #918: walk the render subtree under the keyed [TerminalView] to the

--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -178,6 +178,19 @@ class TerminalRenderBox extends RenderBox {
   var _lastScrollbackRows = 0;
   var _preeditText = '';
 
+  // #921: whether structured-text DETECTION (URL/path patterns) is registered on
+  // the controller. When true, a SECOND libghostty `RenderState` handle (the
+  // controller's detection handle) competes to consume the shared terminal's
+  // per-row damage — and registers its listener BEFORE this render box, so on a
+  // synchronous content notify it consumes the damage before this box's
+  // `_onTerminalChanged` runs, leaving the partial build with nothing to re-read.
+  // When this is set, the PRIMARY screen forces a full visible-grid re-read on
+  // each content change (the same decoupling the #900 fix uses for the alternate
+  // screen) so the paint is immune to that single-consumption race. Default false
+  // keeps the detection-OFF streaming-output path (#805) on the partial-rebuild
+  // path with no extra work.
+  var _detectionActive = false;
+
   // #918 force-repaint robustness layer (the "tap Debug fixes it" mitigation).
   //
   // INPUT-DRIVEN: [forceRepaint] re-reads the FULL visible grid (markAllRowsDirty
@@ -239,6 +252,29 @@ class TerminalRenderBox extends RenderBox {
 
     _applyTerminalThemeColors();
   }
+
+  /// #921: whether structured-text detection is currently active. The widget
+  /// layer sets this when at least one detect pattern (URL/path) is registered
+  /// on the controller and clears it when patterns are cleared. When active, the
+  /// primary screen forces a full visible-grid re-read on content change (see
+  /// [_detectionActive]).
+  bool get detectionActive => _detectionActive;
+
+  set detectionActive(bool value) {
+    if (_detectionActive == value) return;
+    _detectionActive = value;
+    // Turning detection ON: a fresh full re-read self-heals any frame that the
+    // detection-driven extra sync's damage-consume already starved before this
+    // flag was set (the live toggle / first-registration case). Bounded to
+    // visible rows.
+    if (value) {
+      _pipeline.markAllRowsDirty();
+      _markFrameDirty();
+    }
+  }
+
+  /// #921 (test seam): the current detection-active flag.
+  bool get debugDetectionActive => _detectionActive;
 
   bool get blinkVisible => _paintState.blinkVisible;
 
@@ -705,7 +741,19 @@ class TerminalRenderBox extends RenderBox {
     // app redraw. This is scoped to the alternate screen, so #805's primary-screen
     // streaming-output perf path (which relies on partial per-row rebuilds during
     // scrollback growth) is untouched.
-    if (_terminal.activeScreen == .alternate) _pipeline.markAllRowsDirty();
+    //
+    // #921: the SAME single-consumption damage race also breaks the PRIMARY
+    // screen — but ONLY when structured-text DETECTION is active. Detection adds
+    // a SECOND `RenderState` handle (the controller's), registered BEFORE this
+    // render box, that consumes the shared terminal's per-row damage on the same
+    // synchronous notify. With detection OFF nothing competes, so the partial
+    // path works and the #805 streaming perf path is untouched. So widen the
+    // full-re-read gate to the primary screen ONLY while detection is active: a
+    // full VISIBLE-grid re-read (bounded — no scrollback walk), fired only on a
+    // content notify, makes the paint immune to the detection handle's consume.
+    if (_terminal.activeScreen == .alternate || _detectionActive) {
+      _pipeline.markAllRowsDirty();
+    }
 
     // #918 OUTPUT SETTLE TICK: a content-change notify is driven by PTY output (or
     // a local edit). Arm a one-shot timer that forces ONE full frame ~80ms after the

--- a/native/third_party/flterm/test/rendering/detection_consumes_damage_921_test.dart
+++ b/native/third_party/flterm/test/rendering/detection_consumes_damage_921_test.dart
@@ -1,0 +1,199 @@
+@Tags(['ffi'])
+library;
+
+// #921 (P0, device 0.1.10+65) — with detect-URLs ON the terminal does NOT
+// repaint on the PRIMARY screen; with detection OFF it paints. tmux control
+// mode is OFF and irrelevant. This is the FIFTH repaint fix in the flterm
+// render-box frame-sync subsystem (#887, #898, #900, #918) — STRUCTURAL, the
+// same single-consumption libghostty damage root as #900, now on the PRIMARY
+// screen where the #900 fix's `markAllRowsDirty` gate does NOT reach.
+//
+// CONFIRMED ROOT (same single-consumption damage as #900, now on PRIMARY):
+//   `RenderState.update()` "snapshots terminal state and consumes its dirty
+//   flag" (libghostty render_state.dart:165/179). Each libghostty `RenderState`
+//   handle diffs against ITS OWN last snapshot, so the FIRST `update` after a
+//   content change reports the per-row damage and the NEXT `update` (with no new
+//   writes between) reports CLEAN. The render box's frame builder uses ONE such
+//   handle; the partial-build path (`_build(.partial)`) re-emits ONLY the rows
+//   that `update` flagged.
+//
+//   When DETECTION is ON, the controller maintains live anchors and emits an
+//   EXTRA content notify per output change (re-anchor / prune / viewport-wrap
+//   reads), which drives a SECOND frame-builder `sync` on the SAME handle for
+//   that one change. The first sync consumes the per-row damage; the second sync
+//   reads CLEAN and its partial build re-emits NO rows — so the rendered grid
+//   stays stale. This is the exact #900 double-consume, but on the PRIMARY
+//   screen, where the #900 fix's `markAllRowsDirty` gate does NOT reach
+//   (terminal_renderer.dart `if (_terminal.activeScreen == .alternate)`).
+//
+//   Detection OFF: no extra notify → a single sync per change → the damage is
+//   consumed by the sync that PAINTS it → paint works. That is the ON/OFF
+//   asymmetry the user reports.
+//
+// FIX (Option A): widen the `markAllRowsDirty` gate so the PRIMARY screen also
+// forces a full VISIBLE-grid re-read on a content change, but ONLY when
+// detection is active (the only condition that issues the extra consuming sync).
+// `markAllRowsDirty` marks VISIBLE rows only (bounded — no scrollback walk) and
+// fires only on a content notify, so #805 throughput is untouched.
+//
+// This test reproduces the double-consume DETERMINISTICALLY at the pipeline
+// level on the PRIMARY screen, exactly as the #900 test does on the alternate
+// screen: a content change, then a FIRST `sync` that consumes the damage
+// (models detection's extra notify), then the paint `sync`. WITHOUT the fix the
+// partial build re-reads NOTHING (stale grid); the fix's action
+// (`markAllRowsDirty`) re-reads the full visible grid.
+
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flterm/src/foundation/cell_metrics.dart';
+import 'package:flterm/src/foundation/terminal_theme.dart';
+import 'package:flterm/src/rendering/atlas/atlas.dart';
+import 'package:flterm/src/rendering/paint_state.dart';
+import 'package:flterm/src/rendering/terminal_render_pipeline.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+void main() {
+  const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+  AtlasConfig config() => AtlasConfig(
+        fontSize: 14,
+        fontWeight: FontWeight.normal,
+        fontFamily: 'monospace',
+        fontFamilyFallback: const [],
+        metrics: metrics,
+        devicePixelRatio: 1.0,
+      );
+
+  void writeUtf8(Terminal terminal, String text) {
+    terminal.write(Uint8List.fromList(utf8.encode(text)));
+  }
+
+  late Terminal terminal;
+  late Atlas atlas;
+  late TerminalPaintState state;
+  late TerminalRenderPipeline pipeline;
+
+  setUp(() {
+    terminal = Terminal(cols: 16, rows: 4);
+    atlas = Atlas(config());
+    state = TerminalPaintState(TerminalTheme.dark(), metrics)
+      ..cols = 16
+      ..rows = 4;
+    pipeline = TerminalRenderPipeline(
+      atlas: atlas,
+      state: state,
+      onImageReady: () {},
+    )..configureGrid(4, 16);
+  });
+
+  tearDown(() {
+    pipeline.dispose();
+    atlas.dispose();
+    terminal.dispose();
+  });
+
+  // An in-place primary-screen rewrite (addressed cells only): libghostty
+  // reports per-row damage for the change — the path a streaming primary-screen
+  // line update takes.
+  void inPlaceRedraw(String tag) {
+    for (var r = 1; r <= 4; r++) {
+      writeUtf8(terminal, '\x1b[$r;1Hprimary $tag row $r        ');
+    }
+  }
+
+  test(
+    'PRIMARY screen: a content change whose damage a prior (detection-driven) '
+    'sync consumed still re-reads the full grid when markAllRowsDirty is forced '
+    '(the #921 fix) — but re-reads NOTHING without it (the detection-ON freeze)',
+    () {
+      // PRIMARY screen (no \x1b[?1049h) — the exact #921 condition.
+      expect(terminal.activeScreen, TerminalScreen.primary,
+          reason: 'precondition: on the primary screen (normal shell, not tmux '
+              'full-screen)');
+
+      // Content A drawn and painted.
+      inPlaceRedraw('A');
+      pipeline.sync(terminal, terminalDirty: true);
+      expect(pipeline.debugRowsRebuiltLastSync, greaterThan(0),
+          reason: 'precondition: the first redraw re-reads rows');
+
+      // New content B: libghostty now holds per-row damage for the change.
+      inPlaceRedraw('B');
+
+      // Detection ON drives an EXTRA content notify, so the frame builder syncs
+      // the SAME handle once for that change BEFORE the sync that paints. The
+      // first sync's `RenderState.update` consumes the per-row damage.
+      pipeline.sync(terminal, terminalDirty: true);
+
+      // Now the paint sync runs. libghostty reports CLEAN (no NEW damage since
+      // the consuming sync). The #921 fix forces a full re-read via
+      // markAllRowsDirty (gated on detectionActive on the primary screen).
+      pipeline.markAllRowsDirty();
+      pipeline.sync(terminal, terminalDirty: true);
+
+      expect(
+        pipeline.debugRowsRebuiltLastSync,
+        equals(4),
+        reason: 'the #921 fix (markAllRowsDirty when detection is active on the '
+            'primary screen) re-reads the FULL visible grid even when libghostty '
+            'reports clean because an earlier detection-driven sync consumed the '
+            'per-row damage',
+      );
+    },
+  );
+
+  test(
+    'PRIMARY screen WITHOUT the fix: a redraw whose damage a prior sync consumed '
+    're-reads NO rows (documents the detection-ON freeze root)',
+    () {
+      expect(terminal.activeScreen, TerminalScreen.primary);
+
+      inPlaceRedraw('A');
+      pipeline.sync(terminal, terminalDirty: true);
+
+      inPlaceRedraw('B');
+      // First (consuming) sync: detection's extra notify reads + clears the
+      // per-row damage.
+      pipeline.sync(terminal, terminalDirty: true);
+      // Second sync WITHOUT markAllRowsDirty: libghostty has no new damage, so
+      // the partial build re-reads nothing. This is the stale grid the user sees
+      // with detection ON — the #921 root.
+      pipeline.sync(terminal, terminalDirty: true);
+
+      expect(
+        pipeline.debugRowsRebuiltLastSync,
+        equals(0),
+        reason: 'WITHOUT the fix, a redraw whose damage a prior detection-driven '
+            'sync consumed re-reads zero rows — the rendered grid stays stale '
+            '(the #921 detection-ON paint freeze)',
+      );
+    },
+  );
+
+  test(
+    'CONTROL: detection OFF (single sync per change) consumes the damage in the '
+    'sync that PAINTS it and re-reads rows — the detection-OFF path works',
+    () {
+      expect(terminal.activeScreen, TerminalScreen.primary);
+
+      inPlaceRedraw('A');
+      pipeline.sync(terminal, terminalDirty: true);
+
+      inPlaceRedraw('B');
+      // Detection OFF: NO extra notify, so only ONE sync runs per change — the
+      // one that paints consumes the damage. Rows re-read.
+      pipeline.sync(terminal, terminalDirty: true);
+
+      expect(
+        pipeline.debugRowsRebuiltLastSync,
+        greaterThan(0),
+        reason: 'with detection OFF only a single sync per change consumes the '
+            'damage in the sync that paints it — paint works (the ON/OFF '
+            'asymmetry)',
+      );
+    },
+  );
+}

--- a/native/third_party/flterm/test/widgets/detection_glyph_repaint_921_test.dart
+++ b/native/third_party/flterm/test/widgets/detection_glyph_repaint_921_test.dart
@@ -1,0 +1,197 @@
+@Tags(['ffi'])
+library;
+
+// #921 widget-level pin for the PRIMARY-screen detection-active full re-read.
+//
+// With structured-text detection ON, the controller registers a SECOND
+// libghostty `RenderState` handle that consumes the shared terminal's per-row
+// damage on the same synchronous content notify (it registers its listener
+// BEFORE the render box), starving the render box's partial build so the
+// primary screen stops repainting. The #921 fix sets
+// [TerminalRenderBox.detectionActive], which — mirroring the #900 alternate-
+// screen decoupling — forces a FULL visible-grid re-read on each primary-screen
+// content change, immune to that single-consumption damage race.
+//
+// This test asserts the flterm production contract that the app layer relies on:
+//   1. detectionActive = true => a primary-screen content change re-reads the
+//      FULL visible grid (rows == viewport rows), not just libghostty-damaged
+//      rows. (RED before the fix: the gate was alternate-screen-only.)
+//   2. detectionActive = false (the detection-OFF control) => a single-line
+//      change rebuilds FEWER rows than the viewport (the #805 partial path is
+//      preserved — OFF still works).
+//
+// Headless `tester.pump` coalesces notifies into one paint and does not exercise
+// the device's multi-handle damage-consume timing (the orchestrator's on-emulator
+// detection-ON confirm covers that). What it pins is the property that makes the
+// repaint immune: the full re-read when detection is active.
+//
+// Reach the render box via `tester.renderObject<TerminalRenderBox>(find.byType(
+// TerminalRenderer))` — `find.byType(TerminalRenderBox)` fails (it's a
+// RenderObject, not a Widget).
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/src/foundation/structured_text.dart';
+import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+void main() {
+  Future<(TerminalController, TerminalRenderBox)> mount(
+    WidgetTester tester,
+  ) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final controller = TerminalController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 320,
+              height: 160,
+              child: TerminalView(controller: controller),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final box = tester.renderObject<TerminalRenderBox>(
+      find.byType(TerminalRenderer),
+    );
+    return (controller, box);
+  }
+
+  testWidgets(
+    'detection ACTIVE: a primary-screen content change re-reads the FULL '
+    'visible grid (#921 — immune to the detection handle damage-consume)',
+    (tester) async {
+      final (controller, box) = await mount(tester);
+      void write(String s) =>
+          controller.write(Uint8List.fromList(utf8.encode(s)));
+
+      expect(controller.activeScreen, TerminalScreen.primary,
+          reason: 'precondition: primary screen (normal shell, not tmux)');
+
+      // Seed the screen (more rows than fit, to fill the viewport).
+      for (var r = 1; r <= 12; r++) {
+        write('\x1b[$r;1Hseed line $r contents');
+      }
+      await tester.pump();
+      expect(box.debugRowsRebuiltLastSync, greaterThan(1),
+          reason: 'precondition: the seed re-read more than one row');
+
+      // Detection registered: this is what the app's _registerUrlPattern wiring
+      // sets when at least one detect pattern is active. The setter forces an
+      // immediate full re-read; capture that count as the FULL-viewport baseline
+      // (the render box's true visible-row count, which is not exactly
+      // height ~/ cellHeight due to partial-row rendering).
+      controller.registerTextPattern(TextPattern.url());
+      box.detectionActive = true;
+      await tester.pump();
+      expect(box.debugDetectionActive, isTrue);
+      final fullViewportRows = box.debugRowsRebuiltLastSync;
+      expect(fullViewportRows, greaterThan(1),
+          reason: 'precondition: a full re-read covers more than one row so it '
+              'is distinguishable from a single-row partial rebuild');
+
+      // FRESH output (a URL line) — change ONE row, no user input. With
+      // detection active the primary screen must re-read the FULL visible grid
+      // even though detection drives the extra consuming sync.
+      write('\x1b[3;1Hvisit https://example.com/issue/921 now ');
+      await tester.pump();
+
+      expect(
+        box.debugRowsRebuiltLastSync,
+        equals(fullViewportRows),
+        reason: 'with detection active, a single-row primary-screen content '
+            'change re-reads the FULL visible grid ($fullViewportRows rows) — '
+            'not the partial subset a consumed-damage frame shrinks to zero (the '
+            '#921 paint freeze)',
+      );
+
+      // Drain the controller's detection-rescan timer so it does not leak past
+      // teardown (registering a pattern arms a ~120ms rescan).
+      await tester.pump(const Duration(milliseconds: 200));
+    },
+  );
+
+  testWidgets(
+    'detection OFF (control): a single-line primary-screen change rebuilds '
+    'FEWER rows than the viewport (the #805 partial path is preserved)',
+    (tester) async {
+      final (controller, box) = await mount(tester);
+      void write(String s) =>
+          controller.write(Uint8List.fromList(utf8.encode(s)));
+
+      expect(controller.activeScreen, TerminalScreen.primary);
+      expect(box.debugDetectionActive, isFalse,
+          reason: 'precondition: detection is OFF by default');
+
+      for (var r = 1; r <= 8; r++) {
+        write('\x1b[$r;1Hline $r contents here');
+      }
+      await tester.pump();
+
+      // Change ONE line with detection OFF: the partial path must rebuild fewer
+      // rows than the full viewport — proving the fix does not regress #805 and
+      // that the detection-OFF path works (the user's "OFF paints" observation).
+      write('\x1b[4;1Hline 4 CHANGED        ');
+      await tester.pump();
+
+      final fullViewportRows = box.size.height ~/ 16;
+      expect(
+        box.debugRowsRebuiltLastSync,
+        lessThan(fullViewportRows),
+        reason: 'a single-line primary-screen change with detection OFF must '
+            'rebuild fewer rows than the full viewport — the #921 full re-read '
+            'is gated on detectionActive and does not regress #805',
+      );
+    },
+  );
+
+  testWidgets(
+    'turning detection ACTIVE self-heals: it forces an immediate full re-read '
+    'so a frame the detection handle already starved repaints (#921 live toggle)',
+    (tester) async {
+      final (controller, box) = await mount(tester);
+      void write(String s) =>
+          controller.write(Uint8List.fromList(utf8.encode(s)));
+
+      // Seed (fill the viewport) and capture the full re-read row count.
+      for (var r = 1; r <= 12; r++) {
+        write('\x1b[$r;1Hbaseline row $r');
+      }
+      await tester.pump();
+      final fullViewportRows = box.debugRowsRebuiltLastSync;
+      expect(fullViewportRows, greaterThan(1),
+          reason: 'precondition: the seed re-read the full viewport');
+
+      // Flip detection ON. The setter forces markAllRowsDirty + a frame, so the
+      // very next paint re-reads the full grid even with no new terminal output.
+      controller.registerTextPattern(TextPattern.url());
+      box.detectionActive = true;
+      await tester.pump();
+
+      expect(
+        box.debugRowsRebuiltLastSync,
+        equals(fullViewportRows),
+        reason: 'flipping detectionActive ON forces an immediate full visible-'
+            'grid re-read ($fullViewportRows rows) so a frame the detection '
+            'handle already starved heals (the live-toggle case)',
+      );
+
+      // Drain the controller's detection-rescan timer (armed by the pattern
+      // registration) so it does not leak past teardown.
+      await tester.pump(const Duration(milliseconds: 200));
+    },
+  );
+}


### PR DESCRIPTION
## #921 — detection ON froze primary-screen repaint

With detect-URLs ON the terminal stopped repainting on the **primary** screen; with detection OFF it painted. tmux control mode OFF and irrelevant.

### Root cause
Same single-consumption libghostty damage as #900, but on the primary screen where the #900 full-re-read guard (`markAllRowsDirty`, gated alternate-screen-only) doesn't reach.

`RenderState.update()` "snapshots terminal state and consumes its dirty flag" — each libghostty `RenderState` handle diffs against its OWN last snapshot, so a second `update` with no writes between reports CLEAN and the partial build re-emits no rows. Detection ON drives an EXTRA content notify per output change (anchor re-scan / prune / viewport-wrap reads → `_scheduleDetectionRescan`), so the frame builder syncs the SAME handle twice for one change: the first consumes the per-row damage, the second reads clean → stale grid. Detection OFF issues no extra notify, so the sync that paints consumes the damage → paint works (the ON/OFF asymmetry).

> Note: the originally-filed root ("two RenderState handles share one terminal's damage, whichever updates first clears it for all") was disproved — each handle has independent per-row dirty tracking (libghostty docs + a pipeline test). The real mechanism is the same-handle double-`update` (#900 root) triggered on the primary screen by detection's extra notify. The fix is unchanged.

### Fix (Option A)
- Add `_detectionActive` flag + setter on `TerminalRenderBox` (mirrors `blinkVisible`).
- Widen the full-re-read gate: `if (activeScreen == .alternate || _detectionActive) markAllRowsDirty()`.
- Wire `_detectionActive` from the app's URL/path pattern registration (`_registerUrlPattern` / clear listener) via the existing #918 keyed render-box lookup.
- Setter forces an immediate full re-read on toggle-ON to self-heal an already-starved frame (live toggle / first register).

`markAllRowsDirty` marks VISIBLE rows only (bounded) and fires only on a content notify, so #805 streaming perf (detection OFF) is untouched. Option B (non-consuming detection reads / libghostty API change) is filed separately as #922.

### Tests (red→green)
- **flterm pipeline** `detection_consumes_damage_921_test.dart` — primary-screen double-consume → full re-read with the fix action, zero without; detection-OFF control.
- **flterm widget** `detection_glyph_repaint_921_test.dart` — detectionActive → full re-read (RED without the fix); OFF preserves the #805 partial path; live-toggle self-heal.
- **emulator integration** `detection_repaint_921_test.dart` — scrape path, control mode OFF, detection ON: fresh + streaming output with NO user input repaints; idle no-free-run. **PASSED on emulator-5554.**

### Gates
- Full flterm suite: **760 pass** (incl. #887, #900, #898, #805).
- Native fast gate: **1436 pass** (analyze clean; #805 perf test green).
- Emulator integration: **pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)