### PR TITLE
Attention notifications fire while app foregrounded — telemetry + propagation

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -1343,6 +1343,15 @@ class SessionHost {
     String? activeHost,
   ]) {
     if (_disposed) return;
+    // #840 telemetry: log every setActive the task isolate APPLIES so a device
+    // capture can confirm the UI→task foreground/activeHost propagation actually
+    // landed (paired with the UI-side SEND log in main.dart). Pins a stale/null
+    // activeHost — the prime suspect for a bell firing while foregrounded.
+    clifecycle(
+      'attention',
+      'setActive active=$active activeSessionId=$activeSessionId '
+          'host=$activeHost',
+    );
     // Always track the reported active session id (#840 Slice 2) + host (#847) —
     // even when [active] is unchanged the front-most TAB may have switched, and
     // that must update suppression. A null id/host (older UI / none) leaves it
@@ -1481,7 +1490,8 @@ class SessionHost {
     if (!post) {
       clifecycle(
         'attention',
-        'suppressed (foreground same-host) session $sessionId',
+        'suppressed (foreground same-host) session $sessionId '
+            '[${_attentionDecisionInputs(signalHost)}]',
       );
       return;
     }
@@ -1505,11 +1515,32 @@ class SessionHost {
           clifecycle('attention', 'post-error: $e (session $sessionId)');
         }),
       );
-      clifecycle('attention', 'posted notification session $sessionId');
+      // #840: log the FULL decision inputs on a POST so a device capture shows
+      // WHY the gate passed — whether the task isolate saw the app as foreground
+      // and what activeHost it believed at the moment the bell fired. The
+      // suppression branches already log their inputs; this closes the gap for
+      // the one path that previously logged only the outcome. No auth material:
+      // host LABELS are already in the notification body.
+      clifecycle(
+        'attention',
+        'posted notification session $sessionId '
+            '[${_attentionDecisionInputs(signalHost)} reason=not-suppressed]',
+      );
     } catch (e) {
       clifecycle('attention', 'build-error: $e (session $sessionId)');
     }
   }
+
+  /// Render the attention-gate decision inputs for a lifecycle log line (#840
+  /// telemetry). Shows what the TASK ISOLATE believed at decision time:
+  /// `foreground` (the propagated UI foreground flag), the front-most
+  /// `activeSessionId`/`activeHost` it last received, and the `signalHost` of the
+  /// bell. Host LABELS only — no auth material (they already appear in
+  /// notification bodies). `null` is rendered explicitly so a capture can tell a
+  /// NEVER-PROPAGATED null apart from a real value.
+  String _attentionDecisionInputs(String? signalHost) =>
+      'foreground=$_active activeSessionId=$_activeSessionId '
+      'activeHost=$_activeHost signalHost=$signalHost';
 
   void _pushSnapshots() {
     if (_disposed) return;

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -12,6 +12,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import '../diagnostics/connect_trace.dart';
 import '../services/session_host.dart';
 import '../services/session_messages.dart';
 import '../services/task_ssh_gateway.dart';
@@ -173,6 +174,15 @@ class SshSessionProxy {
   /// attention is the host/Claude, not the individual session).
   void setActive(bool active, {String? activeSessionId, String? activeHost}) {
     if (_disposed) return;
+    // #840 telemetry: log the UI-side SEND of every setActive (paired with the
+    // task-isolate APPLY log in session_host). A device capture can then show
+    // whether the UI sent foreground=true + the right activeHost, and whether
+    // the task received it — pinning any per-isolate propagation gap.
+    clifecycle(
+      'ui.attention',
+      'setActive send active=$active activeSessionId=$activeSessionId '
+          'host=$activeHost',
+    );
     gateway.send(
       SshSetActiveCommand(
         active: active,

--- a/native/test/services/session_host_attention_telemetry_test.dart
+++ b/native/test/services/session_host_attention_telemetry_test.dart
@@ -1,0 +1,169 @@
+// SessionHost attention DECISION-INPUT telemetry (#840 follow-up).
+//
+// The attention gate previously logged WHY it SUPPRESSED but, on a POST, logged
+// only the outcome ("posted notification session …") — never the decision
+// inputs. So a device capture of "a bell fired while the app was foreground"
+// could not reveal whether the task isolate believed the app was foreground and
+// what activeHost it had. These tests pin the new telemetry:
+//   1. On a POST the lifecycle ring carries foreground/activeSessionId/
+//      activeHost/signalHost + reason.
+//   2. On a same-host SUPPRESS the same inputs are logged.
+//   3. Every setActive the task isolate APPLIES is logged (UI→task propagation).
+//
+// Headless via InMemoryGatewayPair + an inert controller (mirrors
+// session_host_attention_post_test.dart) against a RecordingAttentionNotifier.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+class _NoConnectController extends SshSessionController {
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+Future<({InMemoryGatewayPair pair, SessionHost host, RecordingAttentionNotifier notifier})>
+_setup({String sid = 'h:22:u:1'}) async {
+  late SshSessionController controller;
+  final pair = InMemoryGatewayPair();
+  final notifier = RecordingAttentionNotifier();
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: () {
+      controller = _NoConnectController();
+      return controller;
+    },
+    snapshotInterval: const Duration(milliseconds: 50),
+    attentionNotifier: notifier,
+    // Disable the (re)connect replay window AND the #856 just-switched grace so
+    // these tests exercise only the foreground/host gate they assert on (both
+    // upstream gates have their own coverage). Without disabling the grace, a
+    // setActive(activeHost:'h') arms the just-switched window and suppresses via
+    // THAT path before the same-host foreground gate is reached.
+    replayWindow: Duration.zero,
+    switchGraceWindow: Duration.zero,
+  );
+  pair.uiSide.send(
+    SshConnectCommand(
+      sessionId: sid,
+      host: 'h',
+      port: 22,
+      username: 'u',
+      authJson: const {'type': 'password', 'password': 'p'},
+    ).toJson(),
+  );
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  controller.debugSetConnectedForTest(_params);
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  return (pair: pair, host: host, notifier: notifier);
+}
+
+/// OSC 9 bytes carrying [text].
+List<int> _osc9(String text) => [0x1b, 0x5d, ...utf8.encode('9;$text'), 0x07];
+
+void main() {
+  setUp(clearConnectLog);
+
+  test('POST logs the full decision inputs (foreground/active/signalHost)',
+      () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    // App backgrounded → posts. The default activeHost is null (never set).
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(active: false).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('ready'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(s.notifier.posted, hasLength(1));
+    final lines = lifecycleLogSnapshot();
+    final postLine = lines.firstWhere(
+      (l) => l.contains('posted notification session h:22:u:1'),
+      orElse: () => '',
+    );
+    expect(postLine, isNotEmpty,
+        reason: 'a POST must emit a lifecycle line');
+    expect(postLine, contains('foreground=false'));
+    expect(postLine, contains('activeSessionId=null'));
+    expect(postLine, contains('activeHost=null'));
+    expect(postLine, contains('signalHost=h'));
+    expect(postLine, contains('reason=not-suppressed'));
+  });
+
+  test('same-host SUPPRESS logs the full decision inputs', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    // Foreground on a DIFFERENT session to the SAME host → suppressed.
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(
+        active: true,
+        activeSessionId: 'h:2222:u:2',
+        activeHost: 'h',
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('ready'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(s.notifier.posted, isEmpty);
+    final lines = lifecycleLogSnapshot();
+    final suppressLine = lines.firstWhere(
+      (l) => l.contains('suppressed (foreground same-host) session h:22:u:1'),
+      orElse: () => '',
+    );
+    expect(suppressLine, isNotEmpty);
+    expect(suppressLine, contains('foreground=true'));
+    expect(suppressLine, contains('activeSessionId=h:2222:u:2'));
+    expect(suppressLine, contains('activeHost=h'));
+    expect(suppressLine, contains('signalHost=h'));
+  });
+
+  test('task isolate logs every setActive it APPLIES', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(
+        active: true,
+        activeSessionId: 'h:22:u:1',
+        activeHost: 'h',
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    final lines = lifecycleLogSnapshot();
+    final applyLine = lines.firstWhere(
+      (l) => l.contains('setActive active=true'),
+      orElse: () => '',
+    );
+    expect(applyLine, isNotEmpty,
+        reason: 'the task isolate must log the applied setActive');
+    expect(applyLine, contains('activeSessionId=h:22:u:1'));
+    expect(applyLine, contains('host=h'));
+  });
+}


### PR DESCRIPTION
## Problem
Owner reports (device) getting many MobiSSH attention notifications even when MobiSSH
is the ACTIVE foreground app. Attention bells should be SUPPRESSED when the user is
already looking at that host's session.

The post gate `_maybePostAttention` (session_host.dart) already has #851 reconnect-replay,
#856 just-switched grace, #847 host-suppression, and #847 dedup — each suppression logs
WHY it suppressed. But on a POST it logged only `posted notification session …`, with
NO decision inputs. So a device capture can't reveal whether the task isolate saw the app
as foreground and what activeHost it believed at the moment a bell fired. That is the
telemetry gap this PR closes.

## Change (telemetry-first — no behavior change, no threshold tuning)
- **POST decision inputs**: the POST path now logs `foreground / activeSessionId /
  activeHost / signalHost + reason` via a new `_attentionDecisionInputs` helper.
- **Suppression parity**: the same-host SUPPRESS log is enriched with the same inputs.
- **setActive APPLY**: `_handleSetActive` (task isolate) logs every applied setActive.
- **setActive SEND**: `ssh_session_proxy.setActive` (UI isolate) logs every send.

Together a capture shows whether the UI SENT foreground=true + the right activeHost and
whether the task isolate RECEIVED + applied it — pinning any per-isolate propagation gap.

Host LABELS only in the new logs (already present in notification bodies) — no auth material.

## Investigation (propagation path)
Read proxy send → `session_messages` decode (`SshSetActiveCommand`) → `session_host`
dispatch → `_handleSetActive`. All structurally correct. **Prime suspect remains a
stale/NULL activeHost on cold start**: `_active=true` by default but `_activeSessionId`/
`_activeHost` default NULL, and on a cold-start first connect no AppLifecycle `resumed`
edge fires, so the gate can run with `activeHost=null` → `shouldPostAttention` returns
true → POSTS (this matches the existing test comment at
`session_host_attention_post_test.dart:78`). This cannot be PROVEN as the owner's cause
without device data, so per the task brief the ROOT FIX is **deferred to avoid blind-tuning**
(a blind tune risks hiding legitimate cross-host alerts).

## Device data needed
A lifecycle capture at the moment of an unexpected foreground bell, showing the new
`posted notification … [foreground=… activeSessionId=… activeHost=… signalHost=…]` line
plus the preceding `setActive send/apply` lines. That pins whether activeHost was null
(never propagated) or stale/wrong.

## Tests
`native/test/services/session_host_attention_telemetry_test.dart` (3 tests):
- POST logs the full decision inputs (backgrounded path)
- same-host SUPPRESS logs the full decision inputs
- task isolate logs every applied setActive

Native fast gate green (1439 tests, analyze clean).

Refs #847 #851 #856 #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)