### PR TITLE
feat(native): copyable app-version line in Settings (so the owner can verify the running build)

### DIFF
--- a/native/lib/ui/feedback_overlay.dart
+++ b/native/lib/ui/feedback_overlay.dart
@@ -227,7 +227,14 @@ Future<Uint8List> _defaultScreenshotCapturer(
   }
 }
 
-Future<String> _defaultVersionResolver() async {
+/// Resolves the baked build version as the `[<build> <hash>]` string the
+/// bug-report carries (`appVersion = ${version}+${buildNumber}`,
+/// `hash = buildSignature` — the git hash baked at build time). This is the
+/// SINGLE source of truth for the human-readable build identifier: the feedback
+/// overlay stamps it into every report AND the Settings version row (#897-adj)
+/// displays the exact same string so the owner can verify/copy his running
+/// build without a bug-report upload.
+Future<String> resolveBuildVersion() async {
   try {
     final pkg = await PackageInfo.fromPlatform();
     final appVersion = '${pkg.version}+${pkg.buildNumber}';
@@ -253,7 +260,7 @@ class FeedbackOverlay extends StatefulWidget {
     required this.navigatorKey,
     required this.messengerKey,
     this.submitter = const HttpFeedbackSubmitter(),
-    this.versionResolver = _defaultVersionResolver,
+    this.versionResolver = resolveBuildVersion,
     this.screenshotCapturer = _defaultScreenshotCapturer,
   });
 

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -8,15 +8,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/battery_optimization.dart';
+import '../services/clipboard.dart';
 import '../state/detection_providers.dart';
 import '../state/keepalive_providers.dart';
 import '../state/sessions.dart';
 import '../state/terminal_backend.dart';
 import '../state/tmux_control_mode_setting.dart';
 import '../state/ui_prefs_providers.dart';
+import 'feedback_overlay.dart' show VersionResolver, resolveBuildVersion;
+import 'top_toast.dart';
 
 class SettingsPanel extends ConsumerWidget {
-  const SettingsPanel({super.key});
+  /// Injectable so widget tests can supply a fixed build string without a
+  /// PackageInfo platform channel. Defaults to [resolveBuildVersion] — the SAME
+  /// source of truth the bug-report `version` field uses, so the row shows the
+  /// owner the exact build string he'd otherwise only see in an upload.
+  const SettingsPanel({super.key, this.versionResolver = resolveBuildVersion});
+
+  final VersionResolver versionResolver;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -35,6 +44,29 @@ class SettingsPanel extends ConsumerWidget {
             : 'Keep alive in background: OFF',
       ),
       children: [
+        // App-version row. Shows the SAME build string the bug-report carries
+        // (`[<version>+<build> <gitHash>]`) so the owner can read/screenshot the
+        // running build on-device instead of pulling it from a feedback upload.
+        // Tap copies the full string to the clipboard. (relates to #897.)
+        FutureBuilder<String>(
+          future: versionResolver(),
+          builder: (context, snap) {
+            final version = snap.data ?? '…';
+            return ListTile(
+              key: const ValueKey('app-version-tile'),
+              leading: const Icon(Icons.info_outline),
+              title: const Text('App version'),
+              subtitle: Text(
+                version,
+                key: const ValueKey('app-version-value'),
+              ),
+              trailing: const Icon(Icons.copy),
+              onTap: snap.hasData
+                  ? () => _copyVersion(context, version)
+                  : null,
+            );
+          },
+        ),
         SwitchListTile(
           key: const ValueKey('keepalive-toggle'),
           title: const Text('Keep alive in background'),
@@ -194,6 +226,14 @@ class SettingsPanel extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  Future<void> _copyVersion(BuildContext context, String version) async {
+    final ok = await copyToClipboard(version);
+    if (!context.mounted) return;
+    if (ok) {
+      showTopToast(context, 'Copied version');
+    }
   }
 
   Future<void> _requestBatteryOptExemption(

--- a/native/test/widget/version_row_widget_test.dart
+++ b/native/test/widget/version_row_widget_test.dart
@@ -1,0 +1,122 @@
+// Widget tests for the Settings panel app-version row.
+//
+// The owner had no on-screen way to see/screenshot the running build — he
+// could only get it from a bug-report upload. This row shows the SAME build
+// string the bug-report carries (`[<version>+<build> <gitHash>]`) and copies
+// it to the clipboard on tap. (relates to #897.)
+//
+// Asserts:
+//   - the row renders the injected version string when the panel is expanded.
+//   - tapping the row routes the full string through copyToClipboard (the
+//     hardened `mobissh/clipboard` channel) — i.e. the clipboard ends up
+//     containing the version.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/settings_panel.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _fixedVersion = '[0.1.10+69 F01111D9]';
+
+Future<void> pumpSettings(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SettingsPanel(
+              versionResolver: () async => _fixedVersion,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  // Bounded pumps to let the hydrate Futures + the version FutureBuilder resolve.
+  for (var i = 0; i < 6; i++) {
+    await tester.pump(const Duration(milliseconds: 20));
+  }
+}
+
+Future<void> expandSettings(WidgetTester tester) async {
+  await tester.tap(find.byKey(const ValueKey('settings-section')));
+  // Settle the ExpansionTile expand animation so inner tiles are hit-testable.
+  for (var i = 0; i < 30; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Mock clipboard so the copy doesn't hit a real platform channel. Mirrors
+  // connect_log_panel_test.dart: copyToClipboard() routes through the hardened
+  // `mobissh/clipboard` native channel and reads back via SystemChannels.platform.
+  final clipboard = <String, dynamic>{};
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    clipboard.clear();
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('mobissh/clipboard'),
+      (call) async {
+        if (call.method == 'setText') {
+          clipboard['text'] = (call.arguments as Map)['text'];
+          return true;
+        }
+        return null;
+      },
+    );
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        clipboard['text'] = (call.arguments as Map)['text'];
+      }
+      if (call.method == 'Clipboard.getData') {
+        return <String, dynamic>{'text': clipboard['text']};
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('mobissh/clipboard'),
+      null,
+    );
+    messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  testWidgets('renders the build version string from the resolver',
+      (tester) async {
+    await pumpSettings(tester);
+    await expandSettings(tester);
+
+    final tile = find.byKey(const ValueKey('app-version-tile'));
+    expect(tile, findsOneWidget);
+
+    final value = tester.widget<Text>(
+      find.byKey(const ValueKey('app-version-value')),
+    );
+    expect(value.data, _fixedVersion);
+  });
+
+  testWidgets('tapping the version row copies the full string to the clipboard',
+      (tester) async {
+    await pumpSettings(tester);
+    await expandSettings(tester);
+
+    await tester.tap(find.byKey(const ValueKey('app-version-tile')));
+    // Settle the async copyToClipboard + read-back + toast.
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+
+    expect(clipboard['text'], _fixedVersion);
+  });
+}


### PR DESCRIPTION
## Why

The owner reported he has "no way to screenshot my actual version" — the running
build string was only retrievable from a bug-report upload, never visible on-screen.

## What

Adds a labeled, tap-to-copy **App version** row near the top of the Settings panel.

- **Same source of truth as the bug-report.** Promotes the feedback overlay's
  version resolver from private `_defaultVersionResolver` to public
  `resolveBuildVersion()`. It formats `${pkg.version}+${pkg.buildNumber}` plus
  `pkg.buildSignature` (the git hash baked at build time) via the existing
  `formatFeedbackVersion()` into the `[<build> <hash>]` string the bug-report
  `version` field carries. The Settings row displays that exact string — no
  second source of truth.
- **Tap to copy.** Tapping the row routes the full string through the existing
  hardened `copyToClipboard()` and shows the existing top-toast
  `Copied version`, so the owner can paste his exact build into a report.
- Monochrome `Icons.info_outline` leading / `Icons.copy` trailing; follows the
  existing settings `ListTile` styling. `versionResolver` is injectable for tests.

## Tests

- `native/test/widget/version_row_widget_test.dart` (new):
  - renders the build version string from the injected resolver,
  - tapping the row puts the full string on the (mocked) clipboard.
- Native fast gate green (`scripts/native-fast-gate.sh`): 1447 tests pass.

## Scope

This is ONLY the version line — not the larger Settings reorganization (#897),
which is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)