### PR TITLE
fix(#931): repaint on resume + typing with detection ON (primary-screen redraw)

### DIFF
--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -2590,6 +2590,17 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     //    auto-pop on resume (the #693/#706/#717 focus-vs-IME separation).
     _focusedThisConnect = false;
     _focusTerminalOnConnect('resume');
+    // #931 GAP 2: re-assert detection-active on the render box after resume. A
+    // background→resume can re-create / re-lay-out the keyed render box, and the
+    // init-time one-shot `_applyDetectionActive` does not re-fire — leaving the
+    // box `_detectionActive=false` would re-freeze the primary-screen typing half
+    // of #931. Re-apply on a post-frame (after the resize-resync re-lays out the
+    // grid) reflecting the CURRENT detection settings.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final detection = ref.read(detectionSettingsProvider);
+      _applyDetectionActive(detection.detectUrls || detection.detectPaths);
+    });
     // 4. FORCE REPAINT WHEN FOCUS WAS RETAINED (#720): the #718 re-focus above
     //    only repaints when focus was LOST while backgrounded — the focus CHANGE
     //    fires flterm's `_onFocusChanged` → `notifyListeners()` → the render
@@ -2692,6 +2703,19 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       );
       return;
     }
+    // #931 GAP 1: the focus cycle alone fires `_onRenderObserverChanged` →
+    // `markNeedsPaint()` ONLY — it does NOT set `_needsFrameSync` or
+    // `markAllRowsDirty()`. On a PRIMARY-screen in-place cursor-addressed redraw
+    // with detection ON (the default), a prior detection-driven sync has already
+    // CONSUMED libghostty's per-row damage, so the resume `_syncFrameState` runs
+    // with NOTHING dirty → the partial build is SKIPPED → the stale buffer
+    // repaints (the "switch to apps and back is frozen" half of #931). Pair the
+    // focus cycle with a REAL frame-sync (`forceRepaint()` → markAllRowsDirty +
+    // frame-dirty, the #918 seam) so resume re-reads the FULL visible grid even
+    // when the damage was consumed. Bounded to the visible rows; coalesced to
+    // once per frame. The structural cure (a non-consuming detection read) is
+    // #922 — this reuses the existing #918 seam.
+    _forceTerminalRepaint();
     // Drop focus now; re-request it next frame so the FocusNode actually
     // transitions (focused → unfocused → focused) and flterm repaints. A
     // same-frame toggle would coalesce to no net change and not notify.
@@ -2702,7 +2726,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       if (c == null) return;
       // Focus ONLY — never showKeyboard(); the keyboard must stay down on resume.
       c.requestFocus();
-      gtrace('ghostty-resume-repaint: focus-cycled (no keyboard)');
+      // #931: also re-force a full re-read on the NEXT frame so the post-focus-
+      // change frame (which a late detection consume could otherwise starve)
+      // re-reads the latest grid too. Coalesces with the focus-driven repaint.
+      _forceTerminalRepaint();
+      gtrace('ghostty-resume-repaint: focus-cycled + forced (no keyboard)');
     });
   }
 
@@ -2735,6 +2763,22 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     if (!mounted) return;
     final controller = _controller;
     if (controller == null) return;
+    // #931 GAP 2: re-assert `_detectionActive` on the render box when THIS view
+    // becomes the active session. `_applyDetectionActive` is otherwise applied
+    // ONCE on a post-frame at init (`_registerUrlPattern`); a view that was
+    // OFFSTAGE at init (its keyed render box not yet laid out, so the lookup
+    // no-oped) could be left `_detectionActive=false` when it later becomes
+    // visible — which drops the primary-screen full re-read and re-freezes the
+    // typing/streaming half of #931. Re-apply on the post-frame after this child
+    // goes onstage (so the keyed render box exists), reflecting the CURRENT
+    // detection settings.
+    if (next == widget.sessionId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final detection = ref.read(detectionSettingsProvider);
+        _applyDetectionActive(detection.detectUrls || detection.detectPaths);
+      });
+    }
     if (ghosttyShouldCaptureKeyboardOnSessionSwitch(
       sessionId: widget.sessionId,
       prevActiveId: prev,

--- a/native/test/ui/ghostty_resume_forcerepaint_931_test.dart
+++ b/native/test/ui/ghostty_resume_forcerepaint_931_test.dart
@@ -1,0 +1,104 @@
+// #931 (P0, device 0.1.10+68, detect-URLs ON = DEFAULT) — on a PRIMARY-screen
+// in-place cursor-addressed redraw the terminal STOPS repainting on (a) app
+// RESUME and (b) TYPING. The RESUME half: `_forceRepaintOnResume` cycled FOCUS
+// only, which fires flterm's `_onRenderObserverChanged` → `markNeedsPaint()`
+// ONLY — no `_needsFrameSync`, no `markAllRowsDirty()`. With detection ON a prior
+// sync already consumed libghostty's per-row damage, so the resume frame-sync
+// runs with nothing dirty → the partial build is SKIPPED → the stale buffer
+// repaints.
+//
+// The #931 GAP 1 fix PAIRS the focus cycle with a REAL `forceRepaint()`
+// (markAllRowsDirty + frame-dirty, the #918 seam) so resume re-reads the FULL
+// visible grid even when the damage was consumed. The force-repaint fires under
+// the SAME guard as the focus cycle ([ghosttyShouldCycleFocusForRepaint]): only
+// the ACTIVE, connected, focus-RETAINED session view. flterm/libghostty can't
+// render headless (native .so), so this gates the PURE decision; the real
+// full-grid repaint (switch-to-apps-and-back shows the latest, no tap, keyboard
+// down) is OWNER-validated on device. The consumed-damage re-read correctness is
+// covered deterministically at the flterm pipeline level in
+// third_party/flterm/test/rendering/resume_typing_repaint_931_test.dart.
+//
+// Structural cure (a non-consuming detection read that removes the damage race
+// entirely) is tracked in #922 — this is the tactical fix on existing seams.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+void main() {
+  group('#931 GAP 1 — resume force-repaint gate', () {
+    test(
+      'forces a full-grid repaint on the RETAINED-focus resume (active + '
+      'connected + hasFocus) — the unlock/switch-back case the focus cycle '
+      'alone left frozen',
+      () {
+        // The #931 RESUME case made concrete: the visible session, a live shell,
+        // focus retained through the background. A plain focus cycle only
+        // markNeedsPaints; the fix ALSO forceRepaints under this same gate.
+        expect(
+          ghosttyShouldCycleFocusForRepaint(
+            active: true,
+            connected: true,
+            hasFocus: true,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'does NOT force a full-grid repaint on an offstage / disconnected / '
+      'focus-lost session (the force-repaint shares the focus-cycle guard)',
+      () {
+        // Offstage session must not force-repaint (would re-read an offstage
+        // grid / steal focus); a dead PTY has nothing to re-read; focus-LOST is
+        // already handled by the #718 plain refocus, so no extra force needed.
+        expect(
+          ghosttyShouldCycleFocusForRepaint(
+            active: false,
+            connected: true,
+            hasFocus: true,
+          ),
+          isFalse,
+          reason: 'offstage session must not force a repaint',
+        );
+        expect(
+          ghosttyShouldCycleFocusForRepaint(
+            active: true,
+            connected: false,
+            hasFocus: true,
+          ),
+          isFalse,
+          reason: 'disconnected session has nothing to re-read',
+        );
+        expect(
+          ghosttyShouldCycleFocusForRepaint(
+            active: true,
+            connected: true,
+            hasFocus: false,
+          ),
+          isFalse,
+          reason: 'focus-lost resume is handled by the plain refocus (#718)',
+        );
+      },
+    );
+
+    test('requires ALL guards — the force-repaint never fires unguarded', () {
+      for (final active in [true, false]) {
+        for (final connected in [true, false]) {
+          for (final hasFocus in [true, false]) {
+            final expected = active && connected && hasFocus;
+            expect(
+              ghosttyShouldCycleFocusForRepaint(
+                active: active,
+                connected: connected,
+                hasFocus: hasFocus,
+              ),
+              expected,
+              reason: 'active=$active connected=$connected hasFocus=$hasFocus',
+            );
+          }
+        }
+      }
+    });
+  });
+}

--- a/native/third_party/flterm/test/rendering/resume_typing_repaint_931_test.dart
+++ b/native/third_party/flterm/test/rendering/resume_typing_repaint_931_test.dart
@@ -1,0 +1,337 @@
+@Tags(['ffi'])
+library;
+
+// #931 (P0, device 0.1.10+68, detect-URLs ON = DEFAULT) — on a PRIMARY-screen
+// in-place cursor-addressed redraw (huge catted page, heavy reflow) the terminal
+// STOPS repainting on (a) app RESUME (return from another Android app) and (b)
+// TYPING. Bytes arrive (telemetry: resume-liveness alive(fresh-bytes)) but the
+// screen stays stale. This is NOT a +67/+68 regression — the paint machinery is
+// byte-identical to +66; a different content shape exposed two paths #921 never
+// covered. The structural cure (a non-consuming detection read) is #922; this is
+// the TACTICAL fix on the existing #918/#921 seams.
+//
+// TWO GAPS (#921 widened the full-re-read gate, terminal_renderer.dart:754, but):
+//
+//   GAP 1 — RESUME forces a repaint via FOCUS-cycle only. On resume the host
+//   widget cycles focus (unfocus → requestFocus next frame), which fires flterm's
+//   `_onRenderObserverChanged` → `markNeedsPaint()` ONLY. It does NOT set
+//   `_needsFrameSync` and does NOT `markAllRowsDirty()`. So when a prior
+//   (detection-driven) sync already consumed the per-row damage, the resume
+//   `_syncFrameState` runs with NOTHING dirty → the partial build re-reads ZERO
+//   rows → the stale buffer repaints. The fix pairs the focus cycle with a real
+//   `forceRepaint()` (markAllRowsDirty + frame-dirty) so resume re-reads the full
+//   visible grid.
+//
+//   GAP 2 — the resilience of `_detectionActive` across an offstage→active /
+//   resize-resync transition. The host applies `_applyDetectionActive` once at
+//   init; a box that becomes visible later can be left `_detectionActive=false`.
+//   Asserted via the `detectionActive` setter self-heal (a fresh full re-read on
+//   the turn-on).
+//
+// The DETERMINISTIC repro of the consumed-damage freeze lives at the pipeline
+// level (mirroring detection_consumes_damage_921_test.dart): a render-box harness
+// cannot reproduce the cross-frame libghostty-handle consume because flterm's
+// `_dirtyRows` marks are STICKY and survive a frame straddle. The render-box
+// tests below assert the SEAM behaviour (forceRepaint re-reads + coalesces, the
+// turn-on self-heals, idle never free-runs); the pipeline tests assert the
+// consumed-damage correctness the resume/typing fix relies on.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/atlas/atlas.dart';
+import 'package:flterm/src/rendering/paint_state.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
+import 'package:flterm/src/rendering/terminal_render_pipeline.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+import 'helpers/font_loader.dart';
+
+void main() {
+  setUpAll(loadBundledFonts);
+
+  const cols = 16;
+  const rows = 4;
+  const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+  void writeUtf8(Terminal terminal, String text) {
+    terminal.write(Uint8List.fromList(utf8.encode(text)));
+  }
+
+  // An in-place primary-screen rewrite (cursor-addressed cells only, ESC[r;cH +
+  // ESC[K). libghostty reports per-row damage — the path a streaming cursor-
+  // addressed redraw of a catted page takes. No alt-screen (no \x1b[?1049h).
+  void inPlaceRedraw(Terminal terminal, String tag) {
+    for (var r = 1; r <= rows; r++) {
+      writeUtf8(terminal, '\x1b[$r;1H\x1b[Kprimary $tag row $r');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // GAP 1 + GAP 2 correctness — PIPELINE level (deterministic consumed-damage).
+  // ---------------------------------------------------------------------------
+  group('#931 consumed-damage on RESUME / TYPING (pipeline, deterministic)', () {
+    AtlasConfig config() => AtlasConfig(
+          fontSize: 14,
+          fontWeight: FontWeight.normal,
+          fontFamily: 'monospace',
+          fontFamilyFallback: const [],
+          metrics: metrics,
+          devicePixelRatio: 1.0,
+        );
+
+    late Terminal terminal;
+    late Atlas atlas;
+    late TerminalPaintState state;
+    late TerminalRenderPipeline pipeline;
+
+    setUp(() {
+      terminal = Terminal(cols: cols, rows: rows);
+      atlas = Atlas(config());
+      state = TerminalPaintState(TerminalTheme.dark(), metrics)
+        ..cols = cols
+        ..rows = rows;
+      pipeline = TerminalRenderPipeline(
+        atlas: atlas,
+        state: state,
+        onImageReady: () {},
+      )..configureGrid(rows, cols);
+    });
+
+    tearDown(() {
+      pipeline.dispose();
+      atlas.dispose();
+      terminal.dispose();
+    });
+
+    test(
+      'RESUME via markNeedsPaint-only (focus cycle) re-reads NOTHING after a '
+      'prior detection sync consumed the damage — the GAP 1 freeze',
+      () {
+        expect(terminal.activeScreen, TerminalScreen.primary);
+
+        // Content drawn + painted before backgrounding.
+        inPlaceRedraw(terminal, 'A');
+        pipeline.sync(terminal, terminalDirty: true);
+
+        // Backgrounded: new content B arrives; a prior (detection-driven) sync
+        // consumes the per-row damage.
+        inPlaceRedraw(terminal, 'B');
+        pipeline.sync(terminal, terminalDirty: true);
+
+        // RESUME via focus cycle = markNeedsPaint() only: NO markAllRowsDirty,
+        // and the terminal reports clean (damage already consumed). The build is
+        // skipped → ZERO rows re-read → the stale buffer repaints.
+        pipeline.sync(terminal, terminalDirty: true);
+
+        expect(
+          pipeline.debugRowsRebuiltLastSync,
+          equals(0),
+          reason: 'a focus-cycle resume (markNeedsPaint only) re-reads nothing '
+              'after a detection sync consumed the damage — the #931 GAP 1 freeze',
+        );
+      },
+    );
+
+    test(
+      'RESUME paired with forceRepaint (markAllRowsDirty) re-reads the FULL '
+      'visible grid even when the damage was consumed — the GAP 1 fix',
+      () {
+        expect(terminal.activeScreen, TerminalScreen.primary);
+
+        inPlaceRedraw(terminal, 'A');
+        pipeline.sync(terminal, terminalDirty: true);
+
+        inPlaceRedraw(terminal, 'B');
+        pipeline.sync(terminal, terminalDirty: true);
+
+        // The #931 fix: resume calls forceRepaint() → markAllRowsDirty before the
+        // paint sync, so the build re-reads the full visible grid.
+        pipeline.markAllRowsDirty();
+        pipeline.sync(terminal, terminalDirty: true);
+
+        expect(
+          pipeline.debugRowsRebuiltLastSync,
+          equals(rows),
+          reason: 'resume paired with forceRepaint re-reads the full grid even '
+              'when libghostty reports clean (the #931 GAP 1 fix)',
+        );
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // SEAM behaviour — RENDER-BOX level.
+  // ---------------------------------------------------------------------------
+  group('#931 render-box seam (forceRepaint / detection self-heal / perf)', () {
+    TerminalRenderCache createRenderCache() {
+      final cache = TerminalRenderCache();
+      addTearDown(cache.dispose);
+      return cache;
+    }
+
+    Widget wrap(Terminal terminal, {TerminalRenderCache? renderCache}) {
+      renderCache ??= createRenderCache();
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: cols * metrics.cellWidth,
+              maxHeight: rows * metrics.cellHeight,
+            ),
+            child: TerminalRenderer(
+              terminal: terminal,
+              theme: TerminalTheme.dark(),
+              metrics: metrics,
+              offset: ViewportOffset.zero(),
+              renderCache: renderCache,
+              renderObserver: _TestRenderObserver(),
+            ),
+          ),
+        ),
+      );
+    }
+
+    late Terminal terminal;
+    setUp(() => terminal = Terminal(cols: cols, rows: rows));
+    tearDown(() => terminal.dispose());
+
+    testWidgets(
+      'GAP 1 wiring: the resume forceRepaint seam re-reads the FULL visible grid '
+      'and increments the forced-repaint count (a real frame-sync, not just '
+      'markNeedsPaint)',
+      (tester) async {
+        await tester.pumpWidget(wrap(terminal));
+        final box = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        box.detectionActive = true;
+        await tester.pump();
+        expect(terminal.activeScreen, TerminalScreen.primary);
+
+        inPlaceRedraw(terminal, 'A');
+        await tester.pump();
+        inPlaceRedraw(terminal, 'B');
+        await tester.pump();
+
+        final forcedBefore = box.debugForceRepaintCount;
+        box.forceRepaint();
+        await tester.pump();
+
+        expect(box.debugForceRepaintCount, greaterThan(forcedBefore),
+            reason: 'resume triggers a real frame-sync (forceRepaint)');
+        expect(box.debugRowsRebuiltLastSync, rows,
+            reason: 'resume re-reads the full visible grid');
+      },
+    );
+
+    testWidgets(
+      'GAP 2 self-heal: turning detectionActive ON forces a fresh full re-read '
+      '(an offstage→active box left false must self-heal on apply)',
+      (tester) async {
+        await tester.pumpWidget(wrap(terminal));
+        final box = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        // Box starts with detection OFF (the offstage-at-init case).
+        expect(box.debugDetectionActive, isFalse);
+
+        inPlaceRedraw(terminal, 'A');
+        await tester.pump();
+
+        // Late detection apply (re-applied after the box became visible / the
+        // resize-resync settled). The setter must self-heal with a full re-read.
+        box.detectionActive = true;
+        await tester.pump();
+
+        expect(box.debugDetectionActive, isTrue);
+        expect(box.debugRowsRebuiltLastSync, rows,
+            reason: 'turning detection ON self-heals with a full visible-grid '
+                're-read (#931 GAP 2 offstage→active resilience)');
+      },
+    );
+
+    testWidgets(
+      '#918 REGRESSION GUARD: many forces within ONE frame coalesce to exactly '
+      'one forced re-snapshot (with detection active)',
+      (tester) async {
+        await tester.pumpWidget(wrap(terminal));
+        final box = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        box.detectionActive = true;
+        await tester.pump();
+        final before = box.debugForceRepaintCount;
+
+        for (var i = 0; i < 5; i++) {
+          box.forceRepaint();
+        }
+        await tester.pump();
+
+        expect(box.debugForceRepaintCount - before, 1,
+            reason: 'multiple forces in one frame coalesce to one (#918)');
+      },
+    );
+
+    testWidgets(
+      '#805 PERF GUARD: with detection active but NO input, NO output, NO resume '
+      'the settle tick never arms and there are zero forced repaints',
+      (tester) async {
+        final scheduled = <void Function()>[];
+        await tester.pumpWidget(wrap(terminal));
+        await tester.pump(const Duration(milliseconds: 200));
+        final box = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        box.detectionActive = true;
+        await tester.pump(const Duration(milliseconds: 200));
+        box.debugSetOutputSettleTickFactory(
+          (_, cb) {
+            scheduled.add(cb);
+            return Timer(const Duration(days: 1), () {})..cancel();
+          },
+        );
+        final forcedBefore = box.debugForceRepaintCount;
+
+        for (var i = 0; i < 10; i++) {
+          await tester.pump(const Duration(milliseconds: 16));
+        }
+
+        expect(box.debugOutputTickArmed, isFalse,
+            reason: 'idle never arms the tick even with detection active');
+        expect(scheduled, isEmpty,
+            reason: 'idle schedules no settle timer (no free-run)');
+        expect(box.debugForceRepaintCount, forcedBefore,
+            reason: 'idle produces zero forced repaints (#805 battery guard)');
+      },
+    );
+  });
+}
+
+class _TestRenderObserver implements TerminalRenderObserver {
+  @override
+  TerminalSelection? get selection => null;
+
+  @override
+  bool get hasFocus => true;
+
+  @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
+  void reportPaintedViewportOffset(int offset) {}
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+}


### PR DESCRIPTION
## #931 — repaint freeze on resume + typing (detection ON, primary-screen redraw)

On a PRIMARY-screen in-place cursor-addressed redraw (huge catted page, heavy reflow)
with detect-URLs ON (the **default**), the terminal stopped repainting on (a) app
RESUME (return from another Android app) and (b) TYPING. Bytes arrived
(`resume-liveness: alive(fresh-bytes)`) but the screen stayed stale. Two paths #921's
primary-screen full-re-read gate never covered. Tactical fix on the existing
#918/#921 seams; the structural cure (a non-consuming detection read) is **#922**.

### GAP 1 — RESUME forced a repaint via focus-cycle only
`_forceRepaintOnResume` cycled focus → flterm's `_onRenderObserverChanged` →
`markNeedsPaint()` ONLY. No `_needsFrameSync`, no `markAllRowsDirty()`. With detection
ON a prior sync already consumed libghostty's per-row damage, so the resume
`_syncFrameState` ran with nothing dirty → the partial build was SKIPPED → the stale
buffer repainted.

**Fix:** pair the focus cycle with a real `forceRepaint()` (the #918 seam →
`markAllRowsDirty` + frame-dirty) so resume re-reads the full visible grid even when
the damage was consumed. Under the same active+connected+focus-retained gate.

### GAP 2 — `_detectionActive` left false on offstage→active / resume
`_applyDetectionActive` was applied ONCE via a post-frame at init. An offstage-at-init
box (lookup no-oped) or a resume-relaidout box could be left `_detectionActive=false`
→ the primary-screen full re-read drops → the typing/streaming half re-freezes.

**Fix:** re-apply detection on active-session change and after resume (post-frame,
reflecting current settings). The flterm `detectionActive` setter already self-heals
with a full re-read.

### Tests
- `native/third_party/flterm/test/rendering/resume_typing_repaint_931_test.dart` —
  deterministic PIPELINE repro of the consumed-damage freeze (markNeedsPaint-only
  re-reads 0 rows; forceRepaint re-reads the full grid) + render-box seam tests
  (forceRepaint full re-read, detection self-heal, #918 coalescing, #805 idle guard).
- `native/test/ui/ghostty_resume_forcerepaint_931_test.dart` — the resume
  force-repaint decision gate.

### Repro honesty
The cross-frame render-timing race is **NOT** deterministically reproducible headlessly
(flterm dirty marks are sticky, so a render-box-level frame straddle is harmless). The
consumed-damage correctness is covered at the pipeline level; the on-device resume +
typing repaint on long content remains **owner-validated**.

### Must not regress (verified)
Full flterm suite — **772 tests green** incl. #900 (alt-screen gate), #921
(detection_consumes_damage), #918 (force coalescing), #805 (no free-run). Native fast
gate green (analyze + unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)