### PR TITLE
fix(#924): clipboard write reaches cross-app paste (drop self-readback interference + non-sensitive ClipDescription)

### DIFF
--- a/native/android/app/src/main/kotlin/com/flavordrake/mobissh/mobissh/MainActivity.kt
+++ b/native/android/app/src/main/kotlin/com/flavordrake/mobissh/mobissh/MainActivity.kt
@@ -2,6 +2,7 @@ package com.flavordrake.mobissh.mobissh
 
 import android.app.Activity
 import android.content.ClipData
+import android.content.ClipDescription
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
@@ -79,6 +80,25 @@ class MainActivity : FlutterActivity() {
                     runOnUiThread {
                         try {
                             val clip = ClipData.newPlainText(label, text)
+                            // #924 — On Android 13+ (API 33) a clip with no
+                            // explicit sensitivity flag can be treated/surfaced
+                            // oddly (preview suppression, redacted history),
+                            // which matched "appears correct but won't paste".
+                            // A URL/path is not a secret, so mark it explicitly
+                            // NON-sensitive so the system propagates it for
+                            // normal cross-app paste.
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                clip.description.extras = android.os.PersistableBundle().apply {
+                                    putBoolean(
+                                        ClipDescription.EXTRA_IS_SENSITIVE,
+                                        false,
+                                    )
+                                }
+                            }
+                            // Resolve the ClipboardManager from the foreground
+                            // activity context (this Activity), not
+                            // applicationContext — the system surfaces the
+                            // primary clip for the focused activity's manager.
                             val manager = getSystemService(Context.CLIPBOARD_SERVICE)
                                 as ClipboardManager
                             manager.setPrimaryClip(clip)

--- a/native/lib/services/clipboard.dart
+++ b/native/lib/services/clipboard.dart
@@ -1,25 +1,34 @@
-// Hardened clipboard write (#845).
+// Hardened clipboard write (#845, #924).
 //
-// The owner reported that copied text shows in the Android system clipboard
-// PREVIEW chip but does NOT reliably surface in Gboard's clipboard HISTORY
-// ("the icon looks empty, then I tap it and it fills in"). There is no lazy /
-// custom clipboard service — every copy site used Flutter's plain
+// #845 — The owner reported that copied text shows in the Android system
+// clipboard PREVIEW chip but does NOT reliably surface in Gboard's clipboard
+// HISTORY. Root cause: every copy site used Flutter's plain
 // `Clipboard.setData(ClipboardData(text:))`, which hands Android a `ClipData`
-// built with an EMPTY label (`newPlainText("", text)`). Some Gboard /
-// clipboard-history implementations index or display poorly on empty-label
-// clips, which matches the "lazy-fills on tap" symptom.
+// built with an EMPTY label (`newPlainText("", text)`). #845's fix routes all
+// copy sites through [copyToClipboard], which writes a properly LABELED
+// plain-text clip natively via a tiny Kotlin `MethodChannel`
+// (`ClipData.newPlainText("MobiSSH", text)` + `setPrimaryClip`). That labeled
+// native write is the real win and is preserved.
 //
-// Fix: route ALL copy sites through [copyToClipboard], which writes a properly
-// LABELED plain-text clip natively via a tiny Kotlin `MethodChannel`
-// (`ClipData.newPlainText("MobiSSH", text)` + `setPrimaryClip`). It then READS
-// BACK the clipboard to prove containment ("make very sure the clipboard
-// actually contains the thing we're copying" — the owner's exact ask) and logs
-// the outcome to the diagnostic ring so containment is provable from device
-// telemetry alone (the owner debugs via Feedback upload).
+// #924 — The copy still didn't reach CROSS-APP PASTE: the toast fires, the
+// preview looks correct, and telemetry logged `verified=true`, yet pasting in
+// another app got nothing. `verified=true` only means our OWN post-write
+// `Clipboard.getData` self-readback found our text in the primary clip — it
+// does NOT prove the clip propagated to the system surface other apps read.
+// Worse, reading the clipboard SYNCHRONOUSLY right after `setPrimaryClip` can,
+// on some Android 13 builds, race/disturb that very propagation.
+//
+// #924 fix: the synchronous, awaited self-readback is REMOVED from the write
+// path. The native `setPrimaryClip` is authoritative — once it returns, the
+// copy is done and we toast. A best-effort diagnostic readback is scheduled on
+// a delayed microtask AFTER the write has settled so it can never block or
+// interfere with propagation; its result is logged only.
 //
 // Non-Android hosts (desktop, widget tests) have no native channel: the call
 // throws `MissingPluginException` / `PlatformException`, and we fall back to
 // the plain `Clipboard.setData` path so those hosts still copy.
+
+import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -43,10 +52,11 @@ const String _clipboardLabel = 'MobiSSH';
 /// Behavior:
 /// - Empty / whitespace-only [text] → no write, returns `false` (callers also
 ///   keep their own #810/#828 empty-payload guards).
-/// - Native write succeeds → reads back via `Clipboard.getData(text/plain)` and
-///   confirms the read-back CONTAINS what we wrote. A null read-back (Android
-///   can deny clipboard READ when focus just changed) is NOT a failure — the
-///   write path is authoritative, so we return `true` and log `verified=null`.
+/// - Native write succeeds → returns `true` immediately. The native
+///   `setPrimaryClip` is authoritative; we do NOT block the copy on a readback
+///   (#924 — a synchronous readback can disturb Android-13 clip propagation).
+///   A best-effort diagnostic readback is scheduled AFTER the write settles and
+///   only logged — it never gates the result.
 /// - Any platform-channel error (desktop / tests / missing plugin) → falls back
 ///   to `Clipboard.setData(ClipboardData(text:))` and returns `true` so
 ///   non-Android hosts and widget tests still copy.
@@ -61,11 +71,13 @@ Future<bool> copyToClipboard(String text) async {
       'label': _clipboardLabel,
       'text': text,
     });
-    final verified = await _readBackVerified(text);
     clifecycle(
       'clipboard',
-      'wrote ${text.length} chars (native), verified=$verified',
+      'wrote ${text.length} chars (native, labeled "$_clipboardLabel")',
     );
+    // Diagnostics-only, deferred so the readback can never race the system
+    // clip propagation that #924 was about. NOT awaited — fire and forget.
+    _scheduleDeferredReadback(text);
     return true;
   } catch (err) {
     // No native channel (desktop / widget tests / missing plugin), or the
@@ -85,20 +97,56 @@ Future<bool> copyToClipboard(String text) async {
   }
 }
 
-/// Reads the clipboard back and reports whether it CONTAINS [text]. Returns:
-/// - `true`  — read-back text contains what we wrote (containment proof).
-/// - `false` — read-back returned non-null text that does NOT contain it
-///   (genuine mismatch — the real bug, if it ever happens).
-/// - `null`  — read-back returned null/empty (READ denied or empty); NOT a
-///   failure, the write path is authoritative.
-Future<bool?> _readBackVerified(String text) async {
-  try {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    final readBack = data?.text;
-    if (readBack == null || readBack.isEmpty) return null;
-    return readBack.contains(text);
-  } catch (_) {
-    // Read-back itself is best-effort diagnostics; never let it fail the copy.
-    return null;
-  }
+/// How long to wait before the diagnostic readback (#924). The native write is
+/// already authoritative; this delay just lets the system clip-propagation
+/// settle so the readback observes the steady state instead of racing it.
+@visibleForTesting
+const Duration clipboardReadbackDelay = Duration(milliseconds: 250);
+
+/// Whether the deferred diagnostic readback is allowed to schedule a timer.
+///
+/// Defaults to OFF under `flutter test` (the binding rejects pending timers in
+/// `testWidgets`, and the readback is on-device-only diagnostics). A single
+/// unit test flips it on to verify the deferral/non-blocking contract.
+bool _deferredReadbackEnabled = !Platform.environment.containsKey('FLUTTER_TEST');
+
+/// Test hook: force-enable the deferred readback so the deferral contract can be
+/// asserted under `flutter test`. Returns the previous value so the test can
+/// restore it. NOT for production use.
+@visibleForTesting
+bool setDeferredReadbackEnabledForTest(bool enabled) {
+  final previous = _deferredReadbackEnabled;
+  _deferredReadbackEnabled = enabled;
+  return previous;
+}
+
+/// Schedules a best-effort, DEFERRED clipboard readback purely for telemetry.
+///
+/// This is NOT awaited by [copyToClipboard] and never affects its result. It
+/// exists only so device feedback uploads can show whether our text was still
+/// present a moment after the write. Crucially it does NOT run synchronously
+/// right after `setPrimaryClip` — that synchronous readback was the #924
+/// suspect (it can disturb Android-13 cross-app propagation).
+///
+/// IMPORTANT: even a `true` readback here does NOT prove cross-app paste works.
+/// It only proves OUR process can still read OUR clip. Cross-app availability
+/// is only observable by pasting in another app (device validation).
+void _scheduleDeferredReadback(String text) {
+  if (!_deferredReadbackEnabled) return;
+  Future<void>.delayed(clipboardReadbackDelay, () async {
+    try {
+      final data = await Clipboard.getData(Clipboard.kTextPlain);
+      final readBack = data?.text;
+      final bool? contains =
+          (readBack == null || readBack.isEmpty) ? null : readBack.contains(text);
+      clifecycle(
+        'clipboard',
+        'deferred readback contains=$contains '
+            '(self-read only; NOT cross-app paste proof)',
+      );
+    } catch (err) {
+      // Readback is best-effort diagnostics; never surface as an error.
+      clifecycle('clipboard', 'deferred readback skipped ($err)');
+    }
+  });
 }

--- a/native/test/services/clipboard_test.dart
+++ b/native/test/services/clipboard_test.dart
@@ -1,10 +1,13 @@
-// Unit tests for the hardened clipboard helper (#845).
+// Unit tests for the hardened clipboard helper (#845, #924).
 //
 // `copyToClipboard` must:
 //   - write via the `mobissh/clipboard` native channel with a NON-empty label
 //     plus the text (the empty-label clip was the root cause of the missing
-//     Gboard history entry);
-//   - read back via `Clipboard.getData(text/plain)` and confirm containment;
+//     Gboard history entry, #845);
+//   - return `true` as soon as the native write completes — the native write is
+//     authoritative and is NOT gated on a synchronous self-readback (#924: the
+//     synchronous readback could disturb Android-13 cross-app propagation, so it
+//     was removed from the write path and deferred to diagnostics);
 //   - treat a NULL native channel (desktop / widget tests) as a fall-back to
 //     Flutter's plain `Clipboard.setData` and still return true;
 //   - skip empty / whitespace-only payloads (return false, no write).
@@ -78,19 +81,99 @@ void main() {
     expect((lastSetText!['label'] as String).isNotEmpty, isTrue);
   });
 
-  test('read-back containment match returns true', () async {
-    // The native handler stores the text; read-back returns it → contains.
+  test('native write is authoritative — returns true without awaiting a '
+      'readback (#924)', () async {
+    // Count how many times Clipboard.getData is invoked DURING the
+    // copyToClipboard call. The #924 fix removed the synchronous, awaited
+    // readback from the write path, so the write must NOT block on getData.
+    var getDataCallsDuringWrite = 0;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        platformClipboard = (call.arguments as Map)['text'] as String?;
+        return null;
+      }
+      if (call.method == 'Clipboard.getData') {
+        getDataCallsDuringWrite++;
+        return <String, dynamic>{'text': platformClipboard};
+      }
+      return null;
+    });
+
     final ok = await copyToClipboard('verify-me');
     expect(ok, isTrue);
-    expect(platformClipboard, 'verify-me');
+    // The native channel write ran with our text.
+    expect(lastSetText!['text'], 'verify-me');
+    // No synchronous readback gated the write (it is deferred / fire-and-forget).
+    expect(getDataCallsDuringWrite, 0);
   });
 
-  test('null read-back is not a failure (write authoritative)', () async {
+  test('null read-back is irrelevant to the result (write authoritative)',
+      () async {
     readBackNull = true;
     final ok = await copyToClipboard('focus-changed');
     expect(ok, isTrue);
-    // The native write still ran.
+    // The native write still ran regardless of any (deferred) readback outcome.
     expect(lastSetText!['text'], 'focus-changed');
+  });
+
+  test('deferred readback runs AFTER the write settles, never gating it (#924)',
+      () async {
+    // The deferred readback is OFF under `flutter test` by default (it would
+    // leave a pending timer that testWidgets rejects, and it's on-device-only
+    // diagnostics). Force it on for this one assertion, then restore.
+    final previous = setDeferredReadbackEnabledForTest(true);
+    addTearDown(() => setDeferredReadbackEnabledForTest(previous));
+
+    var getDataCalls = 0;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.getData') {
+        getDataCalls++;
+        return <String, dynamic>{'text': platformClipboard};
+      }
+      if (call.method == 'Clipboard.setData') {
+        platformClipboard = (call.arguments as Map)['text'] as String?;
+        return null;
+      }
+      return null;
+    });
+
+    final ok = await copyToClipboard('deferred-me');
+    expect(ok, isTrue);
+    // Right after the write returns, the deferred readback has NOT yet fired —
+    // this is the core #924 guarantee (no synchronous readback in the write
+    // path).
+    expect(getDataCalls, 0);
+    // After waiting past the deferral delay, the diagnostic readback has fired.
+    await Future<void>.delayed(
+      clipboardReadbackDelay + const Duration(milliseconds: 50),
+    );
+    expect(getDataCalls, 1);
+  });
+
+  test('deferred readback is OFF by default under flutter test (no timer leak)',
+      () async {
+    // Default path: no force-enable. The write must NOT schedule any readback
+    // timer (that pending timer is what broke the widget tests).
+    var getDataCalls = 0;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.getData') {
+        getDataCalls++;
+        return <String, dynamic>{'text': platformClipboard};
+      }
+      if (call.method == 'Clipboard.setData') {
+        platformClipboard = (call.arguments as Map)['text'] as String?;
+        return null;
+      }
+      return null;
+    });
+
+    final ok = await copyToClipboard('no-timer-leak');
+    expect(ok, isTrue);
+    await Future<void>.delayed(
+      clipboardReadbackDelay + const Duration(milliseconds: 50),
+    );
+    // No readback fired — the timer was never scheduled.
+    expect(getDataCalls, 0);
   });
 
   test('native channel error falls back to Clipboard.setData → true', () async {


### PR DESCRIPTION
## #924 — clipboard write reaches cross-app paste

**Device-confirmed bug (persisted on v0.1.10+69):** copying a URL fires the "Copied" toast, the Android clipboard preview chip looks correct, and telemetry logs `[clipboard] wrote N chars (native), verified=true` — yet pasting into another app gets **nothing**.

**Root insight:** `verified=true` only meant our OWN post-write `Clipboard.getData` self-readback found our text in the primary clip. That proves OUR process can read OUR clip; it does **not** prove the clip propagated to the system surface that other apps read. Cross-app availability is not observable from the writing process's own getData.

### Changes (shared native write path only — parallel-safe)

1. **Drop the synchronous self-readback** (`native/lib/services/clipboard.dart`).
   #845 added `_readBackVerified` (`Clipboard.getData`) immediately after the native `setPrimaryClip`. Reading the clipboard right after writing can **race/disturb system clip-propagation on some Android 13 builds** — the exact "appears correct but won't paste" symptom. The native `setPrimaryClip` is now authoritative: once it returns, we toast. A best-effort diagnostic readback is scheduled on a delayed (250ms), fire-and-forget timer **after** the write settles so it can never block or interfere; it is logged only, and OFF under `flutter test` (it would leave a pending timer `testWidgets` rejects).

2. **Mark the ClipData non-sensitive on API 33+** (`MainActivity.kt`).
   On Android 13+ a clip with no explicit sensitivity flag can have its preview suppressed / history redacted. A URL/path is not a secret, so set `ClipDescription.EXTRA_IS_SENSITIVE=false` so the system propagates it for normal cross-app paste.

Kept #845's actual win: the **LABELED** native plain-text clip via `setPrimaryClip`.

### Hypotheses each change targets
- Change 1 → **self-readback timing interference** with Android-13 propagation (highest confidence; directly explains verified=true + no cross-app paste).
- Change 2 → **sensitive-clip suppression** on API 33+ (secondary, low-risk hardening).

### Tests
`native/test/services/clipboard_test.dart` (8/8 pass):
- native write returns `true` without a synchronous readback gating it (#924)
- deferred readback fires only after the delay and never blocks the write
- deferred readback is OFF by default under `flutter test` (no timer leak)
- fallback to `Clipboard.setData` on native error still works
- empty / whitespace-only payloads → no write, returns false

Native fast gate: analyze pass + 1447 tests pass.

### ⚠️ DEVICE VALIDATION NEEDED
Cross-app paste is **not** verifiable headlessly or on the emulator — the real gate is on-device. Please **tap-copy a URL, then paste into another app** to confirm the data actually arrives.

Closes #924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)