### PR TITLE
fix(#922): structural cure for the flterm repaint saga — carry damage forward so a second consume cannot starve the paint handle

### DIFF
--- a/native/third_party/flterm/lib/src/rendering/terminal_frame_builder.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_frame_builder.dart
@@ -193,6 +193,29 @@ class TerminalFrameBuilder {
   /// other one.
   var debugRowsRebuiltLastSync = 0;
 
+  /// #922: STRUCTURAL cure for the single-consumption damage saga
+  /// (#887/#898/#900/#918/#921/#931). libghostty's [RenderState.update] CONSUMES
+  /// (clears) the terminal's per-row damage as it reads it (render_state.dart:165).
+  /// When DETECTION is active the controller drives an EXTRA content notify per
+  /// output change, so THIS builder's single handle gets `sync(terminalDirty:true)`
+  /// TWICE for one logical change. The FIRST `update` consumes the per-row damage;
+  /// the SECOND reads CLEAN and the partial build re-emits 0 rows — so the
+  /// painting sync (which may be that second, damage-clean one) leaves the grid
+  /// stale (the tmux window-switch "old content stays on screen").
+  ///
+  /// The cure makes the PAINT handle the AUTHORITATIVE consumer without editing
+  /// libghostty (it is not vendored — pub cache) and without a fragile UI-flag
+  /// gate: when an `update` reports damage, the builder remembers it
+  /// ([_damageUnsettled]) until a FOLLOWING sync that reads CLEAN re-reads the
+  /// full visible grid and settles it. So however many redundant damage-consuming
+  /// syncs detection injects, the next clean sync repaints the live cells — a
+  /// second `update` consumer can no longer starve the paint handle (the #922
+  /// acceptance). Bounded to the visible grid, and it adds NO extra work when
+  /// detection is OFF: a single sync per change consumes the damage in the sync
+  /// that builds it, and the next change's `update` is non-clean anyway, so the
+  /// flag never forces a full re-read on the #805 streaming-output path.
+  var _damageUnsettled = false;
+
   TerminalFrameBuilder(this._atlas, this._sprites, this._state)
     : _content = CellContentResolver(_atlas),
       _renderState = RenderState(),
@@ -277,9 +300,25 @@ class TerminalFrameBuilder {
 
     final hasDirtyRows = _dirtyRows.anyDirty;
     if (terminalDirty) {
-      if (dirty != .clean || hasDirtyRows) {
-        _build(dirty == .clean ? .partial : dirty);
+      // #922: an `update` that reports damage marks the content UNSETTLED until a
+      // build that reaches paint clears it. A redundant detection-driven sync
+      // consumes the per-row damage so a LATER painting sync reads CLEAN; without
+      // this carry-forward that sync's partial build re-emits 0 rows and the grid
+      // stays stale. When it reads CLEAN while damage is still unsettled, force a
+      // FULL visible-grid re-read so the painting sync re-reads the live cells —
+      // the paint handle is the authoritative consumer regardless of how many
+      // extra consuming syncs detection injects.
+      if (dirty != .clean) _damageUnsettled = true;
+      final cleanButUnsettled = dirty == .clean && _damageUnsettled;
+      if (dirty != .clean || hasDirtyRows || cleanButUnsettled) {
+        _build(cleanButUnsettled ? .full : (dirty == .clean ? .partial : dirty));
         _renderState.dirty = .clean;
+        // The full re-read off a clean-but-unsettled sync IS the authoritative
+        // repaint of the live cells — it settles the epoch. A partial build off
+        // freshly-consumed damage is NOT guaranteed to be the frame that paints
+        // (a redundant detection sync may have consumed it), so it must NOT
+        // settle: a following clean sync still owes the full re-read.
+        if (cleanButUnsettled) _damageUnsettled = false;
       }
     } else if (hasDirtyRows) {
       _build(.partial);

--- a/native/third_party/flterm/test/rendering/alt_screen_repaint_alternation_900_test.dart
+++ b/native/third_party/flterm/test/rendering/alt_screen_repaint_alternation_900_test.dart
@@ -141,8 +141,9 @@ void main() {
   );
 
   test(
-    'without the fix, a redraw whose damage was already consumed re-reads NO '
-    'rows (documents the alternation root)',
+    '#922 STRUCTURAL: a redraw whose damage was already consumed STILL re-reads '
+    'the full grid on the next CLEAN sync WITHOUT any manual markAllRowsDirty — '
+    'the carry-forward eliminates the alternation root (was 0 = stale before #922)',
     () {
       writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
       inPlaceRedraw('A');
@@ -151,17 +152,18 @@ void main() {
       inPlaceRedraw('B');
       // First (consuming) sync: reads + clears the per-row damage.
       pipeline.sync(terminal, terminalDirty: true);
-      // Second sync WITHOUT markAllRowsDirty: libghostty has no new damage, so
-      // the partial-build re-reads nothing. This is the stale-grid half of the
-      // strict A/B/A/B alternation the fix eliminates.
+      // Second (painting) sync reads CLEAN. Before #922 the partial build
+      // re-read nothing (the stale half of the A/B/A/B alternation). The #922
+      // `_damageUnsettled` carry-forward now forces a full re-read on this clean
+      // sync, with NO markAllRowsDirty — the paint handle is authoritative.
       pipeline.sync(terminal, terminalDirty: true);
 
       expect(
         pipeline.debugRowsRebuiltLastSync,
-        equals(0),
-        reason: 'WITHOUT the fix, a redraw whose damage a prior frame consumed '
-            're-reads zero rows — the rendered grid stays stale every other '
-            'switch (the #900 root)',
+        equals(4),
+        reason: 'after #922, a redraw whose damage a prior frame consumed STILL '
+            're-reads the full visible grid on the next clean sync — the '
+            'alternation root is structurally gone',
       );
     },
   );

--- a/native/third_party/flterm/test/rendering/detection_consumes_damage_921_test.dart
+++ b/native/third_party/flterm/test/rendering/detection_consumes_damage_921_test.dart
@@ -146,8 +146,10 @@ void main() {
   );
 
   test(
-    'PRIMARY screen WITHOUT the fix: a redraw whose damage a prior sync consumed '
-    're-reads NO rows (documents the detection-ON freeze root)',
+    'PRIMARY screen #922 STRUCTURAL: a redraw whose damage a prior (detection-'
+    'driven) sync consumed re-reads the FULL grid on the next CLEAN sync WITHOUT '
+    'any manual markAllRowsDirty — the carry-forward makes the paint handle '
+    'authoritative (the new invariant; was 0 = stale before #922)',
     () {
       expect(terminal.activeScreen, TerminalScreen.primary);
 
@@ -158,17 +160,17 @@ void main() {
       // First (consuming) sync: detection's extra notify reads + clears the
       // per-row damage.
       pipeline.sync(terminal, terminalDirty: true);
-      // Second sync WITHOUT markAllRowsDirty: libghostty has no new damage, so
-      // the partial build re-reads nothing. This is the stale grid the user sees
-      // with detection ON — the #921 root.
+      // Second (painting) sync reads CLEAN — but the #922 `_damageUnsettled`
+      // carry-forward forces a full re-read so the live cells reach the screen.
+      // No markAllRowsDirty, no detectionActive gate.
       pipeline.sync(terminal, terminalDirty: true);
 
       expect(
         pipeline.debugRowsRebuiltLastSync,
-        equals(0),
-        reason: 'WITHOUT the fix, a redraw whose damage a prior detection-driven '
-            'sync consumed re-reads zero rows — the rendered grid stays stale '
-            '(the #921 detection-ON paint freeze)',
+        equals(4),
+        reason: 'after #922, a redraw whose damage a prior detection-driven sync '
+            'consumed STILL re-reads the full visible grid on the next clean '
+            'sync — a second consume can no longer starve the paint handle',
       );
     },
   );

--- a/native/third_party/flterm/test/rendering/resume_typing_repaint_931_test.dart
+++ b/native/third_party/flterm/test/rendering/resume_typing_repaint_931_test.dart
@@ -111,8 +111,9 @@ void main() {
     });
 
     test(
-      'RESUME via markNeedsPaint-only (focus cycle) re-reads NOTHING after a '
-      'prior detection sync consumed the damage — the GAP 1 freeze',
+      '#922 STRUCTURAL: RESUME via a plain terminalDirty sync (no forceRepaint) '
+      'after a prior detection sync consumed the damage STILL re-reads the full '
+      'grid — the carry-forward self-heals the GAP 1 freeze (was 0 before #922)',
       () {
         expect(terminal.activeScreen, TerminalScreen.primary);
 
@@ -125,16 +126,18 @@ void main() {
         inPlaceRedraw(terminal, 'B');
         pipeline.sync(terminal, terminalDirty: true);
 
-        // RESUME via focus cycle = markNeedsPaint() only: NO markAllRowsDirty,
-        // and the terminal reports clean (damage already consumed). The build is
-        // skipped → ZERO rows re-read → the stale buffer repaints.
+        // RESUME drives a terminalDirty sync that reads CLEAN (damage already
+        // consumed). Before #922 the build was skipped → ZERO rows → stale. The
+        // #922 `_damageUnsettled` carry-forward now forces a full re-read so the
+        // resume paints the live grid even without the #931 forceRepaint pairing.
         pipeline.sync(terminal, terminalDirty: true);
 
         expect(
           pipeline.debugRowsRebuiltLastSync,
-          equals(0),
-          reason: 'a focus-cycle resume (markNeedsPaint only) re-reads nothing '
-              'after a detection sync consumed the damage — the #931 GAP 1 freeze',
+          equals(rows),
+          reason: 'after #922 a resume sync that reads clean STILL re-reads the '
+              'full visible grid — the consumed-damage freeze is structurally '
+              'gone (the #931 forceRepaint is now belt-and-suspenders)',
         );
       },
     );

--- a/native/third_party/flterm/test/rendering/window_switch_no_starve_922_test.dart
+++ b/native/third_party/flterm/test/rendering/window_switch_no_starve_922_test.dart
@@ -1,0 +1,216 @@
+@Tags(['ffi'])
+library;
+
+// #922 (P0, device 0.1.10+70) — the STRUCTURAL cure for the repaint saga
+// (#887/#898/#900/#918/#921/#931). After the +70 tactical #931 fix RESUME and
+// TYPING repaint, but switching tmux WINDOWS still leaves the OLD window's
+// content on screen (stale) with detect-URLs ON.
+//
+// ROOT (corrected — see issue #922; the "two RenderState handles share one
+// terminal damage flag" premise was DISPROVEN by a pipeline probe: each
+// libghostty RenderState handle has INDEPENDENT per-row dirty tracking, so a
+// second handle's update does NOT clear the first's damage). The real defect is
+// SAME-HANDLE DOUBLE-UPDATE: `RenderState.update()` CONSUMES the terminal's
+// per-row damage as it reads it (render_state.dart:165). With detection ON the
+// controller drives an EXTRA content notify per output change, so the render
+// box's SINGLE paint handle gets `sync(terminalDirty:true)` TWICE for one
+// logical change. The FIRST `update` consumes the per-row damage; the SECOND
+// reads CLEAN and the partial build re-emits 0 rows. When the painting sync is
+// that second, damage-clean one, the grid stays stale — the tmux window-switch
+// "old content stays on screen".
+//
+// STRUCTURAL FIX (terminal_frame_builder.dart `_damageUnsettled`): an `update`
+// that reports damage marks the content UNSETTLED until a FOLLOWING sync that
+// reads CLEAN re-reads the FULL visible grid and settles it. So a redundant
+// damage-consuming sync can no longer leave a later clean painting sync reading
+// nothing — the paint handle is the AUTHORITATIVE consumer regardless of how
+// many extra consuming syncs detection injects. No libghostty edit (it is not
+// vendored — pub cache), no fragile detectionActive UI gate, and NO extra work
+// on the detection-OFF streaming path (#805): a single sync per change consumes
+// the damage in the sync that builds it, and the next change's `update` is
+// non-clean anyway, so the flag never forces a full re-read while output streams.
+//
+// THE INVARIANT this test pins (so it can NEVER regress to a per-frame guard
+// race): after a content change, a redundant damage-consuming sync followed by a
+// CLEAN sync must STILL re-read the full visible grid — the paint handle is not
+// starved.
+
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flterm/src/foundation/cell_metrics.dart';
+import 'package:flterm/src/foundation/terminal_theme.dart';
+import 'package:flterm/src/rendering/atlas/atlas.dart';
+import 'package:flterm/src/rendering/paint_state.dart';
+import 'package:flterm/src/rendering/terminal_render_pipeline.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+void main() {
+  const rows = 4;
+  const cols = 16;
+  const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+  AtlasConfig config() => AtlasConfig(
+        fontSize: 14,
+        fontWeight: FontWeight.normal,
+        fontFamily: 'monospace',
+        fontFamilyFallback: const [],
+        metrics: metrics,
+        devicePixelRatio: 1.0,
+      );
+
+  void writeUtf8(Terminal terminal, String text) {
+    terminal.write(Uint8List.fromList(utf8.encode(text)));
+  }
+
+  late Terminal terminal;
+  late Atlas atlas;
+  late TerminalPaintState state;
+  late TerminalRenderPipeline pipeline;
+
+  setUp(() {
+    terminal = Terminal(cols: cols, rows: rows);
+    atlas = Atlas(config());
+    state = TerminalPaintState(TerminalTheme.dark(), metrics)
+      ..cols = cols
+      ..rows = rows;
+    pipeline = TerminalRenderPipeline(
+      atlas: atlas,
+      state: state,
+      onImageReady: () {},
+    )..configureGrid(rows, cols);
+  });
+
+  tearDown(() {
+    pipeline.dispose();
+    atlas.dispose();
+    terminal.dispose();
+  });
+
+  // A tmux window switch: an in-place full-screen redraw (addressed cells only,
+  // no \x1b[2J), so libghostty reports per-row damage — the path a tmux window
+  // switch takes. Modelled on BOTH screens (the saga has hit both).
+  void enterAltScreen() => writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
+
+  void switchWindow(String tag) {
+    for (var r = 1; r <= rows; r++) {
+      writeUtf8(terminal, '\x1b[$r;1Hwindow $tag row $r        ');
+    }
+  }
+
+  group('#922 tmux WINDOW SWITCH must repaint with the detection double-update',
+      () {
+    test(
+      'ALT screen: a redundant damage-consuming sync then a CLEAN painting sync '
+      'still re-reads the full visible grid (the structural carry-forward) — the '
+      'paint handle is not starved',
+      () {
+        enterAltScreen();
+        expect(terminal.activeScreen, TerminalScreen.alternate,
+            reason: 'precondition: tmux runs on the alternate screen');
+
+        // Window A drawn and painted.
+        switchWindow('A');
+        pipeline.sync(terminal, terminalDirty: true);
+        expect(pipeline.debugRowsRebuiltLastSync, greaterThan(0),
+            reason: 'precondition: the first window draw re-reads rows');
+
+        // Switch A -> B: the redraw burst writes B's rows; libghostty holds
+        // per-row damage. Detection ON injects an EXTRA content notify, so the
+        // SAME paint handle syncs once for that change BEFORE the painting sync:
+        // this FIRST sync's `update` consumes the per-row damage.
+        switchWindow('B');
+        pipeline.sync(terminal, terminalDirty: true);
+
+        // The painting sync now runs. libghostty reports CLEAN (no NEW damage
+        // since the consuming sync). The #922 carry-forward forces a full
+        // re-read because the damage is still UNSETTLED — no manual
+        // markAllRowsDirty, no detectionActive gate.
+        pipeline.sync(terminal, terminalDirty: true);
+
+        expect(
+          pipeline.debugRowsRebuiltLastSync,
+          equals(rows),
+          reason: 'the window-switch redraw re-reads the FULL visible grid on the '
+              'painting sync even though a redundant detection-driven sync '
+              'consumed the damage first — the paint handle is authoritative '
+              '(#922)',
+        );
+      },
+    );
+
+    test(
+      'PRIMARY screen: the same redundant-consume → clean-paint sequence re-reads '
+      'the full visible grid (the #921 detection-ON case, now structural)',
+      () {
+        expect(terminal.activeScreen, TerminalScreen.primary);
+
+        switchWindow('A');
+        pipeline.sync(terminal, terminalDirty: true);
+
+        switchWindow('B');
+        // Detection's extra notify consumes the damage first.
+        pipeline.sync(terminal, terminalDirty: true);
+        // The painting sync reads clean; the carry-forward re-reads the grid.
+        pipeline.sync(terminal, terminalDirty: true);
+
+        expect(
+          pipeline.debugRowsRebuiltLastSync,
+          equals(rows),
+          reason: 'the primary-screen detection double-update re-reads the full '
+              'grid structurally — no detectionActive gate needed (#922)',
+        );
+      },
+    );
+
+    test(
+      'REPEATED switches A->B->A->B each repaint despite a redundant consuming '
+      'sync per switch (the #900 alternation is now structural, not every-other)',
+      () {
+        enterAltScreen();
+        switchWindow('init');
+        pipeline.sync(terminal, terminalDirty: true);
+
+        for (final tag in ['A', 'B', 'A', 'B', 'A']) {
+          switchWindow(tag);
+          // Redundant detection-driven sync consumes the damage first...
+          pipeline.sync(terminal, terminalDirty: true);
+          // ...then the painting sync reads clean.
+          pipeline.sync(terminal, terminalDirty: true);
+
+          expect(
+            pipeline.debugRowsRebuiltLastSync,
+            equals(rows),
+            reason: 'EVERY window switch ($tag) re-reads the full visible grid — '
+                'no A/B/A/B alternation, no stale window (#900 structural)',
+          );
+        }
+      },
+    );
+
+    test(
+      '#805 GUARD: detection OFF (a SINGLE sync per change) never forces a full '
+      're-read while output streams — the painting sync consumes the damage it '
+      'builds, and the next change is non-clean, so per-redraw work is unchanged',
+      () {
+        expect(terminal.activeScreen, TerminalScreen.primary);
+
+        // Stream several in-place redraws, ONE sync per change (detection OFF).
+        // Each sync sees fresh per-row damage (non-clean), so the build is the
+        // normal PARTIAL per-row rebuild — never a forced full re-read.
+        for (final tag in ['A', 'B', 'C', 'D']) {
+          switchWindow(tag);
+          pipeline.sync(terminal, terminalDirty: true);
+          expect(
+            pipeline.debugRowsRebuiltLastSync,
+            greaterThan(0),
+            reason: 'a single sync per change consumes the damage in the sync '
+                'that builds it ($tag) — paint works with no redundant sync',
+          );
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Structural cure for the flterm repaint saga (#887/#898/#900/#918/#921/#931). With detect-URLs ON, switching tmux windows left the OLD window's content on screen (stale). This makes the render box's paint handle the authoritative damage consumer so detection can never starve it.

## Root (corrected)
libghostty's `RenderState.update()` consumes the terminal's per-row damage as it reads it. The prompt/issue's original "two RenderState handles share one damage flag" premise was **disproven by a pipeline probe**: each handle has independent per-row dirty tracking, and on the alt screen `update()` always returns `DirtyState.full`. The real defect is **SAME-handle double-update**: detection ON injects an EXTRA content notify per output change, so the render box's single paint handle is `sync(terminalDirty:true)`'d TWICE — the first consumes the damage, the second reads CLEAN and the partial build re-emits 0 rows → stale grid.

## Fix
`terminal_frame_builder.dart` — a new `_damageUnsettled` flag. An `update` that reports damage marks the content unsettled until a FOLLOWING sync that reads CLEAN re-reads the FULL visible grid and settles it. So however many redundant consuming syncs detection injects, the next clean (painting) sync repaints the live cells.

- No libghostty edit (it is not vendored — resolves from the pub cache).
- No fragile `detectionActive` UI gate as the load-bearing mechanism (the existing `markAllRowsDirty` gates remain as defense-in-depth).
- #805-safe: the full re-read fires ONLY on a terminalDirty sync that reads clean while damage is unsettled (a redundant detection sync). The detection-OFF streaming path issues one non-clean sync per change, so per-redraw work is unchanged.

## Tests
- **new** `window_switch_no_starve_922_test.dart`: SAME-handle double-update (redundant consume → clean paint) on alt + primary screens; repeated A→B→A→B; a #805 detection-OFF streaming guard.
- rewrote the #900/#921/#931 "documents the stale root" assertions (which asserted 0 rows = stale) to the new invariant: the painting sync re-reads the full grid structurally, no manual `markAllRowsDirty`.

## Verification
- Full flterm fork suite: 776 tests green.
- Native fast gate: 1452 tests green (incl. `replay_scroll_repaint_perf_test.dart` #805 and #873 eviction). `flutter analyze`: No issues found.
- **On-device gate (not widget-reproducible):** tmux WINDOW SWITCH repaints with detect-URLs ON. The pipeline test proves the paint handle is no longer starved.

Closes #922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)