### PR TITLE
fix(#936): suppress attention bell when on a disconnected active session

### DIFF
--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -185,10 +185,16 @@ class _RootRouterState extends ConsumerState<RootRouter> {
       final sessions = ref.read(sessionsProvider);
       final entries = sessions.entries;
       if (entries.isEmpty) return;
+      // #936: derive id + HOST from the FRONT-MOST tab entry, not
+      // `sessions.active`/`activeId`. A disconnected/transitioning front-most
+      // session leaves `active` null, which previously propagated
+      // activeSessionId=null/activeHost=null and let a same-host bell escape
+      // suppression while the user was still on that very tab. The front-most
+      // entry's host is always derivable regardless of connection state.
       entries.first.proxy.setActive(
         true,
-        activeSessionId: sessions.activeId,
-        activeHost: sessions.active?.host,
+        activeSessionId: sessions.frontActiveId,
+        activeHost: sessions.frontActiveHost,
       );
     });
 
@@ -214,12 +220,14 @@ class _RootRouterState extends ConsumerState<RootRouter> {
           final sessions = ref.read(sessionsProvider);
           entries.first.proxy.setActive(
             false,
-            activeSessionId: sessions.activeId,
+            // #936: front-most tab id/host, not `active`/`activeId` (null while
+            // disconnected/transitioning).
+            activeSessionId: sessions.frontActiveId,
             // #847: carry the active session's HOST so the task suppresses by
             // host (the unit of attention is the Claude/host). On background
             // `active:false` means nothing is suppressed anyway, but we send it
             // so the host's last-known activeHost stays accurate.
-            activeHost: sessions.active?.host,
+            activeHost: sessions.frontActiveHost,
           );
         }
         for (final e in entries) {
@@ -242,10 +250,12 @@ class _RootRouterState extends ConsumerState<RootRouter> {
           final sessions = ref.read(sessionsProvider);
           entries.first.proxy.setActive(
             true,
-            activeSessionId: sessions.activeId,
+            // #936: front-most tab id/host, not `active`/`activeId` (null while
+            // disconnected/transitioning).
+            activeSessionId: sessions.frontActiveId,
             // #847: carry the active session's HOST so the task host-suppresses
             // a bell from any (possibly different) session to the same host.
-            activeHost: sessions.active?.host,
+            activeHost: sessions.frontActiveHost,
           );
         }
         for (final e in entries) {

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -1357,8 +1357,25 @@ class SessionHost {
     // that must update suppression. A null id/host (older UI / none) leaves it
     // unknown (degrades to "never host-suppress").
     final prevActiveHost = _activeHost;
-    _activeSessionId = activeSessionId;
-    _activeHost = activeHost;
+    // #936: a TRANSIENT disconnect blip can push a setActive with BOTH a null
+    // id AND a null host while the app is still FOREGROUNDED on that very tab —
+    // the UI's front-most session momentarily fails to resolve. With nothing to
+    // derive a host from, clobbering the last-known id/host to null opens the
+    // suppression gate (`shouldPostAttention` returns true when frontHost is
+    // null), so a same-host bell during the blip fires while the user is
+    // looking at it. Retain the last-known id/host in that no-info case rather
+    // than erasing it. Any usable signal — a non-null id (host derivable via
+    // `hostOfSessionId`) or a non-null host — replaces it normally, as does a
+    // genuine background (`active:false`).
+    final hasUsableActive = (activeHost != null && activeHost.isNotEmpty) ||
+        (activeSessionId != null && activeSessionId.isNotEmpty);
+    if (active && !hasUsableActive) {
+      // Foregrounded with no resolvable front-most session — keep
+      // _activeSessionId/_activeHost at their previous values.
+    } else {
+      _activeSessionId = activeSessionId;
+      _activeHost = activeHost;
+    }
     // #856: when the active HOST actually CHANGES, arm the just-switched grace
     // for the newly-active host so its switch catch-up burst doesn't post a
     // redundant attention notification. Only on a real change (new != previous)

--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -104,6 +104,28 @@ class SessionsState {
     return null;
   }
 
+  /// The front-most session ENTRY — the one the user is looking at. Resolves
+  /// [active] first; falls back to the first entry when [activeId] is null or
+  /// references an entry that no longer exists. Unlike [active] this returns a
+  /// tab whenever ANY exists, regardless of connection state, so callers can
+  /// always recover the front-most session's id + HOST during a disconnect /
+  /// transition (#936). Null only when the collection is empty.
+  SessionEntry? get frontEntry {
+    final a = active;
+    if (a != null) return a;
+    return entries.isEmpty ? null : entries.first;
+  }
+
+  /// Front-most session id (null only when the collection is empty). Used to
+  /// propagate active-session state to the task isolate even while the
+  /// front-most session is disconnected/transitioning (#936).
+  String? get frontActiveId => frontEntry?.id;
+
+  /// Front-most session HOST (null only when the collection is empty). Always
+  /// derivable from the front-most entry regardless of connection state — a
+  /// disconnect never clears [SessionEntry.host] (#936).
+  String? get frontActiveHost => frontEntry?.host;
+
   bool get isEmpty => entries.isEmpty;
   int get length => entries.length;
 

--- a/native/test/services/session_host_attention_disconnected_active_test.dart
+++ b/native/test/services/session_host_attention_disconnected_active_test.dart
@@ -1,0 +1,141 @@
+// SessionHost attention suppression when the front-most session is DISCONNECTED
+// (#936). Telemetry (v0.1.10+70) showed a bell firing while the user was ALREADY
+// on the session: the active session had DISCONNECTED, so the UI propagated
+// activeSessionId=null / activeHost=null, and shouldPostAttention's
+// `if (frontHost == null) return true` branch POSTED. These tests pin the fix:
+//
+//   1. Foreground + active session whose HOST is derivable from a non-null
+//      activeSessionId (even if not "connected") + same-host bell → SUPPRESSED.
+//   2. A TRANSIENT setActive carrying activeHost=null (disconnect blip) while
+//      foregrounded must NOT clobber the last-known activeHost — a subsequent
+//      same-host bell is still SUPPRESSED.
+//
+// Headless via InMemoryGatewayPair + an inert controller (mirrors
+// session_host_attention_telemetry_test.dart) against a RecordingAttentionNotifier.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/services/session_attention_notification.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+class _NoConnectController extends SshSessionController {
+  @override
+  Future<void> connect(SshConnectParams params) async {}
+}
+
+Future<({InMemoryGatewayPair pair, SessionHost host, RecordingAttentionNotifier notifier})>
+_setup({String sid = 'h:22:u:1'}) async {
+  late SshSessionController controller;
+  final pair = InMemoryGatewayPair();
+  final notifier = RecordingAttentionNotifier();
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: () {
+      controller = _NoConnectController();
+      return controller;
+    },
+    snapshotInterval: const Duration(milliseconds: 50),
+    attentionNotifier: notifier,
+    // Disable both upstream gates so these tests exercise only the
+    // foreground/host suppression they assert on (see telemetry test rationale).
+    replayWindow: Duration.zero,
+    switchGraceWindow: Duration.zero,
+  );
+  pair.uiSide.send(
+    SshConnectCommand(
+      sessionId: sid,
+      host: 'h',
+      port: 22,
+      username: 'u',
+      authJson: const {'type': 'password', 'password': 'p'},
+    ).toJson(),
+  );
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  controller.debugSetConnectedForTest(_params);
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  return (pair: pair, host: host, notifier: notifier);
+}
+
+/// OSC 9 bytes carrying [text].
+List<int> _osc9(String text) => [0x1b, 0x5d, ...utf8.encode('9;$text'), 0x07];
+
+void main() {
+  setUp(clearConnectLog);
+
+  test(
+      'foreground + disconnected active session (host derivable) + same-host '
+      'bell → SUPPRESSED', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    // The user is foregrounded on the front-most session tab whose underlying
+    // SSH has DISCONNECTED. The UI no longer resolves a CONNECTED entry, but the
+    // front-most tab's id (and therefore its HOST) is still known and propagated.
+    // Crucially activeHost is omitted (null) — exactly the #936 device case — so
+    // suppression must fall back to deriving the host from activeSessionId.
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(
+        active: true,
+        activeSessionId: 'h:22:u:1',
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('ready'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(s.notifier.posted, isEmpty,
+        reason: 'user is on this very (disconnected) session — must suppress');
+  });
+
+  test(
+      'transient activeHost=null setActive must NOT clobber last-known host — '
+      'same-host bell still SUPPRESSED', () async {
+    final s = await _setup();
+    addTearDown(() async {
+      await s.host.dispose();
+      await s.pair.dispose();
+    });
+    // 1. Foreground on the session to host 'h' — last-known activeHost='h'.
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(
+        active: true,
+        activeSessionId: 'h:22:u:1',
+        activeHost: 'h',
+      ).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    // 2. A transient disconnect blip pushes a setActive with BOTH id and host
+    //    null while STILL foregrounded. This must NOT erase the last-known host.
+    s.pair.uiSide.send(
+      const SshSetActiveCommand(active: true).toJson(),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    // 3. A same-host bell arrives during the blip. The user is still looking at
+    //    host 'h', so it must be suppressed against the retained last-known host.
+    s.host.feedAttentionForTest('h:22:u:1', _osc9('ready'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(s.notifier.posted, isEmpty,
+        reason:
+            'a transient null setActive must retain last-known activeHost so a '
+            'same-host bell during a disconnect blip still suppresses');
+  });
+}

--- a/native/test/state/session_front_active_test.dart
+++ b/native/test/state/session_front_active_test.dart
@@ -1,0 +1,74 @@
+// SessionsState front-most active derivation (#936).
+//
+// The attention-suppression UI→task propagation needs the front-most session's
+// id + HOST even when the session is DISCONNECTED / transitioning. Telemetry
+// (v0.1.10+70) showed `sessions.active` resolving to null during a disconnect,
+// so main.dart propagated activeSessionId=null / activeHost=null and a same-host
+// bell escaped suppression while the user was still on that very tab.
+//
+// SessionEntry.host is always present (it is parsed from the id at construction
+// and never cleared by a disconnect), so the front-most entry's host is ALWAYS
+// derivable when a tab exists. These tests pin the pure getters that main.dart
+// uses to propagate a NON-NULL host whenever a front-most tab exists.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:xterm/xterm.dart';
+
+SessionEntry _entry(String host, int port, String user, int ts) {
+  final id = '$host:$port:$user:$ts';
+  final pair = InMemoryGatewayPair();
+  addTearDown(() async => pair.dispose());
+  return SessionEntry(
+    id: id,
+    host: host,
+    port: port,
+    username: user,
+    proxy: SshSessionProxy(sessionId: id, gateway: pair.uiSide),
+    terminal: Terminal(),
+  );
+}
+
+void main() {
+  group('SessionsState front-most active', () {
+    test('empty collection → null id and host', () {
+      const state = SessionsState();
+      expect(state.frontActiveId, isNull);
+      expect(state.frontActiveHost, isNull);
+    });
+
+    test('activeId resolves an entry → its id and host', () {
+      final a = _entry('alpha', 22, 'u', 1);
+      final b = _entry('beta', 22, 'u', 2);
+      final state = SessionsState(entries: [a, b], activeId: b.id);
+      expect(state.frontActiveId, b.id);
+      expect(state.frontActiveHost, 'beta');
+    });
+
+    test(
+        'activeId is null but a front-most tab exists → falls back to '
+        'entries.first id and host (the #936 disconnected case)', () {
+      final a = _entry('alpha', 22, 'u', 1);
+      final b = _entry('beta', 22, 'u', 2);
+      // activeId null simulates the transient/disconnected state where
+      // `active` would resolve null; the front-most tab (entries.first) is
+      // still alpha and its host is always derivable.
+      final state = SessionsState(entries: [a, b]);
+      expect(state.frontActiveId, a.id,
+          reason: 'must fall back to the front-most entry id');
+      expect(state.frontActiveHost, 'alpha',
+          reason: 'host is always derivable from the front-most entry');
+    });
+
+    test(
+        'activeId references a missing entry → falls back to entries.first '
+        '(non-null host)', () {
+      final a = _entry('alpha', 22, 'u', 1);
+      final state = SessionsState(entries: [a], activeId: 'gone:22:u:99');
+      expect(state.frontActiveId, a.id);
+      expect(state.frontActiveHost, 'alpha');
+    });
+  });
+}


### PR DESCRIPTION
## Issue #936 — attention bell fires while user is on the (disconnected) session

### Root (telemetry-confirmed, v0.1.10+70)
The attention gate posted while the app was foregrounded ON the signalling
session. The decision telemetry showed:

`posted notification … [foreground=true activeSessionId=null activeHost=null signalHost=fd-dev… reason=not-suppressed]`

`shouldPostAttention` suppresses only when `foreground && frontHost == signalHost`;
with both `activeSessionId` and `activeHost` null it hits `if (frontHost == null) return true` and POSTS.

They go null because the active session had **DISCONNECTED**: `main.dart`'s
setActive sends used `sessions.active?.host` / `sessions.activeId`, which both
resolve to null for a disconnected/transitioning front-most tab — even though
the user is still viewing that tab.

### Fix
- **PRIMARY (`native/lib/state/sessions.dart`, `native/lib/main.dart`):** new
  `SessionsState.frontEntry` / `frontActiveId` / `frontActiveHost` resolve
  `active` first then fall back to `entries.first`. The front-most tab is
  returned regardless of connection state and `SessionEntry.host` is parsed from
  the id at construction (never cleared by a disconnect), so the host is always
  derivable while a tab exists. The three setActive sends (activeId listen,
  pause, resume) now propagate these non-null values.
- **DEFENSIVE (`native/lib/services/session_host.dart` `_handleSetActive`):**
  when foregrounded with NO usable incoming active info (both id and host null),
  retain the last-known id/host rather than clobbering to null on a transient
  disconnect blip — a same-host bell during the blip still suppresses. A
  non-null id/host or a real background (`active:false`) replaces it normally.
  No new state enum.

### Tests (red→green)
- `native/test/services/session_host_attention_disconnected_active_test.dart`
  - foreground + disconnected active session (host derivable) + same-host bell → SUPPRESSED
  - transient no-info setActive must NOT clobber last-known host → same-host bell still SUPPRESSED
- `native/test/state/session_front_active_test.dart`
  - `frontActiveId`/`frontActiveHost` fall back to `entries.first` when `active` is null or references a missing entry (non-null host)

Native fast gate green (1458 tests, analyze clean).

### Integration suite (#589)
This touches session active-state propagation — the gate flags the integration
suite as required before merge. Orchestrator should run
`scripts/native-fast-gate.sh --with-integration` on emulator.

### Follow-up (NOT in scope here)
Sibling capture 2026-06-24T02-55-58 ("tapped notification, returned to a
disconnected session") points at the disconnected-tap routing path (#885
sibling). Not addressed in this PR — same disconnect-state gap, separate routing
concern.

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)