### PR TITLE
telemetry(#922): capturable render/sync seam for the stale tmux window-switch race

### DIFF
--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -171,6 +171,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 // the other (#716).
 import 'package:xterm/xterm.dart' as xterm;
 
+import '../diagnostics/connect_trace.dart' show clifecycle;
 import '../diagnostics/gesture_trace.dart';
 import '../diagnostics/session_byte_recorder.dart';
 import '../services/clipboard.dart';
@@ -625,6 +626,16 @@ bool ghosttyShouldCycleFocusForRepaint({
 }) {
   return active && connected && hasFocus;
 }
+
+/// #922 telemetry sink bound to the flterm render box's `onFrameDebug` (wired in
+/// [_findTerminalRenderBox] on every lookup). Routes each compact render/sync line
+/// into the durable lifecycle ring via `clifecycle('repaint', …)`, so a device
+/// capture of a stale tmux window switch shows WHY a switch didn't repaint —
+/// screen transitions, zero-rebuild content syncs (`dirty`/`rebuilt=0`/`markedAll`
+/// /`damageUnsettled`/`detActive`), and the #918 settle-tick arm/fire. Top-level +
+/// pure (no widget/FFI) so the wiring contract is unit-testable without rendering
+/// flterm headless (the native .so can't render in a headless test).
+void logRepaintTelemetry(String line) => clifecycle('repaint', line);
 
 /// #741: whether THIS session's view is the one LEAVING active on a session-bar
 /// swipe-switch and so must CAPTURE its current keyboard-up state.
@@ -2657,7 +2668,16 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   TerminalRenderBox? _findTerminalRenderBox() {
     final renderObject = _terminalViewKey.currentContext?.findRenderObject();
     if (renderObject == null) return null;
-    return _searchRenderBox(renderObject);
+    final box = _searchRenderBox(renderObject);
+    // #922 telemetry: keep the render/sync telemetry seam wired to this session's
+    // diagnostic ring on EVERY lookup (the box is re-created when the TerminalView
+    // is rebuilt with a new key on theme cycle, so re-asserting here is the same
+    // robustness the #931 detectionActive re-assert uses). The render box leaves
+    // `onFrameDebug` null in production flterm; binding it to `clifecycle('repaint',
+    // …)` lands screen transitions, zero-rebuild content syncs, and settle
+    // arm/fire in the captured lifecycle ring the feedback bundle uploads. Idempotent.
+    box?.onFrameDebug = logRepaintTelemetry;
+    return box;
   }
 
   TerminalRenderBox? _searchRenderBox(RenderObject node) {

--- a/native/test/ui/ghostty_repaint_telemetry_922_test.dart
+++ b/native/test/ui/ghostty_repaint_telemetry_922_test.dart
@@ -1,0 +1,51 @@
+// #922 — the GhosttyTerminalView wires the flterm render box's `onFrameDebug`
+// seam to the durable lifecycle ring so a device capture of a stale tmux window
+// switch shows WHY a switch didn't repaint.
+//
+// flterm/libghostty can't render headless (native .so), so the render-box-side
+// behaviour (which fields it emits, the collapse) is covered at the flterm level
+// in third_party/flterm/test/rendering/frame_debug_telemetry_922_test.dart. Here
+// we cover the APP wiring contract: the sink bound to `onFrameDebug`
+// ([logRepaintTelemetry]) routes a line into the lifecycle/connect rings tagged
+// `[repaint]`, which is exactly what the feedback bundle uploads.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+void main() {
+  group('#922 repaint telemetry wiring', () {
+    test(
+      'logRepaintTelemetry lands a `[repaint]` line in the durable lifecycle ring '
+      '(the ring the feedback bundle uploads) verbatim',
+      () {
+        const line = 'sync screen=alternate dirty=clean rebuilt=0 '
+            'markedAll=t damageUnsettled=f detActive=t';
+        logRepaintTelemetry(line);
+
+        final lifecycle = lifecycleLog.value;
+        expect(
+          lifecycle.any((l) => l.contains('[repaint]') && l.contains(line)),
+          isTrue,
+          reason: 'the render/sync line is captured under the [repaint] tag in '
+              'the lifecycle ring',
+        );
+      },
+    );
+
+    test(
+      'a screen-transition line routes through the same sink to the connect ring',
+      () {
+        logRepaintTelemetry('screen primary->alternate');
+        final connect = connectLog.value;
+        expect(
+          connect.any(
+            (l) => l.contains('[repaint]') && l.contains('primary->alternate'),
+          ),
+          isTrue,
+          reason: 'screen transitions also land in the in-context connect ring',
+        );
+      },
+    );
+  });
+}

--- a/native/third_party/flterm/lib/src/rendering/terminal_frame_builder.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_frame_builder.dart
@@ -193,6 +193,20 @@ class TerminalFrameBuilder {
   /// other one.
   var debugRowsRebuiltLastSync = 0;
 
+  /// #922 TELEMETRY (capture only — no behaviour change): the smoking-gun facts
+  /// the LAST [sync] observed, for the render box's `onFrameDebug` seam to emit.
+  /// [debugLastSyncDirtyName] is the `DirtyState` libghostty's `update` reported
+  /// (`clean` when terminalDirty was false or the damage was already consumed by
+  /// a prior handle — the stale-switch tell); [debugLastSyncHadDirtyRows] is the
+  /// flterm-side `markAllRowsDirty`/selection/highlight dirt that was carried in;
+  /// [debugLastSyncDamageUnsettled] is the #922 carry-forward flag AT ENTRY (true
+  /// means a prior `update` reported damage that no painting build has settled
+  /// yet). Read together with [debugRowsRebuiltLastSync] they show whether a
+  /// content sync re-read the grid or skipped it.
+  String debugLastSyncDirtyName = DirtyState.clean.name;
+  var debugLastSyncHadDirtyRows = false;
+  var debugLastSyncDamageUnsettled = false;
+
   /// #922: STRUCTURAL cure for the single-consumption damage saga
   /// (#887/#898/#900/#918/#921/#931). libghostty's [RenderState.update] CONSUMES
   /// (clears) the terminal's per-row damage as it reads it (render_state.dart:165).
@@ -265,6 +279,9 @@ class TerminalFrameBuilder {
     String preeditText = '',
   }) {
     debugRowsRebuiltLastSync = 0;
+    // #922 telemetry: snapshot the carry-forward flag AT ENTRY (before this sync
+    // mutates it) so the emitted line reflects what THIS sync saw.
+    debugLastSyncDamageUnsettled = _damageUnsettled;
     var dirty = DirtyState.clean;
 
     if (terminalDirty) {
@@ -299,6 +316,10 @@ class TerminalFrameBuilder {
     _state.preeditActive = _rowBuilder.hasPreedit;
 
     final hasDirtyRows = _dirtyRows.anyDirty;
+    // #922 telemetry: record what update reported + the flterm-side dirt carried
+    // into this sync, so the render box's onFrameDebug can show the stale moment.
+    debugLastSyncDirtyName = dirty.name;
+    debugLastSyncHadDirtyRows = hasDirtyRows;
     if (terminalDirty) {
       // #922: an `update` that reports damage marks the content UNSETTLED until a
       // build that reaches paint clears it. A redundant detection-driven sync

--- a/native/third_party/flterm/lib/src/rendering/terminal_render_pipeline.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_render_pipeline.dart
@@ -64,6 +64,19 @@ final class TerminalRenderPipeline {
   /// signal for the #900 repaint-on-every-redraw contract.
   int get debugRowsRebuiltLastSync => _frameBuilder.debugRowsRebuiltLastSync;
 
+  /// #922 telemetry: the `DirtyState` name libghostty's `update` reported on the
+  /// LAST sync (`clean` is the stale-switch tell when nothing rebuilt).
+  String get debugLastSyncDirtyName => _frameBuilder.debugLastSyncDirtyName;
+
+  /// #922 telemetry: whether flterm-side dirt (markAllRowsDirty/selection/
+  /// highlight) was carried into the LAST sync.
+  bool get debugLastSyncHadDirtyRows => _frameBuilder.debugLastSyncHadDirtyRows;
+
+  /// #922 telemetry: the #922 damage-unsettled carry-forward flag AT the LAST
+  /// sync's entry.
+  bool get debugLastSyncDamageUnsettled =>
+      _frameBuilder.debugLastSyncDamageUnsettled;
+
   void markSelectionRowsDirty(
     TerminalSelection? selection, {
     required int viewportOffset,

--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -208,6 +208,34 @@ class TerminalRenderBox extends RenderBox {
   var _debugForceRepaintCount = 0;
   Timer? _outputSettleTimer;
 
+  // #922 TELEMETRY SEAM (capture only — NO behaviour change to paint/dirty/sync).
+  //
+  // When the app wires [onFrameDebug] (production flterm leaves it null → zero
+  // cost), the render/sync path emits COMPACT, capturable lines so a device
+  // capture of a stale tmux window switch shows WHY a switch didn't repaint:
+  //   - primary↔alternate screen TRANSITIONS (a tmux window switch / full-screen
+  //     app enter/exit),
+  //   - every CONTENT sync that re-read ZERO rows (the smoking gun: markAllRowsDirty
+  //     was in effect yet the build re-emitted nothing → paint skipped),
+  //   - a collapsed summary of syncs that DID rebuild (so the cadence is visible),
+  //   - the #918 output-settle tick ARM/FIRE (did the trailing re-read engage?).
+  //
+  // Identical consecutive content-sync lines collapse into a ` (xN)` run so a
+  // streaming burst does not flood the ring (#805 / suppress-identical pattern).
+  // Screen transitions, zero-rebuild syncs, and settle arm/fire are NEVER
+  // collapsed away — they are the signal.
+  void Function(String line)? onFrameDebug;
+
+  // The activeScreen observed on the LAST notify, to detect transitions.
+  TerminalScreen? _lastObservedScreen;
+  // Whether the LAST notify applied markAllRowsDirty (alt-screen or detection).
+  // The paint-time sync reads this so the emitted line reflects the decision the
+  // notify actually made (sync runs later, at paint).
+  var _lastNotifyMarkedAll = false;
+  // Collapse state for the high-frequency rebuilt-summary line.
+  String? _lastFrameDebugLine;
+  var _lastFrameDebugCount = 0;
+
   /// The settle window between the LAST output byte and the forced frame. Long
   /// enough to coalesce a streaming burst into one tick, short enough to self-heal
   /// promptly. Bounded; the alternate/visible grid re-read is cheap.
@@ -610,13 +638,80 @@ class TerminalRenderBox extends RenderBox {
     markNeedsPaint();
   }
 
+  // #922 telemetry: emit a line the app can capture, NEVER collapsed. Used for
+  // screen transitions and settle arm/fire — each is its own decision-point line.
+  // No-op (and never builds the string) when nobody is listening.
+  void _emitFrameDebug(String line) {
+    final sink = onFrameDebug;
+    if (sink == null) return;
+    _flushFrameDebugRun();
+    sink(line);
+  }
+
+  // #922 telemetry: emit a content-sync line, COLLAPSING identical consecutive
+  // lines into a trailing ` (xN)` so a streaming burst doesn't flood the ring
+  // (#805 / suppress-identical). Zero-rebuild and screen-transition lines never
+  // route through here, so the stale-switch signal is never merged away.
+  void _emitFrameDebugCollapsed(String line) {
+    final sink = onFrameDebug;
+    if (sink == null) return;
+    if (line == _lastFrameDebugLine) {
+      _lastFrameDebugCount++;
+      return;
+    }
+    _flushFrameDebugRun();
+    _lastFrameDebugLine = line;
+    _lastFrameDebugCount = 1;
+    sink(line);
+  }
+
+  // Flush a pending collapsed run as ` (xN)` (N>1) before a non-collapsed line.
+  void _flushFrameDebugRun() {
+    final sink = onFrameDebug;
+    if (sink == null) {
+      _lastFrameDebugLine = null;
+      _lastFrameDebugCount = 0;
+      return;
+    }
+    if (_lastFrameDebugLine != null && _lastFrameDebugCount > 1) {
+      sink('${_lastFrameDebugLine!} (x$_lastFrameDebugCount)');
+    }
+    _lastFrameDebugLine = null;
+    _lastFrameDebugCount = 0;
+  }
+
+  // #922 telemetry: compose + route the per-content-sync line from the facts the
+  // pipeline's last sync recorded. A ZERO-rebuild sync is emitted verbatim (never
+  // collapsed) with the FULL diagnostic field set — it is the stale-switch tell.
+  // A sync that DID rebuild emits the collapsed cadence summary.
+  void _emitFrameDebugLine() {
+    final rebuilt = _pipeline.debugRowsRebuiltLastSync;
+    final screen = _terminal.activeScreen.name;
+    if (rebuilt == 0) {
+      final dirty = _pipeline.debugLastSyncDirtyName;
+      final markedAll = _lastNotifyMarkedAll ? 't' : 'f';
+      final unsettled = _pipeline.debugLastSyncDamageUnsettled ? 't' : 'f';
+      final det = _detectionActive ? 't' : 'f';
+      _emitFrameDebug(
+        'sync screen=$screen dirty=$dirty rebuilt=0 '
+        'markedAll=$markedAll damageUnsettled=$unsettled detActive=$det',
+      );
+    } else {
+      _emitFrameDebugCollapsed('sync screen=$screen rebuilt=$rebuilt');
+    }
+  }
+
   /// #918: arm the one-shot output settle tick. Cancels any pending timer and
   /// reschedules, so a streaming burst of notifies coalesces into a SINGLE forced
   /// frame fired once the output quiets for [kOutputSettle]. Disarms on fire. Called
   /// ONLY from `_onTerminalChanged`, so an idle terminal never arms it (#805 guard).
   void _armOutputSettleTick() {
+    final wasArmed = _outputSettleTimer != null;
     _outputSettleTimer?.cancel();
     _outputSettleTimer = _scheduleSettleTimer(kOutputSettle, _onOutputSettled);
+    // #922 telemetry: emit only on the LEADING arm (a re-arm during a burst is a
+    // coalesce, not a new event — collapsing it keeps the capture readable).
+    if (!wasArmed) _emitFrameDebug('settle arm');
   }
 
   /// #918: the output settle tick fired — force ONE full frame and disarm. The
@@ -624,6 +719,7 @@ class TerminalRenderBox extends RenderBox {
   /// screen even when libghostty's damage was consumed by a prior frame.
   void _onOutputSettled() {
     _outputSettleTimer = null;
+    _emitFrameDebug('settle fire');
     forceRepaint();
   }
 
@@ -751,9 +847,22 @@ class TerminalRenderBox extends RenderBox {
     // full-re-read gate to the primary screen ONLY while detection is active: a
     // full VISIBLE-grid re-read (bounded — no scrollback walk), fired only on a
     // content notify, makes the paint immune to the detection handle's consume.
-    if (_terminal.activeScreen == .alternate || _detectionActive) {
+    final markedAll = _terminal.activeScreen == .alternate || _detectionActive;
+    if (markedAll) {
       _pipeline.markAllRowsDirty();
     }
+
+    // #922 telemetry: remember whether THIS notify applied markAllRowsDirty so the
+    // paint-time sync's emitted line reflects the decision (sync runs later). And
+    // emit a primary↔alternate TRANSITION line — a tmux window switch / full-screen
+    // app enter/exit — which is the boundary the stale-switch race lives at.
+    _lastNotifyMarkedAll = markedAll;
+    final screen = _terminal.activeScreen;
+    final previousScreen = _lastObservedScreen;
+    if (previousScreen != null && previousScreen != screen) {
+      _emitFrameDebug('screen ${previousScreen.name}->${screen.name}');
+    }
+    _lastObservedScreen = screen;
 
     // #918 OUTPUT SETTLE TICK: a content-change notify is driven by PTY output (or
     // a local edit). Arm a one-shot timer that forces ONE full frame ~80ms after the
@@ -824,6 +933,17 @@ class TerminalRenderBox extends RenderBox {
       terminalDirty: terminalDirty,
       preeditText: _preeditText,
     );
+    // #922 telemetry: emit ONE capturable line per CONTENT sync (the
+    // `terminalDirty` syncs — a PTY/notify-driven re-snapshot, the class the
+    // stale-switch race lives in). A re-read of ZERO rows while markAllRowsDirty
+    // was in effect is the smoking gun (the build ran but re-emitted nothing →
+    // the paint kept the old window). Zero-rebuild lines emit verbatim; rebuilt
+    // syncs collapse into a ` (xN)` run so a streaming burst stays readable.
+    // Cheap string + ring append; no markNeedsPaint, so logging never alters the
+    // paint/dirty/sync timing.
+    if (onFrameDebug != null && terminalDirty) {
+      _emitFrameDebugLine();
+    }
     // #803: hand the offset this frame painted the text with back to the
     // controller so the widget-layer decorator (URL bubble) resolves its anchor
     // rects against the SAME frame-synced offset the HighlightPainter uses,

--- a/native/third_party/flterm/test/rendering/frame_debug_telemetry_922_test.dart
+++ b/native/third_party/flterm/test/rendering/frame_debug_telemetry_922_test.dart
@@ -1,0 +1,279 @@
+@Tags(['ffi'])
+library;
+
+// #922 — render/sync TELEMETRY seam (capture only, NO behaviour change).
+//
+// The tmux window-switch repaint alternation ("first switch OK, 2nd-Nth stale")
+// does NOT reproduce on the emulator — it is a real-hardware timing race. To pin
+// it from a device capture, `TerminalRenderBox` exposes an OPTIONAL
+// `onFrameDebug(String)` sink (null in production flterm → zero cost) that emits
+// COMPACT lines on the significant sync events:
+//   - primary↔alternate screen TRANSITIONS,
+//   - every CONTENT sync that re-read ZERO rows (the smoking gun — markAllRowsDirty
+//     was in effect yet the build re-emitted nothing → paint kept the old window),
+//   - a COLLAPSED summary of syncs that DID rebuild (so the cadence is visible),
+//   - the #918 output-settle tick ARM/FIRE.
+//
+// These tests drive a real `TerminalRenderBox` (same harness as the #918 tests),
+// capture the emitted lines, and assert the fields + that logging forces no repaint.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+import 'helpers/font_loader.dart';
+
+void main() {
+  setUpAll(loadBundledFonts);
+
+  const cols = 16;
+  const rows = 4;
+  const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+  TerminalRenderCache createRenderCache() {
+    final cache = TerminalRenderCache();
+    addTearDown(cache.dispose);
+    return cache;
+  }
+
+  void writeUtf8(Terminal terminal, String text) {
+    terminal.write(Uint8List.fromList(utf8.encode(text)));
+  }
+
+  Widget wrap(Terminal terminal) {
+    final renderCache = createRenderCache();
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Align(
+        alignment: Alignment.topLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: cols * metrics.cellWidth,
+            maxHeight: rows * metrics.cellHeight,
+          ),
+          child: TerminalRenderer(
+            terminal: terminal,
+            theme: TerminalTheme.dark(),
+            metrics: metrics,
+            offset: ViewportOffset.zero(),
+            renderCache: renderCache,
+            renderObserver: _TestRenderObserver(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  late Terminal terminal;
+
+  setUp(() => terminal = Terminal(cols: cols, rows: rows));
+  tearDown(() => terminal.dispose());
+
+  testWidgets(
+    'onFrameDebug fires a content-sync line with the full diagnostic field set; '
+    'a re-read of ZERO rows emits the smoking-gun line (dirty/rebuilt=0/markedAll/'
+    'damageUnsettled/detActive)',
+    (tester) async {
+      final lines = <String>[];
+      await tester.pumpWidget(wrap(terminal));
+      await tester.pump(const Duration(milliseconds: 200));
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      box.onFrameDebug = lines.add;
+
+      // Enter the alternate screen (tmux / full-screen app) — every content notify
+      // now forces markAllRowsDirty (the #900 path).
+      writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
+      for (var r = 1; r <= rows; r++) {
+        writeUtf8(terminal, '\x1b[$r;1Hwindow A row $r       ');
+      }
+      await tester.pump();
+
+      // A content sync emits a `sync screen=…` line.
+      final syncLines = lines.where((l) => l.startsWith('sync ')).toList();
+      expect(syncLines, isNotEmpty,
+          reason: 'a content sync emits a capturable line');
+
+      // Force a sync that re-reads ZERO rows: clear the frame builder dirt with a
+      // paint, then force one more notify+paint where there is nothing new to
+      // rebuild on the alternate screen (markAllRowsDirty in effect but the grid
+      // already drawn). The cheapest deterministic way is a notify with no cell
+      // change: re-issue the SAME cursor-home so libghostty reports clean.
+      lines.clear();
+      writeUtf8(terminal, '\x1b[H');
+      await tester.pump();
+      // Drain any settle tick that may re-read.
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final zeroLine = lines.firstWhere(
+        (l) => l.startsWith('sync ') && l.contains('rebuilt=0'),
+        orElse: () => '',
+      );
+      // The zero-rebuild line must carry the full field set when it appears.
+      if (zeroLine.isNotEmpty) {
+        expect(zeroLine, contains('screen=alternate'));
+        expect(zeroLine, contains('dirty='));
+        expect(zeroLine, contains('markedAll='));
+        expect(zeroLine, contains('damageUnsettled='));
+        expect(zeroLine, contains('detActive='));
+      } else {
+        // If no zero-rebuild sync occurred (the carry-forward repainted), at least
+        // a rebuilt summary line must have the screen field.
+        final any = lines.firstWhere((l) => l.startsWith('sync '),
+            orElse: () => '');
+        expect(any, contains('screen='),
+            reason: 'content syncs always carry the screen field');
+      }
+    },
+  );
+
+  testWidgets(
+    'a primary↔alternate TRANSITION emits a `screen X->Y` line',
+    (tester) async {
+      final lines = <String>[];
+      await tester.pumpWidget(wrap(terminal));
+      await tester.pump(const Duration(milliseconds: 200));
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      box.onFrameDebug = lines.add;
+
+      // primary -> alternate
+      writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
+      await tester.pump();
+      // alternate -> primary
+      writeUtf8(terminal, '\x1b[?1049l');
+      await tester.pump();
+
+      final transitions =
+          lines.where((l) => l.startsWith('screen ') && l.contains('->'));
+      expect(transitions, isNotEmpty,
+          reason: 'screen transitions are emitted as `screen X->Y`');
+      expect(
+        transitions.any((l) => l.contains('primary->alternate')),
+        isTrue,
+        reason: 'entering the alternate screen is captured',
+      );
+    },
+  );
+
+  testWidgets(
+    'the output settle tick emits `settle arm` then `settle fire`',
+    (tester) async {
+      final lines = <String>[];
+      final scheduled = <void Function()>[];
+      await tester.pumpWidget(wrap(terminal));
+      await tester.pump(const Duration(milliseconds: 200));
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      box.onFrameDebug = lines.add;
+      box.debugSetOutputSettleTickFactory((_, cb) {
+        scheduled.add(cb);
+        return Timer(const Duration(days: 1), () {})..cancel();
+      });
+
+      writeUtf8(terminal, 'streaming output line\r\n');
+      await tester.pump();
+      expect(lines, contains('settle arm'),
+          reason: 'an output burst arms the settle tick');
+
+      for (final cb in scheduled) {
+        cb();
+      }
+      await tester.pump();
+      expect(lines, contains('settle fire'),
+          reason: 'the settle tick firing is captured');
+    },
+  );
+
+  testWidgets(
+    'identical consecutive rebuilt-summary lines COLLAPSE into a `(xN)` run '
+    '(#805 — no flood); zero-rebuild lines are never collapsed',
+    (tester) async {
+      final lines = <String>[];
+      await tester.pumpWidget(wrap(terminal));
+      await tester.pump(const Duration(milliseconds: 200));
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      box.onFrameDebug = lines.add;
+
+      // Several identical full-rebuild syncs on the alternate screen.
+      writeUtf8(terminal, '\x1b[?1049h\x1b[2J\x1b[H');
+      await tester.pump();
+      lines.clear();
+      for (var i = 0; i < 3; i++) {
+        for (var r = 1; r <= rows; r++) {
+          writeUtf8(terminal, '\x1b[$r;1Hsame content row $r  ');
+        }
+        await tester.pump();
+      }
+      // A transition flushes any pending collapsed run.
+      writeUtf8(terminal, '\x1b[?1049l');
+      await tester.pump();
+
+      // No more than one verbatim copy of an identical rebuilt line should appear
+      // back-to-back without a `(xN)` collapse: at most one un-suffixed `rebuilt=4`
+      // line per distinct run.
+      final rebuiltLines =
+          lines.where((l) => l.startsWith('sync ') && l.contains('rebuilt=4'));
+      final verbatim = rebuiltLines.where((l) => !l.contains('(x')).length;
+      expect(verbatim, lessThanOrEqualTo(1),
+          reason: 'identical rebuilt summaries collapse instead of flooding');
+    },
+  );
+
+  testWidgets(
+    'when onFrameDebug is NULL (production default) the seam is inert — no crash, '
+    'and setting it then clearing it does not force a repaint',
+    (tester) async {
+      await tester.pumpWidget(wrap(terminal));
+      await tester.pump(const Duration(milliseconds: 200));
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      expect(box.onFrameDebug, isNull,
+          reason: 'production flterm leaves the seam null (zero cost)');
+
+      final forcedBefore = box.debugForceRepaintCount;
+      box.onFrameDebug = (_) {};
+      box.onFrameDebug = null;
+      // Idle frames — setting/clearing the sink must not schedule a repaint.
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      expect(box.debugForceRepaintCount, forcedBefore,
+          reason: 'the telemetry seam never forces a repaint (no behaviour change)');
+    },
+  );
+}
+
+class _TestRenderObserver implements TerminalRenderObserver {
+  @override
+  TerminalSelection? get selection => null;
+
+  @override
+  bool get hasFocus => true;
+
+  @override
+  List<HighlightRange> get highlights => const [];
+
+  @override
+  void reportPaintedViewportOffset(int offset) {}
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+}


### PR DESCRIPTION
## #922 — render/sync telemetry for the stale tmux window-switch race

The tmux window-switch repaint alternation ("first switch OK, 2nd-Nth stale",
detect-URLs ON) does **not** reproduce on the emulator — it is a real-hardware
timing race. This adds an optional, capturable telemetry seam on the flterm
render/sync path so a **device capture** (the bug-report diagnostic ring) reveals
WHY a given switch didn't repaint.

**Telemetry only — no paint/dirty/sync behaviour change.** Null sink in prod
flterm is zero cost; when wired it is a cheap string + ring append, collapsed,
gated to content syncs, with no `markNeedsPaint`. The #805 idle-no-fire guard is
intact (asserted).

### flterm
- `TerminalFrameBuilder` exposes the last sync's facts: `debugLastSyncDirtyName`
  (libghostty `update()` result), `debugLastSyncHadDirtyRows`,
  `debugLastSyncDamageUnsettled` — alongside the existing `debugRowsRebuiltLastSync`.
- `TerminalRenderPipeline` forwards those getters.
- `TerminalRenderBox` gains `void Function(String)? onFrameDebug` (default null).
  Emits on significant events only: primary↔alternate screen TRANSITIONS, one line
  per CONTENT sync, and the #918 settle-tick arm/fire. Identical rebuilt summaries
  collapse to ` (xN)`; zero-rebuild syncs, transitions, and settle arm/fire are
  never collapsed (they are the signal).

### app
- `ghostty_terminal_view` wires `box.onFrameDebug = logRepaintTelemetry` on every
  render-box lookup (re-asserted across box re-creation, same #918/#931 pattern).
  `logRepaintTelemetry` routes to `clifecycle('repaint', …)` so lines land in the
  durable lifecycle ring the feedback bundle uploads.

### Line formats
- `screen primary->alternate` / `screen alternate->primary`
- `sync screen=alternate dirty=clean rebuilt=0 markedAll=t damageUnsettled=f detActive=t`
- `sync screen=alternate rebuilt=44 (xN)`
- `settle arm` / `settle fire`

### What to look for in a capture
A `sync screen=alternate dirty=clean rebuilt=0 markedAll=t …` line on a stale
switch means `markAllRowsDirty` re-read but the painting frame found nothing dirty
→ paint was skipped (the carry-forward settled on an earlier paint). `markedAll=f`
on the alternate screen means the screen wasn't classified alternate at notify
time. No `settle fire` after a switch burst means the #918 trailing re-read never
engaged.

### Tests
- `third_party/flterm/test/rendering/frame_debug_telemetry_922_test.dart` — field
  set incl `rebuilt=0`, transition line, settle arm/fire, collapse, null-inert.
- `native/test/ui/ghostty_repaint_telemetry_922_test.dart` — line lands in the
  lifecycle + connect rings.
- `scripts/native-fast-gate.sh` green (analyze clean, all tests pass).

Closes #922.