### PR TITLE
feat(native): per-profile path favorites in the file browser (#632)

### DIFF
--- a/native/integration_test/sftp_favorites_test.dart
+++ b/native/integration_test/sftp_favorites_test.dart
@@ -1,0 +1,255 @@
+// On-emulator SFTP FAVORITES smoke (#632).
+//
+// Favorites are PER-PROFILE starred remote paths, persisted across restart. The
+// headless widget tests (file_browser_favorites_test.dart) drive a fake gateway
+// + mock SharedPreferences; they cannot catch a device-only long-press timing
+// regression or a real shared_preferences persistence gap. This test runs the
+// REAL app on the emulator against test-sshd and exercises the favorites UX
+// state transitions end to end: TAP star → favorited; LONG-PRESS star → menu →
+// TAP favorite → navigate (deepLink seam); LONG-PRESS favorite → removed; and
+// that the favorite actually landed in the on-device FavoritesStore (persistence
+// proof — the same store a fresh launch reads back).
+//
+// Network + seeding mirror sftp_browse_smoke_test.dart (reuse the bridge + the
+// live-shell seed, per feedback_reuse_pwa_infra). Long-press timing is device-
+// only, so this case is tagged integration and gated behind the emulator suite.
+
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/favorites_store.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+Future<bool> _reachTerminal(WidgetTester tester) {
+  return _pumpUntil(
+    tester,
+    () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+  );
+}
+
+Future<void> _assertShellAlive(
+  WidgetTester tester,
+  SessionEntry entry, {
+  required String marker,
+}) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  addTearDown(sub.cancel);
+  await tester.pump(const Duration(milliseconds: 200));
+  entry.proxy.sendInput(Uint8List.fromList(utf8.encode('echo $marker\n')));
+  final sawMarker = await _pumpUntil(
+    tester,
+    () => utf8.decode(out, allowMalformed: true).contains(marker),
+    maxSlices: 40,
+  );
+  expect(sawMarker, isTrue, reason: 'dead shell / input dead');
+}
+
+Future<void> _seedTree(
+  WidgetTester tester,
+  SessionEntry entry, {
+  required String root,
+}) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  addTearDown(sub.cancel);
+  const done = 'MOBISSH_SEED_DONE_632';
+  final script = StringBuffer()
+    ..write('rm -rf $root; ')
+    ..write('mkdir -p $root/sub; ')
+    ..write('echo hi > $root/sub/inside.txt; ')
+    ..write('echo $done\n');
+  entry.proxy.sendInput(Uint8List.fromList(utf8.encode(script.toString())));
+  final seeded = await _pumpUntil(
+    tester,
+    () => utf8.decode(out, allowMalformed: true).contains(done),
+    maxSlices: 40,
+  );
+  expect(seeded, isTrue, reason: 'seed never completed on test-sshd ($root)');
+}
+
+Future<void> _openBrowserAt(
+  WidgetTester tester,
+  BuildContext context,
+  String sessionId,
+  String path,
+) async {
+  unawaited(
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FileBrowserScreen(sessionId: sessionId, initialPath: path),
+      ),
+    ),
+  );
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('file-browser-list')).evaluate().isNotEmpty,
+  );
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'favorites: star → favorite, long-press → quick-nav, long-press → remove',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      expect(await _reachTerminal(tester), isTrue, reason: 'no terminal');
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull);
+      await _assertShellAlive(tester, entry!, marker: 'MOBISSH_OK_632');
+
+      const root = '/tmp/mobissh_itest_632';
+      await _seedTree(tester, entry, root: root);
+
+      // Open the browser at the seeded root.
+      final ctx = tester.element(find.byKey(const Key('session-menu-button')));
+      await _openBrowserAt(tester, ctx, entry.id, root);
+
+      // 1) TAP the star → favorited (filled).
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('file-browser-star')),
+          matching: find.byIcon(Icons.star_border),
+        ),
+        findsOneWidget,
+        reason: 'star should start as outline',
+      );
+      await tester.tap(find.byKey(const Key('file-browser-star')));
+      final favorited = await _pumpUntil(
+        tester,
+        () => find
+            .descendant(
+              of: find.byKey(const Key('file-browser-star')),
+              matching: find.byIcon(Icons.star),
+            )
+            .evaluate()
+            .isNotEmpty,
+        maxSlices: 20,
+      );
+      expect(favorited, isTrue, reason: 'star did not become filled after tap');
+
+      // Persistence proof: the on-device FavoritesStore (what a fresh launch
+      // reads back) now holds this profile's path.
+      final key = entry.profileKey;
+      expect(
+        await FavoritesStore().isFavorite(key, root),
+        isTrue,
+        reason: 'favorite did not persist to shared_preferences',
+      );
+
+      // Descend into sub so the current dir differs from the favorite.
+      await tester.tap(find.byKey(const Key('file-entry-sub')));
+      await _pumpUntil(
+        tester,
+        () =>
+            find.byKey(const Key('file-entry-inside.txt')).evaluate().isNotEmpty,
+      );
+
+      // 2) LONG-PRESS the star → favorites menu → TAP favorite → navigate back.
+      await tester.longPress(find.byKey(const Key('file-browser-star')));
+      final menuUp = await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('favorites-list')).evaluate().isNotEmpty,
+        maxSlices: 20,
+      );
+      expect(menuUp, isTrue, reason: 'long-press star did not open the menu');
+      expect(find.byKey(Key('favorite-item-$root')), findsOneWidget);
+      await tester.tap(find.byKey(Key('favorite-item-$root')));
+      final navback = await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('file-entry-sub')).evaluate().isNotEmpty,
+      );
+      expect(navback, isTrue, reason: 'quick-nav did not return to the root dir');
+
+      // 3) LONG-PRESS the favorite → removed (gone from the list).
+      await tester.longPress(find.byKey(const Key('file-browser-star')));
+      await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('favorites-list')).evaluate().isNotEmpty,
+        maxSlices: 20,
+      );
+      await tester.longPress(find.byKey(Key('favorite-item-$root')));
+      final removedFromList = await _pumpUntil(
+        tester,
+        () => find.byKey(Key('favorite-item-$root')).evaluate().isEmpty,
+        maxSlices: 20,
+      );
+      expect(
+        removedFromList,
+        isTrue,
+        reason: 'long-press favorite did not remove it from the menu',
+      );
+      expect(
+        await FavoritesStore().isFavorite(key, root),
+        isFalse,
+        reason: 'removal did not persist',
+      );
+
+      // Tear the session + service down.
+      final notifier = container.read(sessionsProvider.notifier);
+      for (final id in container
+          .read(sessionsProvider)
+          .entries
+          .map((e) => e.id)
+          .toList(growable: false)) {
+        notifier.close(id);
+      }
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+    },
+  );
+}

--- a/native/lib/state/favorites_providers.dart
+++ b/native/lib/state/favorites_providers.dart
@@ -1,0 +1,15 @@
+// Riverpod provider for per-profile path favorites (#632).
+//
+// `favoritesStoreProvider` exposes the [FavoritesStore] singleton. The file
+// browser reads it via `ref.read` to toggle/list/remove/clear a profile's
+// favorited paths. Override in tests with a prefs-injected instance:
+// `favoritesStoreProvider.overrideWithValue(FavoritesStore(prefs: ...))`.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../storage/favorites_store.dart';
+
+/// Singleton [FavoritesStore]. Override in tests.
+final favoritesStoreProvider = Provider<FavoritesStore>((ref) {
+  return FavoritesStore();
+});

--- a/native/lib/storage/favorites_store.dart
+++ b/native/lib/storage/favorites_store.dart
@@ -1,0 +1,230 @@
+// Per-profile path favorites for the SFTP file browser (#632).
+//
+// A profile's favorites are a set of starred remote absolute paths, SHARED
+// across every session of that profile and PERSISTED across app restart. They
+// are keyed by profile identity `host:port:username` (the same tuple
+// [SavedProfile.identityKey] / [SessionEntry.profileKey] use), so two different
+// profiles have independent sets while two sessions of the SAME profile see one
+// shared set.
+//
+// Storage: a single JSON blob in shared_preferences under
+// [favoritesPrefsKey]. The schema version lives INSIDE the value (not the key),
+// per .claude/rules code-style — so a future migration never strands data and a
+// staleness bug is never "fixed" by bumping the key. Corrupt / unknown-version
+// data falls back to an empty model (validate → fallback, never crash).
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// One favorited path for a profile. A favorite is a remote absolute path with
+/// an optional human-friendly [label]. Equality is by [path] (normalized) — a
+/// profile favorites a directory once.
+class PathFavorite {
+  const PathFavorite({required this.path, this.label});
+
+  /// Remote path, normalized (no trailing slash except root `/`).
+  final String path;
+
+  /// Optional display label. When null/empty the UI shows the path itself.
+  final String? label;
+
+  /// Display text for the favorites menu — the label when present, else path.
+  String get display => (label != null && label!.isNotEmpty) ? label! : path;
+
+  Map<String, dynamic> toJson() {
+    final out = <String, dynamic>{'path': path};
+    if (label != null && label!.isNotEmpty) out['label'] = label;
+    return out;
+  }
+
+  /// Parse one stored favorite. Returns null for anything that isn't a Map with
+  /// a usable `path` string (corrupt-resilience — a bad entry is dropped, not
+  /// fatal to the whole load).
+  static PathFavorite? fromJson(Object? raw) {
+    if (raw is! Map) return null;
+    final pathRaw = raw['path'];
+    if (pathRaw is! String) return null;
+    final normalized = normalizePath(pathRaw);
+    if (normalized.isEmpty) return null;
+    final labelRaw = raw['label'];
+    final label = (labelRaw is String && labelRaw.isNotEmpty) ? labelRaw : null;
+    return PathFavorite(path: normalized, label: label);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is PathFavorite && other.path == path);
+
+  @override
+  int get hashCode => path.hashCode;
+
+  @override
+  String toString() => 'PathFavorite($path${label != null ? ', $label' : ''})';
+}
+
+/// Normalize a remote path for stable equality / dedupe. Trims whitespace and
+/// strips a single trailing slash unless the whole path is root `/`. Leaves
+/// `~`, relative, and absolute paths otherwise untouched (the SFTP layer
+/// resolves them on navigation — favorites store exactly what the browser uses
+/// as its listing path so quick-nav round-trips).
+String normalizePath(String path) {
+  var p = path.trim();
+  if (p.isEmpty) return '';
+  while (p.length > 1 && p.endsWith('/')) {
+    p = p.substring(0, p.length - 1);
+  }
+  return p;
+}
+
+/// shared_preferences key. Versioned in the NAME only as the storage namespace
+/// (`v1`); the migratable schema version lives inside the value (see
+/// [_schemaVersion]) so a schema change migrates in place without a key bump.
+const String favoritesPrefsKey = 'mobissh.favorites.v1';
+
+/// Current in-value schema version. Bump + migrate in [load] on a shape change.
+const int _schemaVersion = 1;
+
+/// Persistence layer for per-profile path favorites (#632). UI consumers go
+/// through `favoritesStoreProvider` (state/favorites_providers.dart). Tests
+/// inject a [SharedPreferences] via [SharedPreferences.setMockInitialValues]
+/// and construct directly (mirrors [ProfilesStore]).
+class FavoritesStore {
+  FavoritesStore({SharedPreferences? prefs}) : _prefs = prefs;
+
+  // ignore_for_file: prefer_initializing_formals
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> _ensure() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// Read the whole favorites model: `identityKey -> ordered favorites`.
+  /// Returns an empty map when nothing is stored, the JSON is malformed, the
+  /// shape is wrong, or the schema version is unknown (corrupt-resilience per
+  /// .claude/rules — validate → fallback to empty, never crash).
+  Future<Map<String, List<PathFavorite>>> load() async {
+    final prefs = await _ensure();
+    final raw = prefs.getString(favoritesPrefsKey);
+    if (raw == null || raw.isEmpty) return <String, List<PathFavorite>>{};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return <String, List<PathFavorite>>{};
+      final version = decoded['version'];
+      // Unknown / future version: don't risk misreading a shape we don't know.
+      if (version is! int || version != _schemaVersion) {
+        return <String, List<PathFavorite>>{};
+      }
+      final profiles = decoded['profiles'];
+      if (profiles is! Map) return <String, List<PathFavorite>>{};
+      final out = <String, List<PathFavorite>>{};
+      profiles.forEach((key, value) {
+        if (key is! String || value is! List) return;
+        final favs = <PathFavorite>[];
+        final seen = <String>{};
+        for (final entry in value) {
+          final fav = PathFavorite.fromJson(entry);
+          if (fav == null) continue;
+          if (seen.add(fav.path)) favs.add(fav);
+        }
+        if (favs.isNotEmpty) out[key] = favs;
+      });
+      return out;
+    } on FormatException {
+      return <String, List<PathFavorite>>{};
+    }
+  }
+
+  /// Overwrite the entire favorites model. Empty per-profile lists are dropped
+  /// so a cleared profile leaves no residue.
+  Future<void> _saveAll(Map<String, List<PathFavorite>> model) async {
+    final prefs = await _ensure();
+    final profiles = <String, dynamic>{};
+    model.forEach((key, favs) {
+      if (favs.isEmpty) return;
+      profiles[key] = favs.map((f) => f.toJson()).toList();
+    });
+    final encoded = jsonEncode({
+      'version': _schemaVersion,
+      'profiles': profiles,
+    });
+    await prefs.setString(favoritesPrefsKey, encoded);
+  }
+
+  /// Favorites for one profile identity, in insertion order. Empty when none.
+  Future<List<PathFavorite>> favoritesFor(String identityKey) async {
+    final model = await load();
+    return model[identityKey] ?? const <PathFavorite>[];
+  }
+
+  /// True when [path] (normalized) is favorited for [identityKey].
+  Future<bool> isFavorite(String identityKey, String path) async {
+    final target = normalizePath(path);
+    if (target.isEmpty) return false;
+    final favs = await favoritesFor(identityKey);
+    return favs.any((f) => f.path == target);
+  }
+
+  /// Add [path] to [identityKey]'s favorites (no-op if already present).
+  /// Returns the updated list. An empty/blank path is rejected (no-op).
+  Future<List<PathFavorite>> add(
+    String identityKey,
+    String path, {
+    String? label,
+  }) async {
+    final normalized = normalizePath(path);
+    if (normalized.isEmpty) return favoritesFor(identityKey);
+    final model = await load();
+    final favs = List<PathFavorite>.from(
+      model[identityKey] ?? const <PathFavorite>[],
+    );
+    if (!favs.any((f) => f.path == normalized)) {
+      favs.add(PathFavorite(path: normalized, label: label));
+      model[identityKey] = favs;
+      await _saveAll(model);
+    }
+    return model[identityKey] ?? favs;
+  }
+
+  /// Remove [path] from [identityKey]'s favorites. Returns the updated list.
+  Future<List<PathFavorite>> remove(String identityKey, String path) async {
+    final normalized = normalizePath(path);
+    final model = await load();
+    final favs = List<PathFavorite>.from(
+      model[identityKey] ?? const <PathFavorite>[],
+    );
+    final before = favs.length;
+    favs.removeWhere((f) => f.path == normalized);
+    if (favs.length != before) {
+      if (favs.isEmpty) {
+        model.remove(identityKey);
+      } else {
+        model[identityKey] = favs;
+      }
+      await _saveAll(model);
+    }
+    return model[identityKey] ?? const <PathFavorite>[];
+  }
+
+  /// Toggle [path] for [identityKey]. Returns the NEW favorited state
+  /// (true = now favorited). Drives the star control's filled/outline.
+  Future<bool> toggle(String identityKey, String path) async {
+    final normalized = normalizePath(path);
+    if (normalized.isEmpty) return false;
+    if (await isFavorite(identityKey, normalized)) {
+      await remove(identityKey, normalized);
+      return false;
+    }
+    await add(identityKey, normalized);
+    return true;
+  }
+
+  /// Clear ALL favorites for one profile (the "Clear all favorites" action).
+  Future<void> clear(String identityKey) async {
+    final model = await load();
+    if (model.remove(identityKey) != null) {
+      await _saveAll(model);
+    }
+  }
+}

--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -20,9 +20,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/session_messages.dart';
 import '../services/sftp_download.dart';
 import '../ssh/ssh_session_proxy.dart';
+import '../state/favorites_providers.dart';
 import '../state/profiles_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
+import '../storage/favorites_store.dart';
 import 'file_viewer_registry.dart';
 import 'pdf_viewer_screen.dart';
 import 'top_toast.dart';
@@ -172,6 +174,15 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
   bool _loading = true;
   String? _error;
 
+  /// Profile identity (`host:port:username`) this browser's session belongs to.
+  /// Favorites are keyed by this (#632) — a profile's sessions share one set.
+  /// Null only when the session has gone away.
+  String? _profileKey;
+
+  /// Normalized paths currently favorited for [_profileKey]. Drives the app-bar
+  /// star's filled/outline state; refreshed after every favorites mutation.
+  Set<String> _favoritePaths = const {};
+
   /// Monotonic counter → request id, so a late listing for a directory we've
   /// already navigated away from is dropped.
   int _seq = 0;
@@ -212,9 +223,13 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     for (final e in entries) {
       if (e.id == widget.sessionId) {
         proxy = e.proxy;
+        _profileKey = e.profileKey;
         break;
       }
     }
+    // Load this profile's favorites so the star renders correctly on first
+    // build (#632). Fire-and-forget: setState lands when it resolves.
+    unawaited(_refreshFavorites());
     if (proxy == null) {
       // No setState here — didChangeDependencies runs before build, so just
       // set the fields and let the imminent build render the error.
@@ -435,6 +450,127 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     dismissFileBrowserStack(context);
   }
 
+  // --- Favorites (#632) -----------------------------------------------------
+
+  FavoritesStore get _favStore => ref.read(favoritesStoreProvider);
+
+  /// Re-read the profile's favorites into [_favoritePaths] so the star + menu
+  /// reflect the persisted set. No-op without a profile identity.
+  Future<void> _refreshFavorites() async {
+    final key = _profileKey;
+    if (key == null) return;
+    final favs = await _favStore.favoritesFor(key);
+    if (!mounted) return;
+    setState(() {
+      _favoritePaths = favs.map((f) => f.path).toSet();
+    });
+  }
+
+  bool get _currentFavorited => _favoritePaths.contains(normalizePath(_path));
+
+  /// Star TAP: toggle whether the CURRENT directory is favorited for this
+  /// profile. Filled star = favorited; outline = not (#632 bullet 1).
+  Future<void> _toggleStar() async {
+    final key = _profileKey;
+    if (key == null) return;
+    final pathAtTap = _path;
+    final nowFavorited = await _favStore.toggle(key, pathAtTap);
+    await _refreshFavorites();
+    if (!mounted) return;
+    _snack(
+      nowFavorited
+          ? 'Favorited $pathAtTap'
+          : 'Removed favorite $pathAtTap',
+    );
+  }
+
+  /// Navigate the files view to a favorited [path] — drives the SAME `_list`
+  /// sink that `widget.initialPath` feeds on open (the deepLink seam #570/#572
+  /// use). The favorites menu is dismissed by the caller before this runs.
+  void _navigateToFavorite(String path) => _list(path);
+
+  /// Unified favorites menu (#632 bullets 2–5): surfaced from BOTH a long-press
+  /// on the app-bar star AND a long-press on any file/folder entry. Tapping a
+  /// favorite instantly navigates there; long-pressing a favorite removes it;
+  /// "Clear all" empties the profile's set.
+  Future<void> _openFavoritesMenu() async {
+    final key = _profileKey;
+    if (key == null) return;
+    var favs = await _favStore.favoritesFor(key);
+    if (!mounted) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (ctx, setSheetState) {
+            return SafeArea(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ListTile(
+                    leading: const Icon(Icons.star),
+                    title: const Text('Favorites'),
+                    trailing: TextButton(
+                      key: const Key('favorites-clear-all'),
+                      onPressed: favs.isEmpty
+                          ? null
+                          : () async {
+                              await _favStore.clear(key);
+                              await _refreshFavorites();
+                              favs = const [];
+                              setSheetState(() {});
+                            },
+                      child: const Text('Clear all'),
+                    ),
+                  ),
+                  const Divider(height: 1),
+                  if (favs.isEmpty)
+                    const Padding(
+                      key: Key('favorites-empty'),
+                      padding: EdgeInsets.all(24),
+                      child: Text('No favorites yet'),
+                    )
+                  else
+                    Flexible(
+                      child: ListView(
+                        key: const Key('favorites-list'),
+                        shrinkWrap: true,
+                        children: [
+                          for (final f in favs)
+                            ListTile(
+                              key: Key('favorite-item-${f.path}'),
+                              leading: const Icon(Icons.folder_outlined),
+                              title: Text(
+                                f.display,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              subtitle: (f.label != null && f.label!.isNotEmpty)
+                                  ? Text(f.path, overflow: TextOverflow.ellipsis)
+                                  : null,
+                              onTap: () {
+                                Navigator.of(sheetContext).pop();
+                                _navigateToFavorite(f.path);
+                              },
+                              // Long-press a favorite = REMOVE it (#632 bullet 4).
+                              onLongPress: () async {
+                                await _favStore.remove(key, f.path);
+                                await _refreshFavorites();
+                                favs = await _favStore.favoritesFor(key);
+                                setSheetState(() {});
+                              },
+                            ),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final downloading = _downloadRequestId != null;
@@ -483,6 +619,30 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
           ],
         ),
         actions: [
+          // Favorites star (#632): TAP toggles favoriting the current path for
+          // this profile; LONG-PRESS opens the unified favorites menu. Built on
+          // a single InkResponse so both gestures are owned by ONE recognizer
+          // set — an IconButton's `tooltip` wraps it in a Tooltip that would eat
+          // the long-press, so we don't use IconButton here. Accessibility is
+          // preserved via the Semantics label.
+          Semantics(
+            button: true,
+            label: _currentFavorited
+                ? 'Unfavorite this folder'
+                : 'Favorite this folder',
+            child: InkResponse(
+              key: const Key('file-browser-star'),
+              radius: 24,
+              onTap: _toggleStar,
+              onLongPress: _openFavoritesMenu,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Icon(
+                  _currentFavorited ? Icons.star : Icons.star_border,
+                ),
+              ),
+            ),
+          ),
           IconButton(
             key: const Key('file-browser-close-to-terminal'),
             tooltip: 'Close — back to terminal',
@@ -541,7 +701,14 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
       itemCount: _entries.length,
       itemBuilder: (context, i) {
         final e = _entries[i];
-        return _EntryTile(entry: e, onTap: () => _onEntryTap(e));
+        return _EntryTile(
+          entry: e,
+          onTap: () => _onEntryTap(e),
+          // Long-press a file/folder entry opens the SAME unified favorites
+          // menu as long-pressing the star (#632 bullet 3). ListTile routes
+          // long-press separately from onTap, so it never also navigates.
+          onLongPress: _openFavoritesMenu,
+        );
       },
     );
   }
@@ -586,10 +753,15 @@ class _PathBar extends StatelessWidget {
 }
 
 class _EntryTile extends StatelessWidget {
-  const _EntryTile({required this.entry, required this.onTap});
+  const _EntryTile({
+    required this.entry,
+    required this.onTap,
+    this.onLongPress,
+  });
 
   final SftpEntry entry;
   final VoidCallback onTap;
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -603,6 +775,7 @@ class _EntryTile extends StatelessWidget {
       subtitle: entry.isDirectory ? null : Text(_formatSize(entry.size)),
       trailing: entry.isDirectory ? const Icon(Icons.chevron_right) : null,
       onTap: onTap,
+      onLongPress: onLongPress,
     );
   }
 

--- a/native/test/favorites_store_test.dart
+++ b/native/test/favorites_store_test.dart
@@ -1,0 +1,220 @@
+// Unit tests for [FavoritesStore] (#632).
+//
+// Covers:
+//   - add / remove / toggle / clear
+//   - load/save round-trip persistence (fresh store instance re-reads prefs)
+//   - PER-PROFILE ISOLATION: profile A's favorites invisible under profile B;
+//     two "sessions" (two store reads) of the SAME profile share the set
+//   - corrupt JSON / wrong shape / unknown schema version → empty fallback
+//   - schema version lives INSIDE the value JSON (not the key)
+//   - path normalization (trailing slash) so /var/log == /var/log/
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/storage/favorites_store.dart';
+
+const String _profA = 'a.example:22:alice';
+const String _profB = 'b.example:2222:bob';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('PathFavorite', () {
+    test('display prefers label, falls back to path', () {
+      expect(const PathFavorite(path: '/var/log').display, '/var/log');
+      expect(
+        const PathFavorite(path: '/var/log', label: 'Logs').display,
+        'Logs',
+      );
+    });
+
+    test('toJson omits empty/null label', () {
+      expect(const PathFavorite(path: '/x').toJson().containsKey('label'),
+          isFalse);
+      expect(
+        const PathFavorite(path: '/x', label: 'L').toJson()['label'],
+        'L',
+      );
+    });
+
+    test('fromJson drops entries without a usable path', () {
+      expect(PathFavorite.fromJson(<String, Object?>{}), isNull);
+      expect(PathFavorite.fromJson(<String, Object?>{'path': 42}), isNull);
+      expect(PathFavorite.fromJson('not a map'), isNull);
+      expect(PathFavorite.fromJson(<String, Object?>{'path': '/ok'})?.path,
+          '/ok');
+    });
+
+    test('equality is by normalized path', () {
+      expect(
+        const PathFavorite(path: '/a'),
+        const PathFavorite(path: '/a', label: 'different label'),
+      );
+    });
+  });
+
+  group('normalizePath', () {
+    test('strips trailing slash except root', () {
+      expect(normalizePath('/var/log/'), '/var/log');
+      expect(normalizePath('/var/log'), '/var/log');
+      expect(normalizePath('/'), '/');
+      expect(normalizePath('  /etc/  '), '/etc');
+    });
+  });
+
+  group('FavoritesStore add/remove/toggle', () {
+    test('add then favoritesFor returns the path', () async {
+      final store = FavoritesStore();
+      await store.add(_profA, '/var/log');
+      final favs = await store.favoritesFor(_profA);
+      expect(favs.map((f) => f.path), ['/var/log']);
+      expect(await store.isFavorite(_profA, '/var/log'), isTrue);
+    });
+
+    test('add is idempotent (no duplicates)', () async {
+      final store = FavoritesStore();
+      await store.add(_profA, '/var/log');
+      await store.add(_profA, '/var/log/'); // normalizes to same
+      expect((await store.favoritesFor(_profA)).length, 1);
+    });
+
+    test('remove deletes the path', () async {
+      final store = FavoritesStore();
+      await store.add(_profA, '/var/log');
+      await store.remove(_profA, '/var/log');
+      expect(await store.isFavorite(_profA, '/var/log'), isFalse);
+      expect(await store.favoritesFor(_profA), isEmpty);
+    });
+
+    test('toggle flips state and returns the new state', () async {
+      final store = FavoritesStore();
+      expect(await store.toggle(_profA, '/etc'), isTrue);
+      expect(await store.isFavorite(_profA, '/etc'), isTrue);
+      expect(await store.toggle(_profA, '/etc'), isFalse);
+      expect(await store.isFavorite(_profA, '/etc'), isFalse);
+    });
+
+    test('clear empties only the target profile', () async {
+      final store = FavoritesStore();
+      await store.add(_profA, '/var/log');
+      await store.add(_profA, '/etc');
+      await store.add(_profB, '/home');
+      await store.clear(_profA);
+      expect(await store.favoritesFor(_profA), isEmpty);
+      expect((await store.favoritesFor(_profB)).map((f) => f.path), ['/home']);
+    });
+
+    test('blank path is rejected (no-op)', () async {
+      final store = FavoritesStore();
+      await store.add(_profA, '   ');
+      expect(await store.favoritesFor(_profA), isEmpty);
+    });
+  });
+
+  group('persistence', () {
+    test('survives a fresh store instance (round-trip via prefs)', () async {
+      final writer = FavoritesStore();
+      await writer.add(_profA, '/var/log', label: 'Logs');
+      await writer.add(_profA, '/etc');
+
+      // A brand-new store reading the same mock prefs = "after app restart".
+      final reader = FavoritesStore();
+      final favs = await reader.favoritesFor(_profA);
+      expect(favs.map((f) => f.path), ['/var/log', '/etc']);
+      expect(favs.first.label, 'Logs');
+    });
+
+    test('schema version is stored INSIDE the value JSON, not the key',
+        () async {
+      final store = FavoritesStore();
+      await store.add(_profA, '/var/log');
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(favoritesPrefsKey);
+      expect(raw, isNotNull);
+      final decoded = jsonDecode(raw!) as Map<String, dynamic>;
+      expect(decoded['version'], 1);
+      expect(decoded.containsKey('profiles'), isTrue);
+    });
+  });
+
+  group('per-profile isolation', () {
+    test("profile A's favorites are not visible under profile B", () async {
+      final store = FavoritesStore();
+      await store.add(_profA, '/var/log');
+      expect(await store.isFavorite(_profB, '/var/log'), isFalse);
+      expect(await store.favoritesFor(_profB), isEmpty);
+    });
+
+    test('two reads of the SAME profile share one set', () async {
+      // Simulate two sessions of the same profile: each resolves favorites via
+      // the same identity key and sees the same data.
+      final session1 = FavoritesStore();
+      final session2 = FavoritesStore();
+      await session1.add(_profA, '/srv');
+      expect(await session2.isFavorite(_profA, '/srv'), isTrue);
+      // Un-favoriting in one reflects for the profile (both sessions).
+      await session2.remove(_profA, '/srv');
+      expect(await session1.isFavorite(_profA, '/srv'), isFalse);
+    });
+  });
+
+  group('corrupt-data resilience', () {
+    test('malformed JSON → empty fallback (no crash)', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        favoritesPrefsKey: '{not valid json',
+      });
+      final store = FavoritesStore();
+      expect(await store.load(), isEmpty);
+      expect(await store.favoritesFor(_profA), isEmpty);
+    });
+
+    test('wrong top-level shape (a list) → empty fallback', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        favoritesPrefsKey: '[1,2,3]',
+      });
+      final store = FavoritesStore();
+      expect(await store.load(), isEmpty);
+    });
+
+    test('unknown schema version → empty fallback', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        favoritesPrefsKey: jsonEncode({
+          'version': 999,
+          'profiles': {
+            _profA: [
+              {'path': '/var/log'},
+            ],
+          },
+        }),
+      });
+      final store = FavoritesStore();
+      expect(await store.load(), isEmpty);
+    });
+
+    test('drops individual corrupt entries but keeps good ones', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        favoritesPrefsKey: jsonEncode({
+          'version': 1,
+          'profiles': {
+            _profA: [
+              {'path': '/good'},
+              {'nope': true},
+              {'path': 123},
+              {'path': '/good2', 'label': 'two'},
+            ],
+          },
+        }),
+      });
+      final store = FavoritesStore();
+      final favs = await store.favoritesFor(_profA);
+      expect(favs.map((f) => f.path), ['/good', '/good2']);
+    });
+  });
+}

--- a/native/test/widget/file_browser_favorites_test.dart
+++ b/native/test/widget/file_browser_favorites_test.dart
@@ -1,0 +1,287 @@
+// File browser favorites widget tests (#632).
+//
+// Renders [FileBrowserScreen] against the same task-side [SessionHost] +
+// scripted SFTP harness as file_browser_widget_test.dart, and exercises the
+// per-profile favorites UX:
+//   - TAP the app-bar star toggles favoriting the current path (filled/outline)
+//   - LONG-PRESS the star opens the unified favorites menu
+//   - tapping a favorite navigates the files view there (the deepLink seam)
+//   - LONG-PRESS a favorite removes it
+//   - "Clear all" empties the set
+//   - LONG-PRESS a file/folder entry opens the SAME menu (and does NOT navigate)
+//   - favorites are PER-PROFILE and persist (a fresh store reads them back)
+//
+// The host's timers are cancelled inline at the END of each test body via
+// `host.disposeSyncForTest()` — addTearDown runs after the framework's
+// pending-timer invariant check, so it can't be relied on for that (mirrors
+// file_browser_widget_test.dart).
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/favorites_store.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+class _ScriptedSftpSession implements SftpSession {
+  _ScriptedSftpSession(this._byPath);
+
+  final Map<String, List<SftpEntry>> _byPath;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async => _byPath[path] ?? const [];
+
+  @override
+  Future<int?> sizeOf(String path) async => 0;
+
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async => 0;
+
+  @override
+  Future<int> upload(String path, Uint8List bytes) async => bytes.length;
+
+  @override
+  Future<void> close() async {}
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+/// Standard tree: root `/` has `docs/` (→ inner.bin) + `a.bin`. host:port:user
+/// = `h:22:u` so the favorites identity key is deterministic.
+const Map<String, List<SftpEntry>> _tree = {
+  '/': [
+    SftpEntry(name: 'docs', path: '/docs', isDirectory: true),
+    SftpEntry(name: 'a.bin', path: '/a.bin', isDirectory: false, size: 4),
+  ],
+  '/docs': [
+    SftpEntry(
+      name: 'inner.bin',
+      path: '/docs/inner.bin',
+      isDirectory: false,
+      size: 4,
+    ),
+  ],
+};
+
+const SshConnectParams _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+const String _profileKey = 'h:22:u';
+
+class _Harness {
+  _Harness(this.host, this.container, this.entry);
+  final SessionHost host;
+  final ProviderContainer container;
+  final SessionEntry entry;
+
+  /// Cancel the host's timers + drop the container. Call INLINE at the end of a
+  /// test body (before the framework's pending-timer invariant check).
+  void dispose() {
+    host.disposeSyncForTest();
+    container.dispose();
+  }
+}
+
+Future<_Harness> _mount(WidgetTester tester) async {
+  final pair = InMemoryGatewayPair();
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: _stubControllerFactory,
+    sftpOpener: (_) async => _ScriptedSftpSession(_tree),
+    snapshotInterval: const Duration(hours: 1),
+  );
+  final container = ProviderContainer(
+    overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+  );
+  final entry = container.read(sessionsProvider.notifier).addOrActivate(_params);
+  entry.proxy.connect(_params);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(home: FileBrowserScreen(sessionId: entry.id)),
+    ),
+  );
+  await _pump(tester);
+  return _Harness(host, container, entry);
+}
+
+Finder _starIcon(IconData icon) => find.descendant(
+  of: find.byKey(const Key('file-browser-star')),
+  matching: find.byIcon(icon),
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('star is outline by default; tap favorites; tap again clears', (
+    tester,
+  ) async {
+    final h = await _mount(tester);
+
+    // Default: at root `/`, nothing favorited → outline star.
+    expect(_starIcon(Icons.star_border), findsOneWidget);
+    expect(_starIcon(Icons.star), findsNothing);
+
+    // Tap → favorited (filled).
+    await tester.tap(find.byKey(const Key('file-browser-star')));
+    await _pump(tester);
+    expect(_starIcon(Icons.star), findsOneWidget);
+    expect(await FavoritesStore().isFavorite(_profileKey, '/'), isTrue);
+
+    // Tap again → un-favorited (outline).
+    await tester.tap(find.byKey(const Key('file-browser-star')));
+    await _pump(tester);
+    expect(_starIcon(Icons.star_border), findsOneWidget);
+    expect(await FavoritesStore().isFavorite(_profileKey, '/'), isFalse);
+
+    h.dispose();
+  });
+
+  testWidgets('star reflects favorited state of the CURRENT directory', (
+    tester,
+  ) async {
+    await FavoritesStore().add(_profileKey, '/docs');
+
+    final h = await _mount(tester);
+
+    // At `/` (not favorited) → outline.
+    expect(_starIcon(Icons.star_border), findsOneWidget);
+
+    // Navigate into /docs (favorited) → filled.
+    await tester.tap(find.byKey(const Key('file-entry-docs')));
+    await _pump(tester);
+    expect(find.text('/docs'), findsOneWidget);
+    expect(_starIcon(Icons.star), findsOneWidget);
+
+    h.dispose();
+  });
+
+  testWidgets('long-press star opens menu; tap a favorite navigates there', (
+    tester,
+  ) async {
+    await FavoritesStore().add(_profileKey, '/docs');
+
+    final h = await _mount(tester);
+
+    expect(find.byKey(const Key('file-entry-a.bin')), findsOneWidget);
+
+    // Long-press the star → favorites menu.
+    await tester.longPress(find.byKey(const Key('file-browser-star')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorites-list')), findsOneWidget);
+    expect(find.byKey(const Key('favorite-item-/docs')), findsOneWidget);
+
+    // Tap the favorite → files view navigates to /docs (deepLink seam).
+    await tester.tap(find.byKey(const Key('favorite-item-/docs')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorite-item-/docs')), findsNothing);
+    expect(find.byKey(const Key('file-entry-inner.bin')), findsOneWidget);
+    expect(find.text('/docs'), findsOneWidget);
+
+    h.dispose();
+  });
+
+  testWidgets('long-press a favorite removes it', (tester) async {
+    await FavoritesStore().add(_profileKey, '/docs');
+    await FavoritesStore().add(_profileKey, '/a');
+
+    final h = await _mount(tester);
+
+    await tester.longPress(find.byKey(const Key('file-browser-star')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorite-item-/docs')), findsOneWidget);
+
+    // Long-press the favorite → removed from the list + storage.
+    await tester.longPress(find.byKey(const Key('favorite-item-/docs')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorite-item-/docs')), findsNothing);
+    expect(find.byKey(const Key('favorite-item-/a')), findsOneWidget);
+    expect(await FavoritesStore().isFavorite(_profileKey, '/docs'), isFalse);
+
+    h.dispose();
+  });
+
+  testWidgets('clear all empties the favorites set', (tester) async {
+    await FavoritesStore().add(_profileKey, '/docs');
+    await FavoritesStore().add(_profileKey, '/a');
+
+    final h = await _mount(tester);
+
+    await tester.longPress(find.byKey(const Key('file-browser-star')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorites-list')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('favorites-clear-all')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorites-empty')), findsOneWidget);
+    expect(await FavoritesStore().favoritesFor(_profileKey), isEmpty);
+
+    h.dispose();
+  });
+
+  testWidgets('long-press a file entry opens the menu (does NOT navigate)', (
+    tester,
+  ) async {
+    await FavoritesStore().add(_profileKey, '/docs');
+
+    final h = await _mount(tester);
+
+    // Long-press the `docs` directory entry → favorites menu, NOT navigation.
+    await tester.longPress(find.byKey(const Key('file-entry-docs')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorites-list')), findsOneWidget);
+    // Still at root: inner.bin (which only exists inside /docs) is NOT shown.
+    expect(find.byKey(const Key('file-entry-inner.bin')), findsNothing);
+
+    h.dispose();
+  });
+
+  testWidgets('favorites are per-profile (profile B does not see A)', (
+    tester,
+  ) async {
+    await FavoritesStore().add(_profileKey, '/docs');
+    expect(await FavoritesStore().favoritesFor('other:22:bob'), isEmpty);
+
+    final h = await _mount(tester);
+    // This session (profile A) DOES see /docs as favorited.
+    await tester.tap(find.byKey(const Key('file-entry-docs')));
+    await _pump(tester);
+    expect(_starIcon(Icons.star), findsOneWidget);
+
+    h.dispose();
+  });
+}


### PR DESCRIPTION
## Per-profile path favorites in the file browser (#632)

Closes #632.

Adds a **per-PROFILE** favorites system to the SFTP file browser. A profile's
favorited remote paths are shared across that profile's sessions and persist
across app restart — keyed by `host:port:username` (the same identity tuple as
the profile store). Files-view path state stays per-session (#572); only
favorites are per-profile.

### UX (unified affordance)
- **Star** in the file-view app bar: filled = current dir favorited, outline =
  not. **TAP** toggles favoriting the current directory.
- **LONG-PRESS the star** OR **LONG-PRESS any file/folder entry** opens **ONE**
  unified favorites menu (modal bottom sheet). Chosen single affordance:
  both gestures surface the same `showModalBottomSheet` menu.
- In the menu: **tap a favorite** → instantly navigates the files view there
  (drives the existing `_list` sink — the same seam `initialPath`/#570/#572 use,
  no new seam invented); **long-press a favorite** → removes it;
  **"Clear all"** → empties the profile's set.
- Entry long-press routes via `ListTile.onLongPress`, so it never also
  tap-navigates. The star uses an `InkResponse` (not `IconButton`) so its
  long-press isn't swallowed by the `IconButton` tooltip's own long-press.

### Storage
- New `FavoritesStore` (`lib/storage/favorites_store.dart`), `shared_preferences`
  backed under `mobissh.favorites.v1`. Config-system rules honored: default empty
  init, user clear-all reset, **schema version INSIDE the value JSON** (not the
  key), corrupt/unknown-version data → empty fallback (validate → fallback, never
  crash). Monochrome Material star glyphs (no emoji).

### Tests
- **Unit** `favorites_store_test.dart` (19 tests): add/remove/toggle/clear,
  persistence round-trip, **per-profile isolation**, corrupt JSON / wrong shape /
  unknown version → empty, schema-version-in-value, path normalization.
- **Widget** `file_browser_favorites_test.dart` (7 tests): star toggle filled/
  outline, star reflects current dir, long-press star → menu → tap navigates,
  long-press favorite removes, clear-all empties, long-press entry opens menu
  without navigating, per-profile.
- **Integration** (device-gated, `@Tags(['integration'])`) `sftp_favorites_test.dart`:
  connect → seed → tap star → favorite (+ persistence proof via on-device
  FavoritesStore) → long-press star → quick-nav → long-press favorite → remove.

### Gate / validation
- `scripts/native-fast-gate.sh`: **PASSED** (analyze clean; 1495 tests pass).
- Emulator integration suite **NOT run**: no AVD booted and **test-sshd blocked
  by the known port-2222 conflict** (`Bind for 0.0.0.0:2222 failed: port is
  already allocated`). Long-press timing + persistence across a real relaunch
  remain a **device gate for the owner**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)