### PR TITLE
feat(native): markdown embedded media tap-to-fill → forced pinch/pan/zoom (#946)

### DIFF
--- a/native/integration_test/markdown_media_fill_test.dart
+++ b/native/integration_test/markdown_media_fill_test.dart
@@ -1,0 +1,241 @@
+// On-emulator tap-to-fill embedded-media smoke (#946).
+//
+// The markdown viewer renders embedded media (inline images + mermaid diagrams)
+// inline and makes each TAP-TO-FILL: tapping pushes a shared fullscreen viewer
+// (FillMediaViewer) whose InteractiveViewer forces pinch-zoom + pan on. Headless
+// widget tests stub the image bytes + the WebView surface, so they prove the tap
+// → fill routing but cannot prove a real image fetched over SFTP renders, nor
+// the live webview. This test runs the REAL app on the emulator against
+// test-sshd: it seeds a .md that references a relative image plus a mermaid
+// block, opens it through the SFTP browser, and asserts BOTH media items tap
+// into the fill viewer (the InteractiveViewer is present + pan/scale enabled).
+//
+// DEVICE GATE: the actual pinch-zoom + pan gestures (multi-touch on the
+// InteractiveViewer for images, the fullscreen WebView's built-in zoom for
+// mermaid) are verified MANUALLY on a real device/emulator — a synthetic gesture
+// can't assert the visual zoom of rendered pixels / PlatformView. This test
+// asserts the tap→fill route + the forced-zoom widget config; the gesture
+// invariant is owner-validated.
+//
+// Network + bridge: identical setup to mermaid_markdown_render_test.dart.
+
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/fill_media_viewer.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/ui/markdown_file_viewer.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+
+// A minimal valid 1x1 transparent PNG (base64) — seeded as the embedded image.
+const _pngB64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+    '+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+Future<bool> _reachTerminal(WidgetTester tester) {
+  return _pumpUntil(
+    tester,
+    () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+  );
+}
+
+Future<void> _seedFiles(
+  WidgetTester tester,
+  SessionEntry entry, {
+  required String root,
+}) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  addTearDown(sub.cancel);
+
+  const done = 'MOBISSH_SEED_DONE_946';
+  final mdB64 = base64Encode(utf8.encode(_doc));
+  final script = StringBuffer()
+    ..write('rm -rf $root; ')
+    ..write('mkdir -p $root/img; ')
+    ..write("printf '%s' '$mdB64' | base64 -d > $root/doc.md; ")
+    ..write("printf '%s' '$_pngB64' | base64 -d > $root/img/a.png; ")
+    ..write('echo $done\n');
+  entry.proxy.sendInput(Uint8List.fromList(utf8.encode(script.toString())));
+
+  final seeded = await _pumpUntil(
+    tester,
+    () => utf8.decode(out, allowMalformed: true).contains(done),
+    maxSlices: 40,
+  );
+  expect(seeded, isTrue, reason: 'media seed never completed on test-sshd');
+}
+
+Future<void> _openBrowserAt(
+  WidgetTester tester,
+  BuildContext context,
+  String sessionId,
+  String path,
+) async {
+  unawaited(
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FileBrowserScreen(
+          key: const Key('itest-file-browser'),
+          sessionId: sessionId,
+          initialPath: path,
+        ),
+      ),
+    ),
+  );
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('file-browser-list')).evaluate().isNotEmpty,
+  );
+}
+
+const _doc =
+    '# Media\n\n'
+    'An inline image:\n\n'
+    '![a diagram](img/a.png)\n\n'
+    'A flowchart:\n\n'
+    '```mermaid\n'
+    'graph TD;\n'
+    '  A[Start] --> B{Choice};\n'
+    '  B -->|yes| C[Do];\n'
+    '```\n';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('inline image + mermaid both tap-to-fill into the zoom viewer', (
+    tester,
+  ) async {
+    FlutterForegroundTask.initCommunicationPort();
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
+    expect(
+      await _reachTerminal(tester),
+      isTrue,
+      reason: 'never reached the terminal screen',
+    );
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after connect');
+
+    const root = '/tmp/mobissh_itest_946';
+    await _seedFiles(tester, entry!, root: root);
+
+    final ctx = tester.element(find.byKey(const Key('session-menu-button')));
+    await _openBrowserAt(tester, ctx, entry.id, root);
+    expect(
+      find.byKey(const Key('file-entry-doc.md')),
+      findsOneWidget,
+      reason: 'seeded markdown file not listed',
+    );
+
+    await tester.tap(find.byKey(const Key('file-entry-doc.md')));
+    expect(
+      await _pumpUntil(
+        tester,
+        () => find.byType(MarkdownFileViewerScreen).evaluate().isNotEmpty,
+      ),
+      isTrue,
+      reason: 'markdown viewer did not open',
+    );
+
+    // The relative image fetched over the SAME SFTP session and rendered inline.
+    expect(
+      await _pumpUntil(
+        tester,
+        () =>
+            find.byKey(const Key('markdown-inline-image')).evaluate().isNotEmpty,
+      ),
+      isTrue,
+      reason: 'inline image never rendered (SFTP image fetch failed)',
+    );
+
+    // Tap the image → shared fill viewer with forced pinch/pan.
+    await tester.tap(find.byKey(const Key('markdown-inline-image')));
+    expect(
+      await _pumpUntil(
+        tester,
+        () => find.byType(FillMediaViewer).evaluate().isNotEmpty,
+      ),
+      isTrue,
+      reason: 'tapping the image did not open the fill viewer',
+    );
+    final ivImg = tester.widget<InteractiveViewer>(
+      find.byKey(const Key('fill-media-interactive-viewer')),
+    );
+    expect(ivImg.panEnabled && ivImg.scaleEnabled, isTrue);
+
+    // Close and tap the mermaid diagram → same fill viewer.
+    await tester.tap(find.byKey(const Key('fill-media-close')));
+    await _pumpUntil(
+      tester,
+      () => find.byType(FillMediaViewer).evaluate().isEmpty,
+    );
+
+    expect(
+      await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('mermaid-tap-to-fill')).evaluate().isNotEmpty,
+      ),
+      isTrue,
+      reason: 'mermaid diagram never rendered inline',
+    );
+    await tester.tap(find.byKey(const Key('mermaid-tap-to-fill')));
+    expect(
+      await _pumpUntil(
+        tester,
+        () => find.byType(FillMediaViewer).evaluate().isNotEmpty,
+      ),
+      isTrue,
+      reason: 'tapping the mermaid diagram did not open the fill viewer',
+    );
+  });
+}

--- a/native/lib/services/sftp_image_fetcher.dart
+++ b/native/lib/services/sftp_image_fetcher.dart
@@ -1,0 +1,170 @@
+// Image byte-fetch seam for the in-app markdown viewer (#946).
+//
+// The markdown viewer's `imageBuilder` resolves an inline `![](src)` reference
+// to a remote path and streams its BYTES into memory using the SAME machinery
+// the text/code viewer uses (the session proxy's `sftpDownload` command + the
+// `sftpEvents` stream — chunks/done/error), assembling chunks at their byte
+// offsets (#591). Unlike [TextFileFetcher] this does NOT UTF-8 decode and does
+// NOT binary-reject — images ARE binary — it returns the raw [Uint8List].
+//
+// Exposed as a [SftpImageFetcher] interface + a [sftpImageFetcherProvider] so
+// widget tests can substitute a fetcher that returns canned bytes without
+// touching the SSH stack. [resolveSftpImagePath] is a pure path resolver
+// (relative → the .md's directory; absolute → as-is; http(s)/data → null, i.e.
+// not an SFTP path) so it can be unit-tested in isolation.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../ssh/ssh_session_proxy.dart';
+import '../state/sessions.dart';
+import 'session_messages.dart';
+
+/// Resolves a markdown image [src] against the directory of the `.md` file at
+/// [mdPath]. Returns the absolute remote SFTP path to fetch, or `null` when
+/// [src] is NOT an SFTP target (an `http(s)://` / protocol-relative `//` /
+/// `data:` URI — those are handled by the network/placeholder path, matching the
+/// existing offline-first policy).
+///
+/// Relative paths (`img/a.png`, `../b.png`, `./c.png`) resolve against the .md's
+/// directory; absolute paths (`/srv/x.png`) pass through normalized. `..`/`.`
+/// segments are collapsed so the result is a clean absolute POSIX path.
+String? resolveSftpImagePath(String mdPath, String src) {
+  final s = src.trim();
+  if (s.isEmpty) return null;
+  final lower = s.toLowerCase();
+  if (lower.startsWith('http://') ||
+      lower.startsWith('https://') ||
+      lower.startsWith('//') ||
+      lower.startsWith('data:')) {
+    return null;
+  }
+  var rel = s;
+  if (lower.startsWith('file://')) {
+    rel = s.substring('file://'.length);
+  }
+  if (rel.startsWith('/')) {
+    return _normalizePosix(rel);
+  }
+  final dir = _dirnamePosix(mdPath);
+  final base = dir == '/' ? '' : dir;
+  return _normalizePosix('$base/$rel');
+}
+
+String _dirnamePosix(String p) {
+  final i = p.lastIndexOf('/');
+  if (i < 0) return '/';
+  if (i == 0) return '/';
+  return p.substring(0, i);
+}
+
+String _normalizePosix(String p) {
+  final isAbsolute = p.startsWith('/');
+  final out = <String>[];
+  for (final seg in p.split('/')) {
+    if (seg.isEmpty || seg == '.') continue;
+    if (seg == '..') {
+      if (out.isNotEmpty && out.last != '..') {
+        out.removeLast();
+      } else if (!isAbsolute) {
+        out.add('..');
+      }
+      // an absolute path can't escape root — drop leading '..'
+      continue;
+    }
+    out.add(seg);
+  }
+  final joined = out.join('/');
+  if (isAbsolute) return '/$joined';
+  return joined.isEmpty ? '.' : joined;
+}
+
+/// Fetches the raw bytes of a remote image at [path] on [sessionId]. [maxBytes]
+/// caps the in-memory buffer so an oversized image can't exhaust memory (it
+/// throws past the cap, which the viewer renders as a placeholder).
+abstract class SftpImageFetcher {
+  Future<Uint8List> fetch(
+    String sessionId,
+    String path, {
+    int maxBytes = 8 * 1024 * 1024,
+  });
+}
+
+/// Production fetcher: resolves the session's [SshSessionProxy] and streams the
+/// file over SFTP into an offset-indexed buffer (no decode, no binary reject).
+class ProxySftpImageFetcher implements SftpImageFetcher {
+  ProxySftpImageFetcher(this._ref);
+
+  final Ref _ref;
+  int _seq = 0;
+
+  @override
+  Future<Uint8List> fetch(
+    String sessionId,
+    String path, {
+    int maxBytes = 8 * 1024 * 1024,
+  }) async {
+    final proxy = _resolveProxy(sessionId);
+    if (proxy == null) {
+      throw StateError('Session is no longer available');
+    }
+
+    final requestId = '$sessionId#img${_seq++}';
+    final byOffset = <int, Uint8List>{};
+    var received = 0;
+    final completer = Completer<Uint8List>();
+
+    late final StreamSubscription<SshTaskEvent> sub;
+    sub = proxy.sftpEvents.listen((event) {
+      switch (event) {
+        case SftpDownloadChunkEvent():
+          if (event.requestId != requestId) return;
+          received += event.bytes.length;
+          byOffset[event.offset] = event.bytes;
+          if (received > maxBytes && !completer.isCompleted) {
+            completer.completeError(
+              StateError('Image is too large to preview'),
+            );
+          }
+        case SftpDownloadDoneEvent():
+          if (event.requestId != requestId) return;
+          if (completer.isCompleted) return;
+          final builder = BytesBuilder(copy: false);
+          for (final offset in (byOffset.keys.toList()..sort())) {
+            builder.add(byOffset[offset]!);
+          }
+          completer.complete(builder.takeBytes());
+        case SftpErrorEvent():
+          if (event.requestId != requestId) return;
+          if (!completer.isCompleted) {
+            completer.completeError(Exception(event.message));
+          }
+        default:
+          break;
+      }
+    });
+
+    proxy.sftpDownload(requestId: requestId, path: path);
+
+    try {
+      return await completer.future;
+    } finally {
+      await sub.cancel();
+    }
+  }
+
+  SshSessionProxy? _resolveProxy(String sessionId) {
+    for (final e in _ref.read(sessionsProvider).entries) {
+      if (e.id == sessionId) return e.proxy;
+    }
+    return null;
+  }
+}
+
+/// The active [SftpImageFetcher]. Production resolves a [ProxySftpImageFetcher];
+/// widget tests override this with a fetcher that returns canned bytes.
+final sftpImageFetcherProvider = Provider<SftpImageFetcher>(
+  (ref) => ProxySftpImageFetcher(ref),
+);

--- a/native/lib/ui/fill_media_viewer.dart
+++ b/native/lib/ui/fill_media_viewer.dart
@@ -1,0 +1,134 @@
+// Reusable fullscreen "fill" viewer for embedded markdown media (#946, epic #944).
+//
+// EVERY embedded media item in the markdown viewer — inline images (`![](...)`)
+// AND mermaid diagrams — renders inline at a sensible size and is TAP-TO-FILL:
+// tapping pushes this route, where pinch-zoom + pan are FORCE-enabled.
+//
+// Why a dedicated route instead of in-place pinch/pan: a PlatformView (the
+// mermaid WebView) nested inside the scrolling markdown wins the gesture arena,
+// so an in-place InteractiveViewer never receives the scale/pan pointers (the
+// +75 mermaid built-in zoom didn't work on device for exactly this reason). A
+// fullscreen route removes the scroll-vs-zoom contention:
+//   - a plain image child zooms via this [InteractiveViewer] (panEnabled +
+//     scaleEnabled, min/max scale, double-tap to fit/reset);
+//   - a fullscreen WebView child (mermaid) zooms via its own built-in zoom,
+//     which works once it is no longer nested in a scroll view. The
+//     InteractiveViewer still wraps it for a consistent close/scrim chrome.
+//
+// Monochrome Material glyph for the close affordance (no emoji). Dark scrim.
+
+import 'package:flutter/material.dart';
+
+/// Pushes the shared [FillMediaViewer] route with [child] as the zoomable
+/// surface. Returns when the user closes the viewer.
+Future<void> showFillMediaViewer(
+  BuildContext context, {
+  required Widget child,
+  String? label,
+}) {
+  return Navigator.of(context).push(
+    MaterialPageRoute<void>(
+      fullscreenDialog: true,
+      builder: (_) => FillMediaViewer(label: label, child: child),
+    ),
+  );
+}
+
+/// Fullscreen, dark-scrim media viewer. The single [child] is presented inside
+/// an [InteractiveViewer] with pinch-zoom + pan FORCED on. Double-tap toggles
+/// between fit (identity) and a 2.5× zoom centred on the tap point.
+class FillMediaViewer extends StatefulWidget {
+  const FillMediaViewer({super.key, required this.child, this.label});
+
+  /// The media surface — an image widget, or a fullscreen diagram surface.
+  final Widget child;
+
+  /// Optional accessible label / app-bar-less title shown to the user.
+  final String? label;
+
+  @override
+  State<FillMediaViewer> createState() => _FillMediaViewerState();
+}
+
+class _FillMediaViewerState extends State<FillMediaViewer> {
+  final TransformationController _controller = TransformationController();
+  TapDownDetails? _doubleTapDetails;
+
+  static const double _minScale = 0.5;
+  static const double _maxScale = 8.0;
+  static const double _doubleTapScale = 2.5;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onDoubleTapDown(TapDownDetails details) {
+    _doubleTapDetails = details;
+  }
+
+  void _onDoubleTap() {
+    // Already zoomed in → reset to fit. Otherwise zoom toward the tap point.
+    if (_controller.value != Matrix4.identity()) {
+      _controller.value = Matrix4.identity();
+      return;
+    }
+    final pos = _doubleTapDetails?.localPosition;
+    if (pos == null) return;
+    _controller.value = Matrix4.identity()
+      ..translateByDouble(
+        -pos.dx * (_doubleTapScale - 1),
+        -pos.dy * (_doubleTapScale - 1),
+        0,
+        1,
+      )
+      ..scaleByDouble(_doubleTapScale, _doubleTapScale, _doubleTapScale, 1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: const Key('fill-media-viewer'),
+      backgroundColor: Colors.black,
+      body: SafeArea(
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                onDoubleTapDown: _onDoubleTapDown,
+                onDoubleTap: _onDoubleTap,
+                child: InteractiveViewer(
+                  key: const Key('fill-media-interactive-viewer'),
+                  transformationController: _controller,
+                  panEnabled: true,
+                  scaleEnabled: true,
+                  minScale: _minScale,
+                  maxScale: _maxScale,
+                  // Unbounded margin so the user can pan a zoomed image fully
+                  // past the viewport edges.
+                  boundaryMargin: const EdgeInsets.all(double.infinity),
+                  child: Center(child: widget.child),
+                ),
+              ),
+            ),
+            Positioned(
+              top: 8,
+              right: 8,
+              child: Material(
+                color: Colors.black54,
+                shape: const CircleBorder(),
+                child: IconButton(
+                  key: const Key('fill-media-close'),
+                  tooltip: 'Close',
+                  icon: const Icon(Icons.close, color: Colors.white),
+                  onPressed: () => Navigator.of(context).maybePop(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/native/lib/ui/markdown_file_viewer.dart
+++ b/native/lib/ui/markdown_file_viewer.dart
@@ -32,6 +32,7 @@ import '../services/session_messages.dart';
 import '../services/text_file_fetcher.dart';
 import 'file_browser_screen.dart';
 import 'mermaid_diagram_view.dart';
+import 'sftp_markdown_image.dart';
 
 /// Opens a markdown link [href] in the system browser (externalApplication).
 /// Mirrors the terminal URL handler idiom. Injected as a typedef so widget
@@ -160,7 +161,12 @@ class _MarkdownFileViewerScreenState
         final text = _content ?? '';
         return _raw
             ? _RawContent(text: text)
-            : _RenderedContent(text: text, openLink: widget.openLink);
+            : _RenderedContent(
+                text: text,
+                openLink: widget.openLink,
+                sessionId: widget.sessionId,
+                mdPath: widget.entry.path,
+              );
     }
   }
 }
@@ -168,10 +174,20 @@ class _MarkdownFileViewerScreenState
 /// Rendered markdown. `flutter_markdown_plus` does its own scrolling +
 /// selection; links route through [openLink].
 class _RenderedContent extends StatelessWidget {
-  const _RenderedContent({required this.text, required this.openLink});
+  const _RenderedContent({
+    required this.text,
+    required this.openLink,
+    required this.sessionId,
+    required this.mdPath,
+  });
 
   final String text;
   final MarkdownLinkOpener openLink;
+
+  /// Session + .md path threaded to the [imageBuilder] so inline images fetch
+  /// over the SAME SFTP connection and resolve relative paths (#946).
+  final String sessionId;
+  final String mdPath;
 
   @override
   Widget build(BuildContext context) {
@@ -191,6 +207,14 @@ class _RenderedContent extends StatelessWidget {
       // #942/#944: route ```mermaid fenced blocks to an offline-WebView diagram
       // renderer; every other fenced block falls through to the normal code box.
       builders: {'code': MermaidElementBuilder()},
+      // #946: inline images render at a bounded size over SFTP and are
+      // tap-to-fill (the shared zoomable viewer). Broken/network handled inside.
+      imageBuilder: (uri, title, alt) => SftpMarkdownImage(
+        sessionId: sessionId,
+        mdPath: mdPath,
+        uri: uri,
+        alt: alt,
+      ),
       onTapLink: (txt, href, title) {
         if (href != null && href.isNotEmpty) {
           unawaited(openLink(href));

--- a/native/lib/ui/mermaid_diagram_view.dart
+++ b/native/lib/ui/mermaid_diagram_view.dart
@@ -26,6 +26,8 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import 'fill_media_viewer.dart';
+
 /// Builds the live render surface for a mermaid [source]. Swapped out in widget
 /// tests (which have no platform WebView) via [mermaidWebViewBuilder] — the
 /// public [MermaidDiagramView] type stays stable so routing assertions hold.
@@ -43,20 +45,83 @@ MermaidWebViewBuilder mermaidWebViewBuilder = _defaultMermaidWebView;
 MermaidWebViewBuilder get defaultMermaidWebViewBuilderForTest =>
     _defaultMermaidWebView;
 
+/// Builds the FULLSCREEN mermaid surface shown inside the tap-to-fill viewer
+/// (#946). Separate seam from the inline surface so tests can stub it without a
+/// platform channel. On device this is a WebView that FILLS the route, where its
+/// built-in pinch-zoom works (it is no longer nested in a scroll view).
+typedef MermaidFillBuilder = Widget Function(String source);
+
+Widget _defaultMermaidFill(String source) =>
+    _MermaidWebView(source: source, fill: true);
+
+/// Seam: production builds a fullscreen WebView; tests override this to a stub.
+MermaidFillBuilder mermaidFillBuilder = _defaultMermaidFill;
+
+/// Test-only handle to the production fill builder.
+@visibleForTesting
+MermaidFillBuilder get defaultMermaidFillBuilderForTest => _defaultMermaidFill;
+
 /// Inline-rendered mermaid diagram. Returned by the markdown viewer's
 /// `MermaidElementBuilder` in place of a ```mermaid code block.
+///
+/// #946: the inline diagram is a PREVIEW — it no longer relies on the WebView's
+/// in-place built-in zoom (unreliable nested in a scroll view, gesture arena).
+/// A transparent tap overlay ABOVE the platform WebView captures the tap and
+/// pushes the shared [FillMediaViewer] with a fullscreen diagram where
+/// pinch/pan/zoom work.
 class MermaidDiagramView extends StatelessWidget {
   const MermaidDiagramView({super.key, required this.source});
 
   /// The raw mermaid source from inside the fenced block (without the fence).
   final String source;
 
+  void _openFill(BuildContext context) {
+    showFillMediaViewer(context, child: mermaidFillBuilder(source));
+  }
+
   @override
   Widget build(BuildContext context) {
     return Padding(
       key: const Key('mermaid-diagram-view'),
       padding: const EdgeInsets.symmetric(vertical: 8),
-      child: mermaidWebViewBuilder(source),
+      child: Stack(
+        alignment: Alignment.bottomRight,
+        children: [
+          mermaidWebViewBuilder(source),
+          // Transparent layer above the WebView so the tap reaches Flutter
+          // (the platform view otherwise consumes pointers).
+          Positioned.fill(
+            child: GestureDetector(
+              key: const Key('mermaid-tap-to-fill'),
+              behavior: HitTestBehavior.opaque,
+              onTap: () => _openFill(context),
+            ),
+          ),
+          const IgnorePointer(
+            child: Padding(
+              padding: EdgeInsets.all(4),
+              child: _MermaidZoomBadge(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Small monochrome "expand" badge hinting tap-to-fill (no emoji).
+class _MermaidZoomBadge extends StatelessWidget {
+  const _MermaidZoomBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(4),
+      decoration: const BoxDecoration(
+        color: Colors.black54,
+        shape: BoxShape.circle,
+      ),
+      child: const Icon(Icons.zoom_out_map, size: 16, color: Colors.white),
     );
   }
 }
@@ -65,9 +130,13 @@ class MermaidDiagramView extends StatelessWidget {
 /// the source after page load, and sizes itself to the diagram's measured
 /// height (posted back over the [_channelName] JS channel).
 class _MermaidWebView extends StatefulWidget {
-  const _MermaidWebView({required this.source});
+  const _MermaidWebView({required this.source, this.fill = false});
 
   final String source;
+
+  /// When true the surface FILLS its parent (the fullscreen fill viewer) instead
+  /// of sizing to the measured diagram height — built-in zoom is the zoom path.
+  final bool fill;
 
   @override
   State<_MermaidWebView> createState() => _MermaidWebViewState();
@@ -125,6 +194,14 @@ class _MermaidWebViewState extends State<_MermaidWebView> {
   Widget build(BuildContext context) {
     if (_error != null) {
       return _MermaidFallback(source: widget.source, error: _error);
+    }
+    if (widget.fill) {
+      // Fullscreen fill viewer: occupy the whole route so the WebView's built-in
+      // pinch-zoom is the zoom path (no scroll-vs-zoom contention).
+      return SizedBox.expand(
+        key: const Key('mermaid-webview-surface-fill'),
+        child: WebViewWidget(controller: _controller),
+      );
     }
     return SizedBox(
       key: const Key('mermaid-webview-surface'),

--- a/native/lib/ui/sftp_markdown_image.dart
+++ b/native/lib/ui/sftp_markdown_image.dart
@@ -17,6 +17,7 @@
 
 import 'dart:typed_data';
 
+import 'package:flutter/gestures.dart' show kTouchSlop;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -60,6 +61,9 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
   bool _isNetwork = false;
   String? _networkUrl;
   bool _started = false;
+
+  /// Pointer-down position for the raw-pointer tap detection below.
+  Offset? _tapDownPos;
 
   @override
   void didChangeDependencies() {
@@ -166,11 +170,27 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
         errorBuilder: (_, _, _) => _Placeholder(alt: widget.alt),
       );
     }
+    // A raw [Listener] — NOT a GestureDetector — drives tap-to-fill. The viewer
+    // renders the markdown with `selectable: true`, so this inline image is a
+    // WidgetSpan child inside a SelectableText.rich. A child tap GestureDetector
+    // loses the gesture arena to the selection layer there (a known Flutter
+    // limitation), so the onTap never fired on-device even though widget tests —
+    // which tap the detector in isolation — passed. Listener receives pointer
+    // events directly from hit-testing, bypassing the arena: we recognise a tap
+    // as down→up within touch slop and open the fill viewer.
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
-      child: GestureDetector(
+      child: Listener(
         key: const Key('markdown-inline-image'),
-        onTap: _openFill,
+        behavior: HitTestBehavior.opaque,
+        onPointerDown: (e) => _tapDownPos = e.position,
+        onPointerUp: (e) {
+          final down = _tapDownPos;
+          _tapDownPos = null;
+          if (down != null && (e.position - down).distance <= kTouchSlop) {
+            _openFill();
+          }
+        },
         child: Stack(
           alignment: Alignment.bottomRight,
           children: [

--- a/native/lib/ui/sftp_markdown_image.dart
+++ b/native/lib/ui/sftp_markdown_image.dart
@@ -1,0 +1,248 @@
+// Inline image for the markdown viewer's `imageBuilder` (#946).
+//
+// Renders an `![](src)` reference inline at a bounded size, and is TAP-TO-FILL:
+// tapping pushes the shared [FillMediaViewer] with the full image, where
+// pinch-zoom + pan are forced.
+//
+// Resolution policy (offline-first, mirrors the link policy):
+//   - relative / absolute SFTP path → fetched as BYTES over the SAME SFTP
+//     session that fetched the .md (via [sftpImageFetcherProvider]); relative
+//     paths resolve against the .md's directory ([resolveSftpImagePath]),
+//   - explicit `http(s)://` URL → `Image.network` (the only allowed network
+//     fetch),
+//   - anything else / broken / missing / oversized → a graceful placeholder,
+//     never a crash.
+//
+// Monochrome Material glyphs only (no emoji).
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/sftp_image_fetcher.dart';
+import 'fill_media_viewer.dart';
+
+/// Max height of the inline thumbnail; the full image is shown in the fill
+/// viewer. Width is bounded by the available column width.
+const double _inlineMaxHeight = 280;
+
+class SftpMarkdownImage extends ConsumerStatefulWidget {
+  const SftpMarkdownImage({
+    super.key,
+    required this.sessionId,
+    required this.mdPath,
+    required this.uri,
+    this.alt,
+  });
+
+  /// Session whose SFTP connection fetched the .md (reused for the image).
+  final String sessionId;
+
+  /// Absolute remote path of the .md file — relative image src resolves here.
+  final String mdPath;
+
+  /// The image reference as parsed by the markdown renderer.
+  final Uri uri;
+
+  /// Alt text (used as the accessible label / placeholder caption).
+  final String? alt;
+
+  @override
+  ConsumerState<SftpMarkdownImage> createState() => _SftpMarkdownImageState();
+}
+
+enum _ImgPhase { loading, ready, broken }
+
+class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
+  _ImgPhase _phase = _ImgPhase.loading;
+  Uint8List? _bytes;
+  bool _isNetwork = false;
+  String? _networkUrl;
+  bool _started = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_started) return;
+    _started = true;
+    _resolve();
+  }
+
+  void _resolve() {
+    final raw = widget.uri.toString();
+    final lower = raw.toLowerCase();
+    if (lower.startsWith('http://') || lower.startsWith('https://')) {
+      // Explicit absolute network URL — the only allowed network fetch.
+      setState(() {
+        _isNetwork = true;
+        _networkUrl = raw;
+        _phase = _ImgPhase.ready;
+      });
+      return;
+    }
+    final path = resolveSftpImagePath(widget.mdPath, raw);
+    if (path == null) {
+      setState(() => _phase = _ImgPhase.broken);
+      return;
+    }
+    _fetchSftp(path);
+  }
+
+  Future<void> _fetchSftp(String path) async {
+    try {
+      final fetcher = ref.read(sftpImageFetcherProvider);
+      final bytes = await fetcher.fetch(widget.sessionId, path);
+      if (!mounted) return;
+      setState(() {
+        _bytes = bytes;
+        _phase = _ImgPhase.ready;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _phase = _ImgPhase.broken);
+    }
+  }
+
+  void _openFill() {
+    final Widget full;
+    if (_isNetwork && _networkUrl != null) {
+      full = Image.network(
+        _networkUrl!,
+        errorBuilder: (_, _, _) => _fillBroken(),
+      );
+    } else if (_bytes != null) {
+      full = Image.memory(_bytes!, errorBuilder: (_, _, _) => _fillBroken());
+    } else {
+      return;
+    }
+    showFillMediaViewer(context, child: full, label: widget.alt);
+  }
+
+  Widget _fillBroken() => const Icon(
+    Icons.broken_image_outlined,
+    color: Colors.white54,
+    size: 64,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    switch (_phase) {
+      case _ImgPhase.loading:
+        return const Padding(
+          key: Key('markdown-image-loading'),
+          padding: EdgeInsets.symmetric(vertical: 8),
+          child: SizedBox(
+            height: 48,
+            width: 48,
+            child: Center(
+              child: SizedBox(
+                height: 20,
+                width: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+          ),
+        );
+      case _ImgPhase.broken:
+        return _Placeholder(alt: widget.alt);
+      case _ImgPhase.ready:
+        return _buildInline(context);
+    }
+  }
+
+  Widget _buildInline(BuildContext context) {
+    final Widget image;
+    if (_isNetwork && _networkUrl != null) {
+      image = Image.network(
+        _networkUrl!,
+        fit: BoxFit.contain,
+        errorBuilder: (_, _, _) => _Placeholder(alt: widget.alt),
+      );
+    } else {
+      image = Image.memory(
+        _bytes!,
+        fit: BoxFit.contain,
+        errorBuilder: (_, _, _) => _Placeholder(alt: widget.alt),
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: GestureDetector(
+        key: const Key('markdown-inline-image'),
+        onTap: _openFill,
+        child: Stack(
+          alignment: Alignment.bottomRight,
+          children: [
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: _inlineMaxHeight),
+              child: image,
+            ),
+            // Discoverability affordance: a small monochrome "expand" badge.
+            const IgnorePointer(
+              child: Padding(
+                padding: EdgeInsets.all(4),
+                child: _ZoomBadge(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Graceful placeholder for a broken / missing / non-resolvable image. Never
+/// throws — the document stays usable.
+class _Placeholder extends StatelessWidget {
+  const _Placeholder({this.alt});
+
+  final String? alt;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final caption = (alt != null && alt!.trim().isNotEmpty)
+        ? alt!.trim()
+        : 'Image unavailable';
+    return Container(
+      key: const Key('markdown-image-placeholder'),
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.broken_image_outlined, size: 18, color: scheme.outline),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              caption,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ZoomBadge extends StatelessWidget {
+  const _ZoomBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(4),
+      decoration: const BoxDecoration(
+        color: Colors.black54,
+        shape: BoxShape.circle,
+      ),
+      child: const Icon(Icons.zoom_out_map, size: 16, color: Colors.white),
+    );
+  }
+}

--- a/native/test/services/sftp_image_path_test.dart
+++ b/native/test/services/sftp_image_path_test.dart
@@ -1,0 +1,74 @@
+// Unit tests for the markdown-image SFTP path resolver (#946).
+//
+// A relative `![](src)` resolves against the .md's directory; an absolute path
+// passes through normalized; `http(s)`/`data:`/protocol-relative refs are NOT
+// SFTP targets (return null → handled by the network/placeholder path).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/sftp_image_fetcher.dart';
+
+void main() {
+  group('resolveSftpImagePath', () {
+    test('relative path resolves against the .md directory', () {
+      expect(
+        resolveSftpImagePath('/home/me/docs/README.md', 'img/diagram.png'),
+        '/home/me/docs/img/diagram.png',
+      );
+    });
+
+    test('leading ./ relative path resolves against the .md directory', () {
+      expect(
+        resolveSftpImagePath('/home/me/docs/README.md', './pic.png'),
+        '/home/me/docs/pic.png',
+      );
+    });
+
+    test('../ escapes the .md directory', () {
+      expect(
+        resolveSftpImagePath('/home/me/docs/README.md', '../assets/a.png'),
+        '/home/me/assets/a.png',
+      );
+    });
+
+    test('absolute remote path passes through normalized', () {
+      expect(
+        resolveSftpImagePath('/home/me/docs/README.md', '/srv/img/x.png'),
+        '/srv/img/x.png',
+      );
+    });
+
+    test('.md at root resolves a relative sibling at root', () {
+      expect(
+        resolveSftpImagePath('/README.md', 'logo.png'),
+        '/logo.png',
+      );
+    });
+
+    test('http(s) URLs are not SFTP targets', () {
+      expect(
+        resolveSftpImagePath('/docs/README.md', 'https://x.test/a.png'),
+        isNull,
+      );
+      expect(
+        resolveSftpImagePath('/docs/README.md', 'http://x.test/a.png'),
+        isNull,
+      );
+    });
+
+    test('data: and protocol-relative refs are not SFTP targets', () {
+      expect(
+        resolveSftpImagePath('/docs/README.md', 'data:image/png;base64,AAAA'),
+        isNull,
+      );
+      expect(
+        resolveSftpImagePath('/docs/README.md', '//cdn.test/a.png'),
+        isNull,
+      );
+    });
+
+    test('empty / whitespace src returns null', () {
+      expect(resolveSftpImagePath('/docs/README.md', ''), isNull);
+      expect(resolveSftpImagePath('/docs/README.md', '   '), isNull);
+    });
+  });
+}

--- a/native/test/widget/markdown_media_fill_test.dart
+++ b/native/test/widget/markdown_media_fill_test.dart
@@ -1,0 +1,260 @@
+// Widget tests for tap-to-fill embedded media in the markdown viewer (#946).
+//
+// Assert the consistent gesture model for embedded media:
+//   - an inline image (`![](img/a.png)`) renders inline (resolved + fetched over
+//     the injected SFTP image fetcher, relative to the .md's dir) and tapping it
+//     pushes the shared fill viewer (InteractiveViewer with pan + scale forced),
+//   - a broken/failed image falls back to a placeholder and never throws,
+//   - a mermaid block renders inline and tapping it pushes the same fill viewer,
+//   - the raw/source toggle (#854) still shows the source verbatim.
+//
+// Real platform surfaces (WebView, image decode) are swapped/canned so the test
+// runs without a platform channel or socket — mirrors the existing markdown +
+// mermaid widget tests.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/sftp_image_fetcher.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/services/text_file_fetcher.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/fill_media_viewer.dart';
+import 'package:mobissh/ui/markdown_file_viewer.dart';
+import 'package:mobissh/ui/mermaid_diagram_view.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// A minimal valid 1x1 transparent PNG.
+final Uint8List _png = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+  '+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+);
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+class _CannedTextFetcher implements TextFileFetcher {
+  _CannedTextFetcher(this.text);
+  final String text;
+
+  @override
+  Future<String> fetch(
+    String sessionId,
+    SftpEntry entry, {
+    int maxBytes = 2 * 1024 * 1024,
+    void Function(int received, int? total)? onProgress,
+  }) async => text;
+}
+
+/// Records the path it is asked to fetch; returns canned bytes (or throws to
+/// simulate a broken image).
+class _FakeImageFetcher implements SftpImageFetcher {
+  _FakeImageFetcher({required this.bytes, this.fail = false});
+  final Uint8List bytes;
+  final bool fail;
+  String? requestedPath;
+
+  @override
+  Future<Uint8List> fetch(
+    String sessionId,
+    String path, {
+    int maxBytes = 8 * 1024 * 1024,
+  }) async {
+    requestedPath = path;
+    if (fail) throw Exception('boom');
+    return bytes;
+  }
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 14}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+({ProviderContainer container, SessionEntry session, SessionHost host}) _wire(
+  WidgetTester tester, {
+  required String markdown,
+  required SftpImageFetcher imageFetcher,
+}) {
+  final pair = InMemoryGatewayPair();
+  addTearDown(pair.dispose);
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: _stubControllerFactory,
+    snapshotInterval: const Duration(hours: 1),
+  );
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      textFileFetcherProvider.overrideWithValue(_CannedTextFetcher(markdown)),
+      sftpImageFetcherProvider.overrideWithValue(imageFetcher),
+    ],
+  );
+  addTearDown(container.dispose);
+  const params = SshConnectParams(
+    host: 'h',
+    port: 22,
+    username: 'u',
+    auth: SshAuth.password('p'),
+  );
+  final session = container.read(sessionsProvider.notifier).addOrActivate(
+    params,
+  );
+  return (container: container, session: session, host: host);
+}
+
+Future<SessionHost> _open(
+  WidgetTester tester, {
+  required String markdown,
+  required SftpImageFetcher imageFetcher,
+  String mdPath = '/DOC.md',
+}) async {
+  final w = _wire(tester, markdown: markdown, imageFetcher: imageFetcher);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: w.container,
+      child: MaterialApp(
+        home: MarkdownFileViewerScreen(
+          sessionId: w.session.id,
+          entry: SftpEntry(name: 'DOC.md', path: mdPath, isDirectory: false),
+          openLink: (_) async {},
+        ),
+      ),
+    ),
+  );
+  await _pump(tester);
+  return w.host;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    mermaidWebViewBuilder = (source) => Container(key: const Key('mm-stub'));
+    mermaidFillBuilder = (source) => Container(key: const Key('mm-fill-stub'));
+  });
+
+  tearDown(() {
+    mermaidWebViewBuilder = defaultMermaidWebViewBuilderForTest;
+    mermaidFillBuilder = defaultMermaidFillBuilderForTest;
+  });
+
+  testWidgets('inline image resolves over SFTP and renders inline', (
+    tester,
+  ) async {
+    final fetcher = _FakeImageFetcher(bytes: _png);
+    final host = await _open(
+      tester,
+      markdown: '# Doc\n\n![a diagram](img/a.png)\n',
+      imageFetcher: fetcher,
+      mdPath: '/home/me/README.md',
+    );
+
+    expect(find.byKey(const Key('markdown-inline-image')), findsOneWidget);
+    // Relative src resolved against the .md's directory before fetching.
+    expect(fetcher.requestedPath, '/home/me/img/a.png');
+
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('tapping an inline image pushes the zoomable fill viewer', (
+    tester,
+  ) async {
+    final host = await _open(
+      tester,
+      markdown: '![a](pic.png)\n',
+      imageFetcher: _FakeImageFetcher(bytes: _png),
+    );
+
+    expect(find.byType(FillMediaViewer), findsNothing);
+
+    await tester.tap(find.byKey(const Key('markdown-inline-image')));
+    await _pump(tester);
+
+    expect(find.byType(FillMediaViewer), findsOneWidget);
+    final iv = tester.widget<InteractiveViewer>(
+      find.byKey(const Key('fill-media-interactive-viewer')),
+    );
+    expect(iv.panEnabled, isTrue);
+    expect(iv.scaleEnabled, isTrue);
+    expect(find.byKey(const Key('fill-media-close')), findsOneWidget);
+
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('broken image falls back to a placeholder without throwing', (
+    tester,
+  ) async {
+    final host = await _open(
+      tester,
+      markdown: '![missing](nope.png)\n',
+      imageFetcher: _FakeImageFetcher(bytes: _png, fail: true),
+    );
+
+    expect(find.byKey(const Key('markdown-image-placeholder')), findsOneWidget);
+    expect(find.byKey(const Key('markdown-inline-image')), findsNothing);
+    expect(tester.takeException(), isNull);
+
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('mermaid block renders inline and taps into the fill viewer', (
+    tester,
+  ) async {
+    final host = await _open(
+      tester,
+      markdown: '```mermaid\ngraph TD; A-->B;\n```\n',
+      imageFetcher: _FakeImageFetcher(bytes: _png),
+    );
+
+    expect(find.byType(MermaidDiagramView), findsOneWidget);
+    expect(find.byType(FillMediaViewer), findsNothing);
+
+    await tester.tap(find.byKey(const Key('mermaid-tap-to-fill')));
+    await _pump(tester);
+
+    expect(find.byType(FillMediaViewer), findsOneWidget);
+    expect(find.byKey(const Key('mm-fill-stub')), findsOneWidget);
+    expect(
+      find.byKey(const Key('fill-media-interactive-viewer')),
+      findsOneWidget,
+    );
+
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('raw toggle still shows the image source verbatim', (
+    tester,
+  ) async {
+    final host = await _open(
+      tester,
+      markdown: '![a](img/a.png)\n',
+      imageFetcher: _FakeImageFetcher(bytes: _png),
+    );
+
+    await tester.tap(find.byKey(const Key('markdown-raw-toggle')));
+    await _pump(tester);
+
+    expect(find.byKey(const Key('markdown-viewer-raw')), findsOneWidget);
+    expect(find.textContaining('![a](img/a.png)'), findsOneWidget);
+    expect(find.byKey(const Key('markdown-inline-image')), findsNothing);
+
+    host.disposeSyncForTest();
+  });
+}


### PR DESCRIPTION
## What

Consistent gesture model for markdown embedded media (#946, epic #944): flowed
text scrolls; every embedded media item — inline images (`![](...)`) **and**
mermaid diagrams — renders inline at a sensible size and is **tap-to-fill** into
one shared fullscreen viewer where pinch-zoom + pan are forced.

In-place pinch/pan over a PlatformView (the mermaid WebView) nested in scrolling
content is unreliable — the platform view wins the gesture arena, so the +75
built-in zoom didn't work on device. Tap-to-fill is the zoom path.

## Changes

- **`lib/ui/fill_media_viewer.dart`** (new): reusable `FillMediaViewer` +
  `showFillMediaViewer` — `InteractiveViewer` (pan + scale forced, min/max scale,
  double-tap fit/reset), dark scrim, monochrome close glyph. Used by both images
  and mermaid.
- **`lib/services/sftp_image_fetcher.dart`** (new): byte fetcher over the **same**
  proxy `sftpDownload`/`sftpEvents` offset-assembly the text fetcher uses (no
  UTF-8 decode, no binary reject — images are binary) + `resolveSftpImagePath()`
  pure resolver (relative → the .md's dir, absolute → as-is, `http(s)`/`data:`/
  protocol-relative → null = network/placeholder). Provider for test override.
- **`lib/ui/sftp_markdown_image.dart`** (new): `imageBuilder` widget — inline
  bounded image fetched over SFTP, tap → fill; explicit `http(s)` →
  `Image.network`; broken/missing/oversized → graceful placeholder, never crash.
- **`markdown_file_viewer.dart`**: wire `flutter_markdown_plus` `imageBuilder`,
  threading `sessionId` + the .md path. **Raw/source toggle (#854) preserved.**
- **`mermaid_diagram_view.dart`**: keep the inline diagram; transparent tap
  overlay **above** the webview → fill viewer with a fullscreen mermaid surface
  (built-in zoom works once un-nested). Drops reliance on in-place built-in zoom
  for the inline diagram.

## Tests

- **Unit** `sftp_image_path_test.dart` (8): relative/`./`/`../`/absolute/root
  resolution; `http(s)`/`data:`/protocol-relative/empty → null.
- **Widget** `markdown_media_fill_test.dart` (5): inline image resolves over SFTP
  + renders inline; tap → `FillMediaViewer` with `InteractiveViewer`
  pan/scale = true; broken image → placeholder, no throw; mermaid tap → fill
  viewer; raw toggle shows source verbatim.
- **Integration (tagged `integration`)** `markdown_media_fill_test.dart`: seeds a
  .md + relative image over test-sshd, opens it, taps each media item → fill
  viewer.
- Native fast gate green (analyze + 1512 tests).

## Device gate

Pinch/pan is real-hardware — the integration test asserts the tap→fill route +
forced-zoom widget config; the actual multi-touch zoom is owner-validated. The
emulator + test-sshd were **down** in this run (no adb device, port-2222
conflict), so the tagged integration test is written to run when they're
available; widget coverage carries the routing/config assertions.

Refs #944. Closes #946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)