### PR TITLE
feat(profiles): reorder saved profiles via drag handle + Move-to-top/bottom menu (#481)

### DIFF
--- a/native/lib/state/profile_order_providers.dart
+++ b/native/lib/state/profile_order_providers.dart
@@ -1,0 +1,210 @@
+// Persisted display order for saved profiles on the Connect panel (#481).
+//
+// Saved profiles render in an arbitrary/insertion order with no way to reorder.
+// This adds a user-defined order: a SharedPreferences-backed list of profile
+// `identityKey`s (`host:port:username`). The Connect panel applies the order
+// before rendering and exposes drag-reorder + "Move to top / bottom" controls.
+//
+// Storage mirrors the favorites / files-sort stores: a single versioned JSON
+// blob in shared_preferences with the migratable schema version INSIDE the
+// value (never a key bump, per .claude/rules code-style). Corrupt /
+// unknown-version data falls back to an empty order (validate → fallback, never
+// crash) — an empty order means "insertion order", which is the prior behaviour.
+//
+// The order self-heals against the live profile set via [reconcileOrder]:
+//   - a NEW profile (not in the order) appends to the END,
+//   - a DELETED profile (in the order but gone) is dropped,
+//   - IMPORTED profiles merge by identity — existing keep their slot, new append.
+// The RECENT SESSIONS and Active Sessions lists are SEPARATE (chronological /
+// live) and are unaffected by this order.
+
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../storage/profiles_store.dart';
+import 'profiles_providers.dart';
+
+/// shared_preferences key (storage namespace `v1`; the migratable schema
+/// version lives inside the value — see [_schemaVersion]).
+const String profileOrderPrefKey = 'mobissh.profile.order.v1';
+
+const int _schemaVersion = 1;
+
+/// Decode the stored order list from a blob. Returns an empty list on
+/// null/malformed/unknown-version input, and de-dupes / drops non-string
+/// entries (corrupt-resilience — never crash, never surface a bad shape).
+List<String> decodeProfileOrder(String? raw) {
+  if (raw == null || raw.isEmpty) return const <String>[];
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) return const <String>[];
+    final version = decoded['version'];
+    if (version is! int || version != _schemaVersion) return const <String>[];
+    final order = decoded['order'];
+    if (order is! List) return const <String>[];
+    final out = <String>[];
+    final seen = <String>{};
+    for (final entry in order) {
+      if (entry is String && entry.isNotEmpty && seen.add(entry)) {
+        out.add(entry);
+      }
+    }
+    return out;
+  } on FormatException {
+    return const <String>[];
+  }
+}
+
+String encodeProfileOrder(List<String> order) =>
+    jsonEncode({'version': _schemaVersion, 'order': order});
+
+/// Reconcile a stored [order] against the current [profileKeys] set:
+/// keep known keys in their stored order, drop keys whose profile is gone,
+/// and append profile keys that aren't in the order yet (in their given
+/// order). Pure + total — the canonical "self-heal" used on every load and
+/// after add/delete/import. De-dupes defensively.
+List<String> reconcileOrder(List<String> profileKeys, List<String> order) {
+  final known = profileKeys.toSet();
+  final seen = <String>{};
+  final out = <String>[];
+  for (final id in order) {
+    if (known.contains(id) && seen.add(id)) out.add(id);
+  }
+  for (final id in profileKeys) {
+    if (seen.add(id)) out.add(id);
+  }
+  return out;
+}
+
+/// Return [profiles] sorted by [order]: entries listed in [order] come first
+/// in that order, then any profile NOT in the order is appended in its original
+/// position. Order entries with no matching profile are ignored. Pure +
+/// unit-testable; the Connect panel calls this right before rendering.
+List<SavedProfile> applyOrder(
+  List<SavedProfile> profiles,
+  List<String> order,
+) {
+  final byKey = <String, SavedProfile>{
+    for (final p in profiles) p.identityKey: p,
+  };
+  final seen = <String>{};
+  final out = <SavedProfile>[];
+  for (final id in order) {
+    final p = byKey[id];
+    if (p != null && seen.add(id)) out.add(p);
+  }
+  for (final p in profiles) {
+    if (seen.add(p.identityKey)) out.add(p);
+  }
+  return out;
+}
+
+/// Persisted, reactive profile display order (list of `identityKey`s). The
+/// Connect panel watches this and applies it via [applyOrder]; mutations
+/// ([moveToTop]/[moveToBottom]/[reorder]) persist immediately and update the
+/// watcher synchronously. [sync] reconciles the order with the live profile set
+/// so add/delete/import self-heal.
+class ProfileOrderNotifier extends StateNotifier<List<String>> {
+  ProfileOrderNotifier({Future<SharedPreferences>? prefs})
+    : _prefs = prefs ?? SharedPreferences.getInstance(),
+      super(const <String>[]) {
+    _ready = _hydrate();
+  }
+
+  final Future<SharedPreferences> _prefs;
+
+  /// Completes once the stored order has been loaded. [sync] awaits this so an
+  /// auto-reconcile from the live profile set never clobbers the persisted order
+  /// during the async hydrate window.
+  late final Future<void> _ready;
+
+  Future<void> _hydrate() async {
+    try {
+      final prefs = await _prefs;
+      final order = decodeProfileOrder(prefs.getString(profileOrderPrefKey));
+      if (!listEquals(order, state)) state = order;
+    } catch (_) {
+      // best-effort; keep the empty default if prefs is unavailable (tests).
+    }
+  }
+
+  Future<void> _persist() async {
+    try {
+      final prefs = await _prefs;
+      await prefs.setString(profileOrderPrefKey, encodeProfileOrder(state));
+    } catch (_) {
+      // best-effort persistence
+    }
+  }
+
+  /// Reconcile the order against the current profile key set, dropping missing
+  /// keys and appending new ones (#481 add/delete/import self-heal). Updates +
+  /// persists only when something actually changed (idempotent — safe to call
+  /// every build / on every profile-set change).
+  Future<void> sync(List<String> profileKeys) async {
+    await _ready;
+    final next = reconcileOrder(profileKeys, state);
+    if (!listEquals(next, state)) {
+      state = next;
+      await _persist();
+    }
+  }
+
+  /// Move [id] to the front of the order. No-op when [id] isn't present.
+  Future<void> moveToTop(String id) async {
+    if (!state.contains(id)) return;
+    final list = List<String>.from(state)..remove(id);
+    list.insert(0, id);
+    state = list;
+    await _persist();
+  }
+
+  /// Move [id] to the end of the order. No-op when [id] isn't present.
+  Future<void> moveToBottom(String id) async {
+    if (!state.contains(id)) return;
+    final list = List<String>.from(state)..remove(id);
+    list.add(id);
+    state = list;
+    await _persist();
+  }
+
+  /// Reorder via drag. [oldIndex] is the dragged item's current position;
+  /// [newIndex] is its destination index AFTER removal — the
+  /// `ReorderableListView.onReorderItem` contract (the framework already
+  /// adjusts for the removed slot). Indices are into the CURRENT order (the
+  /// rendered list, which the Connect panel keeps in sync via [sync]).
+  Future<void> reorder(int oldIndex, int newIndex) async {
+    if (oldIndex < 0 || oldIndex >= state.length) return;
+    final list = List<String>.from(state);
+    final id = list.removeAt(oldIndex);
+    var target = newIndex;
+    if (target < 0) target = 0;
+    if (target > list.length) target = list.length;
+    list.insert(target, id);
+    if (listEquals(list, state)) return;
+    state = list;
+    await _persist();
+  }
+}
+
+/// Reactive, persisted profile display order (#481). Auto-reconciles against the
+/// live saved-profile set ([savedProfilesProvider]): whenever profiles load or
+/// change (add / delete / import), [ProfileOrderNotifier.sync] drops gone keys
+/// and appends new ones — so the stored order self-heals without any UI plumbing.
+final profileOrderProvider =
+    StateNotifierProvider<ProfileOrderNotifier, List<String>>((ref) {
+      final notifier = ProfileOrderNotifier();
+      ref.listen<AsyncValue<List<SavedProfile>>>(savedProfilesProvider, (
+        _,
+        next,
+      ) {
+        final profiles = next.valueOrNull;
+        if (profiles != null) {
+          notifier.sync(profiles.map((p) => p.identityKey).toList());
+        }
+      }, fireImmediately: true);
+      return notifier;
+    });

--- a/native/lib/ui/profile_list.dart
+++ b/native/lib/ui/profile_list.dart
@@ -22,6 +22,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../ssh/ssh_session.dart';
+import '../state/profile_order_providers.dart';
 import '../state/profiles_providers.dart';
 import '../state/recent_sessions.dart';
 import '../state/sessions.dart';
@@ -110,42 +111,14 @@ class ProfileList extends ConsumerWidget {
             ),
           );
         } else {
-          profilesSection = Expanded(
-            key: const Key('profile-list-populated'),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 4, bottom: 4),
-                  child: Text(
-                    'Saved Profiles',
-                    style: Theme.of(context).textTheme.titleSmall,
-                  ),
-                ),
-                // #643: the list FILLS the available height instead of a fixed
-                // 220px cap that left ~60% of the screen blank below. `Expanded`
-                // takes whatever vertical room the parent gives (the chooser
-                // places ProfileList in its own Expanded), and the ListView
-                // scrolls within that full height when there are more profiles
-                // than fit. No `shrinkWrap` — the list gets a bounded height
-                // from the Expanded.
-                Expanded(
-                  child: ListView.builder(
-                    itemCount: profiles.length,
-                    itemBuilder: (context, i) {
-                      final p = profiles[i];
-                      return _ProfileTile(
-                        profile: p,
-                        onTap: () => onConnect(p),
-                        onEdit: () => onEdit(p),
-                        onRetry: () => onConnect(p),
-                      );
-                    },
-                  ),
-                ),
-                const Divider(height: 1),
-              ],
-            ),
+          // #481: the saved-profile list is user-reorderable (drag the
+          // upper-right handle, or its tap-menu's Move to top / bottom). The
+          // persisted order is applied here before rendering; the section
+          // self-heals the stored order against add/delete/import.
+          profilesSection = _SavedProfilesSection(
+            profiles: profiles,
+            onConnect: onConnect,
+            onEdit: onEdit,
           );
         }
 
@@ -481,15 +454,93 @@ class _RecentTile extends StatelessWidget {
   }
 }
 
+/// The reorderable "Saved Profiles" section (#481). Applies the persisted
+/// [profileOrderProvider] order to [profiles] before rendering, and renders a
+/// [ReorderableListView] whose ONLY drag affordance is each tile's upper-right
+/// handle (`buildDefaultDragHandles: false`). The card body keeps its
+/// tap-to-connect (#579) and the edit pencil keeps editing.
+///
+/// The stored order self-heals against add/delete/import inside the provider
+/// (it `sync`s off [savedProfilesProvider]) — no plumbing needed here. The
+/// Recent / Active sessions groups above are separate and untouched.
+class _SavedProfilesSection extends ConsumerWidget {
+  const _SavedProfilesSection({
+    required this.profiles,
+    required this.onConnect,
+    required this.onEdit,
+  });
+
+  final List<SavedProfile> profiles;
+  final ProfileSelectCallback onConnect;
+  final ProfileSelectCallback onEdit;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final order = ref.watch(profileOrderProvider);
+    final ordered = applyOrder(profiles, order);
+
+    return Expanded(
+      key: const Key('profile-list-populated'),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 4, bottom: 4),
+            child: Text(
+              'Saved Profiles',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+          ),
+          // #643: the list FILLS the available height (Expanded), scrolling
+          // within it. #481: ReorderableListView gives lift/part + auto-scroll
+          // near the edges during a drag. Default drag handles are OFF — only
+          // each tile's upper-right handle starts a drag.
+          Expanded(
+            child: ReorderableListView.builder(
+              buildDefaultDragHandles: false,
+              itemCount: ordered.length,
+              // onReorderItem (not the deprecated onReorder): newIndex is the
+              // destination AFTER removal, which the notifier consumes directly.
+              onReorderItem: (oldIndex, newIndex) {
+                ref
+                    .read(profileOrderProvider.notifier)
+                    .reorder(oldIndex, newIndex);
+              },
+              itemBuilder: (context, i) {
+                final p = ordered[i];
+                return _ProfileTile(
+                  key: ValueKey('profile-reorder-${p.identityKey}'),
+                  index: i,
+                  profile: p,
+                  onTap: () => onConnect(p),
+                  onEdit: () => onEdit(p),
+                  onRetry: () => onConnect(p),
+                );
+              },
+            ),
+          ),
+          const Divider(height: 1),
+        ],
+      ),
+    );
+  }
+}
+
 /// One profile row. A [ConsumerWidget] so it can watch the session collection
 /// and reflect the matching session's live connect state inline (#660).
 class _ProfileTile extends ConsumerWidget {
   const _ProfileTile({
+    super.key,
+    required this.index,
     required this.profile,
     required this.onTap,
     required this.onEdit,
     required this.onRetry,
   });
+
+  /// This tile's position in the rendered (ordered) list — the drag index for
+  /// the upper-right [ReorderableDelayedDragStartListener] handle (#481).
+  final int index;
 
   final SavedProfile profile;
 
@@ -519,32 +570,113 @@ class _ProfileTile extends ConsumerWidget {
     final color = _parseColor(profile.color);
     final entry = _matchingSession(ref);
 
-    return ListTile(
-      key: Key('profile-tile-${profile.identityKey}'),
-      dense: true,
-      leading: CircleAvatar(
-        backgroundColor: color ?? Theme.of(context).colorScheme.primary,
-        radius: 8,
+    // The body is the existing ListTile (tap-to-connect + edit pencil). The
+    // reorder handle is overlaid in the UPPER-RIGHT corner (#481) so ONLY the
+    // glyph drags / opens the menu — the card body stays tap-to-connect.
+    return Stack(
+      children: [
+        ListTile(
+          key: Key('profile-tile-${profile.identityKey}'),
+          dense: true,
+          leading: CircleAvatar(
+            backgroundColor: color ?? Theme.of(context).colorScheme.primary,
+            radius: 8,
+          ),
+          title: Text(profile.title, overflow: TextOverflow.ellipsis),
+          // The subtitle carries the host line PLUS — when a matching session
+          // is mid-connect or failed — an inline connect affordance (#660). It
+          // stays reactive by streaming the matching session's proxy state.
+          subtitle: _ProfileSubtitle(
+            profile: profile,
+            entry: entry,
+            onRetry: onRetry,
+          ),
+          // Reserve right room for the overlaid handle + pencil so long titles
+          // don't run under them.
+          contentPadding: const EdgeInsets.only(left: 16, right: 88),
+          onTap: onTap,
+        ),
+        // Upper-right control cluster: edit pencil + reorder/menu handle.
+        Positioned(
+          top: 0,
+          right: 0,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Edit pencil opens the editor; the body tap connects. Distinct
+              // targets so a body tap never accidentally edits (PWA parity).
+              IconButton(
+                key: Key('profile-edit-${profile.identityKey}'),
+                icon: const Icon(Icons.edit_outlined, size: 20),
+                visualDensity: VisualDensity.compact,
+                tooltip: 'Edit profile',
+                onPressed: onEdit,
+              ),
+              _ReorderHandle(index: index, profile: profile),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The upper-right drag-grip / menu glyph for a profile card (#481).
+///
+/// Touch-and-HOLD then drag → reorder (via [ReorderableDelayedDragStartListener]
+/// so a brief tap doesn't start a drag). TAP → a popup menu with at least
+/// "Move to top" / "Move to bottom". Only this glyph initiates drag/menu; the
+/// card body keeps tap-to-connect (rules/platform/mobile-touch.md — dedicated
+/// control, not an overloaded body gesture). `Icons.drag_indicator` is a
+/// monochrome Material glyph (no emoji), ~18px in a ≥32px tap target.
+class _ReorderHandle extends ConsumerWidget {
+  const _ReorderHandle({required this.index, required this.profile});
+
+  final int index;
+  final SavedProfile profile;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final id = profile.identityKey;
+    return ReorderableDelayedDragStartListener(
+      index: index,
+      child: PopupMenuButton<String>(
+        key: Key('profile-reorder-handle-$id'),
+        tooltip: 'Reorder profile',
+        icon: const Icon(Icons.drag_indicator, size: 18),
+        onSelected: (value) {
+          final notifier = ref.read(profileOrderProvider.notifier);
+          if (value == 'top') {
+            notifier.moveToTop(id);
+          } else if (value == 'bottom') {
+            notifier.moveToBottom(id);
+          }
+        },
+        itemBuilder: (context) => [
+          PopupMenuItem<String>(
+            key: Key('profile-move-top-$id'),
+            value: 'top',
+            child: const Row(
+              children: [
+                Icon(Icons.vertical_align_top, size: 18),
+                SizedBox(width: 12),
+                Text('Move to top'),
+              ],
+            ),
+          ),
+          PopupMenuItem<String>(
+            key: Key('profile-move-bottom-$id'),
+            value: 'bottom',
+            child: const Row(
+              children: [
+                Icon(Icons.vertical_align_bottom, size: 18),
+                SizedBox(width: 12),
+                Text('Move to bottom'),
+              ],
+            ),
+          ),
+        ],
       ),
-      title: Text(profile.title, overflow: TextOverflow.ellipsis),
-      // The subtitle carries the host line PLUS — when a matching session is
-      // mid-connect or failed — an inline connect affordance (#660). It stays
-      // reactive by streaming the matching session's proxy state.
-      subtitle: _ProfileSubtitle(
-        profile: profile,
-        entry: entry,
-        onRetry: onRetry,
-      ),
-      // Edit pencil opens the editor; the row tap (onTap) connects. Keeping
-      // the pencil as a distinct trailing target means a row tap never
-      // accidentally edits — it always connects (PWA parity).
-      trailing: IconButton(
-        key: Key('profile-edit-${profile.identityKey}'),
-        icon: const Icon(Icons.edit_outlined),
-        tooltip: 'Edit profile',
-        onPressed: onEdit,
-      ),
-      onTap: onTap,
     );
   }
 }

--- a/native/test/state/profile_order_test.dart
+++ b/native/test/state/profile_order_test.dart
@@ -1,0 +1,181 @@
+// Unit tests for the persisted saved-profile order (#481).
+//
+// Covers the pure helpers (applyOrder / reconcileOrder) and the
+// ProfileOrderNotifier (moveToTop/Bottom/reorder persist + round-trip via a
+// SharedPreferences mock; corrupt value → empty order).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/profile_order_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SavedProfile _p(String host, {String user = 'u', int port = 22}) =>
+    SavedProfile(title: '$user@$host', host: host, port: port, username: user);
+
+List<String> _keys(List<SavedProfile> ps) =>
+    ps.map((p) => p.identityKey).toList();
+
+void main() {
+  group('applyOrder (pure)', () {
+    final a = _p('a');
+    final b = _p('b');
+    final c = _p('c');
+
+    test('orders profiles by the given key order', () {
+      final out = applyOrder([a, b, c], [c.identityKey, a.identityKey, b.identityKey]);
+      expect(_keys(out), [c.identityKey, a.identityKey, b.identityKey]);
+    });
+
+    test('unknown profile IDs (not in order) append in original order', () {
+      // Only `b` is ordered; a and c are appended in their list order.
+      final out = applyOrder([a, b, c], [b.identityKey]);
+      expect(_keys(out), [b.identityKey, a.identityKey, c.identityKey]);
+    });
+
+    test('order entries with no matching profile are ignored', () {
+      final out = applyOrder([a, b], ['z:22:gone', b.identityKey, a.identityKey]);
+      expect(_keys(out), [b.identityKey, a.identityKey]);
+    });
+
+    test('empty order preserves insertion order', () {
+      final out = applyOrder([a, b, c], const []);
+      expect(_keys(out), [a.identityKey, b.identityKey, c.identityKey]);
+    });
+
+    test('empty profiles yields empty', () {
+      expect(applyOrder(const [], [a.identityKey]), isEmpty);
+    });
+  });
+
+  group('reconcileOrder (pure)', () {
+    test('keeps known keys in stored order, drops missing, appends new', () {
+      final keys = ['a:22:u', 'c:22:u', 'd:22:u'];
+      final stored = ['b:22:u', 'c:22:u', 'a:22:u']; // b gone, d new
+      expect(reconcileOrder(keys, stored), ['c:22:u', 'a:22:u', 'd:22:u']);
+    });
+
+    test('empty stored order yields profile keys in their order', () {
+      expect(reconcileOrder(['a:22:u', 'b:22:u'], const []),
+          ['a:22:u', 'b:22:u']);
+    });
+  });
+
+  group('decode/encode round-trip + corrupt resilience', () {
+    test('decode of a fresh encode preserves the list', () {
+      final order = ['a:22:u', 'b:2222:me'];
+      expect(decodeProfileOrder(encodeProfileOrder(order)), order);
+    });
+
+    test('null / empty / garbage / wrong-shape → empty', () {
+      expect(decodeProfileOrder(null), isEmpty);
+      expect(decodeProfileOrder(''), isEmpty);
+      expect(decodeProfileOrder('not json'), isEmpty);
+      expect(decodeProfileOrder('[1,2,3]'), isEmpty);
+      expect(decodeProfileOrder('{"order":["a"]}'), isEmpty); // no version
+    });
+
+    test('unknown schema version → empty', () {
+      expect(decodeProfileOrder('{"version":99,"order":["a:22:u"]}'), isEmpty);
+    });
+
+    test('drops non-string / blank / duplicate entries', () {
+      expect(
+        decodeProfileOrder('{"version":1,"order":["a:22:u",2,"","a:22:u","b:22:u"]}'),
+        ['a:22:u', 'b:22:u'],
+      );
+    });
+  });
+
+  group('ProfileOrderNotifier — persistence', () {
+    setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+    test('starts empty when nothing stored', () async {
+      final prefs = SharedPreferences.getInstance();
+      final n = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      expect(n.state, isEmpty);
+    });
+
+    test('sync seeds the order from the live profile set and persists', () async {
+      final prefs = SharedPreferences.getInstance();
+      final n = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      await n.sync(['a:22:u', 'b:22:u', 'c:22:u']);
+      expect(n.state, ['a:22:u', 'b:22:u', 'c:22:u']);
+
+      // A fresh notifier hydrates the persisted order.
+      final n2 = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      expect(n2.state, ['a:22:u', 'b:22:u', 'c:22:u']);
+    });
+
+    test('moveToTop persists + round-trips', () async {
+      final prefs = SharedPreferences.getInstance();
+      final n = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      await n.sync(['a:22:u', 'b:22:u', 'c:22:u']);
+      await n.moveToTop('c:22:u');
+      expect(n.state, ['c:22:u', 'a:22:u', 'b:22:u']);
+
+      final n2 = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      expect(n2.state, ['c:22:u', 'a:22:u', 'b:22:u']);
+    });
+
+    test('moveToBottom persists', () async {
+      final prefs = SharedPreferences.getInstance();
+      final n = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      await n.sync(['a:22:u', 'b:22:u', 'c:22:u']);
+      await n.moveToBottom('a:22:u');
+      expect(n.state, ['b:22:u', 'c:22:u', 'a:22:u']);
+    });
+
+    test('reorder moves an item to the post-removal destination index', () async {
+      final prefs = SharedPreferences.getInstance();
+      final n = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      await n.sync(['a:22:u', 'b:22:u', 'c:22:u']);
+      // onReorderItem contract: drag item 0 to sit after item 1 → newIndex=1
+      // (destination after the dragged item is removed).
+      await n.reorder(0, 1);
+      expect(n.state, ['b:22:u', 'a:22:u', 'c:22:u']);
+
+      // Persisted.
+      final n2 = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      expect(n2.state, ['b:22:u', 'a:22:u', 'c:22:u']);
+    });
+
+    test('move/reorder are no-ops for unknown / out-of-range', () async {
+      final prefs = SharedPreferences.getInstance();
+      final n = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      await n.sync(['a:22:u', 'b:22:u']);
+      await n.moveToTop('gone:22:u');
+      await n.reorder(9, 0);
+      expect(n.state, ['a:22:u', 'b:22:u']);
+    });
+
+    test('sync drops a deleted profile + appends a new one', () async {
+      final prefs = SharedPreferences.getInstance();
+      final n = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      await n.sync(['a:22:u', 'b:22:u', 'c:22:u']);
+      await n.moveToTop('c:22:u'); // c,a,b
+      // b deleted, d added.
+      await n.sync(['a:22:u', 'c:22:u', 'd:22:u']);
+      expect(n.state, ['c:22:u', 'a:22:u', 'd:22:u']);
+    });
+
+    test('corrupt stored value hydrates to empty (no crash)', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        profileOrderPrefKey: 'totally not json',
+      });
+      final prefs = SharedPreferences.getInstance();
+      final n = ProfileOrderNotifier(prefs: prefs);
+      await Future<void>.delayed(Duration.zero);
+      expect(n.state, isEmpty);
+    });
+  });
+}

--- a/native/test/widget/profile_reorder_widget_test.dart
+++ b/native/test/widget/profile_reorder_widget_test.dart
@@ -1,0 +1,177 @@
+// Widget tests for the reorderable saved-profile list (#481).
+//
+// Asserts:
+//   - each profile card shows an upper-right reorder/menu handle
+//   - tapping the handle opens a menu with "Move to top" / "Move to bottom"
+//   - "Move to top" reorders the rendered list AND persists the new order
+//   - the card body still taps-to-connect (#579); the handle does not connect
+//   - the Recent Sessions list is a separate group, unaffected by the order
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/profile_order_providers.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/profile_list.dart';
+
+Future<void> _pumpList(
+  WidgetTester tester, {
+  required ProfilesStore store,
+  required void Function(SavedProfile) onConnect,
+  void Function(SavedProfile)? onEdit,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      // Only the store is overridden — the real profileOrderProvider auto-syncs
+      // off savedProfilesProvider and persists to the mocked SharedPreferences.
+      overrides: [profilesStoreProvider.overrideWithValue(store)],
+      child: MaterialApp(
+        home: Scaffold(
+          body: ProfileList(
+            onConnect: onConnect,
+            onEdit: onEdit ?? (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ProfileList reorder (#481)', () {
+    testWidgets('each card shows an upper-right reorder handle', (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(title: 'A', host: 'a.example', port: 22, username: 'me'),
+        SavedProfile(title: 'B', host: 'b.example', port: 22, username: 'me'),
+      ]);
+
+      await _pumpList(tester, store: store, onConnect: (_) {});
+
+      expect(
+        find.byKey(const Key('profile-reorder-handle-a.example:22:me')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('profile-reorder-handle-b.example:22:me')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping the handle opens the Move menu', (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(title: 'A', host: 'a.example', port: 22, username: 'me'),
+        SavedProfile(title: 'B', host: 'b.example', port: 22, username: 'me'),
+      ]);
+
+      await _pumpList(tester, store: store, onConnect: (_) {});
+
+      await tester.tap(
+        find.byKey(const Key('profile-reorder-handle-b.example:22:me')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('profile-move-top-b.example:22:me')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('profile-move-bottom-b.example:22:me')),
+        findsOneWidget,
+      );
+      expect(find.text('Move to top'), findsOneWidget);
+      expect(find.text('Move to bottom'), findsOneWidget);
+    });
+
+    testWidgets('Move to top reorders the list and persists the order', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = SharedPreferences.getInstance();
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(title: 'A', host: 'a.example', port: 22, username: 'me'),
+        SavedProfile(title: 'B', host: 'b.example', port: 22, username: 'me'),
+        SavedProfile(title: 'C', host: 'c.example', port: 22, username: 'me'),
+      ]);
+
+      await _pumpList(tester, store: store, onConnect: (_) {});
+
+      // Initially A is above C.
+      final aTop = tester
+          .getTopLeft(find.byKey(const Key('profile-tile-a.example:22:me')))
+          .dy;
+      final cTop = tester
+          .getTopLeft(find.byKey(const Key('profile-tile-c.example:22:me')))
+          .dy;
+      expect(aTop < cTop, isTrue);
+
+      // Move C to the top via its menu.
+      await tester.tap(
+        find.byKey(const Key('profile-reorder-handle-c.example:22:me')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('profile-move-top-c.example:22:me')),
+      );
+      await tester.pumpAndSettle();
+
+      // The order is persisted.
+      final p = await prefs;
+      final order = decodeProfileOrder(p.getString(profileOrderPrefKey));
+      expect(order.first, 'c.example:22:me');
+
+      // C now renders above A.
+      final aTop2 = tester
+          .getTopLeft(find.byKey(const Key('profile-tile-a.example:22:me')))
+          .dy;
+      final cTop2 = tester
+          .getTopLeft(find.byKey(const Key('profile-tile-c.example:22:me')))
+          .dy;
+      expect(cTop2 < aTop2, isTrue);
+    });
+
+    testWidgets('card body taps-to-connect; handle does not connect', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final store = ProfilesStore();
+      await store.save(<SavedProfile>[
+        SavedProfile(title: 'A', host: 'a.example', port: 22, username: 'me'),
+        SavedProfile(title: 'B', host: 'b.example', port: 22, username: 'me'),
+      ]);
+
+      SavedProfile? connected;
+      await _pumpList(
+        tester,
+        store: store,
+        onConnect: (p) => connected = p,
+      );
+
+      // Tapping the handle opens the menu — it must NOT connect.
+      await tester.tap(
+        find.byKey(const Key('profile-reorder-handle-b.example:22:me')),
+      );
+      await tester.pumpAndSettle();
+      expect(connected, isNull, reason: 'handle tap opens menu, not connect');
+      // Dismiss the menu.
+      await tester.tapAt(const Offset(5, 5));
+      await tester.pumpAndSettle();
+
+      // Tapping the body connects.
+      await tester.tap(find.byKey(const Key('profile-tile-b.example:22:me')));
+      await tester.pump();
+      expect(connected, isNotNull);
+      expect(connected!.host, 'b.example');
+    });
+  });
+}


### PR DESCRIPTION
## What

Native rebuild of the PWA-only "reorder saved profiles" feature (#481). Saved profiles rendered on the Connect panel in insertion order with no way to reorder. This adds a user-defined, persisted order plus per-card controls.

## Changes

- **NEW `native/lib/state/profile_order_providers.dart`**
  - Pure, unit-tested helpers: `applyOrder(profiles, order)` (order respected, unknown IDs appended in original order, missing IDs dropped) and `reconcileOrder(keys, order)`.
  - `ProfileOrderNotifier` — SharedPreferences-backed list of `identityKey`s, **schema version inside the value**, corrupt/unknown-version → empty (validate→fallback, never crash). API: `sync` / `moveToTop` / `moveToBottom` / `reorder`, all persist immediately.
  - `profileOrderProvider` auto-reconciles off `savedProfilesProvider` via `ref.listen(..., fireImmediately: true)`, so **new profiles append, deleted ones drop, imported ones merge by identity** — the stored order self-heals with no UI plumbing.
- **`native/lib/ui/profile_list.dart`**
  - Saved-profile list → `ReorderableListView` (`buildDefaultDragHandles: false`).
  - Each card has an **upper-right `drag_indicator` handle**: touch-hold-drag reorders (`ReorderableDelayedDragStartListener` + `onReorderItem`); **tap** opens a popup menu with **Move to top** / **Move to bottom**.
  - Card body keeps **tap-to-connect**; edit pencil keeps editing — only the glyph initiates drag/menu. Keys: `profile-reorder-handle-$id`, `profile-move-top-$id`, `profile-move-bottom-$id`.
  - Recent Sessions / Active Sessions / favorites are separate and **untouched**.

## Tests

- Unit (`test/state/profile_order_test.dart`): applyOrder/reconcile semantics, notifier move/reorder round-trip via SharedPreferences mock, corrupt-value resilience, add/delete self-heal.
- Widget (`test/widget/profile_reorder_widget_test.dart`): handle renders, tap→menu, Move-to-top reorders the rendered list and persists, body tap still connects (handle does not).
- `scripts/native-fast-gate.sh` green: analyze clean, 1580 tests pass.

## Device-class note

The drag **feel** (touch-hold lift/part, edge auto-scroll) is device-class (`rules/platform/mobile-touch.md`) and needs owner hardware to validate. Widget tests cover the order/menu/persistence logic.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)