### PR TITLE
feat(emulator): auto-rotate /data storage so gates never hit INSUFFICIENT_STORAGE

### DIFF
--- a/scripts/emulator-ctl.sh
+++ b/scripts/emulator-ctl.sh
@@ -9,14 +9,22 @@
 # no contention). Pair with native-connect-test.sh (runs the build on the OTHER
 # cores) so the emulator and the build never share a CPU.
 #
-# Usage: scripts/emulator-ctl.sh {ensure|status|stop|restart} [avd-name]
+# Usage: scripts/emulator-ctl.sh {ensure|status|stop|restart|wipe} [avd-name]
 #   ensure   boot iff not already booted; reuse otherwise. Waits for readiness.
 #   status   print device + boot state (exit 0 booted, 1 not).
 #   stop     kill the emulator.
-#   restart  stop + ensure.
+#   restart  stop + ensure (does NOT reset /data — see wipe).
+#   wipe     stop + cold boot with -wipe-data → HEAVY RESET of the guest /data
+#            partition. The AVD's userdata (config disk.dataPartition) accumulates
+#            installs/caches that are baked into the persistent userdata qcow2 and
+#            RELOAD on every -read-only boot, so a plain restart does NOT free
+#            space — only -wipe-data does. Used by emulator-maintain.sh when
+#            /data crosses the low-space threshold. CPU-pinned exactly like a
+#            normal boot (no swiftshader/contention regression).
 #
 # Env: EMU_CORES (default 0-2), EMU_MEMORY_MB (default 4096), AVD (default
-#      MobiSSH_Pixel7).
+#      MobiSSH_Pixel7), EMU_WIPE (default 0; 1 → boot with -wipe-data and drop
+#      -read-only so the reset persists to the userdata qcow2).
 set -euo pipefail
 
 export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-/opt/android-sdk}"
@@ -26,6 +34,7 @@ EMU="$ANDROID_SDK_ROOT/emulator/emulator"
 AVD="${2:-${AVD:-MobiSSH_Pixel7}}"
 EMU_CORES="${EMU_CORES:-0-2}"
 EMU_MEMORY_MB="${EMU_MEMORY_MB:-4096}"
+EMU_WIPE="${EMU_WIPE:-0}"
 LOGDIR="/tmp/mobissh/logs"
 mkdir -p "$LOGDIR"
 LOG="$LOGDIR/emulator-detached.log"
@@ -83,11 +92,20 @@ boot() {
     "$ADB" -s "$d" emu kill 2>/dev/null || true
   done
   clear_stale
+  # Base flags shared by every boot. -read-only lets multiple instances share the
+  # AVD and keeps writes in a throwaway overlay; a WIPE boot drops it so the fresh
+  # (empty) userdata is written back to the persistent qcow2 — otherwise the next
+  # -read-only boot would just reload the old, full baseline.
+  local flags=(-no-window -no-audio -no-boot-anim -no-snapshot \
+    -memory "$EMU_MEMORY_MB" -gpu swiftshader_indirect -accel auto)
+  if [[ "$EMU_WIPE" == "1" ]]; then
+    log "WIPE boot: -wipe-data (resets guest /data), dropping -read-only so it persists"
+    flags+=(-wipe-data)
+  else
+    flags+=(-read-only)
+  fi
   log "booting $AVD detached, pinned to cores $EMU_CORES, ${EMU_MEMORY_MB}MB"
-  setsid nohup "${PIN[@]}" "$EMU" -avd "$AVD" \
-    -no-window -no-audio -no-boot-anim -no-snapshot -read-only \
-    -memory "$EMU_MEMORY_MB" \
-    -gpu swiftshader_indirect -accel auto >"$LOG" 2>&1 &
+  setsid nohup "${PIN[@]}" "$EMU" -avd "$AVD" "${flags[@]}" >"$LOG" 2>&1 &
   log "launched (pid $!), log: $LOG"
 }
 
@@ -117,7 +135,14 @@ case "$cmd" in
     "$0" stop "$AVD" || true
     "$0" ensure "$AVD"
     ;;
+  wipe)
+    log "WIPE requested — stop + cold boot with -wipe-data (heavy /data reset)"
+    "$0" stop "$AVD" || true
+    clear_stale
+    EMU_WIPE=1 boot
+    wait_booted
+    ;;
   *)
-    err "usage: emulator-ctl.sh {ensure|status|stop|restart} [avd-name]"; exit 2
+    err "usage: emulator-ctl.sh {ensure|status|stop|restart|wipe} [avd-name]"; exit 2
     ;;
 esac

--- a/scripts/emulator-maintain.sh
+++ b/scripts/emulator-maintain.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# scripts/emulator-maintain.sh — keep the always-on emulator's /data healthy so
+# integration installs never hit INSTALL_FAILED_INSUFFICIENT_STORAGE.
+#
+# WHY: the AVD's userdata partition (6 GB, config.ini disk.dataPartition) fills
+# up with app installs + caches across a long-lived, REUSED emulator session.
+# Because boot uses -read-only + -no-snapshot, that baseline is baked into the
+# persistent userdata-qemu.img.qcow2 and RELOADS on every cold boot — a plain
+# restart does NOT free it. Only a -wipe-data cold boot (emulator-ctl.sh wipe)
+# truly resets /data (observed: 88% used → 14% used, ~5 GB free).
+#
+# STRATEGY (idempotent, cheap-first — never wipe a healthy emulator):
+#   1. light clean — uninstall the app + its .test package, pm trim-caches
+#   2. measure — df /data vs a free-space threshold
+#   3. rotate (heavy) — ONLY when still below threshold (or --rotate/rotate):
+#      emulator-ctl.sh wipe → fresh /data, CPU-pinned exactly like a normal boot.
+#
+# Usage: scripts/emulator-maintain.sh {ensure-healthy|check|clean|rotate} [--rotate]
+#   ensure-healthy  (default) ensure booted → clean → rotate iff still low.
+#                   --rotate forces the heavy reset regardless of free space.
+#   check           report df /data; exit 0 healthy, 3 below threshold.
+#   clean           light clean (uninstall + trim), then check.
+#   rotate          force a -wipe-data reset (heavy), then check.
+#
+# Env: EMU_MIN_FREE_MB (default 1536) — rotate when free MB drops below this.
+#      APP_ID          (default com.flavordrake.mobissh) — its .test sibling is
+#                      derived and cleaned too.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MOBISSH_TMPDIR="${MOBISSH_TMPDIR:-/tmp/mobissh}"
+MOBISSH_LOGDIR="${MOBISSH_LOGDIR:-/tmp/mobissh/logs}"
+mkdir -p "$MOBISSH_TMPDIR" "$MOBISSH_LOGDIR"
+LOGFILE="${MOBISSH_LOGDIR}/emulator-maintain.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-/opt/android-sdk}"
+ADB="$ANDROID_SDK_ROOT/platform-tools/adb"
+EMU_MIN_FREE_MB="${EMU_MIN_FREE_MB:-1536}"
+APP_ID="${APP_ID:-com.flavordrake.mobissh}"
+TEST_APP_ID="${APP_ID}.test"
+
+log() { echo "> $(date +%Y%m%dT%H%M%S%z) maintain: $*"; }
+err() { echo "! maintain: $*" >&2; }
+
+device() { "$ADB" devices | awk 'NR>1 && $2=="device" {print $1; exit}'; }
+
+# Free MB on the guest /data partition. Echoes an integer; empty on failure.
+free_mb() {
+  local dev="$1" line avail_kb
+  # df output: Filesystem 1K-blocks Used Available Use% Mounted; Available = col 4.
+  line="$("$ADB" -s "$dev" shell df /data 2>/dev/null | awk 'NR==2{print}' | tr -d '\r')"
+  avail_kb="$(echo "$line" | awk '{print $4}')"
+  [[ "$avail_kb" =~ ^[0-9]+$ ]] || return 1
+  echo $(( avail_kb / 1024 ))
+}
+
+report_df() {
+  local dev="$1"
+  log "df /data on $dev:"
+  "$ADB" -s "$dev" shell df /data 2>/dev/null | tr -d '\r' || true
+}
+
+# Exit 0 if free space >= threshold, 3 if below. Prints the numbers.
+check() {
+  local dev fm
+  dev="$(device)"
+  if [[ -z "$dev" ]]; then err "no online adb device"; return 2; fi
+  report_df "$dev"
+  fm="$(free_mb "$dev")" || { err "could not read df /data"; return 2; }
+  if (( fm < EMU_MIN_FREE_MB )); then
+    log "LOW: ${fm}MB free < ${EMU_MIN_FREE_MB}MB threshold"
+    return 3
+  fi
+  log "OK: ${fm}MB free >= ${EMU_MIN_FREE_MB}MB threshold"
+  return 0
+}
+
+# Light clean: uninstall the app + its instrumentation package, trim caches.
+clean() {
+  local dev
+  dev="$(device)"
+  if [[ -z "$dev" ]]; then err "no online adb device"; return 2; fi
+  log "light clean: uninstall $APP_ID / $TEST_APP_ID + pm trim-caches"
+  "$ADB" -s "$dev" uninstall "$APP_ID" 2>/dev/null || log "  (app not installed / uninstall no-op)"
+  "$ADB" -s "$dev" uninstall "$TEST_APP_ID" 2>/dev/null || log "  (.test not installed / uninstall no-op)"
+  # Trim every cache down to 0 free-space target (max long → drop all cached data).
+  "$ADB" -s "$dev" shell pm trim-caches 9223372036854775807 2>/dev/null || log "  (trim-caches unavailable)"
+}
+
+# Heavy reset: cold boot with -wipe-data via the lifecycle script (keeps CPU pin).
+rotate() {
+  log "ROTATE: heavy /data reset via emulator-ctl.sh wipe"
+  if ! "${REPO_ROOT}/scripts/emulator-ctl.sh" wipe; then
+    err "emulator-ctl.sh wipe failed — see /tmp/mobissh/logs/emulator-detached.log"
+    return 2
+  fi
+}
+
+cmd="${1:-ensure-healthy}"
+FORCE_ROTATE=0
+for a in "$@"; do [[ "$a" == "--rotate" ]] && FORCE_ROTATE=1; done
+
+case "$cmd" in
+  check)
+    check
+    ;;
+  clean)
+    clean
+    check
+    ;;
+  rotate)
+    rotate
+    check
+    ;;
+  ensure-healthy)
+    # Make sure something is booted first (boots-or-reuses, CPU-pinned).
+    if ! "${REPO_ROOT}/scripts/emulator-ctl.sh" ensure; then
+      err "emulator-ctl.sh ensure failed"; exit 2
+    fi
+    if (( FORCE_ROTATE == 1 )); then
+      log "--rotate: forcing heavy reset"
+      rotate
+      check
+      exit $?
+    fi
+    # Cheap path first: light clean, then measure.
+    clean
+    if check; then
+      log "healthy after light clean — no rotate needed"
+      exit 0
+    fi
+    log "still low after light clean — escalating to rotate"
+    rotate
+    if check; then
+      log "healthy after rotate"
+      exit 0
+    fi
+    err "STILL low after wipe — /data threshold unreachable (base image too big?)"
+    exit 3
+    ;;
+  *)
+    err "usage: emulator-maintain.sh {ensure-healthy|check|clean|rotate} [--rotate]"
+    exit 2
+    ;;
+esac

--- a/scripts/native-connect-test.sh
+++ b/scripts/native-connect-test.sh
@@ -91,6 +91,24 @@ if [[ -z "$DEVICE" ]]; then
 fi
 log "device: $DEVICE"
 
+# 1b. Keep the guest /data partition healthy BEFORE the build installs the app +
+#     its instrumentation APK. Installs accumulate across the long-lived reused
+#     emulator and eventually fail with INSTALL_FAILED_INSUFFICIENT_STORAGE (and
+#     even uninstall starts returning DELETE_FAILED_INTERNAL_ERROR). This does a
+#     cheap clean (uninstall + trim) every run and only escalates to a -wipe-data
+#     rotation when free space is below EMU_MIN_FREE_MB. Idempotent + CPU-pinned.
+#     Non-fatal: if maintenance can't run we still try the install.
+if ! "${REPO_ROOT}/scripts/emulator-maintain.sh" ensure-healthy; then
+  err "emulator-maintain reported low storage it could not recover — install may fail"
+fi
+# The device id can change across a rotation (wipe re-boots the emulator).
+DEVICE="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+if [[ -z "$DEVICE" ]]; then
+  err "no online adb device after emulator-maintain"
+  exit 2
+fi
+log "device after maintenance: $DEVICE"
+
 # 2. Verify test-sshd reachable from this container.
 if ! getent hosts "$SSHD_HOST" >/dev/null 2>&1; then
   err "$SSHD_HOST not resolvable — is the mobissh docker network joined + test-sshd up?"


### PR DESCRIPTION
## Problem

The always-on Android emulator's 6 GB guest `/data` partition fills with
accumulated integration-test installs + caches across the long-lived, reused
emulator session, eventually failing with `INSTALL_FAILED_INSUFFICIENT_STORAGE`
-- and once full, even `adb uninstall` returns `DELETE_FAILED_INTERNAL_ERROR`.
This silently breaks the terminal-flow / integration gates and there was **no
automatic cleanup**.

Root cause: boot uses `-read-only -no-snapshot`, so the multi-GB baseline is
baked into the persistent `userdata-qemu.img.qcow2` and **reloads on every cold
boot**. A plain restart does NOT free it -- only a `-wipe-data` cold boot resets
the partition (observed: 88% used -> 14% used, ~5 GB free).

## What changed

- **`scripts/emulator-ctl.sh`** -- new `EMU_WIPE` env + `wipe` subcommand: stop +
  cold boot with `-wipe-data`, dropping `-read-only` so the fresh (empty)
  userdata persists back to the qcow2. Stays CPU-pinned (`EMU_CORES`) exactly
  like a normal boot -- no swiftshader/CPU-contention regression.
- **`scripts/emulator-maintain.sh`** (new) -- cheap-first, idempotent:
  - `ensure-healthy` (default): ensure booted -> **light clean** (uninstall app +
    `.test`, `pm trim-caches`) -> `df /data` vs `EMU_MIN_FREE_MB` (default 1536)
    -> escalate to a `-wipe-data` **rotate only when still below threshold**.
    Never wipes a healthy emulator. `--rotate` forces the heavy reset.
  - Also exposes `check` / `clean` / `rotate`.
- **`scripts/native-connect-test.sh`** -- wires `emulator-maintain ensure-healthy`
  in right after `emulator-ctl ensure`, before the build installs the app +
  instrumentation APK. Non-fatal; re-resolves the device id across a rotation.

## Policy

- Threshold: rotate when free `/data` < **1536 MB** (`EMU_MIN_FREE_MB`). Healthy
  baseline after a wipe is ~5 GB free, so this leaves ample room for the
  ~138 MB debug APK + androidTest APK + overhead.
- Cheap-first: uninstall + trim every run; wipe only when actually low.

## Verification (live, shared device)

| step | `df /data` | result |
|------|-----------|--------|
| broken baseline (fresh cold boot, `-read-only`) | 88% used, 721 MB free | -- |
| after `emulator-ctl.sh wipe` | 11% used, **5.2 GB free** | recovered |
| `adb install -r app-debug.apk` (138 MB) | -- | **`Success`** |
| emulator CPU affinity after wipe | core 0 | pinning intact (`EMU_CORES=0-2`) |

## Follow-up

- The stale `userdata-qemu.img.qcow2` (~6 GB host disk) is wasted space from the
  pre-wipe baseline; a wipe boot rewrites it clean, so it self-heals on first
  rotation. No host-side cleanup needed, but worth noting if host disk pressure
  ever appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa