### PR TITLE
feat(emu): dedicated emulator container on the iGPU (hardware GL, #971)

### DIFF
--- a/docker-compose.emulator.yml
+++ b/docker-compose.emulator.yml
@@ -1,0 +1,63 @@
+# docker-compose.emulator.yml — dedicated Android-emulator sibling container.
+#
+# Isolates the emulator (and its swiftshader crashes / zombie processes) from
+# fd-dev. Recovery is `docker restart mobissh-emulator` — no coding-session loss.
+# Reached by other siblings over the shared `mobissh` network via Docker DNS
+# (name `mobissh-emulator`); there is no docker-proxy in this env so host port
+# mapping (-p) does NOT work — do not add it.
+services:
+  mobissh-emulator:
+    build:
+      context: ./docker/emulator
+    image: mobissh-emulator:${TAG:-latest}
+    container_name: mobissh-emulator
+    restart: unless-stopped
+    networks:
+      - mobissh
+    # KVM gives the x86_64 system image hardware acceleration (present on the
+    # Docker host). Without it the emulator falls back to slow full emulation.
+    devices:
+      - /dev/kvm
+      # iGPU passthrough — LIVE as of 2026-07-05 (PVE dev-passthrough → LXC 105:
+      # /dev/dri/card1 [video 226,1] + renderD128 [render 226,128]). Gives the
+      # emulator hardware GL (`EMU_GPU=host`) instead of swiftshader, which fixes
+      # the software-GPU crash class. If /dev/dri ever disappears, comment this
+      # out AND set EMU_GPU=swiftshader_indirect to fall back to software.
+      - /dev/dri:/dev/dri
+    # The render nodes are group-owned (render=104, video=44). Add the container
+    # process to both so it can open card1 + renderD128 (they are mode 0660).
+    group_add:
+      - "104"
+      - "44"
+    environment:
+      # Guest RAM. Host is 30G/12c so 6G is comfortable.
+      EMU_MEMORY_MB: "${EMU_MEMORY_MB:-6144}"
+      # host = hardware GL on the passed-through Intel iGPU (default now that
+      # /dev/dri is live). Override to `swiftshader_indirect` for software GL.
+      EMU_GPU: "${EMU_GPU:-host}"
+      # Optional taskset core pin for the emulator (e.g. "0-3"). Empty = no pin;
+      # crash isolation no longer needs it since the build lives in fd-dev.
+      EMU_CORES: "${EMU_CORES:-}"
+    # adb server (5037), network-exposed guest adbd (5556 → guest 5555), console
+    # (5554) and the test-sshd bridge (2222) are all reached by Docker DNS on the
+    # mobissh network. `adb connect mobissh-emulator:5556` uses the exposed adbd.
+    expose:
+      - "5037"
+      - "5554"
+      - "5555"
+      - "5556"
+      - "2222"
+    # Emulator boot can take a few minutes on first cold start under swiftshader.
+    healthcheck:
+      test: ["CMD", "sh", "-c", "adb shell getprop sys.boot_completed | grep -q 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 40
+      start_period: 60s
+
+networks:
+  mobissh:
+    # Shared with docker-compose.prod.yml / .test.yml — one network for all
+    # MobiSSH siblings. `external: true` so whichever compose starts first owns it.
+    name: mobissh
+    external: true

--- a/docker/emulator/Dockerfile
+++ b/docker/emulator/Dockerfile
@@ -1,0 +1,125 @@
+# docker/emulator/Dockerfile — dedicated Android-emulator sibling container.
+#
+# WHY: the emulator used to run as a PROCESS inside fd-dev (the coding-agent
+# container). When swiftshader (software GPU) crashed under Gradle render/CPU
+# load it left hundreds of zombie processes in fd-dev (PID 1 doesn't reap them)
+# and could only be reset by restarting fd-dev — which kills the coding session.
+# Moving it to its own container isolates the crashes/zombies: recovery is just
+# `docker restart mobissh-emulator`, no session loss.
+#
+# The image bakes a FRESH AVD (MobiSSH_Pixel7, android-35) so it does NOT depend
+# on fd-dev's /opt/android-sdk (5.9G, not host-mountable). The build is large and
+# slow — the system image alone is ~1.5G.
+FROM ubuntu:24.04
+
+# Non-interactive apt for the image build.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime libs the qemu emulator + swiftshader need even headless (-no-window),
+# plus the toolchain (jre, wget/unzip for the SDK, socat for the test-sshd bridge).
+# libasound2t64 is Ubuntu 24.04 (noble)'s renamed libasound2.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      openjdk-17-jre-headless \
+      wget \
+      unzip \
+      ca-certificates \
+      socat \
+      libpulse0 \
+      libnss3 \
+      libxcb1 \
+      libx11-6 \
+      libxcursor1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxi6 \
+      libxtst6 \
+      libxrender1 \
+      libxrandr2 \
+      libxcomposite1 \
+      libgl1 \
+      libglx-mesa0 \
+      libegl1 \
+      libgles2 \
+      libgl1-mesa-dri \
+      libgbm1 \
+      mesa-vulkan-drivers \
+      libvulkan1 \
+      vulkan-tools \
+      libasound2t64 \
+      libpulse-mainloop-glib0 \
+      libnspr4 \
+      libdbus-1-3 \
+      procps \
+ && rm -rf /var/lib/apt/lists/*
+
+# Android SDK layout matches fd-dev (/opt/android-sdk) so paths are familiar.
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_AVD_HOME=/root/.android/avd
+ENV PATH=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/emulator:${PATH}
+
+# cmdline-tools (12.0, matches fd-dev's Pkg.Revision). Google ships them under a
+# top-level `cmdline-tools/` dir; sdkmanager expects them at
+# cmdline-tools/latest/, so relocate after unzip.
+ARG CMDLINE_TOOLS_ZIP=commandlinetools-linux-11076708_latest.zip
+RUN mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
+ && wget -q "https://dl.google.com/android/repository/${CMDLINE_TOOLS_ZIP}" -O /tmp/cmdline-tools.zip \
+ && unzip -q /tmp/cmdline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
+ && mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/latest \
+ && rm -f /tmp/cmdline-tools.zip
+
+# Accept licenses, then install platform-tools (adb), the emulator, the platform,
+# and the x86_64 google_apis system image (~1.5G — the slow part of the build).
+RUN yes | sdkmanager --licenses > /dev/null \
+ && sdkmanager \
+      "platform-tools" \
+      "emulator" \
+      "platforms;android-35" \
+      "system-images;android-35;google_apis;x86_64"
+
+# Create the AVD fresh in the image (device pixel_7, matching the fd-dev AVD).
+# `echo no` declines the "custom hardware profile" prompt.
+RUN echo "no" | avdmanager create avd \
+      -n MobiSSH_Pixel7 \
+      -k "system-images;android-35;google_apis;x86_64" \
+      -d pixel_7 \
+      --force
+
+# Headless Xorg for the `-gpu host` path (the emulator's host GL renderer is
+# GLX/X11 and needs a DISPLAY). Separate late layer so it does NOT invalidate
+# the cached ~1.5G system-image download above. modesetting (built into
+# xserver-xorg-core) drives modern Intel; mesa-utils gives glxinfo for the probe.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      xserver-xorg-core \
+      xserver-xorg-legacy \
+      xinit \
+      x11-xserver-utils \
+      xauth \
+      mesa-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+# Headless-Xorg configs for the -gpu host path (see entrypoint start_xorg).
+COPY xorg-headless.conf /etc/X11/xorg-headless.conf
+COPY Xwrapper.config /etc/X11/Xwrapper.config
+
+COPY entrypoint.sh /usr/local/bin/emulator-entrypoint.sh
+RUN chmod +x /usr/local/bin/emulator-entrypoint.sh
+
+# adb server (5037), exposed guest adbd (5556 → guest 5555), and the in-emulator
+# test-sshd bridge port (2222) are reached over the mobissh Docker network by DNS
+# name (no host -p mapping in this env). 5554/5555 are the emulator's own
+# console/adbd (internal); 5556 is the network-exposed adbd for `adb connect`.
+EXPOSE 5037 2222 5554 5555 5556
+
+# Tunables (override in docker-compose.emulator.yml or `docker run -e`):
+#   EMU_MEMORY_MB  guest RAM (default 6144)
+#   EMU_GPU        swiftshader_indirect (default, software) | host (needs /dev/dri)
+#   EMU_CORES      optional taskset core pin (e.g. "0-3"); empty = no pin
+ENV EMU_MEMORY_MB=6144
+ENV EMU_GPU=swiftshader_indirect
+ENV EMU_CORES=
+
+ENTRYPOINT ["/usr/local/bin/emulator-entrypoint.sh"]

--- a/docker/emulator/Xwrapper.config
+++ b/docker/emulator/Xwrapper.config
@@ -1,0 +1,3 @@
+# Allow Xorg to start headless inside the container (runs as root, no seat/VT).
+allowed_users=anybody
+needs_root_rights=yes

--- a/docker/emulator/entrypoint.sh
+++ b/docker/emulator/entrypoint.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# docker/emulator/entrypoint.sh — PID 1 of the mobissh-emulator container.
+#
+# Boots the AVD headless, exposes adb + the test-sshd bridge over the mobissh
+# Docker network, waits for the guest to finish booting, then blocks so the
+# container stays alive. Handles SIGTERM so `docker stop`/`restart` is clean.
+#
+# What it wires up (all reachable by other siblings via Docker DNS
+# `mobissh-emulator`, since this environment has no docker-proxy / host -p):
+#   :5037  adb server on ALL interfaces  → remote clients (fd-dev) can
+#          `ANDROID_ADB_SERVER_SOCKET=tcp:mobissh-emulator:5037 adb devices`.
+#   :5556  the emulator's own adbd (guest 5555), socat-exposed on a SEPARATE
+#          port → a client running its OWN adb server can
+#          `adb connect mobissh-emulator:5556` (this path keeps `adb forward`
+#          LOCAL to the client, which flutter integration tests need — see
+#          scripts/native-connect-test.sh). NOTE: the socat MUST NOT listen on
+#          5555 itself — the emulator binds 127.0.0.1:5555 for adbd and a
+#          0.0.0.0:5555 socat collides with it (0.0.0.0 covers loopback),
+#          starving adbd so no device ever registers. Hence a distinct 5556.
+#   :2222  socat → test-sshd:22, so the guest's `adb reverse tcp:2222` (set up
+#          against the REMOTE adb server) lands on a real SSH target.
+set -euo pipefail
+
+ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-/opt/android-sdk}"
+ADB="${ANDROID_SDK_ROOT}/platform-tools/adb"
+EMU="${ANDROID_SDK_ROOT}/emulator/emulator"
+AVD="${AVD:-MobiSSH_Pixel7}"
+EMU_MEMORY_MB="${EMU_MEMORY_MB:-6144}"
+EMU_GPU="${EMU_GPU:-swiftshader_indirect}"
+EMU_CORES="${EMU_CORES:-}"
+SSHD_HOST="${SSHD_HOST:-test-sshd}"
+SSHD_PORT="${SSHD_PORT:-22}"
+BRIDGE_PORT="${BRIDGE_PORT:-2222}"
+CONSOLE_PORT="${CONSOLE_PORT:-5554}"
+ADBD_PORT="${ADBD_PORT:-5555}"
+# The emulator binds 127.0.0.1:${ADBD_PORT} for adbd; expose it to the network on
+# a DIFFERENT port so the socat listener can't collide with that bind.
+ADBD_EXPOSE_PORT="${ADBD_EXPOSE_PORT:-5556}"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-300}"
+
+log() { echo "> [emu-entrypoint] $*"; }
+err() { echo "! [emu-entrypoint] $*" >&2; }
+
+EMU_PID=""
+ADB_SERVER_PID=""
+SOCAT_SSHD_PID=""
+SOCAT_ADBD_PID=""
+XORG_PID=""
+
+shutdown() {
+  log "SIGTERM/EXIT — shutting down cleanly"
+  [[ -n "$XORG_PID" ]] && kill "$XORG_PID" 2>/dev/null || true
+  # Ask the emulator to power off via its adb server (graceful), then fall back
+  # to a signal. This is what stops qemu leaving stale locks in the AVD.
+  "$ADB" emu kill >/dev/null 2>&1 || true
+  [[ -n "$EMU_PID" ]] && kill "$EMU_PID" 2>/dev/null || true
+  [[ -n "$SOCAT_SSHD_PID" ]] && kill "$SOCAT_SSHD_PID" 2>/dev/null || true
+  [[ -n "$SOCAT_ADBD_PID" ]] && kill "$SOCAT_ADBD_PID" 2>/dev/null || true
+  "$ADB" kill-server >/dev/null 2>&1 || true
+  [[ -n "$ADB_SERVER_PID" ]] && kill "$ADB_SERVER_PID" 2>/dev/null || true
+  exit 0
+}
+trap shutdown SIGTERM SIGINT
+
+# A crashed prior run (before a `docker restart`) can leave AVD locks that block
+# a fresh boot ("Running multiple emulators with the same AVD"). Clear them.
+clear_stale() {
+  rm -f "${ANDROID_AVD_HOME:-/root/.android/avd}/${AVD}.avd/multiinstance.lock" \
+        "${ANDROID_AVD_HOME:-/root/.android/avd}/${AVD}.avd/hardware-qemu.ini.lock" 2>/dev/null || true
+  rm -rf "${ANDROID_AVD_HOME:-/root/.android/avd}/running" 2>/dev/null || true
+}
+
+# 0. Headless Xorg for the `-gpu host` path. The android emulator's host GL
+#    renderer is GLX (X11) on Linux — it needs a DISPLAY. Surfaceless EGL does
+#    NOT satisfy it. So stand up a real (but monitorless) Xorg on the iGPU via
+#    the modesetting driver + a Virtual framebuffer, and point the emulator at
+#    it with DISPLAY=:0. glxinfo's renderer string is the hardware-GL verdict.
+start_xorg() {
+  log "EMU_GPU=host → starting headless Xorg :0 on the iGPU (/dev/dri/card1)"
+  Xorg :0 -noreset -config /etc/X11/xorg-headless.conf -logfile /tmp/xorg.log vt1 &
+  XORG_PID=$!
+  export DISPLAY=:0
+  local s=0
+  while (( s < 15 )); do
+    if DISPLAY=:0 xdpyinfo >/dev/null 2>&1; then log "Xorg :0 is up"; break; fi
+    if ! kill -0 "$XORG_PID" 2>/dev/null; then
+      err "Xorg exited during startup — dumping /tmp/xorg.log:"
+      cat /tmp/xorg.log 2>/dev/null | tail -30 || true
+      return 1
+    fi
+    sleep 1; s=$((s + 1))
+  done
+  local glr
+  glr="$(DISPLAY=:0 glxinfo 2>/dev/null | grep -iE 'OpenGL renderer' | head -1 | tr -d '\r' || true)"
+  if [[ -n "$glr" ]]; then
+    log "$glr"
+    if echo "$glr" | grep -qiE 'llvmpipe|softpipe|software rasterizer'; then
+      err "GLX is SOFTWARE (llvmpipe) — Xorg came up but NOT on the iGPU"
+    elif echo "$glr" | grep -qiE 'intel|mesa'; then
+      log "headless hardware GLX CONFIRMED on the iGPU"
+    fi
+  else
+    err "glxinfo produced no renderer — GLX not ready (see /tmp/xorg.log)"
+  fi
+  return 0
+}
+
+# 1. adb server on ALL interfaces (0.0.0.0:5037). `-a nodaemon server` is the
+#    documented way to bind every interface; background it and keep the PID.
+start_adb_server() {
+  log "starting adb server on all interfaces (:5037)"
+  "$ADB" -a -P 5037 nodaemon server &
+  ADB_SERVER_PID=$!
+  # Give it a moment to bind before the emulator tries to register.
+  local s=0
+  while (( s < 10 )); do
+    if "$ADB" version >/dev/null 2>&1; then return 0; fi
+    sleep 1; s=$((s + 1))
+  done
+  return 0
+}
+
+# 2. Boot the emulator headless. -read-only lets a crashed instance's userdata
+#    overlay be thrown away on restart (clean recovery). Deterministic ports so
+#    the :5555 adbd socat below has a fixed target.
+boot_emulator() {
+  clear_stale
+  local flags=(-avd "$AVD" -ports "${CONSOLE_PORT},${ADBD_PORT}" \
+    -no-window -no-audio -no-boot-anim -no-snapshot \
+    -memory "$EMU_MEMORY_MB" -gpu "$EMU_GPU" -accel auto -read-only)
+  local pin=()
+  if [[ -n "$EMU_CORES" ]] && command -v taskset >/dev/null 2>&1; then
+    pin=(taskset -c "$EMU_CORES")
+    log "CPU-pinning emulator to cores $EMU_CORES"
+  fi
+  log "booting $AVD (gpu=$EMU_GPU, ${EMU_MEMORY_MB}MB) headless"
+  "${pin[@]}" "$EMU" "${flags[@]}" &
+  EMU_PID=$!
+  log "emulator pid $EMU_PID"
+}
+
+# 3. socat bridges. test-sshd:22 for the guest reverse-tunnel target; the guest
+#    adbd exposed to the network for the `adb connect` client path.
+start_bridges() {
+  log "socat 0.0.0.0:${BRIDGE_PORT} → ${SSHD_HOST}:${SSHD_PORT} (test-sshd bridge)"
+  socat "TCP-LISTEN:${BRIDGE_PORT},fork,reuseaddr" "TCP:${SSHD_HOST}:${SSHD_PORT}" &
+  SOCAT_SSHD_PID=$!
+  log "socat 0.0.0.0:${ADBD_EXPOSE_PORT} → 127.0.0.1:${ADBD_PORT} (expose guest adbd)"
+  socat "TCP-LISTEN:${ADBD_EXPOSE_PORT},fork,reuseaddr" "TCP:127.0.0.1:${ADBD_PORT}" &
+  SOCAT_ADBD_PID=$!
+}
+
+wait_booted() {
+  log "waiting for sys.boot_completed (<= ${BOOT_TIMEOUT}s)"
+  "$ADB" wait-for-device 2>/dev/null || true
+  local s=0 b
+  while (( s < BOOT_TIMEOUT )); do
+    b="$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)"
+    if [[ "$b" == "1" ]]; then
+      log "BOOTED — sys.boot_completed=1"
+      "$ADB" devices || true
+      return 0
+    fi
+    sleep 3; s=$((s + 3))
+  done
+  err "guest did not finish booting within ${BOOT_TIMEOUT}s"
+  return 1
+}
+
+# After boot, log the ACTUAL GL renderer so `docker logs` states plainly whether
+# we got hardware GL (iGPU) or fell back to software. The emulator translates
+# guest GLES to host GL, so the guest's renderer string embeds the host renderer:
+#   host GL   → "Android Emulator OpenGL ES Translator (Mesa Intel(R) ...)"
+#   software  → "Android Emulator OpenGL ES Translator (Google SwiftShader)"
+probe_gpu() {
+  log "GPU mode requested: EMU_GPU=$EMU_GPU"
+  if [[ -e /dev/dri/renderD128 ]]; then
+    log "/dev/dri present in container: $(ls /dev/dri 2>/dev/null | tr '\n' ' ')"
+  else
+    err "/dev/dri NOT present — hardware GL unavailable, expect software fallback"
+  fi
+  local r
+  r="$("$ADB" shell dumpsys SurfaceFlinger 2>/dev/null | grep -iE 'GLES:|renderer' | head -1 | tr -d '\r' || true)"
+  [[ -n "$r" ]] && log "guest GL renderer → $r"
+  if echo "$r" | grep -qi swiftshader; then
+    err "GL renderer is SwiftShader (software) — hardware GL did NOT engage"
+  elif echo "$r" | grep -qiE 'intel|mesa'; then
+    log "hardware GL CONFIRMED (Intel/Mesa via the iGPU)"
+  fi
+}
+
+start_adb_server
+if [[ "$EMU_GPU" == "host" ]]; then
+  start_xorg || err "Xorg startup failed — -gpu host will fail; surfacing emulator error"
+fi
+boot_emulator
+start_bridges
+if ! wait_booted; then
+  err "boot failed — dumping emulator status; container will stay up for inspection"
+  "$ADB" devices || true
+else
+  probe_gpu
+fi
+
+log "emulator container ready — blocking on emulator process (pid $EMU_PID)"
+# Block on the emulator so the container's lifecycle tracks it, but keep the
+# trap responsive: `wait` returns when a trapped signal fires.
+while kill -0 "$EMU_PID" 2>/dev/null; do
+  wait "$EMU_PID" || true
+done
+err "emulator process exited — container will exit (compose restart policy recovers it)"

--- a/docker/emulator/xorg-headless.conf
+++ b/docker/emulator/xorg-headless.conf
@@ -1,0 +1,26 @@
+# Headless Xorg for the passed-through Intel iGPU (#971). Gives the android
+# emulator's `-gpu host` renderer a GLX-capable X display on /dev/dri/card1 with
+# NO physical monitor. Modern Intel (Arrow Lake) uses the built-in `modesetting`
+# driver; mesa's iris provides the hardware GL. A Virtual framebuffer stands in
+# for the (absent) display so GLX pbuffer/pixmap rendering works offscreen.
+Section "ServerFlags"
+    Option "AutoAddGPU" "false"
+    Option "DontVTSwitch" "true"
+    Option "AllowEmptyInitialConfiguration" "true"
+EndSection
+
+Section "Device"
+    Identifier "iGPU"
+    Driver "modesetting"
+    Option "kmsdev" "/dev/dri/card1"
+EndSection
+
+Section "Screen"
+    Identifier "Screen0"
+    Device "iGPU"
+    DefaultDepth 24
+    SubSection "Display"
+        Depth 24
+        Virtual 1920 1080
+    EndSubSection
+EndSection

--- a/scripts/emu-container-ctl.sh
+++ b/scripts/emu-container-ctl.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# scripts/emu-container-ctl.sh — lifecycle for the DEDICATED emulator container.
+#
+# The Android emulator now runs in its OWN sibling container (mobissh-emulator)
+# instead of as a process inside fd-dev. This script manages that CONTAINER via
+# docker compose and waits for the guest to finish booting. When swiftshader
+# crashes, recovery is `emu-container-ctl.sh restart` — it does NOT touch fd-dev,
+# so the coding session (and any accumulated zombie reaping) is unaffected.
+#
+# Usage: scripts/emu-container-ctl.sh {ensure|restart|wipe|status|logs}
+#   ensure   build (if needed) + start; reuse a booted container. Waits for boot.
+#   restart  recreate the container (fresh -read-only overlay = clean /data) + wait.
+#   wipe     `down` + `up` full recreate (belt-and-suspenders clean /data) + wait.
+#   status   print container + guest boot state (exit 0 booted, 1 not).
+#   logs     tail the emulator container log.
+#
+# Env: EMU_BOOT_TIMEOUT (default 300s), EMU_GPU / EMU_MEMORY_MB / EMU_CORES pass
+#      through to the container (see docker-compose.emulator.yml).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MOBISSH_TMPDIR="${MOBISSH_TMPDIR:-/tmp/mobissh}"
+MOBISSH_LOGDIR="${MOBISSH_LOGDIR:-/tmp/mobissh/logs}"
+mkdir -p "$MOBISSH_TMPDIR" "$MOBISSH_LOGDIR"
+LOGFILE="${MOBISSH_LOGDIR}/emu-container-ctl.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+COMPOSE_FILE="docker-compose.emulator.yml"
+CONTAINER="mobissh-emulator"
+EMU_BOOT_TIMEOUT="${EMU_BOOT_TIMEOUT:-300}"
+
+log() { echo "> [$(date +%Y%m%dT%H%M%S%z)] $*"; }
+err() { echo "! [$(date +%Y%m%dT%H%M%S%z)] $*" >&2; }
+ok()  { echo "+ [$(date +%Y%m%dT%H%M%S%z)] $*"; }
+
+is_running() {
+  docker ps --filter "name=${CONTAINER}" --format '{{.Names}}' 2>/dev/null | grep -q "^${CONTAINER}$"
+}
+
+# Boot state read from INSIDE the container (independent of any remote-adb config
+# on the caller side).
+guest_booted() {
+  local b
+  b="$(docker exec "$CONTAINER" adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)"
+  [[ "$b" == "1" ]]
+}
+
+ensure_network() {
+  # external: true compose network must pre-exist.
+  docker network create mobissh 2>/dev/null || true
+}
+
+wait_boot() {
+  local s=0
+  log "waiting for guest sys.boot_completed (<= ${EMU_BOOT_TIMEOUT}s)"
+  while (( s < EMU_BOOT_TIMEOUT )); do
+    if ! is_running; then
+      err "container ${CONTAINER} exited during boot — see: emu-container-ctl.sh logs"
+      return 1
+    fi
+    if guest_booted; then
+      ok "guest BOOTED (sys.boot_completed=1)"
+      docker exec "$CONTAINER" adb devices || true
+      return 0
+    fi
+    sleep 5; s=$((s + 5))
+  done
+  err "guest did not boot within ${EMU_BOOT_TIMEOUT}s — see: emu-container-ctl.sh logs"
+  return 1
+}
+
+cmd_up() {
+  ensure_network
+  log "docker compose up -d (${CONTAINER})"
+  docker compose -f "$COMPOSE_FILE" up -d --build
+  wait_boot
+}
+
+cmd_ensure() {
+  if is_running && guest_booted; then
+    ok "${CONTAINER} already up + booted."
+    return 0
+  fi
+  if is_running; then
+    log "${CONTAINER} running but guest not booted yet — waiting."
+    wait_boot
+    return $?
+  fi
+  cmd_up
+}
+
+cmd_restart() {
+  ensure_network
+  log "recreating ${CONTAINER} (fresh -read-only overlay = clean /data)"
+  docker compose -f "$COMPOSE_FILE" up -d --build --force-recreate
+  wait_boot
+}
+
+cmd_wipe() {
+  ensure_network
+  log "wipe: full down + up recreate of ${CONTAINER}"
+  docker compose -f "$COMPOSE_FILE" down || true
+  docker compose -f "$COMPOSE_FILE" up -d --build --force-recreate
+  wait_boot
+}
+
+cmd_status() {
+  if ! is_running; then
+    err "${CONTAINER} is NOT running."
+    return 1
+  fi
+  log "container: $(docker ps --filter "name=${CONTAINER}" --format '{{.Status}}')"
+  if guest_booted; then
+    ok "guest booted."
+    docker exec "$CONTAINER" adb devices || true
+    return 0
+  fi
+  err "guest NOT booted yet."
+  return 1
+}
+
+cmd_logs() {
+  docker logs --tail "${TAIL:-80}" "$CONTAINER"
+}
+
+case "${1:-}" in
+  ensure)  cmd_ensure ;;
+  restart) cmd_restart ;;
+  wipe)    cmd_wipe ;;
+  status)  cmd_status ;;
+  logs)    cmd_logs ;;
+  *)
+    echo "Usage: scripts/emu-container-ctl.sh {ensure|restart|wipe|status|logs}"
+    exit 1
+    ;;
+esac

--- a/scripts/native-connect-test.sh
+++ b/scripts/native-connect-test.sh
@@ -6,12 +6,36 @@
 # that headless widget tests can't reach. This is the gate that catches the
 # class of bug in #539 (connect deadlocks at State:idle).
 #
-# Network bridge:
+# EMULATOR LOCATION (P0 infra move):
+#   The emulator now runs in its OWN sibling container (mobissh-emulator) instead
+#   of as a process inside fd-dev, so swiftshader crashes / zombie processes are
+#   isolated (recovery = `docker restart mobissh-emulator`, no session loss).
+#   This script defaults to that containerized emulator (EMU_CONTAINER=1).
+#
+#   ADB_MODE selects how fd-dev reaches the container's emulator:
+#     connect (default) — fd-dev runs its OWN adb server and
+#         `adb connect mobissh-emulator:5555`. This keeps `adb forward` LOCAL to
+#         fd-dev, which flutter integration tests REQUIRE (flutter forwards the
+#         Dart VM-service port then connects to 127.0.0.1:<port> on THIS host —
+#         a remote adb server would bind that port in the emulator container,
+#         unreachable from fd-dev). The test-sshd bridge + adb-reverse therefore
+#         live on fd-dev (below), same as the legacy path.
+#     remote — ANDROID_ADB_SERVER_SOCKET=tcp:mobissh-emulator:5037. flutter/adb
+#         transparently use the container's adb server; the test-sshd bridge is
+#         the socat INSIDE the container and `adb reverse` lands there. Good for
+#         `adb devices` / install / `flutter devices`, but flutter integration
+#         VM-service forwarding is NOT reachable from fd-dev (see above) — so the
+#         end-to-end integration test uses `connect` mode.
+#
+#   EMU_CONTAINER=0 → legacy path: emulator as a process inside fd-dev via
+#   emulator-ctl.sh (CPU-pinned). Kept for environments without the container.
+#
+# Network bridge (connect mode / legacy):
 #   emulator 127.0.0.1:2222 --(adb reverse)--> fd-dev 127.0.0.1:2222
 #                           --(socat)--------> test-sshd:22
 #
-# Requires: a booted emulator, the `mobissh` docker network with test-sshd up,
-# socat, the Flutter SDK. Run from the repo root.
+# Requires: the `mobissh` docker network with test-sshd up, socat, adb, the
+# Flutter SDK. Run from the repo root.
 #
 # Exit 0 = connect reached `connected`. Exit 1 = deadlock / failure. Exit 2 = setup error.
 
@@ -35,12 +59,15 @@ PROXY2_PID_FILE="${MOBISSH_TMPDIR}/connect-test-socat2.pid"
 SSHD_HOST="test-sshd"
 SSHD_PORT="22"
 BRIDGE_PORT="2222"
-# Optional second bridge port → same test-sshd. When set, the emulator can
-# reach a SECOND distinct host:port:username tuple (127.0.0.1:$BRIDGE_PORT2),
-# which the multi-session lifecycle test needs to create two real sessions
-# without a second sshd container. Off by default so the connect smoke is
-# unaffected.
 BRIDGE_PORT2="${BRIDGE_PORT2:-}"
+
+# Emulator location + adb transport (see header).
+EMU_CONTAINER="${EMU_CONTAINER:-1}"
+ADB_MODE="${ADB_MODE:-connect}"
+# The container exposes the guest adbd on 5556 (5555 is the emulator's own
+# loopback bind and cannot be re-listened without colliding with it).
+EMU_CONTAINER_NAME="${EMU_CONTAINER_NAME:-mobissh-emulator}"
+EMU_ADBD_ENDPOINT="${EMU_ADBD_ENDPOINT:-${EMU_CONTAINER_NAME}:5556}"
 
 log() { echo "> $*"; }
 err() { echo "! $*" >&2; }
@@ -76,38 +103,62 @@ cleanup() {
 GRANT_WATCHER_PID=""
 trap cleanup EXIT
 
-# 1. Ensure the always-on, CPU-ISOLATED emulator is up. emulator-ctl.sh boots it
-#    iff needed and REUSES a live one (no reboot/contention), pinned to its own
-#    cores (EMU_CORES) so the build below — pinned to the OTHER cores — never
-#    starves it (the swiftshader crash was CPU contention with Gradle).
-if ! "${REPO_ROOT}/scripts/emulator-ctl.sh" ensure; then
-  err "emulator-ctl ensure failed — see /tmp/mobissh/logs/emulator-detached.log"
-  exit 2
-fi
-DEVICE="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
-if [[ -z "$DEVICE" ]]; then
-  err "no online adb device after emulator-ctl ensure"
-  exit 2
+# 1. Bring up the emulator (container or legacy) and resolve its adb device id.
+if [[ "$EMU_CONTAINER" == "1" ]]; then
+  log "using DEDICATED emulator container ($EMU_CONTAINER_NAME), ADB_MODE=$ADB_MODE"
+  if ! "${REPO_ROOT}/scripts/emu-container-ctl.sh" ensure; then
+    err "emu-container-ctl ensure failed — see: scripts/emu-container-ctl.sh logs"
+    exit 2
+  fi
+  if [[ "$ADB_MODE" == "remote" ]]; then
+    # flutter/adb talk to the container's adb server; the test-sshd bridge is the
+    # socat INSIDE the container, so no fd-dev socat is started below.
+    export ANDROID_ADB_SERVER_SOCKET="tcp:${EMU_CONTAINER_NAME}:5037"
+    log "ANDROID_ADB_SERVER_SOCKET=$ANDROID_ADB_SERVER_SOCKET"
+    adb wait-for-device 2>/dev/null || true
+    DEVICE="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+  else
+    # connect mode: fd-dev's own adb server connects to the exposed guest adbd.
+    log "adb connect ${EMU_ADBD_ENDPOINT}"
+    secs=0
+    DEVICE=""
+    while (( secs < 60 )); do
+      adb connect "$EMU_ADBD_ENDPOINT" 2>/dev/null || true
+      if adb -s "$EMU_ADBD_ENDPOINT" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q 1; then
+        DEVICE="$EMU_ADBD_ENDPOINT"
+        break
+      fi
+      sleep 2; secs=$((secs + 2))
+    done
+  fi
+  if [[ -z "${DEVICE:-}" ]]; then
+    err "no online device from emulator container (mode=$ADB_MODE)"
+    err "diagnostics: scripts/emu-container-ctl.sh status ; scripts/emu-container-ctl.sh logs"
+    exit 2
+  fi
+else
+  # Legacy: emulator as a process inside fd-dev, CPU-pinned. emulator-ctl.sh
+  # boots iff needed and reuses a live one; emulator-maintain keeps /data healthy.
+  log "using LEGACY in-fd-dev emulator (EMU_CONTAINER=0)"
+  if ! "${REPO_ROOT}/scripts/emulator-ctl.sh" ensure; then
+    err "emulator-ctl ensure failed — see /tmp/mobissh/logs/emulator-detached.log"
+    exit 2
+  fi
+  DEVICE="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+  if [[ -z "$DEVICE" ]]; then
+    err "no online adb device after emulator-ctl ensure"
+    exit 2
+  fi
+  if ! "${REPO_ROOT}/scripts/emulator-maintain.sh" ensure-healthy; then
+    err "emulator-maintain reported low storage it could not recover — install may fail"
+  fi
+  DEVICE="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+  if [[ -z "$DEVICE" ]]; then
+    err "no online adb device after emulator-maintain"
+    exit 2
+  fi
 fi
 log "device: $DEVICE"
-
-# 1b. Keep the guest /data partition healthy BEFORE the build installs the app +
-#     its instrumentation APK. Installs accumulate across the long-lived reused
-#     emulator and eventually fail with INSTALL_FAILED_INSUFFICIENT_STORAGE (and
-#     even uninstall starts returning DELETE_FAILED_INTERNAL_ERROR). This does a
-#     cheap clean (uninstall + trim) every run and only escalates to a -wipe-data
-#     rotation when free space is below EMU_MIN_FREE_MB. Idempotent + CPU-pinned.
-#     Non-fatal: if maintenance can't run we still try the install.
-if ! "${REPO_ROOT}/scripts/emulator-maintain.sh" ensure-healthy; then
-  err "emulator-maintain reported low storage it could not recover — install may fail"
-fi
-# The device id can change across a rotation (wipe re-boots the emulator).
-DEVICE="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
-if [[ -z "$DEVICE" ]]; then
-  err "no online adb device after emulator-maintain"
-  exit 2
-fi
-log "device after maintenance: $DEVICE"
 
 # 2. Verify test-sshd reachable from this container.
 if ! getent hosts "$SSHD_HOST" >/dev/null 2>&1; then
@@ -117,28 +168,34 @@ if ! getent hosts "$SSHD_HOST" >/dev/null 2>&1; then
 fi
 log "$SSHD_HOST resolves OK"
 
-# 3. socat proxy: fd-dev 127.0.0.1:$BRIDGE_PORT → test-sshd:22.
-#    (adb reverse can only target the adb-server host's loopback, and
-#    test-sshd is a sibling container not on loopback — so we bounce through
-#    socat.)
-log "starting socat 127.0.0.1:${BRIDGE_PORT} → ${SSHD_HOST}:${SSHD_PORT}"
-socat "TCP-LISTEN:${BRIDGE_PORT},fork,reuseaddr,bind=127.0.0.1" "TCP:${SSHD_HOST}:${SSHD_PORT}" &
-echo $! > "$PROXY_PID_FILE"
-sleep 1
-
-# 4. adb reverse: emulator 127.0.0.1:$BRIDGE_PORT → fd-dev 127.0.0.1:$BRIDGE_PORT.
-log "adb reverse tcp:${BRIDGE_PORT}"
-adb -s "$DEVICE" reverse "tcp:${BRIDGE_PORT}" "tcp:${BRIDGE_PORT}"
-
-# 3b/4b. Optional second bridge (same test-sshd, different loopback port) so a
-#        second distinct host:port:username session is reachable on-device.
-if [[ -n "$BRIDGE_PORT2" ]]; then
-  log "starting socat 127.0.0.1:${BRIDGE_PORT2} → ${SSHD_HOST}:${SSHD_PORT}"
-  socat "TCP-LISTEN:${BRIDGE_PORT2},fork,reuseaddr,bind=127.0.0.1" "TCP:${SSHD_HOST}:${SSHD_PORT}" &
-  echo $! > "$PROXY2_PID_FILE"
+# 3./4. Bridge + reverse. In `remote` mode the container's own socat already
+#       bridges 2222→test-sshd and `adb reverse` lands there, so we skip the
+#       fd-dev socat. In connect/legacy mode the reverse binds on fd-dev, so we
+#       start the fd-dev socat and reverse here.
+if [[ "$EMU_CONTAINER" == "1" && "$ADB_MODE" == "remote" ]]; then
+  log "remote adb mode: test-sshd bridge is the container's socat; adb reverse tcp:${BRIDGE_PORT}"
+  adb -s "$DEVICE" reverse "tcp:${BRIDGE_PORT}" "tcp:${BRIDGE_PORT}"
+  if [[ -n "$BRIDGE_PORT2" ]]; then
+    adb -s "$DEVICE" reverse "tcp:${BRIDGE_PORT2}" "tcp:${BRIDGE_PORT}"
+  fi
+else
+  log "starting socat 127.0.0.1:${BRIDGE_PORT} → ${SSHD_HOST}:${SSHD_PORT}"
+  socat "TCP-LISTEN:${BRIDGE_PORT},fork,reuseaddr,bind=127.0.0.1" "TCP:${SSHD_HOST}:${SSHD_PORT}" &
+  echo $! > "$PROXY_PID_FILE"
   sleep 1
-  log "adb reverse tcp:${BRIDGE_PORT2}"
-  adb -s "$DEVICE" reverse "tcp:${BRIDGE_PORT2}" "tcp:${BRIDGE_PORT2}"
+  log "adb reverse tcp:${BRIDGE_PORT}"
+  adb -s "$DEVICE" reverse "tcp:${BRIDGE_PORT}" "tcp:${BRIDGE_PORT}"
+
+  # Optional second bridge (same test-sshd, different loopback port) so a second
+  # distinct host:port:username session is reachable on-device.
+  if [[ -n "$BRIDGE_PORT2" ]]; then
+    log "starting socat 127.0.0.1:${BRIDGE_PORT2} → ${SSHD_HOST}:${SSHD_PORT}"
+    socat "TCP-LISTEN:${BRIDGE_PORT2},fork,reuseaddr,bind=127.0.0.1" "TCP:${SSHD_HOST}:${SSHD_PORT}" &
+    echo $! > "$PROXY2_PID_FILE"
+    sleep 1
+    log "adb reverse tcp:${BRIDGE_PORT2}"
+    adb -s "$DEVICE" reverse "tcp:${BRIDGE_PORT2}" "tcp:${BRIDGE_PORT2}"
+  fi
 fi
 
 # 4b. POST_NOTIFICATIONS grant-watcher. The app requests this at first
@@ -158,13 +215,12 @@ log "starting POST_NOTIFICATIONS grant-watcher"
 GRANT_WATCHER_PID=$!
 
 # 5. Run the integration test on the device. This builds + installs a debug
-#    APK carrying the integration driver and runs connect_smoke_test.dart,
-#    which fills the form (127.0.0.1:2222 / testuser / testpass), taps Connect,
-#    accepts the host key, and asserts the terminal screen mounts.
-# Pin the build/test to the BUILD cores (off the emulator's EMU_CORES=0-3) so
-# Gradle can't starve the emulator's swiftshader render threads (the crash root).
-# #971: ALSO nice + ionice it so, even during a spike, the emulator wins the CPU
-# + IO scheduler — belt-and-suspenders over the core pin.
+#    APK carrying the integration driver and runs the test, which fills the form
+#    (127.0.0.1:2222 / testuser / testpass), taps Connect, accepts the host key,
+#    and asserts the terminal screen mounts.
+# The BUILD runs in fd-dev. Pin it to the BUILD cores + nice/ionice so, even
+# though the emulator now lives in its own container, a build spike still yields
+# CPU/IO (belt-and-suspenders; the container's KVM guest is already isolated).
 BUILD_CORES="${BUILD_CORES:-4-11}"
 TASKSET=()
 if command -v ionice >/dev/null 2>&1; then TASKSET+=(ionice -c 3); fi


### PR DESCRIPTION
## Dedicated emulator container on the iGPU (hardware GL)

Moves the Android emulator **out of `fd-dev`** into its own sibling container (`mobissh-emulator`). Fixes the root cause behind the #971 emulator instability: the emulator ran as a process *inside* the coding-agent container, so swiftshader crashes left hundreds of zombies in `fd-dev` (PID 1 doesn't reap) and could only be reset by restarting `fd-dev` — which killed the coding session.

### What it delivers
- **Isolation** — recovery is `docker restart mobissh-emulator`, no session loss, zombies stay out of `fd-dev`.
- **Hardware GL on the passed-through Intel iGPU** — the guest now renders on the iGPU instead of `Google SwiftShader` (the crash source). Verified end-to-end:
  ```
  OpenGL renderer string: Mesa Intel(R) Graphics (ARL)
  guest GL renderer → Android Emulator OpenGL ES Translator (Mesa Intel(R) Graphics (ARL)), Mesa 25.2.8
  hardware GL CONFIRMED — BOOTED sys.boot_completed=1
  ```
- **Reachable from fd-dev** over the `mobissh` network: `adb connect mobissh-emulator:5556` → `device`.

### Pieces
- `docker/emulator/Dockerfile` — ubuntu 24.04 + a **fresh** `MobiSSH_Pixel7`/android-35 AVD via sdkmanager (self-contained, no dependency on fd-dev's 5.9G SDK) + mesa `iris`/`anv` + headless Xorg.
- `docker/emulator/entrypoint.sh` — adb server on `0.0.0.0:5037`, guest adbd exposed on `:5556` (dodges the `127.0.0.1:5555` bind collision), `socat test-sshd:22→:2222` bridge, clean SIGTERM, and a GL probe that logs the guest renderer.
- `docker/emulator/xorg-headless.conf` + `Xwrapper.config` — headless Xorg (see gotcha below).
- `docker-compose.emulator.yml` — `mobissh` network, `/dev/kvm`, `/dev/dri` + `group_add: [104, 44]`, `EMU_GPU=host`.
- `scripts/emu-container-ctl.sh` — `ensure/restart/wipe/status/logs`.
- `scripts/native-connect-test.sh` — drive the remote emulator (local adb server + `adb connect :5556`, keeps `adb forward`/`reverse` local).

### The headless-GL gotcha (documented for the next person)
The emulator's `-gpu host` renderer is **GLX/X11-only** on Linux — it needs a `DISPLAY`. Surfaceless EGL does **not** satisfy it (`Failed to get EGL display` → `Failed to open display 0`). The fix is a **headless Xorg** in the container (`modesetting` on `card1` + a `Virtual` framebuffer, no monitor), then `DISPLAY=:0` + `-gpu host`. Hardware Vulkan (`anv`) was found without X, but the GLES host renderer needs the X display.

### Host dependency (already done)
The PVE dev-passthrough of the Intel iGPU to the Docker-host LXC 105 (`/dev/dri/card1` + `renderD128`) was applied by the hub operator. If `/dev/dri` ever disappears, comment the device out and set `EMU_GPU=swiftshader_indirect` to fall back to software.

Refs #971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)