### PR TITLE
fix(emu): animate the soft keyboard (animator_duration_scale=0 → 1.0) so keyboard-race bugs are reproducible (#971)

### DIFF
--- a/docker/emulator/entrypoint.sh
+++ b/docker/emulator/entrypoint.sh
@@ -189,6 +189,26 @@ probe_gpu() {
   fi
 }
 
+# After boot, force the animation scales ON so the soft-keyboard (IME) inset
+# ANIMATES on show/hide instead of snapping. WHY (#971): this AVD ships with
+# `animator_duration_scale` UNSET, and on this system image an unset value
+# resolves to 0 (animations off) — so the IME inset jumps 0 → full in a single
+# frame. The InsetsController's IME show/hide animation is timed by the animator
+# duration scale (NOT window/transition scale), so an explicit 1.0 is what makes
+# `WindowInsets`/`viewInsets.bottom` transition over ~200-300ms (~14 rendered
+# frames at 60Hz), letting integration tests stage a keyboard-animation resize
+# race. Re-applied every boot because the container runs `-read-only`: global
+# settings live in the throwaway /data overlay and are lost on restart.
+enable_ime_animation() {
+  log "forcing animation scales ON (IME inset must animate, not snap — #971)"
+  "$ADB" shell settings put global window_animation_scale 1.0 || true
+  "$ADB" shell settings put global transition_animation_scale 1.0 || true
+  "$ADB" shell settings put global animator_duration_scale 1.0 || true
+  local a
+  a="$("$ADB" shell settings get global animator_duration_scale 2>/dev/null | tr -d '\r' || true)"
+  log "animator_duration_scale now = ${a:-unknown} (1.0 = IME slide animates)"
+}
+
 start_adb_server
 if [[ "$EMU_GPU" == "host" ]]; then
   start_xorg || err "Xorg startup failed — -gpu host will fail; surfacing emulator error"
@@ -200,6 +220,7 @@ if ! wait_booted; then
   "$ADB" devices || true
 else
   probe_gpu
+  enable_ime_animation
 fi
 
 log "emulator container ready — blocking on emulator process (pid $EMU_PID)"


### PR DESCRIPTION
The dedicated emulator's soft-keyboard inset SNAPPED (0 → full in one frame) instead of animating, so device-class keyboard-animation bugs (the #922/#975 resize race behind the tmux tap-switch failure) could not be staged in tests.

Root: the AVD ships `animator_duration_scale` UNSET (null), which on the android-35 system image resolves to 0 (animations off). The IME show/hide slide is timed by the ANIMATOR duration scale — not `window_animation_scale`/`transition_animation_scale` (both already 1.0, which is why they didn't help).

Fix: `docker/emulator/entrypoint.sh` sets all three scales to 1.0 after boot_completed (re-applied every boot because the container runs `-read-only` — global settings live in the throwaway /data overlay). +21 lines, one file.

Proof (headless screenrecord, per-frame PTS): animator unset/0 → 0 intermediate frames (SNAP); animator=1.0 → 14 frames over ~226ms (ANIMATES). Survives a cold restart (14 frames / 218ms purely from baked config). Crank to `animator_duration_scale 5` to stretch the slide to ~1s for race-timing in tests.

Refs #971, #975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)