### PR TITLE
fix(native): grid single-source-of-truth so the tmux status tap lands on the right row (#975)

### DIFF
--- a/native/integration_test/tmux_status_tap_kbrace_test.dart
+++ b/native/integration_test/tmux_status_tap_kbrace_test.dart
@@ -1,0 +1,282 @@
+// tmux_status_tap_kbrace_test.dart — #975 grid single-source-of-truth guard
+// across a keyboard toggle (device-class regression for the tmux status tap).
+//
+// #975 root: flterm's `controller.onResize` fires from its OWN layout, which under
+// the soft-keyboard show/hide RACES and can settle BACK to the pre-keyboard tall
+// size, CLOBBERING the keyboard-aware `_rows` mirror; once
+// `_submitKeyboardAwareGrid`'s guard latched the correct size it could not
+// re-correct, leaving `_rows` (gutter-selection clamp + gesture geometry) and the
+// status-tap target STALE vs the visible viewport (device "grid=58x34 sent=58x33"
+// → the SGR row missed tmux's status row). The fix makes the keyboard-aware grid
+// the SINGLE writer of `_cols/_rows` (onResize no longer mirrors them), so the
+// live grid mirror stays == the grid SENT to tmux.
+//
+// This test connects, sets tmux mouse+status on with two short-named windows
+// (AAA/BBB), then in BOTH keyboard states (DOWN settled tall, UP settled short):
+//   - asserts the live mirror `_rows` == `lastSentRows` (the invariant the clobber
+//     broke — read via the #975 `debugGrids` seam), and
+//   - firm-taps window 1's status label at the visible bottom and asserts the
+//     viewport switches to window 1.
+//
+// NOTE on the emulator: its IME inset SNAPS (no slide even at
+// animator_duration_scale 5) and its flterm onResize tracks the box faithfully,
+// so it does NOT exhibit the device's onResize "settle-back" clobber — the mirror
+// stays consistent here, so this is a REGRESSION GUARD (green) that also documents
+// the invariant. The MID-animation transient (tmux resize is deliberately
+// deferred by the #903 coalescer, so the status bar is briefly off-screen) is
+// EXPECTED and intentionally NOT asserted. On-device is the authoritative gate for
+// the clobber itself.
+//
+// Run: scripts/native-connect-test.sh
+//        integration_test/tmux_status_tap_kbrace_test.dart
+//      (scripts/run-kbrace-repro.sh stretches the keyboard slide for manual
+//      inspection of the transient; not required for this assertion.)
+
+import 'dart:convert';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/diagnostics/gesture_trace.dart';
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+const int _rowsFallback = 24;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'a firm tmux status-bar tap switches windows with the keyboard DOWN and UP '
+    '(settled), and _rows stays == lastSentRows across the toggle (#975)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+      final sessionId = entry.id;
+      TerminalController? ctrlOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && ctrlOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = ctrlOf()!;
+
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'dead PTY — no shell output');
+
+      void send(String cmd) =>
+          entry.proxy.sendInput(Uint8List.fromList(utf8.encode(cmd)));
+
+      // tmux mouse ON, status ON, one session.
+      send('tmux kill-server 2>/dev/null; tmux set -g mouse on \\; '
+          'set -g status on \\; new -s ws\n');
+      for (var i = 0; i < 80; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (controller.mouseTracking != MouseTracking.none) break;
+        if (i % 5 == 4) {
+          send('tmux kill-server 2>/dev/null; tmux set -g mouse on \\; '
+              'set -g status on \\; new -s ws\n');
+        }
+      }
+      expect(controller.mouseTracking, isNot(MouseTracking.none),
+          reason: 'tmux mouse mode never engaged');
+
+      Future<void> settle([int ticks = 14]) async {
+        for (var i = 0; i < ticks; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+        }
+      }
+
+      int visibleRows() {
+        final v = controller.scrollbar.visible;
+        return v > 0 ? v : _rowsFallback;
+      }
+
+      String rendered() {
+        final rows = visibleRows();
+        return controller.visibleRowsText(0, rows > 0 ? rows - 1 : 0);
+      }
+
+      String statusRowText() {
+        final rows = visibleRows();
+        final last = rows > 0 ? rows - 1 : 0;
+        return controller.visibleRowsText(last, last);
+      }
+
+      List<int> grids() =>
+          GhosttyTerminalView.debugGrids[sessionId] ?? const <int>[0, 0, 0, 0];
+      final coalescer = GhosttyTerminalView.debugResizeCoalescers[sessionId];
+
+      const w0Name = 'AAA';
+      const w1Name = 'BBB';
+      const m0 = 'STAP_WINDOW_ZERO_ZZZ';
+      const m1 = 'STAP_WINDOW_ONE_OOO';
+      send('tmux rename-window $w0Name\n');
+      await settle();
+      send('clear; printf "$m0\\n"\n');
+      await settle();
+      send('tmux new-window -n $w1Name\n');
+      await settle();
+      send('clear; printf "$m1\\n"\n');
+      await settle();
+      send('tmux select-window -t 0\n');
+      for (var i = 0; i < 24; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        if (rendered().contains(m0)) break;
+      }
+      expect(rendered().contains(m0), isTrue,
+          reason: 'setup: never landed back on window 0 ($m0)');
+
+      double insetNow() =>
+          tester.platformDispatcher.views.first.viewInsets.bottom;
+
+      // A settled-state status tap: land on window 0, then FIRM-tap window 1's
+      // status label at the CURRENT visible bottom (a firm status-bar tap dwells
+      // past the long-press deadline — the device gesture). Assert the live grid
+      // mirror equals the grid SENT to tmux (the #975 single-source-of-truth
+      // invariant the clobber violated: device "grid=58x34 sent=58x33"), then
+      // report whether the viewport switched to window 1.
+      Future<bool> firmTapStatusSwitchesToW1(String phase) async {
+        send('tmux select-window -t 0\n');
+        for (var i = 0; i < 24; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+          if (rendered().contains(m0)) break;
+        }
+        // Wait for the resize to fully SETTLE and PROPAGATE: the grid SENT to
+        // tmux (coalescer.lastEmittedRows) == the visible viewport AND a rebuild
+        // has carried that grid into the widget snapshot (debugGrids g[3]) — so
+        // the router the tap hits reads a FRESH lastSentRows, not a value the
+        // coalescer's Timer emitted after the last build (debugGrids/router lag
+        // _sendResize, which runs off a Timer). Without this the tap can target a
+        // stale grid purely from build timing, not the #975 clobber.
+        var g = grids();
+        var le = coalescer?.lastEmittedRows ?? -1;
+        for (var i = 0; i < 60; i++) {
+          g = grids();
+          le = coalescer?.lastEmittedRows ?? -1;
+          if (le > 0 && le == visibleRows() && g.length > 3 && g[3] == le) break;
+          await tester.pump(const Duration(milliseconds: 120));
+        }
+        final vis = visibleRows();
+        final status = statusRowText();
+        final labelCol = status.indexOf(w1Name);
+        debugPrint('KBRACE $phase: visible=$vis grids=$g lastEmitted=$le '
+            'inset=${insetNow()} status="$status" w1Col=$labelCol');
+        expect(labelCol, greaterThanOrEqualTo(0),
+            reason: '$phase: window-1 label "$w1Name" not in the status row '
+                '"$status" — tmux status bar off-screen / at the wrong row');
+        // #922/#975 sizing: the grid SENT to tmux must track the VISIBLE viewport
+        // so tmux keeps its status bar at the visible bottom (where we tap).
+        expect(le, vis,
+            reason: '$phase: sent grid ($le) != visible viewport ($vis) — the '
+                'keyboard-aware grid did not track the box (#922/#975).');
+        // #975 single source of truth: the live mirror `_rows` (g[1], consumed by
+        // the gutter-select clamp + gesture geometry) MUST equal the grid sent to
+        // tmux (g[3] == lastSentRows). flterm's onResize used to clobber the
+        // mirror back to a stale grid; the fix keeps them in lockstep.
+        expect(g[1], g[3],
+            reason: '$phase: _rows(${g[1]}) != lastSentRows(${g[3]}) — flterm '
+                'onResize clobbered the keyboard-aware mirror (#975).');
+
+        final rect = tester.getRect(
+          find.byKey(Key('ghostty-terminal-$sessionId')),
+        );
+        final c = GhosttyTerminalView.debugCellSizes[sessionId]!;
+        final bottomRow = visibleRows() - 1;
+        final tapX =
+            rect.left + kGhosttyTerminalPadding + (labelCol + 0.5) * c.width;
+        final tapY =
+            rect.top + kGhosttyTerminalPadding + (bottomRow + 0.5) * c.height;
+        final gesture = await tester.startGesture(Offset(tapX, tapY));
+        await tester.pump(const Duration(milliseconds: 700)); // firm dwell
+        await gesture.up();
+        await settle(10);
+        final switched = rendered().contains(m1);
+        final log = gestureLogSnapshot();
+        final tail = log.length > 8 ? log.sublist(log.length - 8) : log;
+        debugPrint('KBRACE $phase result: switched=$switched '
+            'gridsNow=${grids()} tail=$tail');
+        return switched;
+      }
+
+      // Phase 1 — keyboard DOWN (text entry during connect leaves the IME up, so
+      // hide it and let the box grow + the sent grid settle tall).
+      await SystemChannels.textInput.invokeMethod('TextInput.hide');
+      controller.hideKeyboard();
+      for (var i = 0; i < 45; i++) {
+        await tester.pump(const Duration(milliseconds: 120));
+        if (insetNow() == 0 && coalescer?.lastEmittedRows == visibleRows()) break;
+      }
+      final downSwitched = await firmTapStatusSwitchesToW1('down');
+
+      // Phase 2 — keyboard UP (raise it and let the keyboard-reduced box settle
+      // short). The keyboard-aware grid keeps tmux's status bar at the visible
+      // bottom; the single-source-of-truth mirror keeps _rows == lastSentRows.
+      controller.requestFocus();
+      await SystemChannels.textInput.invokeMethod('TextInput.show');
+      controller.showKeyboard();
+      for (var i = 0; i < 45; i++) {
+        await tester.pump(const Duration(milliseconds: 120));
+        if (insetNow() > 0 && coalescer?.lastEmittedRows == visibleRows()) break;
+      }
+      final upSwitched = await firmTapStatusSwitchesToW1('up');
+
+      expect(downSwitched, isTrue,
+          reason: '#975/#971: a firm status-bar tap with the keyboard DOWN '
+              '(settled) must switch to window 1 — the steady-state tap must land '
+              'on tmux\'s real status row.');
+      expect(upSwitched, isTrue,
+          reason: '#975/#971: a firm status-bar tap with the keyboard UP '
+              '(settled, keyboard-reduced viewport) must switch to window 1 — the '
+              'keyboard-aware grid keeps tmux\'s status bar at the visible bottom '
+              'and _rows==lastSentRows so the SGR lands on it.');
+    },
+  );
+}

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -2118,6 +2118,16 @@ class GhosttyTerminalView extends ConsumerStatefulWidget {
   @visibleForTesting
   static final Map<String, Size> debugCellSizes = <String, Size>{};
 
+  /// #975 grid-race: the grid the gesture router sees THIS frame, as
+  /// `[cols, rows, lastSentCols, lastSentRows]`. `rows` is the live keyboard-
+  /// aware mirror; `lastSentRows` is what the status-tap SGR actually targets
+  /// (`_gridRows`). Exposed so the keyboard-race repro can log, at tap time, the
+  /// grid the SGR lands in versus the visible (keyboard-reduced) viewport — the
+  /// divergence IS the bug (SGR row misses tmux's real status row). Set every
+  /// build, cleared on dispose. Test-only — no production code reads it.
+  @visibleForTesting
+  static final Map<String, List<int>> debugGrids = <String, List<int>>{};
+
   @override
   ConsumerState<GhosttyTerminalView> createState() =>
       _GhosttyTerminalViewState();
@@ -2370,29 +2380,28 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         // damage/frame path dropped the redraw. Coalesced to once per frame.
         _forceTerminalRepaint();
       };
-      // Grid resize -> PTY resize. flterm reports (cols, rows); the proxy's
-      // pixel sizes default to 0 (the task isolate only needs cols/rows). Also
-      // mirror (cols, rows) so the #692 gesture router can map touch -> cell.
+      // Grid resize. flterm reports (cols, rows) from its OWN layout; we RECORD
+      // it for the replay harness but do NOT let it write _cols/_rows or the PTY.
       controller.onResize = (cols, rows) {
-        // Mirror the live grid SYNCHRONOUSLY (the touch->cell map reads
-        // `_cols`/`_rows` for selection/URL geometry, so they must track
-        // flterm's real render grid the instant it changes).
-        _cols = cols;
-        _rows = rows;
         // #790: record the live viewport grid so the replay harness can lay out
         // the captured byte stream at the SAME cols×rows the bug occurred at.
         _byteRecorder.recordGrid(cols, rows);
-        // #922: the PTY resize is NO LONGER driven from flterm's onResize. flterm
-        // fires onResize from its OWN layout, which under the soft-keyboard
-        // show/hide animation RACES — the device capture (2026-06-25T18-09-02)
-        // showed it settling BACK to the pre-keyboard tall size (grid=58x57) even
-        // though the visible box was keyboard-reduced (597px ≈ 34 rows), so tmux
-        // kept a 57-row grid and drew its status bar off-screen below the
-        // keyboard; the status-tap then missed. The authoritative size is now
-        // computed from the laid-out (keyboard-reduced) box in the LayoutBuilder
-        // ([_submitKeyboardAwareGrid] → the SAME #903 coalescer). flterm's grid
-        // here is only the gesture-geometry mirror. The #767 in-terminal URL
-        // re-detect still runs on the controller's own notify cycle.
+        // #975: flterm's onResize is NO LONGER a writer of _cols/_rows (nor the
+        // PTY). It USED to mirror (cols, rows) here synchronously, but flterm
+        // fires onResize from its own layout, which under the soft-keyboard
+        // show/hide animation RACES and can settle BACK to the pre-keyboard tall
+        // size (device capture 2026-06-25T18-09-02: grid=58x57 while the visible
+        // box was keyboard-reduced to ~34 rows). That stale write CLOBBERED the
+        // keyboard-aware mirror, and once [_submitKeyboardAwareGrid]'s
+        // `_lastSubmittedGridRows` guard had latched the correct size it could not
+        // re-correct — leaving `_rows` (the gutter-selection row clamp + gesture
+        // geometry) and the status-tap target stale vs the VISIBLE viewport (the
+        // "selection cut off at the keyboard line" + "status tap wrong row"
+        // symptoms). The SINGLE SOURCE OF TRUTH for _cols/_rows AND the PTY grid
+        // is now the keyboard-aware grid computed from the laid-out (keyboard-
+        // reduced) box in the LayoutBuilder ([_submitKeyboardAwareGrid] → the
+        // #903 coalescer). The #767 in-terminal URL re-detect still runs on the
+        // controller's own notify cycle.
       };
       // PTY output bytes -> terminal. The subscription lives on this state so
       // dispose() cancels it.
@@ -2762,8 +2771,23 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     final proxy = _proxy;
     if (proxy == null) return;
     proxy.sendResize(cols, rows);
+    final changed = cols != _lastSentCols || rows != _lastSentRows;
     _lastSentCols = cols;
     _lastSentRows = rows;
+    // #975: the gesture router + gutter-select layer read _lastSentCols/
+    // _lastSentRows (the grid the status-tap SGR targets) and _cols/_rows from
+    // THIS widget's build. _sendResize runs off the #903 coalescer's settle Timer
+    // (and the #702/#970 resync/nudge timers) — OUTSIDE the build/notify cycle,
+    // and plain terminal output does NOT rebuild this widget (_onControllerChanged
+    // only setState's on a mouse-mode / selection CHANGE). So after a keyboard-
+    // toggle resize SETTLES, the router kept a STALE last-sent grid and a status
+    // tap targeted the OLD status row (tmux had already reflowed) → no window
+    // switch (#975 "tap wrong row"). Rebuild when the sent grid changes so the
+    // tap/selection map to tmux's CURRENT grid. Cheap + can't loop (the
+    // LayoutBuilder's _submitKeyboardAwareGrid guard no-ops an unchanged grid, so
+    // this never re-triggers a send). Never called during build (Timer/stream
+    // callbacks only), so setState is safe here.
+    if (changed && mounted) setState(() {});
   }
 
   /// #717: focus the terminal ONCE per connect so flterm scroll/interaction is
@@ -3523,6 +3547,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // #971 (test-only): drop the debug byte-recorder + cell-size handles.
     GhosttyTerminalView.debugByteRecorders.remove(widget.sessionId);
     GhosttyTerminalView.debugCellSizes.remove(widget.sessionId);
+    GhosttyTerminalView.debugGrids.remove(widget.sessionId);
     _controller?.removeListener(_onControllerChanged);
     _controller?.onOutput = null;
     _controller?.onResize = null;
@@ -3692,12 +3717,17 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     }
     _lastSubmittedGridCols = cols;
     _lastSubmittedGridRows = rows;
+    // #975: mirror the keyboard-aware grid into _cols/_rows NOW (synchronous
+    // plain-field writes during layout are legal — no setState). This is the
+    // SOLE writer of the mirror since flterm's onResize no longer clobbers it, so
+    // the gesture router / gutter-select layer read the visible-viewport grid on
+    // THIS frame instead of lagging a frame behind (they used to get flterm's
+    // synchronous onResize write). The coalesced PTY SEND stays deferred to a
+    // post-frame (it may schedule a Timer + later setState via the send seam).
+    _cols = cols;
+    _rows = rows;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      // Mirror the live grid synchronously (the gesture map reads _cols/_rows),
-      // then coalesce the PTY send exactly as flterm's onResize did (#903).
-      _cols = cols;
-      _rows = rows;
       _byteRecorder.recordGrid(cols, rows);
       _resizeCoalescer.submit(cols, rows);
       gtrace('ghostty-kbgrid: cols=$cols rows=$rows box=${box.height.round()}');
@@ -3710,6 +3740,10 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     required Size cellSize,
     required Color highlightColor,
   }) {
+    // #975 (test-only): publish the grid the router will map gestures with this
+    // frame so the keyboard-race repro can see the SGR target vs the visible box.
+    GhosttyTerminalView.debugGrids[widget.sessionId] =
+        <int>[_cols, _rows, _lastSentCols, _lastSentRows];
     return Stack(
       key: Key('ghostty-terminal-${widget.sessionId}'),
       children: [

--- a/scripts/run-kbrace-repro.sh
+++ b/scripts/run-kbrace-repro.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# scripts/run-kbrace-repro.sh — run the #975 keyboard-race tmux-tap repro with a
+# STRETCHED soft-keyboard slide so the mid-animation window is wide enough to tap.
+#
+# Sets the emulator's animation scales to $1 (default 5 → ~1s slide), runs the
+# kbrace integration test over the standard native-connect-test bridge, then
+# resets the scales to 1.0. The container entrypoint sets 1.0 at boot; this only
+# needs to widen it for the duration of the run.
+#
+# Usage: scripts/run-kbrace-repro.sh [scale]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MOBISSH_TMPDIR="${MOBISSH_TMPDIR:-/tmp/mobissh}"
+MOBISSH_LOGDIR="${MOBISSH_LOGDIR:-/tmp/mobissh/logs}"
+mkdir -p "$MOBISSH_TMPDIR" "$MOBISSH_LOGDIR"
+LOGFILE="${MOBISSH_LOGDIR}/kbrace-repro.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+SCALE="${1:-5}"
+EMU_CONTAINER_NAME="${EMU_CONTAINER_NAME:-mobissh-emulator}"
+EMU_ADBD_ENDPOINT="${EMU_ADBD_ENDPOINT:-${EMU_CONTAINER_NAME}:5556}"
+TEST_FILE="integration_test/tmux_status_tap_kbrace_test.dart"
+
+log() { echo "> $*"; }
+
+log "ensuring emulator container is up"
+"${REPO_ROOT}/scripts/emu-container-ctl.sh" ensure
+
+log "adb connect ${EMU_ADBD_ENDPOINT}"
+adb connect "$EMU_ADBD_ENDPOINT" || true
+
+set_scales() {
+  local v="$1"
+  adb -s "$EMU_ADBD_ENDPOINT" shell settings put global animator_duration_scale "$v" || true
+  adb -s "$EMU_ADBD_ENDPOINT" shell settings put global transition_animation_scale "$v" || true
+  adb -s "$EMU_ADBD_ENDPOINT" shell settings put global window_animation_scale "$v" || true
+}
+
+reset_scales() {
+  log "resetting animation scales to 1.0"
+  set_scales 1.0
+}
+trap reset_scales EXIT
+
+log "setting animation scales to ${SCALE}"
+set_scales "$SCALE"
+adb -s "$EMU_ADBD_ENDPOINT" shell settings get global animator_duration_scale || true
+
+log "running ${TEST_FILE}"
+"${REPO_ROOT}/scripts/native-connect-test.sh" "$TEST_FILE"


### PR DESCRIPTION
Fixes #975.

## Root cause (grid single source of truth)

The gesture router and gutter-select layer decide the tmux status-tap SGR row (and the selection row clamp) from the grid this widget last built with — `_cols/_rows` (live mirror) and `_lastSentCols/_lastSentRows` (what tmux was told). Two ways that grid went stale vs the visible viewport:

1. **`controller.onResize` clobbered the mirror.** flterm fires `onResize` from its own layout, which under the soft-keyboard animation races and can settle **back** to the pre-keyboard tall size (device capture 2026-06-25: `grid=58x57` while the box was keyboard-reduced to ~34 rows). That stale synchronous write overwrote the keyboard-aware `_rows`, and once `_submitKeyboardAwareGrid`'s `_lastSubmittedGridRows` guard had latched the correct size it could not re-correct → `_rows` stuck stale (the "selection cut off at the keyboard line" symptom; device `grid=58x34 sent=58x33`).

2. **The view didn't rebuild after a resize SENT.** `_sendResize` runs off the #903 coalescer's settle Timer (and the #702/#970 resync/nudge timers), **outside** the build/notify cycle, and plain terminal output does not rebuild this widget (`_onControllerChanged` only `setState`s on a mouse-mode/selection change). So after a keyboard-toggle resize settled, the gesture router kept a **stale `lastSentRows`** and a status tap targeted the **old** status row (tmux had already reflowed) → no window switch (the "status tap wrong row" symptom).

## Fix (3 coupled changes in `ghostty_terminal_view.dart`)

- `controller.onResize` no longer writes `_cols/_rows` (nor the PTY) — it only records the grid for the replay harness.
- `_submitKeyboardAwareGrid` writes `_cols/_rows` **synchronously** during layout (the sole writer), so the router/gutter read the visible-viewport grid on the same frame.
- `_sendResize` triggers `setState` when the sent grid **changes**, so the router/gutter map to tmux's current grid. Can't loop (the LayoutBuilder guard no-ops an unchanged grid); never called during build.

## Validation

Emulator repro `integration_test/tmux_status_tap_kbrace_test.dart`: a firm tmux status-bar tap switches windows with the keyboard **DOWN and UP** (settled), and `_rows == lastSentRows` across the toggle.

- **RED** before the `_sendResize` rebuild: the tap after a keyboard toggle used a stale last-sent grid (`grids=[50,44,50,25]`, tmux already at 44) → SGR at the wrong row → no switch.
- **GREEN** after: both taps click through (`sent=50x44` → `ESC[<0;16;44M`; `sent=50x25` → `ESC[<0;16;25M`) and switch.

Adds a test-only `debugGrids` seam exposing `[cols, rows, lastSentCols, lastSentRows]` per session.

Fast gate (analyze + unit) passes; #903 / #922 / #723 sizing tests unaffected.

## Emulator limitation (on-device gate authoritative)

The emulator's IME inset **snaps** (no slide even at `animator_duration_scale 5`) and its flterm `onResize` tracks the box faithfully, so it does **not** reproduce the device-specific onResize "settle-back" clobber (root #1) — on the emulator the mirror stays consistent, so the test guards the invariant and validates root #2 (the rebuild-after-send). The **mid-animation** transient (the #903 coalescer deliberately defers the resize during the slide, so the status bar is briefly off-screen — a tap during the slide can't switch) is **expected** and intentionally not asserted. The device keyboard *animation* clobber (root #1) needs on-device confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa