### PR TITLE
feat(native): -CC capture-pane render layer — attach-render (Stage 1) + scroll byte-path (Stage 2, grid render blocked) (#906)

### DIFF
--- a/native/integration_test/cc_capture_attach_test.dart
+++ b/native/integration_test/cc_capture_attach_test.dart
@@ -1,0 +1,129 @@
+// On-emulator tmux control-mode (`-CC`) CAPTURE-PANE ATTACH-RENDER (#906 Stage 1).
+//
+// The gap: `tmux -CC attach` pushes NO initial screen (only `%session-changed`),
+// and MobiSSH's `-CC` path rendered only live `%output` — so an idle attached
+// pane stayed BLANK until the next byte. Real `-CC` clients (iTerm2) fix this by
+// REQUESTING `capture-pane` on attach and drawing the response themselves. Stage 1
+// implements that: on `%session-changed` the channel requests `capture-pane -p -e
+// -J`, correlates the `%begin…%end` response by FIFO order, and renders it (clear
+// + write) into flterm.
+//
+// This test PROVES the capture render END-TO-END: scripts/cc-capture-setup.sh
+// pre-creates a PERSISTENT `main` session whose active pane shows a STATIC marker
+// (`CAPTURE_SCREEN_MARKER_XYZ`) on an otherwise-quiet screen. The app then attaches
+// with control mode ON and — WITHOUT sending a single keystroke — the marker must
+// appear in the rendered output. Because the pane produces no live `%output`, the
+// marker can ONLY have reached the grid via the capture-pane render. On the OLD
+// behaviour (no capture) the grid stays blank and this test is RED.
+//
+// The orchestrator runs this FLAG-ON; the shipped build keeps the flag OFF.
+//
+// Setup (run FIRST): scripts/cc-capture-setup.sh
+// Run: scripts/native-connect-test.sh integration_test/cc_capture_attach_test.dart
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/tmux_control_mode_setting.dart';
+import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late bool prevFlag;
+  setUp(() => prevFlag = setTmuxControlModeForTest(true));
+  tearDown(() => setTmuxControlModeForTest(prevFlag));
+
+  testWidgets(
+    '-CC renders the attached pane via capture-pane, no new output (#906)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Enable control mode THROUGH the provider (the notifier's async hydrate
+      // resets the raw global, so the setUp flag alone races it) — set(true)
+      // persists + syncs the global so connect carries controlMode=true.
+      await container.read(tmuxControlModeProvider.notifier).set(true);
+      for (var i = 0; i < 4; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(tmuxControlMode, isTrue,
+          reason: 'control-mode global must be ON before connect');
+
+      // Control mode ON → entry is `tmux -CC attach …`, grabbing the PRE-EXISTING
+      // `main` (created by scripts/cc-capture-setup.sh).
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      String rendered() => utf8.decode(out, allowMalformed: true);
+
+      // THE ASSERTION: without sending ANY input, the pre-existing pane's static
+      // screen must render — proof that capture-pane painted the attach. The pane
+      // is idle (no live %output), so the marker can arrive ONLY via the capture.
+      var sawMarker = false;
+      for (var i = 0; i < 80; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (rendered().contains('CAPTURE_SCREEN_MARKER_XYZ')) {
+          sawMarker = true;
+          break;
+        }
+      }
+      expect(sawMarker, isTrue,
+          reason: 'the attached pane did NOT render via capture-pane — the grid '
+              'stayed blank on an idle attach (Stage-1 regression). '
+              'Ensure scripts/cc-capture-setup.sh ran. Saw: ${rendered()}');
+
+      // Hold on the rendered state (emu-shot capture point).
+      await tester.pump(const Duration(seconds: 3));
+
+      expect(find.byKey(const Key('session-menu-button')), findsOneWidget,
+          reason: 'session torn down during the capture-attach render');
+
+      debugPrint('CC_CAPTURE_ATTACH: capture-pane rendered the idle attached '
+          'pane (CAPTURE_SCREEN_MARKER_XYZ) with zero new %output');
+    },
+  );
+}

--- a/native/integration_test/cc_capture_scroll_test.dart
+++ b/native/integration_test/cc_capture_scroll_test.dart
@@ -1,0 +1,161 @@
+// On-emulator tmux control-mode (`-CC`) CAPTURE-PANE SCROLLBACK (#906 Stage 2).
+//
+// Control mode emits NO `%output` for copy-mode / scrollback scroll, so MobiSSH's
+// local flterm scroll shows nothing back there — the grid only ever held the live
+// tail. Real `-CC` clients (iTerm2) scroll by REQUESTING `capture-pane -S -E`
+// history windows and drawing them. Stage 2 implements that: a vertical swipe
+// (here driven through the same `proxy.sendTmuxScroll` IPC the gesture calls)
+// advances the channel's scroll offset and captures the matching history window,
+// which renders as the scrollback view.
+//
+// scripts/cc-scroll-setup.sh pre-fills the active pane with LINE_001..LINE_200 —
+// far more than the viewport — so early line numbers live ONLY in scrollback. The
+// test attaches (control mode ON), confirms the live tail (LINE_200) rendered but
+// an early line (LINE_050) is NOT on screen, then scrolls BACK and asserts LINE_050
+// arrives on the session's OUTPUT stream (`proxy.output`). That older number can
+// ONLY have come from a scrollback capture-pane response.
+//
+// SCOPE / KNOWN BLOCKER (#906 Stage 2): this proves the IPC + capture-request +
+// response BYTE path end-to-end — the scroll gesture reaches the host, the channel
+// advances its offset and captures the right history window, and those bytes reach
+// the terminal controller. It does NOT yet prove the on-GRID render: emulator
+// screenshots show flterm still displaying the LIVE tail (cursor parked at the live
+// prompt) even though `controller.write` received the captured rows. Rendering a
+// captured history WINDOW into flterm's grid (vs. its own growing scrollback buffer
+// + follow-to-bottom) is the unresolved structural blocker; a green here is a
+// byte-path signal, NOT device proof (see feedback_device_run_not_headless_green).
+//
+// The orchestrator runs this FLAG-ON; the shipped build keeps the flag OFF.
+//
+// Setup (run FIRST): scripts/cc-scroll-setup.sh
+// Run: scripts/native-connect-test.sh integration_test/cc_capture_scroll_test.dart
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/tmux_control_mode_setting.dart';
+import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late bool prevFlag;
+  setUp(() => prevFlag = setTmuxControlModeForTest(true));
+  tearDown(() => setTmuxControlModeForTest(prevFlag));
+
+  testWidgets(
+    '-CC scrolls the scrollback via capture-pane history (#906)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await container.read(tmuxControlModeProvider.notifier).set(true);
+      for (var i = 0; i < 4; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(tmuxControlMode, isTrue,
+          reason: 'control-mode global must be ON before connect');
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      String rendered() => utf8.decode(out, allowMalformed: true);
+
+      // The attach capture renders the LIVE tail (LINE_200), not the early lines.
+      var sawTail = false;
+      for (var i = 0; i < 80; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (rendered().contains('LINE_200')) {
+          sawTail = true;
+          break;
+        }
+      }
+      expect(sawTail, isTrue,
+          reason: 'the live tail (LINE_200) did not render on attach. '
+              'Ensure scripts/cc-scroll-setup.sh ran. Saw: ${rendered()}');
+      expect(rendered().contains('LINE_050'), isFalse,
+          reason: 'LINE_050 is deep in scrollback — it must NOT be on the initial '
+              'tail screen (else the scroll proof is vacuous). Saw: ${rendered()}');
+
+      // Hold on the TAIL (before) — emu-shot capture point.
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+
+      // SCROLL BACK. Each step advances the scroll offset ~20 lines and captures
+      // a fresh history window; LINE_050 falls into the window after ~6 steps.
+      var sawHistory = false;
+      out.clear();
+      for (var step = 0; step < 12 && !sawHistory; step++) {
+        entry.proxy.sendTmuxScroll(20); // >0 = back into history
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+          if (rendered().contains('LINE_050')) {
+            sawHistory = true;
+            break;
+          }
+        }
+      }
+      expect(sawHistory, isTrue,
+          reason: 'scrolling back never delivered LINE_050 on proxy.output — the '
+              'scrollback capture request/response byte path failed. '
+              'Saw: ${rendered()}');
+
+      // Hold on the SCROLLED-BACK state (after) — emu-shot capture point. NOTE:
+      // the grid may still show the live tail (the Stage-2 on-grid blocker).
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+
+      expect(find.byKey(const Key('session-menu-button')), findsOneWidget,
+          reason: 'session torn down during the scrollback sequence');
+
+      debugPrint('CC_CAPTURE_SCROLL: the scroll gesture drove a capture-pane '
+          'history request and LINE_050 reached proxy.output (byte path OK). '
+          'On-grid flterm render remains the open Stage-2 blocker.');
+    },
+  );
+}

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -332,6 +332,8 @@ class SessionHost {
         _handleControlCommand(cmd);
       case SshTmuxGestureCommand():
         _handleTmuxGesture(cmd);
+      case SshTmuxScrollCommand():
+        _handleTmuxScroll(cmd);
     }
   }
 
@@ -382,6 +384,27 @@ class SessionHost {
     if (line == null) return; // no window known yet — nothing to target.
     try {
       hosted.shell?.send(tmux.frameControl(line));
+    } catch (_) {
+      // Channel closed; reconnect re-syncs.
+    }
+  }
+
+  /// #906 Stage 2: a vertical swipe under control mode. Advance the channel's
+  /// scroll offset by the signed line delta and send the matching `capture-pane`
+  /// history window (or a live re-capture when snapped back to bottom). The
+  /// rendered response — correlated through the capture FIFO — IS the scrollback
+  /// view (control mode emits no `%output` for copy-mode scroll). A no-op unless
+  /// control mode is ON. The viewport height comes from the last resize so the
+  /// captured window is exactly one screen tall.
+  void _handleTmuxScroll(SshTmuxScrollCommand cmd) {
+    final hosted = _sessions[cmd.sessionId];
+    if (hosted == null) return;
+    final tmux = hosted.tmuxChannel;
+    if (tmux == null) return; // flag OFF — ignore.
+    if (cmd.deltaLines == 0) return;
+    final rows = hosted.metrics.lastRows ?? 24;
+    try {
+      hosted.shell?.send(tmux.frameScroll(cmd.deltaLines, rows));
     } catch (_) {
       // Channel closed; reconnect re-syncs.
     }

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -346,9 +346,12 @@ class SessionHost {
   void _handleControlCommand(SshControlCommand cmd) {
     final hosted = _sessions[cmd.sessionId];
     if (hosted == null) return;
-    if (hosted.tmuxChannel == null) return; // flag OFF — ignore.
+    final tmux = hosted.tmuxChannel;
+    if (tmux == null) return; // flag OFF — ignore.
     try {
-      hosted.shell?.send(TmuxControlChannel.controlCommand(cmd.command));
+      // #906: frame through the channel so the command's `%begin…%end` ack is
+      // registered in the capture-correlation FIFO.
+      hosted.shell?.send(tmux.frameControl(cmd.command));
     } catch (_) {
       // Channel closed mid-command; the next connect re-syncs.
     }
@@ -378,7 +381,7 @@ class SessionHost {
     }
     if (line == null) return; // no window known yet — nothing to target.
     try {
-      hosted.shell?.send(TmuxControlChannel.controlCommand(line));
+      hosted.shell?.send(tmux.frameControl(line));
     } catch (_) {
       // Channel closed; reconnect re-syncs.
     }
@@ -798,7 +801,10 @@ class SessionHost {
         hosted.refreshCoalescer = RefreshClientCoalescer(
           onSettled: (cols, rows) {
             try {
-              transport.send(TmuxControlChannel.resizeCommand(cols, rows));
+              // #906: frame through the channel so the resize's `%begin…%end` ack
+              // is registered in the capture-correlation FIFO (and can't be
+              // mistaken for a capture response).
+              transport.send(tmux.frameResize(cols, rows));
             } catch (_) {
               // Channel closed; the next connect re-syncs.
             }
@@ -871,9 +877,24 @@ class SessionHost {
               final cols = hosted.metrics.lastCols ?? 80;
               final rows = hosted.metrics.lastRows ?? 24;
               try {
-                hosted.shell?.send(TmuxControlChannel.resizeCommand(cols, rows));
+                // #906: frame through the channel (FIFO ack) so the ordering with
+                // the following capture request is preserved.
+                hosted.shell?.send(tmux.frameResize(cols, rows));
               } catch (_) {
                 // Channel closed mid-switch; the next connect re-syncs.
+              }
+            }
+            // #906 Stage 1: ATTACH or SWITCH → request `capture-pane` so the
+            // active pane's CURRENT screen renders even with no `%output` (tmux
+            // pushes none on attach / an idle switched-to window). Sent AFTER the
+            // switch redraw so the capture ack follows the resize ack in the FIFO.
+            // The correlated response is rendered by a later `ingest` (clear +
+            // write), exactly as a real `-CC` client repaints.
+            if (result.captureRequested) {
+              try {
+                hosted.shell?.send(tmux.frameCapture());
+              } catch (_) {
+                // Channel closed; the next connect re-syncs.
               }
             }
             final render = result.renderBytes;

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -92,6 +92,14 @@ enum SshTaskCommandKind {
   /// atomic control-command path. Keeping the index lookup TASK-SIDE means the UI
   /// never needs the window list and a status tap maps with no pixel guessing.
   tmuxGesture,
+
+  /// UI → task: a tmux `-CC` SCROLLBACK gesture (#906 Stage 2). Carries a signed
+  /// line delta (>0 = back into history, <0 = toward live). The host advances the
+  /// channel's scroll offset and requests the matching `capture-pane` history
+  /// window, whose rendered response IS the scrollback view — control mode emits
+  /// no `%output` for copy-mode scroll, so the client must capture it. A no-op
+  /// unless control mode is ON. NEVER used by the scrape (flag-OFF) path.
+  tmuxScroll,
 }
 
 /// The kind of tmux window gesture an [SshTmuxGestureCommand] carries (#911).
@@ -321,6 +329,11 @@ sealed class SshTaskCommand {
           ),
           statusCol: (json['statusCol'] as int?) ?? 0,
           statusCols: (json['statusCols'] as int?) ?? 0,
+        );
+      case SshTaskCommandKind.tmuxScroll:
+        return SshTmuxScrollCommand(
+          sessionId: sessionId,
+          deltaLines: (json['deltaLines'] as int?) ?? 0,
         );
     }
   }
@@ -743,6 +756,31 @@ class SshTmuxGestureCommand extends SshTaskCommand {
         'gesture': gesture.name,
         'statusCol': statusCol,
         'statusCols': statusCols,
+      };
+}
+
+/// UI → task: a tmux `-CC` SCROLLBACK gesture (#906 Stage 2). [deltaLines] is a
+/// signed line delta — positive scrolls BACK into history (a downward swipe),
+/// negative scrolls toward live. The host advances the channel's scroll offset
+/// and requests the matching `capture-pane` history window; the rendered response
+/// is the scrollback view. Per-session; a no-op unless control mode is ON.
+class SshTmuxScrollCommand extends SshTaskCommand {
+  const SshTmuxScrollCommand({
+    required String sessionId,
+    required this.deltaLines,
+  }) : super(sessionId);
+
+  /// Signed line delta: >0 = older/back, <0 = toward live.
+  final int deltaLines;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.tmuxScroll;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'sessionId': sessionId,
+        'deltaLines': deltaLines,
       };
 }
 

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -298,6 +298,20 @@ class SshSessionProxy {
     );
   }
 
+  /// Scroll the tmux `-CC` scrollback view by [deltaLines] (#906 Stage 2) —
+  /// positive scrolls BACK into history (a downward swipe), negative toward live.
+  /// The host advances the channel's scroll offset and captures the matching
+  /// history window; the rendered response arrives on [output] as the scrollback
+  /// view. A no-op on the task side unless control mode is ON for this session.
+  void sendTmuxScroll(int deltaLines) {
+    gateway.send(
+      SshTmuxScrollCommand(
+        sessionId: sessionId,
+        deltaLines: deltaLines,
+      ).toJson(),
+    );
+  }
+
   /// Request a directory listing over SFTP (#559). The matching
   /// [SftpListingEvent] (or [SftpErrorEvent]) arrives on [sftpEvents] with the
   /// same [requestId].

--- a/native/lib/terminal/tmux_control_channel.dart
+++ b/native/lib/terminal/tmux_control_channel.dart
@@ -49,10 +49,21 @@
 // and the on-emulator `integration_test/cc_render_test.dart` parity test.
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
 
 import 'tmux_control_parser.dart';
+
+/// The kind of an outstanding `-CC` control command whose `%begin…%end` response
+/// block the channel is waiting on (#906 Stage 1). tmux emits exactly ONE
+/// command-output block per client command, IN ORDER, so the channel keeps a
+/// FIFO of the kinds it has sent and pops the front on each block: a
+/// [_PendingKind.capture] block carries pane content to RENDER; anything else
+/// ([_PendingKind.other] — resize, gesture, control) is a plain ack we discard.
+/// This is exactly how iTerm2 correlates responses (a queue popped per block),
+/// not a guess at tmux's opaque command number.
+enum _PendingKind { capture, other }
 
 /// The result of [TmuxControlChannel.ingest]: the bytes to render now, plus the
 /// authoritative active-window signal so the host can force a redraw on switch.
@@ -61,6 +72,7 @@ class TmuxIngestResult {
     required this.renderBytes,
     required this.activeWindowChanged,
     required this.exited,
+    this.captureRequested = false,
   });
 
   /// The octal-UNESCAPED bytes of the ACTIVE window's panes, demultiplexed and
@@ -76,6 +88,16 @@ class TmuxIngestResult {
   /// True when `%exit` was seen — control mode ended (tmux detached / server
   /// died). The host treats this like a shell close.
   final bool exited;
+
+  /// True when this chunk warrants a `capture-pane` request — an ATTACH
+  /// (`%session-changed`) or an active-window SWITCH (`%session-window-changed`)
+  /// (#906 Stage 1). Real `-CC` clients (iTerm2) render the pane by REQUESTING
+  /// `capture-pane` and drawing the response themselves; `tmux -CC attach` pushes
+  /// NO initial screen (only `%session-changed`) and a switched-to idle window
+  /// emits no `%output`, so without this the grid stays blank/stale. The host
+  /// responds by sending [TmuxControlChannel.frameCapture]; the correlated
+  /// `%begin…%end` response is rendered (clear + write) back through [ingest].
+  final bool captureRequested;
 }
 
 /// An ordered tmux window the control channel knows about (Part C, #911). Built
@@ -133,6 +155,19 @@ class TmuxControlChannel {
   /// the host's redraw-on-switch wiring.
   int? get activeWindowId => _activeWindowId;
 
+  /// FIFO of the outstanding client commands' kinds (#906 Stage 1). Every
+  /// command the host writes to the `-CC` channel is FIRST registered here (via
+  /// [frameCapture]/[frameCaptureRange]/[frameResize]/[frameControl], in send
+  /// order); each `%begin…%end` block pops the front and — iff it was a
+  /// [_PendingKind.capture] — renders the captured pane. A block that arrives
+  /// with an EMPTY queue is tmux's startup block (or a stray) → ignored. This is
+  /// the order-based correlation real `-CC` clients use.
+  final Queue<_PendingKind> _pending = Queue<_PendingKind>();
+
+  /// The number of outstanding (un-answered) command blocks. Exposed for unit
+  /// tests of the block-correlation FIFO.
+  int get pendingCommandCount => _pending.length;
+
   /// The ordered windows the channel knows about (Part C, #911), in tmux
   /// index/status order. A snapshot — mutating it does not affect the channel.
   List<TmuxWindow> get windows => List<TmuxWindow>.unmodifiable(
@@ -187,6 +222,55 @@ class TmuxControlChannel {
     return Uint8List.fromList(utf8.encode('$trimmed\n'));
   }
 
+  /// The `capture-pane -p -e -J` command line (#906 Stage 1) — dump the ACTIVE
+  /// pane's VISIBLE screen with escape sequences (`-e`, colours) and wrapped
+  /// lines joined (`-J`), to stdout (`-p`) as the command's `%begin…%end`
+  /// response. No `-t` target: `-CC`'s current pane IS the attached session's
+  /// active pane (and follows `select-window`), so this always captures what the
+  /// user is looking at. This is what real `-CC` clients request to paint the
+  /// screen tmux does NOT push on attach.
+  static Uint8List capturePaneCommand() =>
+      controlCommand('capture-pane -p -e -J');
+
+  /// The `capture-pane -p -e -S <start> -E <end>` command line (#906 Stage 2) —
+  /// a WINDOW into the active pane's history, from line [start] to [end]
+  /// (tmux line numbers: 0 is the top visible row, NEGATIVE indices reach into
+  /// scrollback, so a start of `-40` is 40 lines back). Renders the scrollback
+  /// view the local grid can't (control mode gets no `%output` for copy-mode
+  /// scroll).
+  static Uint8List capturePaneRangeCommand(int start, int end) =>
+      controlCommand('capture-pane -p -e -S $start -E $end');
+
+  /// Register + frame a `capture-pane` request (#906 Stage 1). Pushes a
+  /// [_PendingKind.capture] so the correlated response block renders, and returns
+  /// the bytes for the host to write. The host MUST send framed commands in the
+  /// order it frames them so the FIFO stays aligned with tmux's block order.
+  Uint8List frameCapture() {
+    _pending.add(_PendingKind.capture);
+    return capturePaneCommand();
+  }
+
+  /// Register + frame a scrollback `capture-pane -S -E` request (#906 Stage 2).
+  Uint8List frameCaptureRange(int start, int end) {
+    _pending.add(_PendingKind.capture);
+    return capturePaneRangeCommand(start, end);
+  }
+
+  /// Register + frame a `refresh-client -C` resize (#906 Stage 1). Its response
+  /// block is a plain ack ([_PendingKind.other]) — registered so it can't be
+  /// mistaken for a capture response and consume a real capture out of order.
+  Uint8List frameResize(int cols, int rows) {
+    _pending.add(_PendingKind.other);
+    return resizeCommand(cols, rows);
+  }
+
+  /// Register + frame an arbitrary control command line (gesture / select-window
+  /// / user command, #906 Stage 1). Its response block is a plain ack.
+  Uint8List frameControl(String line) {
+    _pending.add(_PendingKind.other);
+    return controlCommand(line);
+  }
+
   /// The `next-window` control-command line (Part C, #911) — a horizontal swipe
   /// RIGHT advances to the next window. No window-list lookup needed; tmux steps
   /// the session's active window itself and pushes `%session-window-changed`.
@@ -237,9 +321,26 @@ class TmuxControlChannel {
     final render = BytesBuilder(copy: false);
     var activeChanged = false;
     var exited = false;
+    var captureRequested = false;
 
     for (final ev in events) {
       switch (ev) {
+        case CommandEnd():
+          // #906 Stage 1: a command-output block completed. Correlate it to the
+          // client command that produced it by FIFO order (tmux emits exactly one
+          // block per command, in order). A capture block carries the pane content
+          // to RENDER (clear + write); any other ack is discarded. An EMPTY queue
+          // means this is tmux's startup block (or a stray) → ignore.
+          if (_pending.isNotEmpty) {
+            final kind = _pending.removeFirst();
+            if (kind == _PendingKind.capture && !ev.isError) {
+              render.add(_renderCapture(ev.response));
+            }
+          }
+        case SessionChanged():
+          // #906 Stage 1: ATTACH. tmux pushes no screen on `-CC attach`, so ask
+          // for one — the host sends `capture-pane` and the response renders.
+          captureRequested = true;
         case LayoutChange():
           // Record which window each leaf pane belongs to so %output can be
           // filtered to the active window.
@@ -266,6 +367,10 @@ class TmuxControlChannel {
           if (ev.windowId != _activeWindowId) {
             _activeWindowId = ev.windowId;
             activeChanged = true;
+            // #906 Stage 1: the switched-to window may be IDLE (no `%output`), so
+            // capture its screen to repaint — the same request iTerm2 makes on a
+            // window switch.
+            captureRequested = true;
           }
         case PaneOutput():
           if (_shouldRender(ev.paneId)) render.add(ev.data);
@@ -278,7 +383,7 @@ class TmuxControlChannel {
         case ControlModeExit():
           exited = true;
         default:
-          // CommandBegin/End, session/client notifications, UnhandledNotification,
+          // CommandBegin, client notifications, UnhandledNotification,
           // UnknownLine, ControlModeEntered: no render or window-tracking effect
           // here. The parser already updated its own active-window/layout view.
           break;
@@ -289,7 +394,26 @@ class TmuxControlChannel {
       renderBytes: render.toBytes(),
       activeWindowChanged: activeChanged,
       exited: exited,
+      captureRequested: captureRequested,
     );
+  }
+
+  /// Turn a `capture-pane` response (the visible pane rows, verbatim with SGR
+  /// from `-e`) into the bytes that repaint the grid (#906 Stage 1): reset
+  /// attributes, clear the whole screen + scrollback, home the cursor, then write
+  /// the rows joined by CRLF. `\x1b[3J` clears flterm's scrollback too so a
+  /// re-capture (window switch / Stage-2 scroll snap-back) can't leave stale rows
+  /// above. The response strings are LATIN-1 code units (the channel decodes the
+  /// stream 1:1), so each maps back to one byte.
+  static Uint8List _renderCapture(List<String> lines) {
+    final sb = StringBuffer('\x1b[m\x1b[3J\x1b[2J\x1b[H');
+    sb.write(lines.join('\r\n'));
+    final s = sb.toString();
+    final out = Uint8List(s.length);
+    for (var i = 0; i < s.length; i++) {
+      out[i] = s.codeUnitAt(i) & 0xff;
+    }
+    return out;
   }
 
   /// Whether a `%output %paneId` should render: yes when no active window is

--- a/native/lib/terminal/tmux_control_channel.dart
+++ b/native/lib/terminal/tmux_control_channel.dart
@@ -168,6 +168,23 @@ class TmuxControlChannel {
   /// tests of the block-correlation FIFO.
   int get pendingCommandCount => _pending.length;
 
+  /// Lines the scrollback view is offset ABOVE the live bottom (#906 Stage 2).
+  /// 0 = live (following `%output`); >0 = showing captured history that many
+  /// lines back. Only [frameScroll] mutates it; a window switch resets it.
+  int _scrollOffset = 0;
+  int get scrollOffset => _scrollOffset;
+
+  /// Whether the grid is currently showing a scrolled-back HISTORY view (#906
+  /// Stage 2). While true, live `%output` is NOT rendered (it would clobber the
+  /// history window at the bottom, like copy-mode freezing the view); rendering
+  /// resumes — with a fresh live capture — when the user scrolls back to bottom.
+  bool get scrolledBack => _scrollOffset > 0;
+
+  /// Hard cap on how far back a swipe can scroll (#906 Stage 2). tmux clamps to
+  /// the real history itself (a too-old `-S` just returns the oldest lines), so
+  /// this only bounds the offset integer from running away on a long fling.
+  static const int _maxScrollOffset = 100000;
+
   /// The ordered windows the channel knows about (Part C, #911), in tmux
   /// index/status order. A snapshot — mutating it does not affect the channel.
   List<TmuxWindow> get windows => List<TmuxWindow>.unmodifiable(
@@ -271,6 +288,30 @@ class TmuxControlChannel {
     return controlCommand(line);
   }
 
+  /// Advance the scrollback view by [deltaLines] and frame the `capture-pane`
+  /// that renders it (#906 Stage 2). [deltaLines] > 0 scrolls BACK into history
+  /// (older; a downward swipe); < 0 scrolls toward live. [rows] is the current
+  /// viewport height so the captured window is exactly one screen tall.
+  ///
+  /// At offset 0 (scrolled back to the bottom) this captures the LIVE visible
+  /// screen (`capture-pane -p -e -J`) so the current state repaints and `%output`
+  /// rendering resumes; otherwise it captures the `rows`-tall history window
+  /// ending [scrollOffset] lines above the bottom (`-S -offset -E -offset+rows-1`,
+  /// tmux line numbers: 0 = top of the visible screen, negatives reach history).
+  /// Always registers a capture block so the correlated response renders.
+  Uint8List frameScroll(int deltaLines, int rows) {
+    final r = rows < 1 ? 1 : rows;
+    _scrollOffset = (_scrollOffset + deltaLines).clamp(0, _maxScrollOffset);
+    _pending.add(_PendingKind.capture);
+    if (_scrollOffset == 0) {
+      // Snapped to live — repaint the current visible screen; %output resumes.
+      return capturePaneCommand();
+    }
+    final start = -_scrollOffset;
+    final end = start + r - 1;
+    return capturePaneRangeCommand(start, end);
+  }
+
   /// The `next-window` control-command line (Part C, #911) — a horizontal swipe
   /// RIGHT advances to the next window. No window-list lookup needed; tmux steps
   /// the session's active window itself and pushes `%session-window-changed`.
@@ -371,9 +412,15 @@ class TmuxControlChannel {
             // capture its screen to repaint — the same request iTerm2 makes on a
             // window switch.
             captureRequested = true;
+            // #906 Stage 2: a switch lands at the new window's LIVE bottom.
+            _scrollOffset = 0;
           }
         case PaneOutput():
-          if (_shouldRender(ev.paneId)) render.add(ev.data);
+          // #906 Stage 2: while showing a scrolled-back history view, freeze the
+          // live view — dropping `%output` keeps the history window from being
+          // clobbered at the bottom (copy-mode semantics). Snapping to live
+          // re-captures + resumes.
+          if (!scrolledBack && _shouldRender(ev.paneId)) render.add(ev.data);
         case WindowClose():
           _paneWindow.removeWhere((_, w) => w == ev.windowId);
           // #911: drop the closed window from the order + names so a tap can't

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -1495,6 +1495,7 @@ class GhosttyPointerGestureRouter extends StatefulWidget {
     this.controlModeGestures = false,
     this.onWindowSwitch,
     this.onStatusTap,
+    this.onScroll,
   });
 
   /// #911 Part C: when true (the `tmuxControlMode` flag is ON), window switching
@@ -1517,6 +1518,14 @@ class GhosttyPointerGestureRouter extends StatefulWidget {
   /// Called (instead of the SGR click) only when [controlModeGestures] is true
   /// AND the tap landed on the status row.
   final void Function({required int col, required int totalCols})? onStatusTap;
+
+  /// #906 Stage 2: a vertical swipe → scroll the tmux scrollback via a real
+  /// `capture-pane` history request. Called (INSTEAD of the local [_applyScroll])
+  /// only when [controlModeGestures] is true. [deltaLines] is a signed line delta
+  /// — positive scrolls BACK into history (a downward swipe), negative toward
+  /// live. Control mode gets no `%output` for copy-mode scroll, so the local
+  /// scrollback is near-empty; the host captures the history window instead.
+  final void Function(int deltaLines)? onScroll;
 
   /// Whether to intercept touch (the remote has mouse tracking on).
   final bool active;
@@ -1657,6 +1666,31 @@ class _GhosttyPointerGestureRouterState
     _panDy = 0;
     _axis = GhosttySwipeAxis.none;
     _windowSwitchDx = 0;
+    _scrollAccumPx = 0;
+  }
+
+  /// Whether a vertical swipe drives the tmux `-CC` scrollback (#906 Stage 2)
+  /// instead of the local flterm scroll: only under the control-mode flag with a
+  /// wired [onScroll]. The scrape path (flag OFF) keeps [_applyScroll] unchanged.
+  bool get _useControlScroll =>
+      widget.controlModeGestures && widget.onScroll != null;
+
+  /// Accumulated vertical finger travel (px) not yet converted to whole lines
+  /// (#906 Stage 2). Reset on every pan start.
+  double _scrollAccumPx = 0;
+
+  /// Convert a vertical finger delta to whole tmux line scrolls and emit them via
+  /// [onScroll] (#906 Stage 2). A downward swipe (dy > 0) scrolls BACK into
+  /// history (older); upward scrolls toward live. Sub-cell travel accumulates so
+  /// a slow drag still scrolls once it crosses a full cell height.
+  void _controlScroll(double fingerDy) {
+    final ch = widget.cellHeight;
+    if (ch <= 0) return;
+    _scrollAccumPx += fingerDy;
+    final lines = (_scrollAccumPx / ch).truncate();
+    if (lines == 0) return;
+    _scrollAccumPx -= lines * ch;
+    widget.onScroll!(lines);
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
@@ -1678,6 +1712,8 @@ class _GhosttyPointerGestureRouterState
       // far so the first committed update isn't lost.
       if (_axis == GhosttySwipeAxis.horizontal) {
         _windowSwitchDx = _panDx;
+      } else if (_useControlScroll) {
+        _controlScroll(_panDy); // #906 Stage 2: drive the tmux scrollback
       } else {
         _applyScroll(_panDy);
       }
@@ -1686,6 +1722,8 @@ class _GhosttyPointerGestureRouterState
     // Committed: run ONLY the locked axis; the off-axis component is ignored.
     if (_axis == GhosttySwipeAxis.horizontal) {
       _windowSwitchDx += dx; // accumulate for the on-lift window-switch
+    } else if (_useControlScroll) {
+      _controlScroll(dy); // #906 Stage 2: drive the tmux scrollback
     } else {
       _applyScroll(dy); // drive the local scrollback
     }
@@ -3883,6 +3921,16 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
                 statusCols: totalCols,
               );
               // #918: a status-row tap (tmux window select) is user input.
+              _forceTerminalRepaint();
+            },
+            // #906 Stage 2: a vertical swipe scrolls the tmux scrollback via a
+            // real capture-pane history request (control mode emits no %output
+            // for copy-mode scroll, so the local scrollback can't show it).
+            onScroll: (deltaLines) {
+              final proxy = _resolveProxy();
+              if (proxy == null) return;
+              if (proxy.data.state != SshSessionState.connected) return;
+              proxy.sendTmuxScroll(deltaLines);
               _forceTerminalRepaint();
             },
             // #705: long-press-drag drives flterm's LOCAL selection (persists

--- a/native/test/terminal/tmux_control_channel_test.dart
+++ b/native/test/terminal/tmux_control_channel_test.dart
@@ -152,6 +152,66 @@ void main() {
     });
   });
 
+  group('scrollback via capture (#906 Stage 2)', () {
+    test('scroll BACK captures a history window one screen tall', () {
+      final ch = TmuxControlChannel();
+      // Swipe back 10 lines with a 24-row viewport: window is [-10, 13].
+      expect(text(ch.frameScroll(10, 24)), 'capture-pane -p -e -S -10 -E 13\n');
+      expect(ch.scrollOffset, 10);
+      expect(ch.scrolledBack, isTrue);
+    });
+
+    test('further scroll-back moves the window further up', () {
+      final ch = TmuxControlChannel();
+      ch.frameScroll(10, 24);
+      expect(text(ch.frameScroll(5, 24)), 'capture-pane -p -e -S -15 -E 8\n');
+      expect(ch.scrollOffset, 15);
+    });
+
+    test('scrolling to the bottom snaps to a LIVE capture (offset 0)', () {
+      final ch = TmuxControlChannel();
+      ch.frameScroll(10, 24);
+      // Scroll forward past the offset — clamps to 0 and re-captures live.
+      expect(text(ch.frameScroll(-40, 24)), 'capture-pane -p -e -J\n');
+      expect(ch.scrollOffset, 0);
+      expect(ch.scrolledBack, isFalse);
+    });
+
+    test('while scrolled back, live %output is FROZEN (not rendered)', () {
+      final ch = TmuxControlChannel();
+      ch.frameScroll(10, 24); // now scrolled back
+      final r = ch.ingest(bytes('%output %0 LIVE-TAIL\n'));
+      expect(text(r.renderBytes), isEmpty,
+          reason: 'history view must not be clobbered by live output');
+    });
+
+    test('after snapping to live, %output renders again', () {
+      final ch = TmuxControlChannel();
+      ch.frameScroll(10, 24);
+      ch.frameScroll(-10, 24); // back to live
+      final r = ch.ingest(bytes('%output %0 LIVE-AGAIN\n'));
+      expect(text(r.renderBytes), 'LIVE-AGAIN');
+    });
+
+    test('a window switch resets the scroll offset to live bottom', () {
+      final ch = TmuxControlChannel();
+      ch.frameScroll(20, 24);
+      expect(ch.scrolledBack, isTrue);
+      ch.ingest(bytes('%session-window-changed \$0 @1\n'));
+      expect(ch.scrollOffset, 0);
+      expect(ch.scrolledBack, isFalse);
+    });
+
+    test('the scroll capture response renders as the history view', () {
+      final ch = TmuxControlChannel();
+      ch.frameScroll(10, 24); // registers a capture block
+      final r = ch.ingest(bytes(
+        '%begin 1 9 1\nold line 1\nold line 2\n%end 1 9 1\n',
+      ));
+      expect(text(r.renderBytes), contains('old line 1\r\nold line 2'));
+    });
+  });
+
   group('%output → render demux', () {
     test('renders active window %output unescaped to the grid', () {
       final ch = TmuxControlChannel();

--- a/native/test/terminal/tmux_control_channel_test.dart
+++ b/native/test/terminal/tmux_control_channel_test.dart
@@ -62,6 +62,96 @@ void main() {
     });
   });
 
+  group('capture-pane command builders (#906 Stage 1/2)', () {
+    test('capturePaneCommand is capture-pane -p -e -J, one trailing newline', () {
+      expect(
+        text(TmuxControlChannel.capturePaneCommand()),
+        'capture-pane -p -e -J\n',
+      );
+    });
+
+    test('capturePaneRangeCommand carries -S start -E end (scroll window)', () {
+      expect(
+        text(TmuxControlChannel.capturePaneRangeCommand(-40, -10)),
+        'capture-pane -p -e -S -40 -E -10\n',
+      );
+    });
+
+    test('frameCapture returns the capture line AND registers a pending block', () {
+      final ch = TmuxControlChannel();
+      expect(ch.pendingCommandCount, 0);
+      expect(text(ch.frameCapture()), 'capture-pane -p -e -J\n');
+      expect(ch.pendingCommandCount, 1);
+    });
+
+    test('frameResize/frameControl register a (non-capture) pending block', () {
+      final ch = TmuxControlChannel();
+      expect(text(ch.frameResize(80, 24)), 'refresh-client -C 80,24\n');
+      expect(text(ch.frameControl('next-window')), 'next-window\n');
+      expect(ch.pendingCommandCount, 2);
+    });
+  });
+
+  group('capture-pane response correlation → render (#906 Stage 1)', () {
+    test('ATTACH (%session-changed) requests a capture', () {
+      final ch = TmuxControlChannel();
+      final r = ch.ingest(bytes('%session-changed \$0 main\n'));
+      expect(r.captureRequested, isTrue);
+    });
+
+    test('the capture response block renders (clear + captured rows)', () {
+      final ch = TmuxControlChannel();
+      // Host framed a capture (registers the pending block); tmux answers with a
+      // %begin…%end command-output block carrying the pane rows.
+      ch.frameCapture();
+      final r = ch.ingest(bytes(
+        '%begin 1 7 1\nline one\nline two\n%end 1 7 1\n',
+      ));
+      final out = text(r.renderBytes);
+      expect(out, contains('line one\r\nline two'));
+      // A screen clear precedes the rows so no stale content bleeds through.
+      expect(out, contains('\x1b[2J'));
+    });
+
+    test('tmux STARTUP block (no client command outstanding) does NOT render', () {
+      final ch = TmuxControlChannel();
+      // On entering control mode tmux emits an initial block with an EMPTY queue.
+      final r = ch.ingest(bytes(
+        '\x1bP1000p%begin 1 0 1\n%end 1 0 1\n',
+      ));
+      expect(text(r.renderBytes), isEmpty);
+    });
+
+    test('a NON-capture ack block is discarded (does not render)', () {
+      final ch = TmuxControlChannel();
+      ch.frameResize(80, 24); // pending: other
+      final r = ch.ingest(bytes('%begin 1 3 1\nok\n%end 1 3 1\n'));
+      expect(text(r.renderBytes), isEmpty);
+      expect(ch.pendingCommandCount, 0);
+    });
+
+    test('FIFO order: resize ack then capture render, correlated by order', () {
+      final ch = TmuxControlChannel();
+      // Host sends a resize, then a capture (the switch-repaint ordering).
+      ch.frameResize(80, 24);
+      ch.frameCapture();
+      // First block correlates to the resize (discarded)…
+      final r1 = ch.ingest(bytes('%begin 1 1 1\n%end 1 1 1\n'));
+      expect(text(r1.renderBytes), isEmpty);
+      // …the second to the capture (rendered).
+      final r2 = ch.ingest(bytes('%begin 1 2 1\nCAPTURED\n%end 1 2 1\n'));
+      expect(text(r2.renderBytes), contains('CAPTURED'));
+      expect(ch.pendingCommandCount, 0);
+    });
+
+    test('a %error capture block does not render (failed capture)', () {
+      final ch = TmuxControlChannel();
+      ch.frameCapture();
+      final r = ch.ingest(bytes('%begin 1 4 1\nboom\n%error 1 4 1\n'));
+      expect(text(r.renderBytes), isEmpty);
+    });
+  });
+
   group('%output → render demux', () {
     test('renders active window %output unescaped to the grid', () {
       final ch = TmuxControlChannel();

--- a/scripts/cc-capture-setup.sh
+++ b/scripts/cc-capture-setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/cc-capture-setup.sh — pre-create a PERSISTENT tmux `main` session on
+# test-sshd whose ACTIVE pane holds a STATIC, distinctive screen and produces NO
+# ongoing output, for the cc_capture_attach emulator test (#906 Stage 1).
+#
+# Stage 1 renders the attached pane by REQUESTING `capture-pane` (real -CC clients
+# do this; MobiSSH's old path showed only new %output, so an idle attach stayed
+# blank). To PROVE the capture render we need a session that exists BEFORE the app
+# connects, whose visible screen contains a known marker and is otherwise quiet —
+# so the marker can ONLY reach the grid via capture-pane, never via live %output.
+#
+# Run this immediately before scripts/native-connect-test.sh
+# integration_test/cc_capture_attach_test.dart
+set -euo pipefail
+
+MOBISSH_CC_DIR="${MOBISSH_CC_DIR:-/tmp/mobissh/cc-capture}"
+mkdir -p "$MOBISSH_CC_DIR"
+LOGFILE="${MOBISSH_CC_DIR}/setup.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+KEY="${MOBISSH_CC_DIR}/testuser_key"
+cp "${REPO_ROOT}/docker/test-sshd/testuser_id_ed25519" "$KEY"
+chmod 600 "$KEY"
+
+echo "> pre-creating persistent tmux 'main' with a STATIC marker screen ($(date +%Y%m%dT%H%M%S%z))"
+ssh -i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  testuser@test-sshd '
+tmux kill-server >/dev/null 2>&1 || true
+tmux new-session -d -s main -n WCAP -x 80 -y 24
+tmux send-keys -t main:WCAP "clear; echo CAPTURE_SCREEN_MARKER_XYZ" Enter
+sleep 1
+echo "sessions:"; tmux list-sessions
+echo "capture (what -CC attach must render):"
+tmux capture-pane -p -t main:WCAP
+'
+echo "+ persistent main session ready (WCAP holds CAPTURE_SCREEN_MARKER_XYZ, idle)"

--- a/scripts/cc-scroll-setup.sh
+++ b/scripts/cc-scroll-setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/cc-scroll-setup.sh — pre-create a PERSISTENT tmux `main` session on
+# test-sshd whose ACTIVE pane holds 200 NUMBERED lines (LINE_001..LINE_200), far
+# exceeding the viewport, for the cc_capture_scroll emulator test (#906 Stage 2).
+#
+# Stage 2 scrolls the `-CC` scrollback by REQUESTING `capture-pane -S -E` history
+# windows (control mode emits no `%output` for copy-mode scroll, so the local grid
+# can't show it). To PROVE it we need a pane whose history holds known early line
+# numbers that are NOT on the initial (tail) screen — so seeing e.g. LINE_005 can
+# ONLY be the scrollback capture, never the live tail.
+#
+# Run this immediately before scripts/native-connect-test.sh
+# integration_test/cc_capture_scroll_test.dart
+set -euo pipefail
+
+MOBISSH_CC_DIR="${MOBISSH_CC_DIR:-/tmp/mobissh/cc-scroll}"
+mkdir -p "$MOBISSH_CC_DIR"
+LOGFILE="${MOBISSH_CC_DIR}/setup.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+KEY="${MOBISSH_CC_DIR}/testuser_key"
+cp "${REPO_ROOT}/docker/test-sshd/testuser_id_ed25519" "$KEY"
+chmod 600 "$KEY"
+
+echo "> pre-creating persistent tmux 'main' with 200 numbered lines ($(date +%Y%m%dT%H%M%S%z))"
+ssh -i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  testuser@test-sshd '
+tmux kill-server >/dev/null 2>&1 || true
+tmux new-session -d -s main -n WSCROLL -x 80 -y 24
+tmux send-keys -t main:WSCROLL "clear; awk '"'"'BEGIN{for(i=1;i<=200;i++)printf \"LINE_%03d\\n\", i}'"'"'" Enter
+sleep 2
+echo "sessions:"; tmux list-sessions
+echo "history size:"; tmux display-message -p -t main:WSCROLL "#{history_size}"
+echo "tail (initial visible screen):"; tmux capture-pane -p -t main:WSCROLL
+'
+echo "+ persistent main session ready (WSCROLL: LINE_001..LINE_200, tail visible)"


### PR DESCRIPTION
## tmux `-CC` capture-pane render layer (#906)

Real `tmux -CC` clients (iTerm2) render the pane by REQUESTING `capture-pane` and drawing the response themselves. MobiSSH's `-CC` path rendered only live `%output`, so `tmux -CC attach` (which pushes no initial screen, only `%session-changed`) left the grid blank until the next byte, and copy-mode/scrollback scroll produced nothing. This PR adds the missing client-side capture render layer. Staged behind the control-mode flag (default OFF); the shipped scrape path is untouched.

### Stage 1 — render the current screen on ATTACH ✅ proven on device
- On `%session-changed` (attach) and a real `%session-window-changed` (switch), the channel requests `capture-pane -p -e -J`; the `%begin…%end` response is correlated to its request by a FIFO of outstanding command kinds (tmux emits one block per client command, in order — the order-based correlation iTerm2 uses, not a guess at tmux's opaque command number). A capture block renders (reset + clear + write the rows); other acks and the startup block are discarded.
- Every outgoing control command (resize, gesture, control, capture) now frames through the channel so the FIFO stays aligned with tmux's block order.
- **Emulator proof:** `cc_capture_attach_test` attaches a pre-created idle `main` (setup: `scripts/cc-capture-setup.sh`) whose pane holds `CAPTURE_SCREEN_MARKER_XYZ`; the marker renders on the grid with ZERO new `%output` (screenshot confirms). Fixes "blank/stale on attach".

### Stage 2 — SCROLL via captured history ⚠️ byte path proven, on-grid render BLOCKED
- Channel `frameScroll(deltaLines, rows)` advances a scroll offset and captures the matching history window (`capture-pane -S -E`); live `%output` is frozen while scrolled back; a switch resets to the live bottom. New `SshTmuxScrollCommand` IPC + `proxy.sendTmuxScroll`; host `_handleTmuxScroll`; a vertical swipe under control mode routes to `onScroll` (off the local `_applyScroll`).
- **Honest status:** the IPC + capture request/response BYTE path is proven end-to-end (`cc_capture_scroll_test`: a scroll-back gesture drives the capture and `LINE_050` — off the live tail — reaches `proxy.output`/`controller.write`). But the on-GRID render does NOT update: emulator screenshots show flterm still displaying the live tail (cursor parked at the live prompt) despite receiving the captured rows. **Blocker:** rendering a captured history WINDOW into flterm's grid — vs. its own growing scrollback buffer + follow-to-bottom — needs a different integration (flterm-internal). The scroll test's green is a byte-path signal, not device proof.

### Tests
- Pure unit tests: capture command builders + block-correlation FIFO (Stage 1); scroll offset math, live-freeze, switch-reset, history render (Stage 2). `task_ipc` round-trips the new command.
- Existing `cc_*` / parser / channel / host tests remain green; flag-OFF scrape path unchanged.

Parity status: **attach-render ✅**, **scroll ⚠️ (byte path only; flterm grid render open)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa