### PR TITLE
fix(native): enter tmux -CC via SSH exec — zero leak in nested tmux (#982)

### DIFF
--- a/native/integration_test/cc_nested_exec_test.dart
+++ b/native/integration_test/cc_nested_exec_test.dart
@@ -1,0 +1,153 @@
+// On-emulator RED→GREEN gate for #982: control mode (`-CC`) must WORK — attach
+// the pre-existing session with ZERO leak — in a NESTED tmux (the owner's real
+// env where login auto-attaches a persistent tmux).
+//
+// THE BUG (RED, on the typed-entry path): the app opens an INTERACTIVE shell and
+// TYPES `tmux -CC attach 2>/dev/null || tmux -CC new-session -A -s main` into its
+// stdin. The login already auto-attached tmux, so (a) that inner shell is INSIDE
+// tmux → `-CC attach` can never attach (nested), and (b) the typed entry LINE
+// ECHOES into the tmux pane as visible text. The owner sees `tmux -CC attach…`
+// leak into their persistent session on every connect.
+//
+// THE FIX (GREEN): enter `-CC` by running the tmux invocation AS the SSH
+// channel's EXEC command (with a PTY), not by typing into an interactive shell.
+// A non-interactive exec does NOT source `.bashrc`/`.bash_profile`, so the
+// login's tmux auto-attach is SKIPPED → the exec is NOT nested → `tmux -CC
+// attach` attaches the persistent session cleanly. Nothing is typed → no echo.
+//
+// This test connects with control mode ON to the NESTED fixture and asserts the
+// WORKING case (not just fallback):
+//   1. the pre-existing session's screen renders (its NESTED_SCREEN_MARKER shows)
+//      — proof `-CC attach` + capture-pane painted the existing session, and
+//   2. NO entry-command text (`tmux -CC attach`) leaked into the pane, and
+//   3. NO raw `-CC` protocol (`%output`, `%layout-change`, `refresh-client`)
+//      leaked as literal text — proof the stream was PARSED as `-CC`, not shown
+//      raw (a stuck/scraped -CC stream would dump the protocol verbatim).
+//
+// On the typed-entry path (unmodified) the marker never renders via -CC AND the
+// entry line leaks → RED. After the exec fix → GREEN.
+//
+// Setup (run FIRST): scripts/cc-nested-setup.sh
+// Run: scripts/native-connect-test.sh integration_test/cc_nested_exec_test.dart
+// Teardown (restore plain login): scripts/cc-nested-teardown.sh
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/tmux_control_mode_setting.dart';
+import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late bool prevFlag;
+  setUp(() => prevFlag = setTmuxControlModeForTest(true));
+  tearDown(() => setTmuxControlModeForTest(prevFlag));
+
+  testWidgets(
+    'control mode ON ATTACHES the pre-existing session via -CC exec — zero '
+    'leak in a NESTED tmux (#982)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await container.read(tmuxControlModeProvider.notifier).set(true);
+      for (var i = 0; i < 4; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(tmuxControlMode, isTrue,
+          reason: 'control-mode global must be ON before connect');
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      String rendered() => utf8.decode(out, allowMalformed: true);
+
+      // Give the `-CC` exec channel time to hand-shake (P1000p DCS) and paint the
+      // attached session via the attach capture-pane. This is the WORKING path —
+      // it must NOT need the 4s scrape-fallback timeout to become usable.
+      var sawMarker = false;
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (rendered().contains('NESTED_SCREEN_MARKER')) {
+          sawMarker = true;
+          break;
+        }
+      }
+
+      // Hold on-screen for the emu-shot capture point.
+      await tester.pump(const Duration(seconds: 2));
+
+      final text = rendered();
+
+      // 1. The pre-existing session rendered via `-CC` attach + capture.
+      expect(sawMarker, isTrue,
+          reason: 'the pre-existing NESTED session never rendered — `-CC attach` '
+              'did not attach + capture the existing session (it was nested, or '
+              'fell through to a fresh/blank session). Saw: $text');
+
+      // 2. The entry command must NOT echo into the pane (the owner's leak).
+      expect(text.contains('tmux -CC attach'), isFalse,
+          reason: 'the entry command `tmux -CC attach…` leaked into the pane as '
+              'literal text — it was typed into an interactive (nested) shell '
+              'instead of run as the exec command. Saw: $text');
+
+      // 3. Raw `-CC` protocol must NOT appear as literal text — proof the stream
+      //    was PARSED as control mode, not dumped raw (scrape of the -CC stream).
+      expect(text.contains('%output '), isFalse,
+          reason: 'raw `%output` protocol leaked — the -CC stream was not parsed. '
+              'Saw: $text');
+      expect(text.contains('%layout-change'), isFalse,
+          reason: 'raw `%layout-change` protocol leaked — the -CC stream was not '
+              'parsed. Saw: $text');
+      expect(text.contains('refresh-client -C'), isFalse,
+          reason: 'a refresh-client control command leaked into the pane as text. '
+              'Saw: $text');
+
+      debugPrint('CC_NESTED_EXEC: control mode ATTACHED the pre-existing session '
+          'via -CC exec in a nested tmux — rendered its content, ZERO leak');
+    },
+  );
+}

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -52,6 +52,22 @@ Future<SshShellTransport?> _defaultShellOpener(
   int rows,
 ) => openSshShellTransportSized(client, width: cols, height: rows);
 
+/// Opens a PTY-backed EXEC transport running [command] — the control-mode entry
+/// path (#982). Production uses [openSshExecTransportSized]; tests inject a fake
+/// that records the exec command. Running `tmux -CC …` as a non-interactive exec
+/// (vs typing it into an interactive shell) bypasses the login's tmux
+/// auto-attach AND cannot echo the entry line into the pane — the #982 fix.
+typedef HostExecOpener =
+    Future<SshShellTransport?> Function(
+        SSHClient client, String command, int cols, int rows);
+
+Future<SshShellTransport?> _defaultExecOpener(
+  SSHClient client,
+  String command,
+  int cols,
+  int rows,
+) => openSshExecTransportSized(client, command, width: cols, height: rows);
+
 SshSessionController _defaultControllerFactory() => SshSessionController();
 
 /// #982: how long to wait for the `-CC` handshake (the `\x1bP1000p` DCS) after
@@ -70,6 +86,7 @@ class SessionHost {
     SshControllerFactory? controllerFactory,
     SftpSessionOpener? sftpOpener,
     HostShellOpener? shellOpener,
+    HostExecOpener? execOpener,
     this.snapshotInterval = const Duration(seconds: 2),
     this.resumeProbeTimeout = const Duration(seconds: 2),
     this.resumeStaleThreshold = const Duration(seconds: 20),
@@ -82,6 +99,7 @@ class SessionHost {
        _factory = controllerFactory ?? _defaultControllerFactory,
        _sftpOpener = sftpOpener,
        _shellOpener = shellOpener ?? _defaultShellOpener,
+       _execOpener = execOpener ?? _defaultExecOpener,
        _attentionNotifier = attentionNotifier,
        _nowMs = nowMs ?? (() => DateTime.now().millisecondsSinceEpoch) {
     _commandSub = _gateway.incoming.listen(_dispatch);
@@ -114,8 +132,13 @@ class SessionHost {
   /// Tests inject a fake so the handlers run without a real socket.
   final SftpSessionOpener? _sftpOpener;
 
-  /// Opens the PTY shell once a session reaches `connected`.
+  /// Opens the PTY shell once a session reaches `connected` (scrape path).
   final HostShellOpener _shellOpener;
+
+  /// Opens a PTY-backed EXEC transport for the control-mode entry (#982). Only
+  /// used when [tmuxControlMode] is ON: the tmux `-CC` invocation runs as the
+  /// channel's exec command instead of being typed into an interactive shell.
+  final HostExecOpener _execOpener;
 
   /// How often a snapshot is pushed to the UI side. Tests use a short
   /// interval; production defaults to two seconds.
@@ -835,7 +858,16 @@ class SessionHost {
     try {
       final cols = hosted.metrics.lastCols ?? 80;
       final rows = hosted.metrics.lastRows ?? 24;
-      final transport = await _shellOpener(client, cols, rows);
+      // #982: control mode ON enters `-CC` by running the tmux invocation as the
+      // SSH channel's EXEC command (non-interactive, no rc sourcing) instead of
+      // opening an interactive shell and TYPING the entry line into it. This
+      // bypasses a login's tmux auto-attach (so `-CC attach` is not nested) AND
+      // cannot echo the entry line into the pane (the owner's leak). The scrape
+      // path (flag OFF) keeps the unchanged interactive `shell()` opener.
+      final transport = tmuxControlMode
+          ? await _execOpener(
+              client, TmuxControlChannel.entryExecCommand, cols, rows)
+          : await _shellOpener(client, cols, rows);
       if (transport == null) {
         _emitStatus(sessionId, '\r\n[mobissh] no shell channel available\r\n');
         return;
@@ -859,12 +891,13 @@ class SessionHost {
       hosted.da2Responder.reset();
       // Fresh attach => fresh attention-signal dedup state (#840).
       hosted.attentionScanner.reset();
-      // #909 control mode (flag ON): the freshly-opened login shell is plain;
-      // we ENTER tmux control mode by writing `tmux -CC …` into its stdin, then
-      // route ALL subsequent output through the per-session TmuxControlChannel.
-      // A fresh channel per (re)open mirrors the da2/attention reset above. When
-      // the flag is OFF, `tmuxChannel` stays null and the listener below takes
-      // the unchanged scrape path — so the shipped path is provably untouched.
+      // #909/#982 control mode (flag ON): the transport opened above is the
+      // `tmux -CC …` EXEC channel itself (not an interactive shell we type into),
+      // so control mode is already entered; we route ALL subsequent output
+      // through the per-session TmuxControlChannel. A fresh channel per (re)open
+      // mirrors the da2/attention reset above. When the flag is OFF, `tmuxChannel`
+      // stays null and the listener below takes the unchanged scrape path — so
+      // the shipped path is provably untouched.
       if (tmuxControlMode) {
         final tmux = TmuxControlChannel();
         hosted.tmuxChannel = tmux;
@@ -895,22 +928,19 @@ class SessionHost {
             }
           },
         );
-        try {
-          transport.send(TmuxControlChannel.entryCommand);
-          // #982: arm the fallback timer. If the `-CC` handshake (the P1000p DCS)
-          // is not confirmed before it fires, control mode FAILED (nested tmux,
-          // no tmux) — tear it down and fall back to scrape so the connection
-          // still WORKS instead of bricking on a swallowed/leaking channel.
-          hosted.tmuxHandshakeTimer?.cancel();
-          hosted.tmuxHandshakeTimer = Timer(kTmuxHandshakeTimeout, () {
-            if (!hosted.tmuxHandshakeConfirmed) {
-              _fallbackToScrape(sessionId, hosted);
-            }
-          });
-        } catch (_) {
-          // If the entry write fails the channel is dead; the controller's close
-          // path drives reconnect, which re-opens + re-enters control mode.
-        }
+        // #982: the entry command is the exec channel's command line — it is
+        // ALREADY running (opened above via `_execOpener`), so NOTHING is typed
+        // into the shell here. Arm the fallback timer: if the `-CC` handshake
+        // (the P1000p DCS) is not confirmed before it fires, control mode FAILED
+        // (exec still nested somehow, no tmux, or a login shell that ignores the
+        // exec command) — tear it down and fall back to scrape so the connection
+        // still WORKS instead of bricking on a swallowed/leaking channel.
+        hosted.tmuxHandshakeTimer?.cancel();
+        hosted.tmuxHandshakeTimer = Timer(kTmuxHandshakeTimeout, () {
+          if (!hosted.tmuxHandshakeConfirmed) {
+            _fallbackToScrape(sessionId, hosted);
+          }
+        });
       } else {
         hosted.tmuxChannel = null;
         hosted.refreshCoalescer = null;

--- a/native/lib/ssh/ssh_shell.dart
+++ b/native/lib/ssh/ssh_shell.dart
@@ -123,6 +123,33 @@ Future<SshShellTransport> openSshShellTransportSized(
   return _SshSessionTransport(session);
 }
 
+/// Open a PTY-backed EXEC channel running [command] and return an
+/// [SshShellTransport] wrapping the resulting `dartssh2.SSHSession` (#982).
+///
+/// This is the CONTROL-MODE entry path. Instead of opening an interactive
+/// `shell()` and TYPING `tmux -CC …` into its stdin, we run the tmux invocation
+/// AS the SSH channel's exec command (with a PTY, so tmux's control client has a
+/// terminal). Two things this fixes that the interactive-shell path could not:
+///   1. A non-interactive exec does NOT source `.bashrc`/`.bash_profile`, so a
+///      login that auto-attaches tmux (the owner's real env) is SKIPPED — the
+///      exec is NOT inside tmux, so `tmux -CC attach` attaches the persistent
+///      session cleanly instead of failing "sessions should be nested".
+///   2. Nothing is typed into an interactive shell → the entry line can NEVER
+///      echo into the attached pane as literal text (the #982 leak).
+/// The scrape path (control mode OFF) keeps using [openSshShellTransportSized].
+Future<SshShellTransport> openSshExecTransportSized(
+  ssh.SSHClient client,
+  String command, {
+  int width = 80,
+  int height = 24,
+}) async {
+  final session = await client.execute(
+    command,
+    pty: ssh.SSHPtyConfig(width: width, height: height),
+  );
+  return _SshSessionTransport(session);
+}
+
 /// Owns the bidirectional byte pipe between a [Terminal] model and an SSH
 /// PTY channel.
 ///

--- a/native/lib/terminal/tmux_control_channel.dart
+++ b/native/lib/terminal/tmux_control_channel.dart
@@ -228,9 +228,25 @@ class TmuxControlChannel {
   /// replaces the old `new-session -A -s mobissh`, which forced a SEPARATE empty
   /// session → the device "zero gestures" (nothing to switch, not your windows).
   /// A trailing newline submits the line to the login shell. (#906)
-  static Uint8List get entryCommand => Uint8List.fromList(
-    utf8.encode('tmux -CC attach 2>/dev/null || tmux -CC new-session -A -s main\n'),
-  );
+  ///
+  /// #982: this is the INTERACTIVE-shell form (typed into a shell's stdin). The
+  /// shipped control-mode path no longer types it — it runs [entryExecCommand]
+  /// as the SSH channel's exec command instead (no echo, bypasses the login's
+  /// tmux auto-attach). Kept as the canonical string source (and for the unit
+  /// test of the invocation), with the exec form derived from it below.
+  static Uint8List get entryCommand =>
+      Uint8List.fromList(utf8.encode('$entryExecCommand\n'));
+
+  /// The tmux `-CC` invocation run as the SSH channel's EXEC command (#982) —
+  /// the shipped control-mode entry path. ATTACH the owner's EXISTING
+  /// (most-recent) session; fall back to creating/attaching `main` ONLY when no
+  /// server/session exists yet. `2>/dev/null` drops the "no server" stderr so it
+  /// never reaches the `-CC` stdout parser. NO trailing newline — it is the exec
+  /// command line, not a shell keystroke. Run via a non-interactive exec, it
+  /// does NOT source login rc files, so a login that auto-attaches tmux is
+  /// bypassed → `-CC attach` is not nested and enters control mode cleanly.
+  static const String entryExecCommand =
+      'tmux -CC attach 2>/dev/null || tmux -CC new-session -A -s main';
 
   /// Build the `refresh-client -C cols,rows` command line — the SINGLE resize
   /// primitive in control mode (issue #909). The host writes these bytes to the

--- a/native/test/services/session_host_control_mode_test.dart
+++ b/native/test/services/session_host_control_mode_test.dart
@@ -25,6 +25,7 @@ import 'package:mobissh/ssh/ssh_session.dart';
 import 'package:mobissh/ssh/ssh_session_proxy.dart';
 import 'package:mobissh/ssh/ssh_shell.dart';
 import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/terminal/tmux_control_channel.dart';
 import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
 
 class _SilentSocket implements SSHSocket {
@@ -93,6 +94,7 @@ void main() {
         SshSessionProxy proxy,
         InMemoryGatewayPair pair,
         List<_DriveableShellTransport> opened,
+        List<String> execCommands,
         StringBuffer forwarded,
       })> setUpConnectedShell(String sid, {bool confirmHandshake = true}) async {
     final socket = _SilentSocket();
@@ -111,7 +113,21 @@ void main() {
     }
 
     final opened = <_DriveableShellTransport>[];
+    // #982: control mode ON now opens the transport via the EXEC opener (the
+    // `tmux -CC …` invocation runs AS the channel command, not typed into a
+    // shell). The scrape path (flag OFF) still uses the shell opener. Both
+    // register into `opened` so the existing assertions on the transport hold;
+    // `execCommands` records what the exec opener was asked to run.
+    final execCommands = <String>[];
     Future<SshShellTransport?> opener(SSHClient c, int cols, int rows) async {
+      final t = _DriveableShellTransport();
+      opened.add(t);
+      return t;
+    }
+
+    Future<SshShellTransport?> execOpener(
+        SSHClient c, String command, int cols, int rows) async {
+      execCommands.add(command);
       final t = _DriveableShellTransport();
       opened.add(t);
       return t;
@@ -122,6 +138,7 @@ void main() {
       gateway: pair.taskSide,
       controllerFactory: factory,
       shellOpener: opener,
+      execOpener: execOpener,
       snapshotInterval: const Duration(hours: 1),
     );
     final proxy = SshSessionProxy(sessionId: sid, gateway: pair.uiSide);
@@ -165,6 +182,7 @@ void main() {
       proxy: proxy,
       pair: pair,
       opened: opened,
+      execCommands: execCommands,
       forwarded: forwarded,
     );
   }
@@ -174,10 +192,30 @@ void main() {
     setUp(() => prev = setTmuxControlModeForTest(true));
     tearDown(() => setTmuxControlModeForTest(prev));
 
-    test('enters control mode by writing tmux -CC to the shell stdin', () async {
-      final ctx = await setUpConnectedShell('cc:22:u:1');
+    test('enters control mode by RUNNING tmux -CC as the exec command — nothing '
+        'is typed into the shell (#982)', () async {
+      // Hold the handshake so no post-confirm resize flush muddies `sent` — we
+      // assert the ENTRY writes nothing into stdin.
+      final ctx =
+          await setUpConnectedShell('cc:22:u:1', confirmHandshake: false);
       expect(ctx.opened, hasLength(1));
-      expect(_s(ctx.opened.first.sent.toBytes()), startsWith('tmux -CC'));
+      // The `-CC` invocation is the EXEC channel's command, not a stdin write.
+      expect(ctx.execCommands, hasLength(1));
+      expect(ctx.execCommands.first, startsWith('tmux -CC'));
+      // #982: the entry line must NEVER be typed into the shell (the leak) — the
+      // exec channel carries it, so no bytes are written to stdin at entry.
+      expect(ctx.opened.first.sent.length, 0,
+          reason: 'the entry command must not be typed into the shell stdin — '
+              'that is exactly the #982 echo leak');
+    });
+
+    test('the exec command is entryExecCommand exactly (no trailing newline)',
+        () async {
+      final ctx = await setUpConnectedShell('cc:22:u:exec');
+      // The exec command line carries NO trailing newline (it is the channel
+      // command, not a keystroke) and matches the canonical entry invocation.
+      expect(ctx.execCommands.single, TmuxControlChannel.entryExecCommand);
+      expect(ctx.execCommands.single.endsWith('\n'), isFalse);
     });
 
     test('%output renders demuxed bytes to the UI (the grid)', () async {
@@ -361,12 +399,14 @@ void main() {
     // ---- #982: handshake gate — NO -CC write leaks before the DCS ----
 
     test('BEFORE the handshake, a resize does NOT leak refresh-client into the '
-        'shell (only the entry command was written)', () async {
+        'shell (nothing was written — entry runs as the exec command)', () async {
       final ctx = await setUpConnectedShell('cc:22:u:gate1',
           confirmHandshake: false);
       final shell = ctx.opened.first;
-      // The entry command is the ONLY allowed pre-handshake write.
-      expect(_s(shell.sent.toBytes()), startsWith('tmux -CC'));
+      // #982: the entry command runs as the EXEC channel command, so NOTHING is
+      // written to stdin at entry — not even the entry line.
+      expect(shell.sent.length, 0);
+      expect(ctx.execCommands.single, startsWith('tmux -CC'));
       shell.sent.clear();
       ctx.proxy.sendResize(100, 30);
       // Past the resize-coalescer settle: with the gate closed it must be BUFFERED,
@@ -470,6 +510,9 @@ void main() {
       final shell = ctx.opened.first;
       // No tmux -CC entry written.
       expect(shell.sent.length, 0);
+      // #982: the scrape path opens the interactive SHELL, never the exec opener.
+      expect(ctx.execCommands, isEmpty,
+          reason: 'flag OFF must use the shell opener, not the -CC exec opener');
       shell.emit(_b('\x1b[32mhello\x1b[0m\r\n'));
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(ctx.forwarded.toString(), contains('\x1b[32mhello\x1b[0m\r\n'));


### PR DESCRIPTION
## What

Make tmux control mode (`-CC`) actually WORK — attach the pre-existing session with **zero leak** — in a nested-tmux environment (the owner's hosts auto-attach tmux on login). Fixes the remaining `#982` leak reported on +118: "entering text it shouldn't on the control channel."

## Root cause

Control mode opened an **interactive shell** and **typed** the entry command into its stdin:

```
tmux -CC attach 2>/dev/null || tmux -CC new-session -A -s main
```

The owner's login auto-attaches a persistent tmux, so that shell lands **inside** tmux:
- `-CC attach` can't attach (nested) → the handshake never completes, and
- the typed entry **line echoes into the pane** as literal text on every connect (the leak).

## Fix

Enter `-CC` by running the tmux invocation **as the SSH channel's exec command** (with a PTY) instead of typing into an interactive shell:

```dart
client.execute(entryExecCommand, pty: SSHPtyConfig(...))
```

A non-interactive exec does **not** source `.bashrc`/`.bash_profile`, so the login's tmux auto-attach is skipped → the exec is **not** nested → `-CC attach` attaches the persistent session cleanly. Nothing is typed → **no echo**.

- Scrape path (control mode OFF) keeps the unchanged interactive `shell()` opener.
- The `#983` handshake gate + scrape fallback stay intact as the safety net.

## Changes

- `ssh_shell.dart` — `openSshExecTransportSized`: PTY-backed exec transport.
- `tmux_control_channel.dart` — `entryExecCommand` (no trailing newline); `entryCommand` derives from it.
- `session_host.dart` — `HostExecOpener` seam; the control-mode branch opens via exec and no longer writes the entry line into stdin (it only arms the fallback timer).
- `session_host_control_mode_test.dart` — assert the entry runs as the exec command with **no** stdin write; scrape path uses the shell opener.
- `integration_test/cc_nested_exec_test.dart` — on the nested fixture, control mode ON **attaches** the pre-existing session via `-CC` (renders its marker) with no entry-command / raw-protocol / `refresh-client` leak.

## Reproduced RED → GREEN (emulator, nested fixture)

`scripts/cc-nested-setup.sh` reproduces the owner's env (login auto-attaches tmux).

- **RED** (unmodified typed-entry path): test FAILS — the pane shows `hostname:~$ tmux -CC attach 2>/dev/null || tmux -CC new-session -A -s main` echoed as literal text, and `-CC` never attaches (marker absent).
- **GREEN** (exec fix): test PASSES — `control mode ATTACHED the pre-existing session via -CC exec in a nested tmux — rendered its content, ZERO leak`.

## Verification

- Emulator: `cc_nested_exec` RED→GREEN; `cc_gestures` GREEN (deterministic window switching, non-nested exec path); `cc_capture_attach` GREEN (capture-pane renders idle attached pane).
- `scripts/native-fast-gate.sh` green (analyzer + full unit suite).

Refs #982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa