### PR TITLE
feat(native): control-mode telemetry in bug report + deterministic window list on attach (#906)

### DIFF
--- a/native/integration_test/cc_exec_switch_test.dart
+++ b/native/integration_test/cc_exec_switch_test.dart
@@ -1,0 +1,173 @@
+// On-emulator gate for #906: control mode (`-CC`) window-list determinism +
+// telemetry on a PRE-EXISTING (pre-populated) tmux session attached via exec.
+//
+// PROTOCOL GAP (verified against real tmux -CC, scripts probe): on `tmux -CC
+// attach` to a session whose windows existed BEFORE the client attached, tmux
+// emits NO `%window-add`/`%layout-change` for those windows — only
+// `%session-changed` + `%output`. So the channel window order is EMPTY right
+// after attach. The app currently only recovers because its startup grid
+// RESIZE triggers a `refresh-client -C`, which makes tmux re-lay-out and emit
+// `%layout-change` for every window — a FRAGILE, incidental population (it never
+// happens if the device grid already matches the session size). The fix QUERIES
+// `list-windows` on attach and parses it into the ordered list, so the status-
+// tap mapping is populated DETERMINISTICALLY, independent of any resize.
+//
+// RED→GREEN discriminator (deterministic): the control-mode trace ring (#906,
+// forwarded task→UI) must, after attach, contain `list-windows parsed` + a
+// `windowList @0(alpha) @1(bravo) @2(charlie)` snapshot. On main there is NO
+// control-mode telemetry AT ALL (the coordinator's exact complaint — "the bug
+// report has NO task-side control-mode state") and `list-windows` is never
+// queried → the ring is EMPTY → RED. With the change → GREEN. The behavioral
+// switch (tap LAST segment → charlie repaints) is asserted as a GREEN
+// confirmation; note it can ALSO pass on main via the incidental resize path,
+// so the trace — not the switch — is the load-bearing discriminator.
+//
+// Setup (run FIRST): scripts/cc-exec-switch-setup.sh
+// Run: scripts/native-connect-test.sh integration_test/cc_exec_switch_test.dart
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/diagnostics/connect_trace.dart' show controlModeLogSnapshot;
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/session_messages.dart' show TmuxWindowGesture;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/tmux_control_mode_setting.dart';
+import 'package:mobissh/terminal/tmux_control_mode_flag.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late bool prevFlag;
+  setUp(() => prevFlag = setTmuxControlModeForTest(true));
+  tearDown(() => setTmuxControlModeForTest(prevFlag));
+
+  testWidgets(
+    'control mode ON: a status-bar tap switches windows on a PRE-EXISTING '
+    'session (list-windows on attach) (#906)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Turn control mode ON through the provider — the widget's provider init
+      // resets the per-isolate global to its stored default (false), so the
+      // setUp flag alone is overwritten during pump (the cc_nested pattern).
+      await container.read(tmuxControlModeProvider.notifier).set(true);
+      for (var i = 0; i < 4; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(tmuxControlMode, isTrue,
+          reason: 'control-mode global must be ON before connect');
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      String rendered() => utf8.decode(out, allowMalformed: true);
+
+      Future<bool> waitFor(String marker, {int ticks = 40}) async {
+        for (var i = 0; i < ticks; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+          if (rendered().contains(marker)) return true;
+        }
+        return false;
+      }
+
+      // The pre-existing session's ACTIVE window (alpha) is painted by the
+      // attach capture-pane — proof `-CC attach` attached the pre-populated
+      // session. (charlie's marker is NOT here: capture-pane paints only the
+      // ACTIVE window, so charlie can only appear AFTER a real switch.)
+      expect(await waitFor('WIN_ALPHA_MARKER'), isTrue,
+          reason: 'the pre-existing ACTIVE window never rendered — attach '
+              'capture failed. Saw: ${rendered()}');
+
+      // DETERMINISTIC RED→GREEN: the control-mode trace ring (forwarded task→UI)
+      // must show `list-windows` was queried on attach and built the ordered
+      // window list. On main there is NO control-mode telemetry at all AND
+      // list-windows is never queried, so this ring is EMPTY → RED. With the
+      // change the ring carries the whole decision path → GREEN. This is the
+      // load-bearing discriminator (the behavioral switch below can also pass on
+      // main via the incidental startup-resize %layout-change path).
+      var traceOk = false;
+      for (var i = 0; i < 20 && !traceOk; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final trace = controlModeLogSnapshot().join('\n');
+        traceOk = trace.contains('list-windows parsed') &&
+            trace.contains('windowList @0(alpha) @1(bravo) @2(charlie)');
+      }
+      expect(traceOk, isTrue,
+          reason: 'the control-mode trace never showed list-windows building the '
+              'window order on attach — either the fix is absent (order left to '
+              'the fragile resize path) or the task→UI trace forwarding is '
+              'broken. Trace: ${controlModeLogSnapshot().join('\n')}');
+
+      // BEHAVIORAL confirmation: tap the LAST status segment → window 2
+      // (charlie), which must repaint charlie's marker. Retry across a generous
+      // window so a single dropped envelope can't flake it.
+      var switched = false;
+      for (var attempt = 0; attempt < 6 && !switched; attempt++) {
+        out.clear();
+        entry.proxy.sendTmuxGesture(
+          TmuxWindowGesture.tapStatusCol,
+          statusCol: 85,
+          statusCols: 90,
+        );
+        switched = await waitFor('WIN_CHARLIE_MARKER', ticks: 16);
+      }
+
+      await tester.pump(const Duration(seconds: 2)); // hold for emu-shot
+
+      expect(switched, isTrue,
+          reason: 'the status-bar tap did not switch to the tapped window — '
+              'charlie never repainted. Saw: ${rendered()}');
+
+      // The gesture RESOLUTION must be in the trace too (one report diagnoses it).
+      expect(controlModeLogSnapshot().join('\n'),
+          contains('resolved=select-window'),
+          reason: 'the gesture resolution was not recorded in the control-mode '
+              'trace. Trace: ${controlModeLogSnapshot().join('\n')}');
+
+      debugPrint('CC_EXEC_SWITCH: list-windows built the order on attach '
+          '(deterministic, in the trace); status-bar tap switched to charlie');
+    },
+  );
+}

--- a/native/lib/diagnostics/connect_trace.dart
+++ b/native/lib/diagnostics/connect_trace.dart
@@ -43,8 +43,17 @@ const int connectLogCapacity = 600;
 /// bundle ships both rings.
 const int lifecycleLogCapacity = 80;
 
+/// Maximum number of lines retained by the dedicated [controlModeLog] ring
+/// (#906). tmux control-mode (`-CC`) telemetry — attach path, window-list
+/// snapshots, parsed `%…` notifications, gesture resolutions — is written in the
+/// foreground-task isolate. A DEDICATED ring (not the churny connect ring) keeps
+/// a full control-mode session's decisions intact so ONE bug report diagnoses a
+/// "not switching" issue. Bounded; empty when control mode is OFF (no cmtrace).
+const int controlModeLogCapacity = 200;
+
 final List<String> _ring = <String>[];
 final List<String> _lifecycleRing = <String>[];
+final List<String> _controlModeRing = <String>[];
 
 /// Optional sink invoked with every formatted lifecycle line as it is recorded
 /// by [clifecycle] (#766). The lifecycle ring is written ONLY in the
@@ -60,6 +69,15 @@ final List<String> _lifecycleRing = <String>[];
 /// isolate's host arms it; clearing it (set to null) on host dispose detaches
 /// the forwarder.
 void Function(String line)? lifecycleForwarder;
+
+/// Optional sink invoked with every formatted control-mode line as it is
+/// recorded by [cmtrace] (#906). Mirrors [lifecycleForwarder]: the control-mode
+/// ring is written ONLY in the foreground-task isolate, but the feedback bundle
+/// is assembled in the UI isolate. The task isolate's host sets this forwarder
+/// so each line is shipped across the UI↔task gateway, where the gateway calls
+/// [recordControlModeLine] to land it in the UI-side ring the bundle reads.
+/// Null by default (no IPC coupling); the host arms it and clears it on dispose.
+void Function(String line)? controlModeForwarder;
 
 // Consecutive-duplicate suppression: when the same `[where] msg` repeats
 // back-to-back (e.g. keepalive `recv`/`send` pings), collapse it into the last
@@ -95,6 +113,19 @@ ValueListenable<List<String>> get lifecycleLog => _lifecycleLog;
 /// resume-liveness probe outcome survives the connect-ring churn.
 List<String> lifecycleLogSnapshot() =>
     List<String>.unmodifiable(_lifecycleRing);
+
+final ValueNotifier<List<String>> _controlModeLog =
+    ValueNotifier<List<String>>(const <String>[]);
+
+/// Live, read-only view of the dedicated control-mode (`-CC`) telemetry ring
+/// (#906). The newest line is last.
+ValueListenable<List<String>> get controlModeLog => _controlModeLog;
+
+/// Read-only snapshot of the control-mode ring, newest line last (#906).
+/// Bundled into the feedback upload so a control-mode ("not switching") issue is
+/// fully diagnosable from the report alone. Empty when control mode is OFF.
+List<String> controlModeLogSnapshot() =>
+    List<String>.unmodifiable(_controlModeRing);
 
 String _timestamp(DateTime now) {
   String two(int n) => n.toString().padLeft(2, '0');
@@ -194,13 +225,59 @@ void recordLifecycleLine(String line) {
   _connectLog.value = List<String>.unmodifiable(_ring);
 }
 
-/// Clears the on-device connect-log + lifecycle-event ring buffers. Does not
-/// affect logcat.
+/// Record one structured tmux control-mode (`-CC`) telemetry line (#906): the
+/// attach entry-path, a window-list snapshot, a parsed `%…` notification, or a
+/// gesture resolution. Appends to the dedicated [controlModeLog] ring AND logcat
+/// (tagged `[CONTROLMODE]`), then ships the formatted line across the isolate
+/// boundary via [controlModeForwarder] so the UI-side ring the feedback bundle
+/// reads carries it. Written ONLY when control mode is active (flag-off-safe:
+/// nothing calls this on the scrape path, so the ring stays empty). Never
+/// collapsed — every control-mode decision is its own line. Never throws.
+void cmtrace(String msg) {
+  final ts = _timestamp(DateTime.now());
+  final line = '$ts [cc] $msg';
+
+  _controlModeRing.add(line);
+  while (_controlModeRing.length > controlModeLogCapacity) {
+    _controlModeRing.removeAt(0);
+  }
+  _controlModeLog.value = List<String>.unmodifiable(_controlModeRing);
+  debugPrint('[CONTROLMODE]$line');
+
+  final forward = controlModeForwarder;
+  if (forward != null) {
+    try {
+      forward(line);
+    } catch (_) {
+      // Swallow — diagnostics must not throw into the control-mode hot path.
+    }
+  }
+}
+
+/// Records an already-formatted control-mode [line] into the [controlModeLog]
+/// ring (#906). Counterpart to [cmtrace] for lines that ORIGINATED in the
+/// foreground-task isolate: the task forwards each line across the gateway and
+/// the UI-side gateway calls this so it lands in the UI isolate's ring — the one
+/// the feedback bundle reads. Stored verbatim (task-side timestamp preserved);
+/// the forwarder is NOT re-invoked (no echo back).
+void recordControlModeLine(String line) {
+  _controlModeRing.add(line);
+  while (_controlModeRing.length > controlModeLogCapacity) {
+    _controlModeRing.removeAt(0);
+  }
+  _controlModeLog.value = List<String>.unmodifiable(_controlModeRing);
+  debugPrint('[CONTROLMODE]$line');
+}
+
+/// Clears the on-device connect-log + lifecycle-event + control-mode ring
+/// buffers. Does not affect logcat.
 void clearConnectLog() {
   _ring.clear();
   _lifecycleRing.clear();
+  _controlModeRing.clear();
   _lastKey = null;
   _lastCount = 0;
   _connectLog.value = const <String>[];
   _lifecycleLog.value = const <String>[];
+  _controlModeLog.value = const <String>[];
 }

--- a/native/lib/diagnostics/feedback_bundle.dart
+++ b/native/lib/diagnostics/feedback_bundle.dart
@@ -73,6 +73,7 @@ String assembleFeedbackBundle({
   required List<String> connectLog,
   List<String> gestureLog = const <String>[],
   List<String> lifecycleLog = const <String>[],
+  List<String> controlModeTrace = const <String>[],
   String? crashJson,
 }) {
   final scrubbedLog = connectLog.map(scrubSecrets).toList(growable: false);
@@ -85,6 +86,14 @@ String assembleFeedbackBundle({
   // reconnect decisions). Survives the 200-event connect-ring churn so the next
   // wake-frozen occurrence is diagnosable from the bundle alone.
   final scrubbedLifecycleLog = lifecycleLog
+      .map(scrubSecrets)
+      .toList(growable: false);
+  // #906: dedicated control-mode (`-CC`) trace ring — attach path, window-list
+  // snapshots, parsed notifications, gesture resolutions — so ONE report fully
+  // diagnoses a "not switching" control-mode issue. Scrubbed like the others;
+  // it carries only ids/indices/commands, never terminal content. Empty when
+  // control mode is OFF.
+  final scrubbedControlModeTrace = controlModeTrace
       .map(scrubSecrets)
       .toList(growable: false);
 
@@ -112,6 +121,7 @@ String assembleFeedbackBundle({
     'connectLog': scrubbedLog,
     'gestureLog': scrubbedGestureLog,
     'lifecycleLog': scrubbedLifecycleLog,
+    'controlModeTrace': scrubbedControlModeTrace,
     'lastCrash': lastCrash,
     // Null-aware element: the entry is omitted entirely when there is no raw
     // (non-JSON) crash blob to preserve.

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -115,6 +115,14 @@ class SessionHost {
       _gateway.send(SshLifecycleEvent(line: line).toJson());
     };
     lifecycleForwarder = _lifecycleForward;
+    // #906: arm the control-mode-trace forwarder the same way, so every
+    // `cmtrace` line (attach path, window-list, notifications, gesture
+    // resolution) reaches the UI-side control-mode ring the bundle reads.
+    _controlModeForward = (line) {
+      if (_disposed) return;
+      _gateway.send(SshControlModeTraceEvent(line: line).toJson());
+    };
+    controlModeForwarder = _controlModeForward;
     ctrace('task.host', 'ctor: listening; sending SshTaskReadyEvent');
     // Announce readiness as the FIRST task → UI payload (#539). The host is the
     // component that actually consumes commands, so its existence is the true
@@ -248,6 +256,10 @@ class SessionHost {
   /// it won't clobber a forwarder a different host installed afterward (matters
   /// for the desktop / in-process path where hosts share one isolate).
   void Function(String line)? _lifecycleForward;
+
+  /// The exact control-mode-forwarder closure this host installed into the global
+  /// [controlModeForwarder] (#906). Held so dispose detaches OUR closure only.
+  void Function(String line)? _controlModeForward;
 
   /// Minimum spacing between liveness-heartbeat lines per session (#838).
   /// The heartbeat piggybacks the 2s snapshot tick but only emits this often so
@@ -401,7 +413,19 @@ class SessionHost {
     if (hosted == null) return;
     final tmux = hosted.tmuxChannel;
     if (tmux == null) return; // flag OFF — ignore.
-    if (!hosted.tmuxHandshakeConfirmed) return; // #982: no -CC write pre-handshake.
+    // #906 telemetry: describe the RAW gesture so the resolution is traceable.
+    final raw = switch (cmd.gesture) {
+      TmuxWindowGesture.nextWindow => 'next-window',
+      TmuxWindowGesture.previousWindow => 'previous-window',
+      TmuxWindowGesture.tapStatusCol =>
+        'tapStatusCol col=${cmd.statusCol} cols=${cmd.statusCols}',
+    };
+    if (!hosted.tmuxHandshakeConfirmed) {
+      // #982: no -CC write pre-handshake. Trace the drop so a report shows a tap
+      // that arrived before the channel was live (vs a resolution failure).
+      cmtrace('gesture raw=$raw → dropped(reason=handshake-not-confirmed)');
+      return;
+    }
     final String? line;
     switch (cmd.gesture) {
       case TmuxWindowGesture.nextWindow:
@@ -414,7 +438,15 @@ class SessionHost {
           cmd.statusCols,
         );
     }
-    if (line == null) return; // no window known yet — nothing to target.
+    if (line == null) {
+      // No window known yet — nothing to target. This is EXACTLY the owner's
+      // "not switching" symptom, so trace it WITH the current window list so one
+      // report shows whether the list was empty (the pre-existing-attach bug).
+      cmtrace('gesture raw=$raw → dropped(reason=no-window-known) '
+          'windows=${tmux.windowListTrace()}');
+      return;
+    }
+    cmtrace('gesture raw=$raw → resolved=$line → sent');
     try {
       hosted.shell?.send(tmux.frameControl(line));
     } catch (_) {
@@ -800,6 +832,7 @@ class SessionHost {
     hosted.pendingCcCols = null;
     hosted.pendingCcRows = null;
     hosted.pendingCcCapture = false;
+    hosted.pendingCcWindowList = false;
     final shell = hosted.shell;
     hosted.shell = null;
     if (shell != null) {
@@ -823,6 +856,9 @@ class SessionHost {
     if (hosted.tmuxHandshakeConfirmed || hosted.tmuxChannel == null) return;
     ctrace('task.host',
         'control-mode handshake timed out sid=$sessionId → scrape fallback');
+    // #906 telemetry: record the fallback so a report distinguishes "control
+    // mode fell back to scrape" from "control mode live but not switching".
+    cmtrace('attach sid=$sessionId fellBackToScrape=true reason=handshake-timeout');
     hosted.tmuxHandshakeTimer?.cancel();
     hosted.tmuxHandshakeTimer = null;
     // Drop the -CC adapter + coalescer; the output listener's `tmuxChannel == null`
@@ -833,6 +869,7 @@ class SessionHost {
     hosted.pendingCcCols = null;
     hosted.pendingCcRows = null;
     hosted.pendingCcCapture = false;
+    hosted.pendingCcWindowList = false;
     // Force the remote to repaint what -CC swallowed: a winsize resize makes a
     // shell/tmux redraw. dartssh2 rejects non-positive dims, so clamp.
     final cols = hosted.metrics.lastCols ?? 80;
@@ -901,6 +938,9 @@ class SessionHost {
       if (tmuxControlMode) {
         final tmux = TmuxControlChannel();
         hosted.tmuxChannel = tmux;
+        // #906 telemetry: record the attach entry-path so a report shows control
+        // mode entered via exec (the #982 path) and is awaiting the handshake.
+        cmtrace('attach sid=$sessionId entry=exec handshakeConfirmed=false');
         // #916: the per-session refresh-client coalescer. Its settled emit is the
         // ONLY place a `refresh-client -C` is written to the shell — both the
         // resize handler and the switch-redraw enqueue here, so a burst collapses
@@ -970,10 +1010,18 @@ class SessionHost {
           final tmux = hosted.tmuxChannel;
           if (tmux != null) {
             final result = tmux.ingest(bytes);
+            // #906 telemetry: emit the channel's structured notification /
+            // window-list trace lines so a bug report fully diagnoses control
+            // mode (each `%…` notification + window-list snapshots).
+            for (final t in result.traceLines) {
+              cmtrace(t);
+            }
             // #982: track whether the attach capture was fired inside the confirm
             // branch this chunk, so the captureRequested block below does not
             // double-send it (a harmless second repaint, but avoid the churn).
             var capturedOnConfirm = false;
+            // #906 switch fix: same, for the attach `list-windows` request.
+            var windowListOnConfirm = false;
             // #909/#916: control mode ENDED (tmux detached / server died). Surface
             // it as ONE clean shell close so the controller drives a SINGLE
             // reconnect through its normal close path — instead of silently
@@ -999,6 +1047,9 @@ class SessionHost {
               hosted.tmuxHandshakeConfirmed = true;
               hosted.tmuxHandshakeTimer?.cancel();
               hosted.tmuxHandshakeTimer = null;
+              // #906 telemetry: the `-CC` handshake confirmed — control mode is
+              // live (the working path, not the scrape fallback).
+              cmtrace('attach sid=$sessionId handshakeConfirmed=true');
               final cols =
                   hosted.pendingCcCols ?? hosted.metrics.lastCols ?? 80;
               final rows =
@@ -1025,6 +1076,19 @@ class SessionHost {
                   // Channel closed; the next connect re-syncs.
                 }
               }
+              // #906 switch fix: flush the attach `list-windows` too, so the
+              // window order is built on a pre-existing session (tmux pushes no
+              // %window-add for pre-attach windows). Sent AFTER the capture so
+              // the FIFO order matches the send order.
+              if (result.windowListRequested || hosted.pendingCcWindowList) {
+                hosted.pendingCcWindowList = false;
+                windowListOnConfirm = true;
+                try {
+                  hosted.shell?.send(tmux.frameWindowList());
+                } catch (_) {
+                  // Channel closed; the next connect re-syncs.
+                }
+              }
             }
             // #982: still waiting on the handshake — do NOT issue any capture /
             // switch / resize command (it would leak). The buffered resize above
@@ -1032,6 +1096,7 @@ class SessionHost {
             // flushed at confirm. Render bytes (if any) still pass through below.
             if (!hosted.tmuxHandshakeConfirmed) {
               if (result.captureRequested) hosted.pendingCcCapture = true;
+              if (result.windowListRequested) hosted.pendingCcWindowList = true;
               final render = result.renderBytes;
               if (render.isNotEmpty) {
                 _scanAttention(sessionId, hosted, render);
@@ -1074,6 +1139,17 @@ class SessionHost {
             if (result.captureRequested && !capturedOnConfirm) {
               try {
                 hosted.shell?.send(tmux.frameCapture());
+              } catch (_) {
+                // Channel closed; the next connect re-syncs.
+              }
+            }
+            // #906 switch fix: on attach, also request the window list so a
+            // status-bar tap resolves on a pre-existing session (tmux emits no
+            // %window-add for pre-attach windows). Sent after the capture so the
+            // FIFO order matches; the response is parsed into the window order.
+            if (result.windowListRequested && !windowListOnConfirm) {
+              try {
+                hosted.shell?.send(tmux.frameWindowList());
               } catch (_) {
                 // Channel closed; the next connect re-syncs.
               }
@@ -1865,6 +1941,11 @@ class SessionHost {
       lifecycleForwarder = null;
     }
     _lifecycleForward = null;
+    // #906: detach the control-mode forwarder the same way (only if still ours).
+    if (identical(controlModeForwarder, _controlModeForward)) {
+      controlModeForwarder = null;
+    }
+    _controlModeForward = null;
   }
 
   Future<void> dispose() async {
@@ -2034,6 +2115,13 @@ class _HostedSession {
   /// `frameCapture` the moment the handshake confirms, so a gated attach capture
   /// is never lost (the Stage-1 attach-render regression).
   bool pendingCcCapture = false;
+
+  /// #906 switch fix: a `list-windows` was requested (ATTACH `%session-changed`)
+  /// while the handshake gate was still closed. Mirrors [pendingCcCapture]:
+  /// buffer the request and flush ONE `frameWindowList` the moment the handshake
+  /// confirms, so the window order is built even when `%session-changed` shared
+  /// the confirm chunk (or arrived while gated).
+  bool pendingCcWindowList = false;
 
   /// #982: bounded timer armed when the entry command is written. If the `-CC`
   /// handshake is not confirmed before it fires, control mode FAILED (nested/no

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -169,6 +169,15 @@ enum SshTaskEventKind {
   /// so the UI-side ring — the one the bundle reads — actually contains them.
   /// Task-global, so [sessionId] is the empty sentinel (mirrors ready).
   lifecycle,
+
+  /// Task → UI: one structured tmux control-mode (`-CC`) telemetry line (#906).
+  /// The control-mode trace (`cmtrace` / `controlModeLog`) is written in the
+  /// foreground-task isolate (attach path, window-list snapshots, parsed
+  /// notifications, gesture resolutions) whose ring the UI never reads. Mirrors
+  /// [lifecycle]: the task forwards each line so the UI-side ring — the one the
+  /// feedback bundle reads — carries it, so ONE bug report fully diagnoses a
+  /// control-mode issue. Task-global, so [sessionId] is the empty sentinel.
+  controlModeTrace,
 }
 
 /// One remote filesystem entry surfaced to the file browser (#559). Kept small
@@ -899,6 +908,8 @@ sealed class SshTaskEvent {
         );
       case SshTaskEventKind.lifecycle:
         return SshLifecycleEvent(line: json['line'] as String);
+      case SshTaskEventKind.controlModeTrace:
+        return SshControlModeTraceEvent(line: json['line'] as String);
     }
   }
 }
@@ -1115,6 +1126,39 @@ class SshLifecycleEvent extends SshTaskEvent {
 
   @override
   SshTaskEventKind get kind => SshTaskEventKind.lifecycle;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'line': line,
+  };
+}
+
+/// Task → UI: one already-formatted control-mode (`-CC`) telemetry line (#906).
+///
+/// The control-mode trace (`cmtrace` / `controlModeLog`) is written ONLY in the
+/// foreground-task isolate (the session host + the `-CC` channel adapter): the
+/// attach entry-path, window-list snapshots, each parsed `%…` notification, and
+/// each gesture RESOLUTION (raw → resolved command → sent|dropped). Its ring is
+/// a per-isolate static, so the copy the UI-side feedback bundle reads is
+/// otherwise EMPTY. The task forwards each line as one of these events; the
+/// UI-side gateway records it into the UI isolate's control-mode ring so the
+/// bundle carries it — one report fully diagnoses a "not switching" issue.
+///
+/// [line] is the fully-formatted ring line (`HH:mm:ss.SSS [cc] msg`), recorded
+/// verbatim on the UI side. Task-global, so [sessionId] is the empty sentinel.
+///
+/// [SYNC] single-codebase wire contract; keep the forwarder (SessionHost) and
+/// the UI-side recorder (FlutterForegroundSshGateway) in step.
+class SshControlModeTraceEvent extends SshTaskEvent {
+  const SshControlModeTraceEvent({required this.line}) : super('');
+
+  /// The fully-formatted control-mode ring line, preserved verbatim.
+  final String line;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.controlModeTrace;
 
   @override
   Map<String, dynamic> toJson() => {

--- a/native/lib/services/task_ssh_gateway.dart
+++ b/native/lib/services/task_ssh_gateway.dart
@@ -427,6 +427,16 @@ class FlutterForegroundSshGateway implements TaskSshGateway {
       if (line is String) recordLifecycleLine(line);
       return;
     }
+    // #906: control-mode (`-CC`) telemetry forwarded from the task isolate.
+    // Record the (already-formatted) line into THIS (UI) isolate's control-mode
+    // ring — the copy the feedback bundle reads — then return. Like the lifecycle
+    // line above, it is task-global (not a session event), so intercept it here
+    // where every inbound payload passes, before the per-session proxy filter.
+    if (map['kind'] == SshTaskEventKind.controlModeTrace.name) {
+      final line = map['line'];
+      if (line is String) recordControlModeLine(line);
+      return;
+    }
     // First inbound payload proves the task isolate is alive and listening:
     // flush anything we buffered during spin-up, in order (#539).
     if (!_ready) {

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -504,6 +504,11 @@ class SshSessionProxy {
         // recorded it into the lifecycle ring before _incoming, so a per-session
         // proxy has nothing to do — handle it for switch exhaustiveness only.
         break;
+      case SshControlModeTraceEvent():
+        // Task-global control-mode telemetry (#906). The UI-side gateway already
+        // recorded it into the control-mode ring before _incoming; a per-session
+        // proxy has nothing to do — handle it for switch exhaustiveness only.
+        break;
       case SftpListingEvent():
       case SftpDownloadChunkEvent():
       case SftpDownloadDoneEvent():

--- a/native/lib/terminal/tmux_control_channel.dart
+++ b/native/lib/terminal/tmux_control_channel.dart
@@ -63,7 +63,15 @@ import 'tmux_control_parser.dart';
 /// ([_PendingKind.other] — resize, gesture, control) is a plain ack we discard.
 /// This is exactly how iTerm2 correlates responses (a queue popped per block),
 /// not a guess at tmux's opaque command number.
-enum _PendingKind { capture, other }
+///
+/// [_PendingKind.windowList] (#906 switch fix) is the `list-windows -F …`
+/// response: on `-CC attach` to a PRE-EXISTING session tmux emits NO
+/// `%window-add`/`%layout-change` for the windows that existed before the client
+/// attached (verified against real tmux `-CC`), so the channel's window order
+/// stays empty and a status-bar tap can't resolve a target. We query the window
+/// list on attach and parse its block to build the order — mirroring the
+/// capture-pane-on-attach pattern, but for the WINDOW LIST instead of the SCREEN.
+enum _PendingKind { capture, windowList, other }
 
 /// The result of [TmuxControlChannel.ingest]: the bytes to render now, plus the
 /// authoritative active-window signal so the host can force a redraw on switch.
@@ -73,7 +81,9 @@ class TmuxIngestResult {
     required this.activeWindowChanged,
     required this.exited,
     this.captureRequested = false,
+    this.windowListRequested = false,
     this.handshakeConfirmed = false,
+    this.traceLines = const <String>[],
   });
 
   /// The octal-UNESCAPED bytes of the ACTIVE window's panes, demultiplexed and
@@ -100,6 +110,16 @@ class TmuxIngestResult {
   /// `%begin…%end` response is rendered (clear + write) back through [ingest].
   final bool captureRequested;
 
+  /// True when this chunk warrants a `list-windows` request — an ATTACH
+  /// (`%session-changed`) (#906 switch fix). On `-CC attach` to a pre-existing
+  /// session tmux emits NO `%window-add`/`%layout-change` for the pre-existing
+  /// windows, so the channel's window order stays empty and a status-bar tap
+  /// resolves to null (no switch). The host responds by sending
+  /// [TmuxControlChannel.frameWindowList]; the correlated `%begin…%end` response
+  /// is parsed (NOT rendered) into the ordered window list, so the tap mapping
+  /// works on a freshly-attached pre-populated session.
+  final bool windowListRequested;
+
   /// True on the FIRST chunk in which tmux's `-CC` handshake was confirmed — the
   /// `\x1bP1000p` DCS that ONLY a real control-mode session emits (#982). Until
   /// this fires the host must NOT write ANY `-CC` command (refresh-client /
@@ -107,6 +127,13 @@ class TmuxIngestResult {
   /// arrives, and any command written into the plain/nested pane LEAKS as literal
   /// text (the owner's brick). The entry command is the only pre-handshake write.
   final bool handshakeConfirmed;
+
+  /// Structured control-mode telemetry lines produced by THIS ingest (#906):
+  /// each parsed `%…` notification and a window-list snapshot whenever the order
+  /// changes. The pure channel only BUILDS these strings; the (impure) host
+  /// emits them via `cmtrace` so they reach the feedback bundle. Empty when the
+  /// chunk had nothing trace-worthy. Carries only ids/indices/names — no content.
+  final List<String> traceLines;
 }
 
 /// An ordered tmux window the control channel knows about (Part C, #911). Built
@@ -311,6 +338,23 @@ class TmuxControlChannel {
     return capturePaneRangeCommand(start, end);
   }
 
+  /// The `list-windows -F …` command line (#906 switch fix) — enumerate the
+  /// session's windows so the status-bar-tap mapping has a real ordered list on a
+  /// freshly-attached PRE-EXISTING session (tmux pushes no `%window-add` for
+  /// windows that predate the attach). `-F '#{window_id} #{window_index}
+  /// #{window_name}'` yields one line per window (`@id index name`), in index
+  /// order; the response is parsed by [_ingestWindowList], not rendered.
+  static Uint8List windowListCommand() =>
+      controlCommand("list-windows -F '#{window_id} #{window_index} #{window_name}'");
+
+  /// Register + frame a `list-windows` request (#906 switch fix). Pushes a
+  /// [_PendingKind.windowList] so the correlated response block is PARSED into
+  /// the ordered window list (not rendered). The host sends this on attach.
+  Uint8List frameWindowList() {
+    _pending.add(_PendingKind.windowList);
+    return windowListCommand();
+  }
+
   /// Register + frame a `refresh-client -C` resize (#906 Stage 1). Its response
   /// block is a plain ack ([_PendingKind.other]) — registered so it can't be
   /// mistaken for a capture response and consume a real capture out of order.
@@ -401,7 +445,13 @@ class TmuxControlChannel {
     var activeChanged = false;
     var exited = false;
     var captureRequested = false;
+    var windowListRequested = false;
     var handshakeConfirmed = false;
+    // #906 telemetry: structured lines the host will `cmtrace`. The window
+    // order at entry — compared at the end so ONE snapshot line is appended when
+    // the order changed this chunk (not one per mutation).
+    final trace = <String>[];
+    final beforeOrder = List<int>.of(_windowOrder);
 
     for (final ev in events) {
       switch (ev) {
@@ -423,6 +473,12 @@ class TmuxControlChannel {
             final kind = _pending.removeFirst();
             if (kind == _PendingKind.capture && !ev.isError) {
               render.add(_renderCapture(ev.response));
+            } else if (kind == _PendingKind.windowList && !ev.isError) {
+              // #906 switch fix: the `list-windows` response — parse it into the
+              // ordered window list so a status-bar tap resolves on a
+              // freshly-attached pre-existing session.
+              _ingestWindowList(ev.response);
+              trace.add('list-windows parsed rows=${ev.response.length}');
             }
           }
         case SessionChanged():
@@ -445,6 +501,12 @@ class TmuxControlChannel {
           _scrollOffset = 0;
           _utf8Carry = const <int>[]; // #982: drop any partial char from the old session.
           captureRequested = true;
+          trace.add('notif session-changed \$${ev.sessionId} name=${ev.name}');
+          // #906 switch fix: also QUERY the window list. tmux emits no
+          // `%window-add`/`%layout-change` for windows that predate this attach,
+          // so without an explicit `list-windows` the order stays empty and a
+          // status-bar tap can't resolve a target (the owner's "not switching").
+          windowListRequested = true;
         case LayoutChange():
           // Record which window each leaf pane belongs to so %output can be
           // filtered to the active window.
@@ -456,18 +518,24 @@ class TmuxControlChannel {
           // (e.g. we missed/lagged its %window-add) still registers it so a tap
           // can target it. Insertion order tracks tmux's index/status order.
           _trackWindow(ev.windowId);
+          trace.add('notif layout-change @${ev.windowId} '
+              'panes=${ev.layout.panes.length}');
         case WindowAdd():
           // #911: a new window enters the status bar (next index/position).
           _trackWindow(ev.windowId);
+          trace.add('notif window-add @${ev.windowId}');
         case WindowRenamed():
           // #911: track + record the latest name (diagnostic; mapping uses order).
           _trackWindow(ev.windowId);
           _windowNames[ev.windowId] = ev.name;
+          trace.add('notif window-renamed @${ev.windowId} name=${ev.name}');
         case SessionWindowChanged():
           // AUTHORITATIVE active window. A real change flips the rendered window
           // and signals the host to force a redraw so the grid repaints. Also
           // track it (#911) — the active window is necessarily a real window.
           _trackWindow(ev.windowId);
+          trace.add('notif session-window-changed @${ev.windowId} '
+              '(authoritative active)');
           if (ev.windowId != _activeWindowId) {
             _activeWindowId = ev.windowId;
             activeChanged = true;
@@ -490,6 +558,7 @@ class TmuxControlChannel {
           // target a gone window and the status mapping stays correct.
           _windowOrder.remove(ev.windowId);
           _windowNames.remove(ev.windowId);
+          trace.add('notif window-close @${ev.windowId}');
         case ControlModeExit():
           exited = true;
         default:
@@ -500,13 +569,76 @@ class TmuxControlChannel {
       }
     }
 
+    // #906 telemetry: if the window order changed this chunk, append ONE
+    // snapshot of the resulting ordered list (the tappable status mapping).
+    if (!_sameOrder(beforeOrder, _windowOrder)) {
+      trace.add('windowList ${windowListTrace()}');
+    }
+
     return TmuxIngestResult(
       renderBytes: _emitOnUtf8Boundary(render.toBytes()),
       activeWindowChanged: activeChanged,
       exited: exited,
       captureRequested: captureRequested,
+      windowListRequested: windowListRequested,
       handshakeConfirmed: handshakeConfirmed,
+      traceLines: trace,
     );
+  }
+
+  /// A compact, greppable snapshot of the ordered window list for the control-
+  /// mode trace (#906): `@id(name)` in status order, e.g. `@0(alpha) @1(bravo)`.
+  /// `[none]` when empty (the "not switching" precondition). Pure.
+  String windowListTrace() {
+    if (_windowOrder.isEmpty) return '[none]';
+    return _windowOrder
+        .map((id) => '@$id(${_windowNames[id] ?? '?'})')
+        .join(' ');
+  }
+
+  /// Whether two window-order lists are identical (same ids, same order). Pure —
+  /// avoids a foundation `listEquals` import in this deliberately Flutter-free
+  /// file (#906 telemetry).
+  static bool _sameOrder(List<int> a, List<int> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
+  /// Parse a `list-windows -F '#{window_id} #{window_index} #{window_name}'`
+  /// response into the ordered window list (#906 switch fix). Each line is
+  /// `@<id> <index> <name…>` (name may contain spaces). REBUILDS the order from
+  /// this authoritative snapshot (sorted by index — tmux already emits them in
+  /// index order) so a freshly-attached pre-existing session gets a correct
+  /// status-tap mapping. Malformed lines are skipped (fail-open, never throw).
+  /// The active window id is NOT set here — it stays authoritative from
+  /// `%session-window-changed`; this only builds the tappable order + names.
+  void _ingestWindowList(List<String> lines) {
+    final parsed = <({int id, int index, String name})>[];
+    for (final raw in lines) {
+      final line = raw.trimRight();
+      if (line.isEmpty) continue;
+      final parts = line.split(' ');
+      if (parts.length < 2) continue;
+      final idTok = parts[0];
+      if (!idTok.startsWith('@')) continue;
+      final id = int.tryParse(idTok.substring(1));
+      final index = int.tryParse(parts[1]);
+      if (id == null || index == null) continue;
+      final name = parts.length > 2 ? parts.sublist(2).join(' ') : '';
+      parsed.add((id: id, index: index, name: name));
+    }
+    if (parsed.isEmpty) return;
+    parsed.sort((a, b) => a.index.compareTo(b.index));
+    _windowOrder
+      ..clear()
+      ..addAll(parsed.map((w) => w.id));
+    _windowNames.clear();
+    for (final w in parsed) {
+      if (w.name.isNotEmpty) _windowNames[w.id] = w.name;
+    }
   }
 
   /// Prepend any carried partial UTF-8 sequence to [bytes], then split off a NEW

--- a/native/lib/ui/diagnostics_section.dart
+++ b/native/lib/ui/diagnostics_section.dart
@@ -90,6 +90,7 @@ class _DiagnosticsSectionState extends State<DiagnosticsSection> {
         connectLog: connectLogSnapshot(),
         gestureLog: gestureLogSnapshot(),
         lifecycleLog: lifecycleLogSnapshot(),
+        controlModeTrace: controlModeLogSnapshot(),
         crashJson: crashJson,
       );
 

--- a/native/lib/ui/feedback_overlay.dart
+++ b/native/lib/ui/feedback_overlay.dart
@@ -85,6 +85,7 @@ Map<String, Object?> buildFeedbackPayload({
   List<String> connectLog = const <String>[],
   List<String> gestureLog = const <String>[],
   List<String> lifecycleLog = const <String>[],
+  List<String> controlModeTrace = const <String>[],
   List<Map<String, Object?>> byteTrace = const <Map<String, Object?>>[],
   List<Map<String, Object?>> scrollTrace = const <Map<String, Object?>>[],
   List<Map<String, Object?>> sentSgrTrace = const <Map<String, Object?>>[],
@@ -139,6 +140,14 @@ Map<String, Object?> buildFeedbackPayload({
       .map(scrubSecrets)
       .toList(growable: false);
 
+  // #906: the dedicated control-mode (`-CC`) trace ring — attach path, window-
+  // list snapshots, parsed notifications, gesture resolutions — so ONE report
+  // fully diagnoses a "not switching" issue. Scrubbed like the others (it
+  // carries only ids/indices/commands, never terminal content).
+  final scrubbedControlModeTrace = controlModeTrace
+      .map(scrubSecrets)
+      .toList(growable: false);
+
   return <String, Object?>{
     'title': title,
     // FULL comment — the server stores this untruncated (#661).
@@ -158,6 +167,8 @@ Map<String, Object?> buildFeedbackPayload({
       'gestureLog': scrubbedGestureLog,
     if (includeTraces && scrubbedLifecycleLog.isNotEmpty)
       'lifecycleLog': scrubbedLifecycleLog,
+    if (includeTraces && scrubbedControlModeTrace.isNotEmpty)
+      'controlModeTrace': scrubbedControlModeTrace,
     // #790: the replay-harness trace. byteTrace = raw bytes that reached the
     // Terminal ({tMs,b64}); scrollTrace = scroll-offset events ({tMs,offset});
     // grid = the active session's viewport {cols,rows}. The server (#790)
@@ -358,6 +369,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     final connectLog = connectLogSnapshot();
     final gestureLog = gestureLogSnapshot();
     final lifecycleLog = lifecycleLogSnapshot();
+    final controlModeTrace = controlModeLogSnapshot();
     // #790: the byte/scroll recorder is BACKWARD-looking, so snapshot it at the
     // END (just before the sheet) where the trace covers the bug the owner just
     // reproduced. Captured below after the frame burst.
@@ -404,6 +416,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       connectLog: connectLog,
       gestureLog: gestureLog,
       lifecycleLog: lifecycleLog,
+      controlModeTrace: controlModeTrace,
       // #790: backward-looking — snapshot NOW so the trace covers the bug just
       // reproduced during the burst.
       byteTrace: activeByteTraceSnapshot(),
@@ -429,6 +442,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     final connectLog = connectLogSnapshot();
     final gestureLog = gestureLogSnapshot();
     final lifecycleLog = lifecycleLogSnapshot();
+    final controlModeTrace = controlModeLogSnapshot();
     // #790: snapshot the byte/scroll recorder at the EXACT moment of tap — it's
     // backward-looking, so the rings hold the input + scroll that produced the
     // current (buggy) frame the owner is reporting.
@@ -450,6 +464,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       connectLog: connectLog,
       gestureLog: gestureLog,
       lifecycleLog: lifecycleLog,
+      controlModeTrace: controlModeTrace,
       byteTrace: byteTrace,
       scrollTrace: scrollTrace,
       sentSgrTrace: sentSgrTrace,
@@ -463,6 +478,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     required List<String> connectLog,
     required List<String> gestureLog,
     required List<String> lifecycleLog,
+    List<String> controlModeTrace = const <String>[],
     List<String> frameDataUrls = const <String>[],
     List<Map<String, Object?>> byteTrace = const <Map<String, Object?>>[],
     List<Map<String, Object?>> scrollTrace = const <Map<String, Object?>>[],
@@ -491,6 +507,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
         connectLog: connectLog,
         gestureLog: gestureLog,
         lifecycleLog: lifecycleLog,
+        controlModeTrace: controlModeTrace,
         byteTrace: byteTrace,
         scrollTrace: scrollTrace,
         sentSgrTrace: sentSgrTrace,
@@ -507,6 +524,7 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       connectLog: connectLog,
       gestureLog: gestureLog,
       lifecycleLog: lifecycleLog,
+      controlModeTrace: controlModeTrace,
       byteTrace: byteTrace,
       scrollTrace: scrollTrace,
       sentSgrTrace: sentSgrTrace,
@@ -633,6 +651,7 @@ class _FeedbackReviewSheet extends StatefulWidget {
     required this.connectLog,
     required this.gestureLog,
     required this.lifecycleLog,
+    this.controlModeTrace = const <String>[],
     required this.byteTrace,
     required this.scrollTrace,
     required this.sentSgrTrace,
@@ -645,6 +664,7 @@ class _FeedbackReviewSheet extends StatefulWidget {
   final List<String> connectLog;
   final List<String> gestureLog;
   final List<String> lifecycleLog;
+  final List<String> controlModeTrace;
   final List<Map<String, Object?>> byteTrace;
   final List<Map<String, Object?>> scrollTrace;
   final List<Map<String, Object?>> sentSgrTrace;
@@ -709,7 +729,8 @@ class _FeedbackReviewSheetState extends State<_FeedbackReviewSheet> {
   int get _traceLineCount =>
       widget.connectLog.length +
       widget.gestureLog.length +
-      widget.lifecycleLog.length;
+      widget.lifecycleLog.length +
+      widget.controlModeTrace.length;
 
   @override
   Widget build(BuildContext context) {
@@ -885,6 +906,7 @@ class _FeedbackReviewSheetState extends State<_FeedbackReviewSheet> {
       ...widget.connectLog,
       ...widget.gestureLog,
       ...widget.lifecycleLog,
+      ...widget.controlModeTrace,
     ].map(scrubSecrets).toList(growable: false);
     if (scrubbed.isEmpty) return const SizedBox.shrink();
     return Theme(

--- a/native/test/diagnostics/connect_trace_test.dart
+++ b/native/test/diagnostics/connect_trace_test.dart
@@ -272,4 +272,63 @@ void main() {
       );
     });
   });
+
+  group('control-mode trace ring + forwarder (#906)', () {
+    tearDown(() => controlModeForwarder = null);
+
+    test('cmtrace appends a [cc]-tagged line to the control-mode ring', () {
+      cmtrace('attach sid=s entry=exec handshakeConfirmed=false');
+      expect(controlModeLogSnapshot(), hasLength(1));
+      expect(controlModeLogSnapshot().single, contains('[cc]'));
+      expect(controlModeLogSnapshot().single, contains('entry=exec'));
+    });
+
+    test('cmtrace invokes the forwarder with the same formatted line', () {
+      final forwarded = <String>[];
+      controlModeForwarder = forwarded.add;
+      cmtrace('gesture raw=tapStatusCol col=45 cols=90 → dropped(reason=no-window-known)');
+      expect(forwarded, hasLength(1));
+      expect(forwarded.single, controlModeLog.value.single);
+      expect(forwarded.single, contains('no-window-known'));
+    });
+
+    test('cmtrace does NOT touch the connect or lifecycle rings', () {
+      cmtrace('notif window-add @3');
+      expect(connectLog.value, isEmpty);
+      expect(lifecycleLog.value, isEmpty);
+    });
+
+    test('a throwing forwarder never breaks cmtrace recording', () {
+      controlModeForwarder = (_) => throw StateError('boom');
+      cmtrace('notif session-window-changed @1 (authoritative active)');
+      expect(controlModeLog.value.single, contains('session-window-changed @1'));
+    });
+
+    test('recordControlModeLine lands a pre-formatted line verbatim', () {
+      const line = '12:34:56.789 [cc] windowList @0(alpha) @1(bravo)';
+      recordControlModeLine(line);
+      expect(controlModeLogSnapshot().single, line);
+    });
+
+    test('recordControlModeLine does NOT re-invoke the forwarder (no echo)', () {
+      final forwarded = <String>[];
+      controlModeForwarder = forwarded.add;
+      recordControlModeLine('12:00:00.000 [cc] attach handshakeConfirmed=true');
+      expect(forwarded, isEmpty);
+    });
+
+    test('clearConnectLog also clears the control-mode ring', () {
+      cmtrace('notif window-add @0');
+      expect(controlModeLogSnapshot(), isNotEmpty);
+      clearConnectLog();
+      expect(controlModeLogSnapshot(), isEmpty);
+    });
+
+    test('the control-mode ring is bounded to controlModeLogCapacity', () {
+      for (var i = 0; i < controlModeLogCapacity + 40; i++) {
+        cmtrace('notif window-add @$i');
+      }
+      expect(controlModeLogSnapshot().length, controlModeLogCapacity);
+    });
+  });
 }

--- a/native/test/diagnostics/feedback_bundle_test.dart
+++ b/native/test/diagnostics/feedback_bundle_test.dart
@@ -126,6 +126,38 @@ void main() {
       expect((decoded['lifecycleLog'] as List), isEmpty);
     });
 
+    test('includes the control-mode trace when supplied (#906)', () {
+      final blob = assembleFeedbackBundle(
+        info: info,
+        connectLog: const [],
+        controlModeTrace: const [
+          '19:22:19.001 [cc] gesture raw=tapStatusCol col=45 cols=90 → '
+              'dropped(reason=no-window-known) windows=[none]',
+        ],
+        crashJson: null,
+      );
+      final decoded = jsonDecode(blob) as Map<String, Object?>;
+      expect(decoded['controlModeTrace'], isA<List<Object?>>());
+      expect(
+        (decoded['controlModeTrace'] as List).single,
+        contains('no-window-known'),
+        reason:
+            'the control-mode trace must survive into the bundle so a "not '
+            'switching" report is diagnosable from one report (#906)',
+      );
+    });
+
+    test('controlModeTrace defaults to an empty list when omitted (#906)', () {
+      final blob = assembleFeedbackBundle(
+        info: info,
+        connectLog: const [],
+        crashJson: null,
+      );
+      final decoded = jsonDecode(blob) as Map<String, Object?>;
+      expect(decoded['controlModeTrace'], isA<List<Object?>>());
+      expect((decoded['controlModeTrace'] as List), isEmpty);
+    });
+
     test('gestureLog defaults to an empty list when omitted (#699)', () {
       final blob = assembleFeedbackBundle(
         info: info,

--- a/native/test/services/session_host_control_mode_test.dart
+++ b/native/test/services/session_host_control_mode_test.dart
@@ -328,6 +328,23 @@ void main() {
           reason: '%exit must close the shell transport exactly once');
     });
 
+    // ---- #906 switch fix: query the window list on attach ----
+
+    test('ATTACH requests list-windows so a pre-existing session is tappable',
+        () async {
+      final ctx = await setUpConnectedShell('cc:22:u:winlist');
+      final shell = ctx.opened.first;
+      shell.sent.clear();
+      // tmux -CC attach to a PRE-EXISTING session: %session-changed with NO
+      // %window-add for the pre-attach windows. The host must query list-windows.
+      shell.emit(_b('%session-changed \$0 main\n'));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final written = _s(shell.sent.toBytes());
+      expect(written, contains('list-windows -F'),
+          reason: 'attach must query the window list so a status-bar tap can '
+              'resolve a target on a pre-existing session (the "not switching" bug)');
+    });
+
     // ---- #911 Part C: atomic control-command delivery + real gestures ----
 
     test('a multi-token control command is delivered as ONE atomic line', () async {

--- a/native/test/services/task_ipc_test.dart
+++ b/native/test/services/task_ipc_test.dart
@@ -234,6 +234,19 @@ void main() {
       expect(restored.sessionId, '');
       expect(restored.kind, SshTaskEventKind.lifecycle);
     });
+
+    test('SshControlModeTraceEvent preserves the formatted line verbatim (#906)',
+        () {
+      const line = '12:34:56.789 [cc] gesture raw=tapStatusCol col=45 cols=90 → '
+          'resolved=select-window -t @1 → sent';
+      const ev = SshControlModeTraceEvent(line: line);
+      final restored =
+          SshTaskEvent.fromJson(ev.toJson()) as SshControlModeTraceEvent;
+      expect(restored.line, line);
+      // Task-global: empty sentinel sessionId (mirrors SshLifecycleEvent).
+      expect(restored.sessionId, '');
+      expect(restored.kind, SshTaskEventKind.controlModeTrace);
+    });
   });
 
   group('SessionHost.encodeAuth', () {

--- a/native/test/terminal/tmux_control_channel_test.dart
+++ b/native/test/terminal/tmux_control_channel_test.dart
@@ -371,6 +371,133 @@ void main() {
     });
   });
 
+  group('list-windows on attach — pre-existing-session switch fix (#906)', () {
+    test('ATTACH (%session-changed) requests a window list', () {
+      final ch = TmuxControlChannel();
+      final r = ch.ingest(bytes('%session-changed \$0 main\n'));
+      expect(r.windowListRequested, isTrue,
+          reason: 'attach to a pre-existing session must query the window list — '
+              'tmux emits no %window-add for pre-attach windows');
+    });
+
+    test('frameWindowList returns the list-windows line AND registers a block', () {
+      final ch = TmuxControlChannel();
+      expect(text(ch.frameWindowList()),
+          "list-windows -F '#{window_id} #{window_index} #{window_name}'\n");
+      expect(ch.pendingCommandCount, 1);
+    });
+
+    test('the list-windows response builds the ordered window list + names', () {
+      final ch = TmuxControlChannel();
+      ch.frameWindowList();
+      ch.ingest(bytes(
+        '%begin 1 9 1\n@0 0 alpha\n@1 1 bravo\n@2 2 charlie\n%end 1 9 1\n',
+      ));
+      expect(ch.windows.map((w) => w.id).toList(), [0, 1, 2]);
+      expect(ch.windows.map((w) => w.name).toList(), ['alpha', 'bravo', 'charlie']);
+    });
+
+    test('list-windows ALONE (no %window-add) makes a status tap resolve — the '
+        'pre-existing-attach bug', () {
+      final ch = TmuxControlChannel();
+      // The reproduced failure: on attach to a pre-existing session tmux pushes
+      // NO %window-add, so without list-windows the order is empty and the tap
+      // resolves to null (no switch). With the list-windows response parsed, the
+      // three windows are known and the tap resolves.
+      expect(ch.selectWindowCommandForStatusCol(45, 90), isNull,
+          reason: 'precondition: empty order → null (the bug)');
+      ch.frameWindowList();
+      ch.ingest(bytes(
+        '%begin 1 9 1\n@0 0 alpha\n@1 1 bravo\n@2 2 charlie\n%end 1 9 1\n',
+      ));
+      expect(ch.selectWindowCommandForStatusCol(45, 90), 'select-window -t @1',
+          reason: 'after list-windows the middle-segment tap resolves to @1');
+    });
+
+    test('list-windows rebuilds order sorted by window index', () {
+      final ch = TmuxControlChannel();
+      ch.frameWindowList();
+      // Deliberately out of index order in the response.
+      ch.ingest(bytes(
+        '%begin 1 9 1\n@2 2 charlie\n@0 0 alpha\n@1 1 bravo\n%end 1 9 1\n',
+      ));
+      expect(ch.windows.map((w) => w.id).toList(), [0, 1, 2]);
+    });
+
+    test('malformed list-windows lines are skipped (fail-open)', () {
+      final ch = TmuxControlChannel();
+      ch.frameWindowList();
+      ch.ingest(bytes(
+        '%begin 1 9 1\ngarbage line\n@0 0 alpha\nnot-a-window\n@1 1 bravo\n%end 1 9 1\n',
+      ));
+      expect(ch.windows.map((w) => w.id).toList(), [0, 1]);
+    });
+
+    test('window names with spaces are preserved', () {
+      final ch = TmuxControlChannel();
+      ch.frameWindowList();
+      ch.ingest(bytes(
+        '%begin 1 9 1\n@0 0 my editor\n@1 1 log tail\n%end 1 9 1\n',
+      ));
+      expect(ch.windows.map((w) => w.name).toList(), ['my editor', 'log tail']);
+    });
+
+    test('the list-windows response does NOT render as screen bytes', () {
+      final ch = TmuxControlChannel();
+      ch.frameWindowList();
+      final r = ch.ingest(bytes(
+        '%begin 1 9 1\n@0 0 alpha\n@1 1 bravo\n%end 1 9 1\n',
+      ));
+      expect(text(r.renderBytes), isEmpty,
+          reason: 'a window-list block is parsed, not painted to the grid');
+    });
+
+    // ---- #906 telemetry: structured trace lines from ingest ----
+
+    test('a %window-add produces a notif trace line + a window-list snapshot', () {
+      final ch = TmuxControlChannel();
+      final r = ch.ingest(bytes('%window-add @3\n'));
+      expect(r.traceLines, contains('notif window-add @3'));
+      // The order changed, so a single snapshot line is appended.
+      expect(r.traceLines.any((l) => l.startsWith('windowList ')), isTrue);
+    });
+
+    test('a %session-window-changed produces an authoritative-active trace line',
+        () {
+      final ch = TmuxControlChannel();
+      final r = ch.ingest(bytes('%session-window-changed \$0 @2\n'));
+      expect(
+        r.traceLines,
+        contains('notif session-window-changed @2 (authoritative active)'),
+      );
+    });
+
+    test('the list-windows parse emits a windowList snapshot with @id(name)', () {
+      final ch = TmuxControlChannel();
+      ch.frameWindowList();
+      final r = ch.ingest(bytes(
+        '%begin 1 9 1\n@0 0 alpha\n@1 1 bravo\n%end 1 9 1\n',
+      ));
+      expect(r.traceLines, contains('list-windows parsed rows=2'));
+      expect(
+        r.traceLines,
+        contains('windowList @0(alpha) @1(bravo)'),
+      );
+    });
+
+    test('windowListTrace is [none] when no windows are known', () {
+      final ch = TmuxControlChannel();
+      expect(ch.windowListTrace(), '[none]');
+    });
+
+    test('an unchanged chunk emits NO windowList snapshot (bounded)', () {
+      final ch = TmuxControlChannel();
+      ch.ingest(bytes('%window-add @0\n')); // establishes order
+      final r = ch.ingest(bytes('%output %0 hello\n')); // no order change
+      expect(r.traceLines.any((l) => l.startsWith('windowList ')), isFalse);
+    });
+  });
+
   group('status-col → window mapping (#911 Step 2)', () {
     TmuxControlChannel threeWindows() {
       final ch = TmuxControlChannel();

--- a/scripts/cc-exec-switch-setup.sh
+++ b/scripts/cc-exec-switch-setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# scripts/cc-exec-switch-setup.sh — pre-create a PERSISTENT tmux `main` session
+# with THREE named windows, each holding a DISTINCT on-screen marker, BEFORE the
+# app connects, for the cc_exec_switch emulator test (#906 "not switching").
+#
+# THE BUG this reproduces: on `tmux -CC attach` to a PRE-EXISTING session, tmux
+# emits NO `%window-add`/`%layout-change` for the windows that existed before the
+# client attached (verified against real tmux -CC). So MobiSSH's channel window
+# order stays EMPTY → a status-bar tap resolves to null → NO `select-window` →
+# no switch. cc_gestures passes only because it CREATES windows AFTER attach
+# (emitting %window-add); the owner attaches a PRE-POPULATED session.
+#
+# The windows exist BEFORE the app connects, so the app must QUERY the window
+# list (`list-windows`) on attach to make the tap resolvable — the fix under
+# test. Window 0 (alpha) is left ACTIVE, so a tap on the LAST status segment
+# must switch to window 2 (charlie) and repaint its CHARLIE marker.
+#
+# Run immediately before scripts/native-connect-test.sh
+# integration_test/cc_exec_switch_test.dart
+set -euo pipefail
+
+MOBISSH_CC_DIR="${MOBISSH_CC_DIR:-/tmp/mobissh/cc-exec-switch}"
+mkdir -p "$MOBISSH_CC_DIR"
+LOGFILE="${MOBISSH_CC_DIR}/setup.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+KEY="${MOBISSH_CC_DIR}/testuser_key"
+cp "${REPO_ROOT}/docker/test-sshd/testuser_id_ed25519" "$KEY"
+chmod 600 "$KEY"
+
+echo "> pre-creating persistent tmux 'main' with 3 marker windows ($(date +%Y%m%dT%H%M%S%z))"
+ssh -i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  testuser@test-sshd '
+rm -f /home/testuser/.bash_profile
+tmux kill-server >/dev/null 2>&1 || true
+# Create all 3 windows FIRST, then let every windows shell finish printing its
+# login MOTD before painting markers (a send-keys into a not-yet-ready shell is
+# lost — the marker then never renders). alpha stays active (created first).
+tmux new-session -d -s main -n alpha -x 80 -y 24
+tmux new-window -t main -n bravo
+tmux new-window -t main -n charlie
+sleep 2
+# Paint each windows marker on its OWN screen (clear wipes the MOTD), then wait
+# so the echo lands before the next step.
+tmux send-keys -t main:alpha "clear; echo WIN_ALPHA_MARKER_000" Enter
+tmux send-keys -t main:bravo "clear; echo WIN_BRAVO_MARKER_111" Enter
+tmux send-keys -t main:charlie "clear; echo WIN_CHARLIE_MARKER_222" Enter
+sleep 2
+tmux select-window -t main:alpha
+sleep 1
+echo "windows (tmux truth, alpha active):"
+tmux list-windows -t main -F "#{window_id} #{window_index} #{window_name} active=#{window_active}"
+echo "alpha capture (must contain WIN_ALPHA_MARKER):"
+tmux capture-pane -p -t main:alpha
+echo "charlie capture (must contain WIN_CHARLIE_MARKER):"
+tmux capture-pane -p -t main:charlie
+'
+echo "+ persistent main ready: alpha(active)/bravo/charlie, each with a marker"


### PR DESCRIPTION
## What

Two deliverables for the owner's report "control mode on, not switching" (control mode active, `send tmuxGesture → transport` in the log, but tmux doesn't switch windows).

## Deliverable 2 (primary) — control-mode telemetry in the bug report

The in-app report carried only UI-side traces (gestureLog/connectLog/byteTrace/sentSgr), so a control-mode issue was undiagnosable from one report. This adds a bounded, structured **`controlModeTrace`** ring (`cmtrace`, 200 lines), populated task-side by the `-CC` channel + session host and forwarded UI-ward (mirrors the #766 lifecycle forwarder), so the Feedback payload and the Diagnostics share both carry it. Flag-OFF-safe (empty when control mode is off). Captures:

- **attach**: entry-path (`exec`), `handshakeConfirmed`, `fellBackToScrape`.
- **windowList snapshots**: ordered `@id(name)` whenever the order changes.
- **each parsed notification**: `%session-changed`, `%session-window-changed @W`, `%layout-change @W`, `%window-add @W`, `%window-close @W`, `%window-renamed`.
- **each gesture RESOLUTION**: raw (`tapStatusCol col= cols=` | next/previous) → resolved (`select-window -t @N` | `dropped(reason=no-window-known … windows=…)` | `dropped(reason=handshake-not-confirmed)`) → sent.
- **authoritative active-window changes** from tmux.

New `SshControlModeTraceEvent` IPC envelope (round-trips).

## Deliverable 1 — query `list-windows` on attach

**Verified against real tmux `-CC`** (a live capture on test-sshd): on `-CC attach` to a **pre-existing** session, tmux emits **NO** `%window-add`/`%layout-change` for the pre-attach windows — only `%session-changed` + `%output`. So the channel window order is **empty** right after attach and a status-bar tap resolves to null. The app only recovered because its startup grid **resize** incidentally makes tmux re-lay-out and emit `%layout-change` for every window — fragile (never happens if the device grid already matches the session size). The fix sends `list-windows -F '#{window_id} #{window_index} #{window_name}'` on attach and parses it into the ordered list, so the tap mapping is populated **deterministically**, independent of any resize.

## Honesty / reproduce-first

**The emulator does NOT reproduce a behavioral "not switching" RED.** Because the app always resizes at least once on startup (the grid settles `50x25 → 50x44`), the incidental `%layout-change` path populates the order and the tap **switches on `main` too**. The list-windows fix closes the probe-proven protocol gap (same-size attach) but is **not proven to be the owner's exact root cause**. The telemetry (D2) is what will pinpoint it from the owner's next report — most likely a wrong-column status mapping or the status-bar-tap-lands-off-screen (keyboard-resize sizing, per prior `#922`) path, both of which the new gesture-resolution trace makes visible (a tap that never reaches the handler leaves no `gesture` line; a wrong resolution shows the wrong `@N`).

## Verification

- **Unit**: +8 channel tests (list-windows parse / order build / snapshot / the empty-order→resolve at unit level); host test (attach queries `list-windows`); control-mode ring + forwarder + bundle + IPC round-trip. `native-fast-gate.sh` green (+1663).
- **Emulator** (all GREEN): `cc_exec_switch_test` (new, deterministic — the forwarded control-mode trace must show `list-windows parsed` + `windowList @0(alpha) @1(bravo) @2(charlie)` on attach, and the tap switches to charlie); `cc_gestures`; `cc_capture_attach`.
- New `scripts/cc-exec-switch-setup.sh` pre-populates a 3-window session.

Refs #906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa