### PR TITLE
feat(native): gutter detection mark as a physical tappable chip (#989)

### DIFF
--- a/native/integration_test/gutter_mark_restyle_shot_test.dart
+++ b/native/integration_test/gutter_mark_restyle_shot_test.dart
@@ -1,0 +1,123 @@
+// On-emulator VISUAL smoke for the #989 gutter mark restyle.
+//
+// Connects to test-sshd, prints one URL line and one absolute-path line, waits
+// until BOTH are detected (a `url` anchor and a `path` anchor), then HOLDS the
+// terminal on screen for a screenshot window: the orchestrator runs
+// `scripts/emu-shot.sh gutter-restyle` during the hold and reviews the PNG —
+// the chip marks must read as physical tappable buttons at phone density (the
+// screenshot IS the test; the geometry/contrast minimums are asserted headlessly
+// in test/ui/ghostty_gutter_layer_test.dart).
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/gutter_mark_restyle_shot_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'gutter marks (URL + path) render for screenshot review (#989)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller for session');
+
+      // Wait for a live shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      const url = 'https://example.com/gutter/restyle';
+      const path = '/etc/hosts';
+      entry.proxy.sendInput(
+        Uint8List.fromList(
+          utf8.encode('echo VISIT989 $url; echo CONFIG989 $path\n'),
+        ),
+      );
+
+      bool bothDetected() =>
+          controller!.anchors.any(
+            (a) => a.patternId == 'url' && a.payload == url,
+          ) &&
+          controller.anchors.any((a) => a.patternId == 'path');
+      for (var i = 0; i < 40 && !bothDetected(); i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(
+        bothDetected(),
+        isTrue,
+        reason: 'URL + path anchors never both appeared (#989 shot precondition)',
+      );
+
+      // Screenshot HOLD: keep the marks on screen for the external emu-shot.
+      debugPrint('GUTTER989_SHOT_WINDOW_OPEN');
+      for (var i = 0; i < 90; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      debugPrint('GUTTER989_SHOT_WINDOW_CLOSED');
+    },
+  );
+}

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -37,9 +37,56 @@ import 'url_action_overlay.dart';
 import 'ghostty_terminal_decorators.dart';
 
 /// Width (logical px) of the right-edge gutter strip the marks sit in (#955).
-/// Thin so it never eats terminal real estate; the strip is a translucent
-/// overlay, not a reserved column (the PTY grid width is unchanged).
-const double kGutterStripWidth = 16.0;
+/// Still a translucent overlay, not a reserved column (the PTY grid width is
+/// unchanged). #989 widened it from 16 to match the line-select strip
+/// (`kGutterSelectStripWidth`) so the bigger chip fits inside it.
+const double kGutterStripWidth = 28.0;
+
+/// Sizing + colour derivation for the gutter detection mark chip (#989).
+///
+/// The mark is a FILLED opaque chip behind a bigger glyph so it reads as a
+/// physical, tappable button against terminal text in both themes — not a
+/// faint 14px glyph. Kept as a value type so #990's VERIFIED-path variant is
+/// one more static const (a bolder shade via [chipColor]) with zero paint-code
+/// rework.
+@immutable
+class GutterMarkStyle {
+  const GutterMarkStyle({
+    required this.chipSize,
+    required this.glyphSize,
+    required this.minTapExtent,
+  });
+
+  /// The standard mark style. (#990 adds a `bold` verified-path variant here.)
+  static const GutterMarkStyle normal = GutterMarkStyle(
+    chipSize: 24.0,
+    glyphSize: 16.0,
+    minTapExtent: 40.0,
+  );
+
+  /// Diameter of the filled chip behind the glyph.
+  final double chipSize;
+
+  /// Glyph (icon) size inside the chip; the count badge scales off it.
+  final double glyphSize;
+
+  /// Minimum effective touch target (Material's comfortable ~40dp minimum).
+  /// The mark's HIT box is expanded to this even though the painted chip is
+  /// smaller — the extra area is invisible and centred on the row.
+  final double minTapExtent;
+
+  /// The chip fill: the theme accent forced OPAQUE. The session selection
+  /// colour is often translucent (e.g. `0x33` alpha) — a see-through chip has
+  /// no contrast over terminal text.
+  Color chipColor(Color accent) => accent.withValues(alpha: 1.0);
+
+  /// Contrasting monochrome glyph colour for [chipColor] (luminance-picked, so
+  /// the glyph pops on the chip in both light and dark session themes).
+  Color onChipColor(Color accent) =>
+      ThemeData.estimateBrightnessForColor(chipColor(accent)) == Brightness.dark
+      ? Colors.white
+      : Colors.black;
+}
 
 /// One tap action shown for a match in the multi-match list sheet (#955).
 @immutable
@@ -263,6 +310,7 @@ class GhosttyGutterLayer extends StatelessWidget {
     required this.cellHeight,
     this.padding = 4.0,
     this.stripWidth = kGutterStripWidth,
+    this.style = GutterMarkStyle.normal,
   });
 
   /// The SAME controller handed to the flterm `TerminalView`.
@@ -285,6 +333,9 @@ class GhosttyGutterLayer extends StatelessWidget {
   /// Width of the right-edge strip the marks sit in.
   final double stripWidth;
 
+  /// Chip sizing + colour derivation for the marks (#989).
+  final GutterMarkStyle style;
+
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
@@ -300,7 +351,16 @@ class GhosttyGutterLayer extends StatelessWidget {
           hasPresentation: (id) => registry.forPattern(id) != null,
         );
         if (byRow.isEmpty) return const SizedBox.shrink();
+        // #989: the HIT box is at least minTapExtent square (invisible slack
+        // centred on the row); the painted chip stays inside the strip.
+        final boxWidth = stripWidth > style.minTapExtent
+            ? stripWidth
+            : style.minTapExtent;
+        final boxHeight = cellHeight > style.minTapExtent
+            ? cellHeight
+            : style.minTapExtent;
         return Stack(
+          clipBehavior: Clip.none,
           children: [
             // Translucent right-edge strip (visual hint only, never absorbs
             // taps — the marks below it are the hit targets).
@@ -316,14 +376,19 @@ class GhosttyGutterLayer extends StatelessWidget {
             for (final entry in byRow.entries)
               Positioned(
                 right: 0,
-                width: stripWidth,
-                top: padding + entry.key * cellHeight,
-                height: cellHeight,
+                width: boxWidth,
+                top:
+                    padding +
+                    entry.key * cellHeight -
+                    (boxHeight - cellHeight) / 2,
+                height: boxHeight,
                 child: _GutterMark(
                   key: Key('gutter-mark-${entry.key}'),
                   anchors: entry.value,
                   registry: registry,
                   color: color,
+                  style: style,
+                  stripWidth: stripWidth,
                 ),
               ),
           ],
@@ -335,21 +400,42 @@ class GhosttyGutterLayer extends StatelessWidget {
 
 /// One row's mark: a single-pattern glyph (taps straight to the action overlay)
 /// or a count badge for a multi-match row (taps to the list sheet) (#955).
-class _GutterMark extends StatelessWidget {
+///
+/// #989: the glyph sits on a FILLED opaque chip ([GutterMarkStyle]) so it reads
+/// as a physical button, and the chip scales down while pressed (cheap
+/// [AnimatedScale] — no cost when idle). Tap SEMANTICS are unchanged.
+class _GutterMark extends StatefulWidget {
   const _GutterMark({
     super.key,
     required this.anchors,
     required this.registry,
     required this.color,
+    required this.style,
+    required this.stripWidth,
   });
 
   final List<StructuredAnchor> anchors;
   final GutterPatternRegistry registry;
   final Color color;
+  final GutterMarkStyle style;
+  final double stripWidth;
+
+  @override
+  State<_GutterMark> createState() => _GutterMarkState();
+}
+
+class _GutterMarkState extends State<_GutterMark> {
+  bool _pressed = false;
+
+  void _setPressed(bool value) {
+    if (_pressed == value) return;
+    setState(() => _pressed = value);
+  }
 
   void _onTap(BuildContext context, Offset markGlobal) {
+    final anchors = widget.anchors;
     if (anchors.length == 1) {
-      final presentation = registry.forPattern(anchors.first.patternId);
+      final presentation = widget.registry.forPattern(anchors.first.patternId);
       if (presentation == null) return;
       presentation.showActions(context, anchors.first, markGlobal);
       return;
@@ -357,39 +443,69 @@ class _GutterMark extends StatelessWidget {
     showGutterPatternList(
       context,
       anchors: anchors,
-      registry: registry,
-      color: color,
+      registry: widget.registry,
+      color: widget.color,
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    final multi = anchors.length > 1;
-    final single = registry.forPattern(anchors.first.patternId);
+    final style = widget.style;
+    final multi = widget.anchors.length > 1;
+    final single = widget.registry.forPattern(widget.anchors.first.patternId);
+    final chipFill = style.chipColor(widget.color);
+    final onChip = style.onChipColor(widget.color);
+    // Centre the chip inside the visible strip (the hit box is wider).
+    final inset = (widget.stripWidth - style.chipSize) / 2;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTapUp: (details) => _onTap(context, details.globalPosition),
-      child: Center(
-        child: multi
-            ? Container(
-                width: 14,
-                height: 14,
-                alignment: Alignment.center,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  border: Border.all(color: color, width: 1.2),
-                ),
-                child: Text(
-                  '${anchors.length}',
-                  style: TextStyle(
-                    color: color,
-                    fontSize: 9,
-                    height: 1,
-                    fontWeight: FontWeight.w600,
+      onTapDown: (_) => _setPressed(true),
+      onTapCancel: () => _setPressed(false),
+      onTapUp: (details) {
+        _setPressed(false);
+        _onTap(context, details.globalPosition);
+      },
+      child: Align(
+        alignment: Alignment.centerRight,
+        child: Padding(
+          padding: EdgeInsets.only(right: inset > 0 ? inset : 0),
+          child: AnimatedScale(
+            scale: _pressed ? 0.85 : 1.0,
+            duration: const Duration(milliseconds: 90),
+            curve: Curves.easeOut,
+            child: Container(
+              width: style.chipSize,
+              height: style.chipSize,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: chipFill,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.35),
+                    blurRadius: 3,
+                    offset: const Offset(0, 1),
                   ),
-                ),
-              )
-            : Icon(single?.icon ?? Icons.adjust, size: 14, color: color),
+                ],
+              ),
+              child: multi
+                  ? Text(
+                      '${widget.anchors.length}',
+                      style: TextStyle(
+                        color: onChip,
+                        fontSize: style.glyphSize * 0.75,
+                        height: 1,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    )
+                  : Icon(
+                      single?.icon ?? Icons.adjust,
+                      size: style.glyphSize,
+                      color: onChip,
+                    ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/native/test/ui/ghostty_gutter_layer_test.dart
+++ b/native/test/ui/ghostty_gutter_layer_test.dart
@@ -149,6 +149,7 @@ void main() {
       WidgetTester tester, {
       Future<bool> Function(String path)? openPath,
       double cellHeight = 20,
+      Color color = const Color(0xFF5B9BD5),
     }) async {
       final controller = _FakeController();
       await tester.pumpWidget(
@@ -162,7 +163,7 @@ void main() {
                     registry: GutterPatternRegistry.standard(
                       openPath: openPath ?? (_) async => true,
                     ),
-                    color: const Color(0xFF5B9BD5),
+                    color: color,
                     cellHeight: cellHeight,
                   ),
                 ),
@@ -264,6 +265,122 @@ void main() {
       expect(find.byKey(const Key('gutter-item-1')), findsOneWidget);
       expect(find.text('https://example.com'), findsOneWidget);
       expect(find.text('/etc/hosts'), findsOneWidget);
+    });
+
+    // #989 — the mark must read as a physical tappable BUTTON: a filled chip
+    // backing (high contrast against terminal text), a bigger glyph, a >=40dp
+    // effective touch target, and pressed feedback. Visual/affordance only —
+    // the dispatch tests above must stay green unchanged.
+    group('mark affordance (#989)', () {
+      /// The chip [DecoratedBox] inside the mark for [row] — the FILLED backing
+      /// (a BoxDecoration with a colour), not the translucent strip.
+      BoxDecoration chipDecorationOf(WidgetTester tester, int row) {
+        final boxes = tester.widgetList<DecoratedBox>(
+          find.descendant(
+            of: find.byKey(Key('gutter-mark-$row')),
+            matching: find.byType(DecoratedBox),
+          ),
+        );
+        return boxes
+                .map((b) => b.decoration)
+                .whereType<BoxDecoration>()
+                .firstWhere((d) => d.color != null)
+            ;
+      }
+
+      testWidgets('mark hit target is at least 40x40 logical px', (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([_urlAnchor('https://example.com', row: 4)]);
+        await tester.pump();
+        final size = tester.getSize(find.byKey(const Key('gutter-mark-4')));
+        expect(size.width, greaterThanOrEqualTo(GutterMarkStyle.normal.minTapExtent));
+        expect(size.height, greaterThanOrEqualTo(GutterMarkStyle.normal.minTapExtent));
+      });
+
+      testWidgets('mark has an OPAQUE filled chip even from a translucent accent',
+          (tester) async {
+        // The session selection colour is often translucent (e.g. 0x33 alpha) —
+        // the chip must force full opacity or it vanishes over terminal text.
+        final controller = await pumpLayer(
+          tester,
+          color: const Color(0x335B9BD5),
+        );
+        controller.setAnchors([_urlAnchor('https://example.com', row: 4)]);
+        await tester.pump();
+        final deco = chipDecorationOf(tester, 4);
+        expect(deco.color, isNotNull);
+        expect(deco.color!.a, 1.0, reason: 'chip fill must be fully opaque');
+      });
+
+      testWidgets('glyphs are bigger and stay DISTINCT per pattern', (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([
+          _urlAnchor('https://example.com', row: 2),
+          _pathAnchor('/etc/hosts', row: 5),
+        ]);
+        await tester.pump();
+
+        final urlIcon = tester.widget<Icon>(
+          find.descendant(
+            of: find.byKey(const Key('gutter-mark-2')),
+            matching: find.byType(Icon),
+          ),
+        );
+        final pathIcon = tester.widget<Icon>(
+          find.descendant(
+            of: find.byKey(const Key('gutter-mark-5')),
+            matching: find.byType(Icon),
+          ),
+        );
+        expect(urlIcon.icon, isNot(pathIcon.icon));
+        expect(urlIcon.size, greaterThanOrEqualTo(GutterMarkStyle.normal.glyphSize));
+        expect(pathIcon.size, greaterThanOrEqualTo(GutterMarkStyle.normal.glyphSize));
+        expect(GutterMarkStyle.normal.glyphSize, greaterThan(14.0),
+            reason: 'the legacy faint mark was a bare 14px icon');
+      });
+
+      testWidgets('a multi-match count badge gets the chip backing too',
+          (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([
+          _urlAnchor('https://example.com', row: 5),
+          _pathAnchor('/etc/hosts', row: 5),
+        ]);
+        await tester.pump();
+        final deco = chipDecorationOf(tester, 5);
+        expect(deco.color!.a, 1.0);
+        expect(find.text('2'), findsOneWidget);
+      });
+
+      testWidgets('pressed feedback: the chip scales down while the pointer is down',
+          (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([_urlAnchor('https://example.com', row: 4)]);
+        await tester.pump();
+
+        final scaleFinder = find.descendant(
+          of: find.byKey(const Key('gutter-mark-4')),
+          matching: find.byType(AnimatedScale),
+        );
+        expect(tester.widget<AnimatedScale>(scaleFinder).scale, 1.0);
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byKey(const Key('gutter-mark-4'))),
+        );
+        // Past the tap-deadline so the sole-competitor recognizer fires tapDown.
+        await tester.pump(const Duration(milliseconds: 200));
+        expect(
+          tester.widget<AnimatedScale>(scaleFinder).scale,
+          lessThan(1.0),
+          reason: 'the mark must visibly respond to touch (physical affordance)',
+        );
+
+        await gesture.up();
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(tester.widget<AnimatedScale>(scaleFinder).scale, 1.0);
+        // The tap-up fired the single-URL action overlay — tear it down.
+        debugDismissUrlActions();
+      });
     });
 
     testWidgets('tap a PATH item in the list sheet → opens the browser at path',


### PR DESCRIPTION
## Summary
- The right-edge gutter detection mark is now a physical, tappable BUTTON (#989): the glyph sits on a filled opaque chip (24dp circle, subtle drop shadow) instead of a faint 14px icon.
- New `GutterMarkStyle` value type (`normal` variant) centralises chip size, glyph size, min touch target, and colour derivation — #990's bolder verified-path shade slots in as one more static const, no paint-code rework.
- Chip fill forces the theme accent OPAQUE (session selection colour is often 0x33-alpha) and picks a luminance-contrasting monochrome glyph colour, so the mark pops in both light and dark themes.
- Effective touch target expanded to >=40dp (invisible hit slack centred on the row; painted chip stays inside the strip). Strip widened 16 -> 28 to match the line-select strip.
- Pressed feedback: the chip scales to 0.85 while the pointer is down (AnimatedScale, zero cost when idle).
- URL (link) and path (folder_open) glyphs stay distinct; multi-match count badge gets the same chip. Tap/long-press SEMANTICS and detection logic untouched.

## TDD Analysis
- Type: feature (visual/affordance pass)
- Behavior change: visual only — dispatch semantics unchanged
- TDD approach: full for geometry/contrast/feedback; emulator screenshot for aesthetics

## Test coverage
- **Existing tests updated**: none needed — all 12 pre-existing gutter tests pass unchanged (semantics preserved)
- **New tests added (fail→pass)** in `native/test/ui/ghostty_gutter_layer_test.dart` group `mark affordance (#989)`:
  - mark hit target is at least 40x40 logical px
  - mark has an OPAQUE filled chip even from a translucent accent
  - glyphs are bigger and stay DISTINCT per pattern (link vs folder_open, >=16px)
  - multi-match count badge gets the chip backing too
  - pressed feedback: chip scales down while the pointer is down
- **Smoketest**: new emulator visual test `native/integration_test/gutter_mark_restyle_shot_test.dart` (URL + path anchors detected, holds a screenshot window)

## Test results
- flutter analyze: PASS
- flutter test: PASS (1672 tests; 5 new fail→pass)
- native-fast-gate.sh: PASS (in worktree)
- Emulator test: PASS (gutter_mark_restyle_shot_test.dart on the always-on emulator)
- Screenshot (reviewed — chips read as tappable buttons at phone density, URL/path glyphs distinct, high contrast): `test-results/emulator-shots/20260708T132716+0000-gutter-restyle_.png`

## Diff stats
- Files changed: 3
- Lines: +390 / -34 (impl +182/-34; the rest is tests)

Closes #989

## Cycles used
1/3