### PR TITLE
feat(native): restore inline URL/path bubble + single-tap copy, wrap-aware (#988)

### DIFF
--- a/native/integration_test/url_bubble_wrap_988_test.dart
+++ b/native/integration_test/url_bubble_wrap_988_test.dart
@@ -1,0 +1,300 @@
+// On-emulator acceptance for #988 — the restored inline URL BUBBLE + single-tap
+// copy, wrap-aware, on the post-#985 painted-offset geometry.
+//
+// Device-class behaviour a headless test cannot cover: a REAL ~200-char URL
+// soft-wrapped by the live libghostty grid (authoritative rowWrap flags, real
+// cell metrics, real scroll offsets), the bubble layer painting over it, a real
+// tap routed through the gesture router at a bubble rect, and the system
+// clipboard receiving the EXACT wrap-joined URL. Then the #930 regression
+// guard: stream output to scroll the URL away (bubble must be HIDDEN or
+// aligned — never misaligned), scroll back, and tap-copy again at the freshly
+// resolved bubble rect: if the bubble/hit geometry drifted, the tap misses and
+// the clipboard keeps its sentinel.
+//
+// The URL is delivered via base64 so the typed COMMAND ECHO never contains the
+// URL text — exactly ONE detected anchor carries the payload.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/url_bubble_wrap_988_test.dart
+
+import 'dart:convert';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'a wrapped ~200-char URL bubbles across its rows, a single tap copies it '
+    'exactly, and the bubble never drifts across a scroll (#988)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      // Reach the terminal screen, accepting the host-key prompt if shown.
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller for session');
+
+      // Wait for a live shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // A ~200-char no-whitespace URL: on any sane emulator grid width it
+      // soft-wraps across >= 3 rows (authoritative rowWrap flags). The length
+      // is PRIME (197) so NO grid width can leave the last row flush with the
+      // right edge — a flush last row triggers the scanner's width-join
+      // fallback onto the next (prompt) line and corrupts the payload.
+      final url = 'https://example.com/${'b' * 177}';
+      expect(url.length, 197);
+      // Deliver via base64 so the typed command echo never contains the URL —
+      // exactly ONE anchor will carry the payload. The encoded text INCLUDES
+      // the trailing newline: without it the shell prompt prints on the SAME
+      // row as the URL tail and the regex swallows it into the payload.
+      final b64 = base64Encode(utf8.encode('$url\n'));
+      entry.proxy.sendInput(
+        Uint8List.fromList(utf8.encode('echo $b64 | base64 -d\n')),
+      );
+
+      // Wait until the in-terminal scanner detects the FULL wrap-joined URL.
+      StructuredAnchor? anchorOf() {
+        for (final a in controller!.anchors) {
+          if (a.payload == url) return a;
+        }
+        return null;
+      }
+
+      for (var i = 0; i < 60 && anchorOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      final found = [
+        for (final a in controller!.anchors)
+          if (a.patternId == 'url') '${a.payload}'.length,
+      ];
+      expect(
+        anchorOf(),
+        isNotNull,
+        reason:
+            'the wrapped URL was never detected with its FULL payload — '
+            'url anchor payload lengths found: $found',
+      );
+
+      // The anchor spans the wrapped rows: one per-row range each (#925).
+      var anchor = anchorOf()!;
+      expect(
+        anchor.ranges.length,
+        greaterThanOrEqualTo(3),
+        reason: 'a 200-char URL must wrap across >= 3 rows',
+      );
+
+      // Wait for the scroll-settle so the bubble layer is SHOWN, then assert
+      // the bubble paint exists and its geometry spans ALL wrapped rows.
+      Finder bubble() => find.byKey(const Key('ghostty-bubble-paint'));
+      for (var i = 0;
+          i < 30 && (controller.isScrolling || bubble().evaluate().isEmpty);
+          i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      expect(
+        bubble(),
+        findsOneWidget,
+        reason: 'the bubble layer never painted for the detected anchor',
+      );
+
+      List<Rect> bubbleRects() => [
+        for (final range in anchorOf()!.ranges)
+          ...controller.anchorRects(range),
+      ];
+      var rects = bubbleRects();
+      expect(
+        rects.length,
+        anchor.ranges.length,
+        reason: 'one on-screen rect per wrapped row (all rows visible)',
+      );
+      for (var i = 1; i < rects.length; i++) {
+        expect(
+          rects[i].top,
+          greaterThan(rects[i - 1].top),
+          reason: 'per-row rects stack top-to-bottom (one per wrapped row)',
+        );
+      }
+
+      // Hold with the bubble on screen (~20s) so the host can screenshot it.
+      debugPrint('BUBBLE_HOLD_988 bubble visible, rows=${rects.length} '
+          '(screenshot now)');
+      for (var i = 0; i < 80; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      // Single TAP on a CONTINUATION-row bubble segment copies the EXACT URL.
+      // Seed the clipboard with a sentinel so a missed tap is detectable.
+      await Clipboard.setData(const ClipboardData(text: 'SEED-988-A'));
+      final viewOrigin = tester.getTopLeft(find.byType(TerminalView));
+      rects = bubbleRects();
+      final tapLocal = rects[1].center;
+      await tester.tapAt(viewOrigin + tapLocal);
+      String? clip;
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+        clip = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
+        if (clip == url) break;
+      }
+      expect(
+        clip,
+        url,
+        reason:
+            'a single tap on the continuation-row bubble must copy the EXACT '
+            'wrap-joined URL (no injected whitespace); clipboard: '
+            '${clip == null ? 'null' : '${clip.length} chars'}',
+      );
+
+      // #930 regression guard, part 1: stream a screenful+ so the URL scrolls
+      // into scrollback. Mid-stream the bubble must be HIDDEN whenever the
+      // controller reports scrolling (hidden is acceptable — misaligned is
+      // not), and once the anchor is fully off-screen the bubble paints
+      // NOTHING (no stale outline over unrelated text).
+      entry.proxy.sendInput(Uint8List.fromList(utf8.encode('seq 1 200\n')));
+      for (var i = 0; i < 24; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (!controller.isScrolling) continue;
+        // The hide is driven by the controller's POST-FRAME decoration notify
+        // (#812 rising edge): isScrolling flips during the paint that moved
+        // the offset, and the layer rebuilds one frame later. Grant exactly
+        // that frame, then (still scrolling) the bubble MUST be gone.
+        await tester.pump();
+        if (!controller.isScrolling) continue; // settled in the meantime
+        expect(
+          bubble(),
+          findsNothing,
+          reason: 'mid-scroll the bubble must hide, never drift (#930)',
+        );
+      }
+      expect(
+        anchorOf(),
+        isNotNull,
+        reason: 'the URL anchor vanished from the scanned window (#767)',
+      );
+      expect(
+        bubbleRects(),
+        isEmpty,
+        reason: 'the URL is in scrollback — no on-screen rects expected',
+      );
+      expect(
+        bubble(),
+        findsNothing,
+        reason: 'no stale bubble may remain once its anchor is off-screen',
+      );
+
+      // Part 2: scroll BACK to the URL and prove paint+hit still agree — the
+      // freshly resolved bubble rect is tappable and copies the exact URL. A
+      // drifted bubble would put the rect off the glyphs and the tap would
+      // miss (clipboard keeps the sentinel).
+      controller.scrollToTop();
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+        if (!controller.isScrolling && bubbleRects().isNotEmpty) break;
+      }
+      anchor = anchorOf()!;
+      rects = bubbleRects();
+      expect(
+        rects,
+        isNotEmpty,
+        reason: 'after scrolling back the anchor must resolve on-screen rects',
+      );
+      expect(
+        bubble(),
+        findsOneWidget,
+        reason: 'the bubble must re-show on scroll settle',
+      );
+
+      // Up to 3 attempts, each RE-RESOLVING the rect first: the earlier tap
+      // focused the terminal, so a soft-keyboard inset animation can still be
+      // shifting rows between resolve and tap. Re-resolving absorbs that
+      // transient; a genuinely DRIFTED bubble (rect off its glyphs) fails all
+      // attempts because the rect itself points at the wrong cells.
+      clip = null;
+      for (var attempt = 0; attempt < 3 && clip != url; attempt++) {
+        await Clipboard.setData(const ClipboardData(text: 'SEED-988-B'));
+        for (var i = 0; i < 10; i++) {
+          await tester.pump(const Duration(milliseconds: 300));
+          if (!controller.isScrolling && bubbleRects().isNotEmpty) break;
+        }
+        final fresh = bubbleRects();
+        if (fresh.isEmpty) continue;
+        await tester.tapAt(viewOrigin + fresh.first.center);
+        for (var i = 0; i < 10; i++) {
+          await tester.pump(const Duration(milliseconds: 300));
+          clip = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
+          if (clip == url) break;
+        }
+      }
+      expect(
+        clip,
+        url,
+        reason:
+            'after a scroll round-trip the tap at the re-resolved bubble rect '
+            'must still copy the exact URL — a miss means the bubble drifted '
+            'off its glyphs (#930); clipboard: '
+            '${clip == null ? 'null' : '${clip.length} chars'}',
+      );
+    },
+  );
+}

--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -1,20 +1,24 @@
-// ghostty_terminal_decorators.dart — structured-text pattern ids + highlight
-// style for the forked flterm terminal.
+// ghostty_terminal_decorators.dart — structured-text pattern ids, highlight
+// style, and the INLINE BUBBLE decorator for the forked flterm terminal.
 //
-// #955 PIVOT: the INLINE per-glyph decorations that used to live here (the URL
-// bubble / path underline painters + the `GhosttyTerminalDecoratorLayer` that
-// resolved anchor rects every frame) were RETIRED. They had to hug the matched
-// glyph cells to sub-pixel precision each frame, so they drifted off their text
-// during scroll (the still-open #930 + the #803/#812/#863/#864 saga). They are
-// replaced by `ghostty_gutter_layer.dart`'s `GhosttyGutterLayer`: a right-edge
-// gutter mark needs only a ROW + a fixed edge X, so the whole drift class is
-// gone (no text under the mark to drift away from).
+// #955 retired the original inline bubble: it drifted off its glyphs during
+// scroll (the #930 + #803/#812/#863/#864 saga) because the geometry it resolved
+// could disagree with the painted frame. #985 removed that drift class at the
+// ROOT — the controller runs NO damage-consuming RenderState reads and
+// `anchorRects` resolves per-row rects purely from the resize-seam grid cache +
+// the PAINTED viewport offset, the SAME source `matchAt` hit-tests with (#863).
+// #988 restores the bubble on that stable geometry as the primary affordance:
+// a rounded outline that visibly respects line wraps and omits injected margin
+// whitespace, so the bubble IS the preview of what a single tap will copy. The
+// right-edge gutter marks (`ghostty_gutter_layer.dart`) coexist unchanged.
 //
-// What REMAINS here is the small shared contract both the controller's pattern
-// registration and the gutter layer key off: the pattern ids and the (empty)
-// URL highlight style.
+// This file keeps the shared contract (pattern ids + the EMPTY highlight style
+// — the bubble is a WIDGET-layer decorator per the #767 Slice B design, never a
+// per-glyph fill) and adds the restored bubble: the pure per-row segment
+// computation ([ghosttyBubbleSegments]) and the paint-only [GhosttyBubbleLayer].
 
-import 'package:flterm/flterm.dart';
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/widgets.dart';
 
 /// The id of the built-in URL pattern. Mirrors the pattern id the view registers
 /// on the controller so the gutter registry can route URL anchors to their mark.
@@ -32,11 +36,215 @@ const String kGhosttyOsc8PatternId = 'osc8';
 const String kGhosttyPathPatternId = 'path';
 
 /// #864: the URL/OSC-8 pattern highlight style — DELIBERATELY EMPTY (no
-/// background fill, no underline). With the inline bubble retired (#955) the URL
-/// affordance is the GUTTER mark; the fork's `HighlightPainter` only draws a
-/// fill/underline when a range's style opts in, so a null-on-both style leaves
-/// the glyphs completely untouched (no app-painted ink over the URL text). A
-/// genuine SGR-4 underline emitted by the remote is the shell's own ink and is
-/// unaffected — this only governs the APP's structured-text decoration.
+/// background fill, no underline). The bubble is a WIDGET-layer decorator
+/// ([GhosttyBubbleLayer], #767 Slice B / #988) — never a per-glyph fill; the
+/// fork's `HighlightPainter` only draws a fill/underline when a range's style
+/// opts in, so a null-on-both style leaves the glyphs completely untouched (no
+/// app-painted ink over the URL text). A genuine SGR-4 underline emitted by the
+/// remote is the shell's own ink and is unaffected — this only governs the
+/// APP's structured-text decoration.
 const HighlightStyle kGhosttyUrlHighlightStyle =
     HighlightStyle(background: null, underline: null);
+
+/// One per-row piece of a (possibly wrapped) bubble (#988).
+///
+/// [rect] is the DRAW rect (the row's cell rect padded/inset by
+/// [ghosttyBubbleSegments]); [roundLeft]/[roundRight] mark the capsule ends —
+/// rounded ONLY where the anchor actually starts/ends, so a wrapped match reads
+/// as ONE object flowing through the wrap: the first row's segment rounds its
+/// left end, the last row's segment rounds its right end, middle rows are cut
+/// square on both ends (the wrap continues), and a single-row match is a full
+/// capsule.
+@immutable
+class GhosttyBubbleSegment {
+  const GhosttyBubbleSegment({
+    required this.rect,
+    required this.roundLeft,
+    required this.roundRight,
+  });
+
+  final Rect rect;
+  final bool roundLeft;
+  final bool roundRight;
+
+  /// The rounded rect to stroke: capsule radius (half the segment height) on
+  /// the rounded end(s), square corners on a cut (wrap-continuation) end.
+  RRect toRRect() {
+    final radius = Radius.circular(rect.height / 2);
+    return RRect.fromRectAndCorners(
+      rect,
+      topLeft: roundLeft ? radius : Radius.zero,
+      bottomLeft: roundLeft ? radius : Radius.zero,
+      topRight: roundRight ? radius : Radius.zero,
+      bottomRight: roundRight ? radius : Radius.zero,
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(rect, roundLeft, roundRight);
+
+  @override
+  bool operator ==(Object other) =>
+      other is GhosttyBubbleSegment &&
+      other.rect == rect &&
+      other.roundLeft == roundLeft &&
+      other.roundRight == roundRight;
+}
+
+/// HORIZONTAL padding on both sides so the capsule FRAMES the text with a
+/// little breathing room instead of clipping the first/last glyph (#864 device
+/// feedback, carried over from the retired bubble's polish).
+const double _kBubblePadX = 3.0;
+
+/// VERTICAL inset: flterm's cell rect spans the full typographic line height
+/// (ascender + descender slack), so an uninset outline sits top-heavy over the
+/// glyphs (#864). Insetting shrinks that slack.
+const double _kBubblePadY = 1.0;
+
+/// DOWNWARD shift: after insetting, nudge the outline down so it is vertically
+/// CENTERED on the glyph ink (the cell's empty band is at the TOP, #864).
+const double _kBubbleShiftY = 1.5;
+
+/// Compute the per-row bubble segments for an anchor's on-screen row rects
+/// (#988). Pure and headless-testable.
+///
+/// [rowRects] are the anchor's per-row viewport rects in top-to-bottom order —
+/// one per visible wrapped row, ALREADY content-hugging: the scanner's per-row
+/// ranges start at the match's start col on the first row and at the row's
+/// CONTENT start on continuation rows (injected margin whitespace excluded,
+/// #925/#928), and `TerminalController.anchorRects` resolves them against the
+/// painted offset. Each rect becomes one padded segment; capsule ends land ONLY
+/// on the first/last segments (see [GhosttyBubbleSegment]). Degenerate rects
+/// are skipped. Empty when the anchor is fully off-screen.
+List<GhosttyBubbleSegment> ghosttyBubbleSegments(List<Rect> rowRects) {
+  final padded = <Rect>[];
+  for (final rect in rowRects) {
+    if (rect.width <= 0 || rect.height <= 0) continue;
+    final bubble = Rect.fromLTRB(
+      rect.left - _kBubblePadX,
+      rect.top + _kBubblePadY + _kBubbleShiftY,
+      rect.right + _kBubblePadX,
+      rect.bottom - _kBubblePadY + _kBubbleShiftY,
+    );
+    if (bubble.width <= 0 || bubble.height <= 0) continue;
+    padded.add(bubble);
+  }
+  return [
+    for (var i = 0; i < padded.length; i++)
+      GhosttyBubbleSegment(
+        rect: padded[i],
+        roundLeft: i == 0,
+        roundRight: i == padded.length - 1,
+      ),
+  ];
+}
+
+/// The restored inline bubble layer (#988) — a paint-only overlay drawing one
+/// wrap-aware outline bubble per detected URL / OSC-8 link / file path.
+///
+/// Geometry: `controller.anchorRects` per per-row range — the post-#985
+/// painted-offset resolver, the SAME source `matchAt` hit-tests with (#863), so
+/// the painted bubble and the tappable region cannot diverge. Listens to the
+/// controller's NARROW `decorationListenable` (#805: fires only when the anchor
+/// set or the painted offset changes) and HIDES while `isScrolling` (#812
+/// stance: mid-scroll the painted offset is in flight; hidden is acceptable,
+/// a drifting bubble is not — it re-shows on settle at exact placement).
+///
+/// [IgnorePointer]: taps fall through to the gesture router below, whose
+/// `matchAt` hit-test routes a tap anywhere on the bubble to the single-tap
+/// copy (`_copyUrl`), so the bubble needs no gesture handling of its own.
+/// Mounted in the terminal Stack above the router, below the gutter layers.
+class GhosttyBubbleLayer extends StatelessWidget {
+  const GhosttyBubbleLayer({
+    super.key,
+    required this.controller,
+    required this.color,
+  });
+
+  /// The SAME controller handed to the flterm `TerminalView`. Its `anchors` /
+  /// `anchorRects` drive the bubbles; its notifications drive repaint.
+  final TerminalController controller;
+
+  /// The theme accent the bubbles are stroked in (the session selection
+  /// colour). Rebuilds when the parent re-creates the layer with a new colour.
+  final Color color;
+
+  /// The pattern ids that render a bubble. URL, OSC-8 and path share the ONE
+  /// mechanism (#988); a per-pattern shade difference is a separate issue.
+  static const Set<String> _bubblePatternIds = {
+    kGhosttyUrlPatternId,
+    kGhosttyOsc8PatternId,
+    kGhosttyPathPatternId,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: controller.decorationListenable,
+      builder: (context, _) {
+        if (controller.isScrolling) return const SizedBox.shrink();
+        final bubbles = <List<GhosttyBubbleSegment>>[];
+        for (final anchor in controller.anchors) {
+          if (!_bubblePatternIds.contains(anchor.patternId)) continue;
+          final rects = <Rect>[];
+          for (final range in anchor.ranges) {
+            rects.addAll(controller.anchorRects(range));
+          }
+          final segments = ghosttyBubbleSegments(rects);
+          if (segments.isEmpty) continue; // fully off-screen
+          bubbles.add(segments);
+        }
+        if (bubbles.isEmpty) return const SizedBox.shrink();
+        return IgnorePointer(
+          child: CustomPaint(
+            key: const Key('ghostty-bubble-paint'),
+            painter: _GhosttyBubblePainter(bubbles: bubbles, color: color),
+            size: Size.infinite,
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Strokes one outline per bubble segment — an OUTLINE (never an opaque fill
+/// over the glyphs) so the text stays readable and the capsule reads as a
+/// physical chip around it.
+class _GhosttyBubblePainter extends CustomPainter {
+  _GhosttyBubblePainter({required this.bubbles, required this.color});
+
+  final List<List<GhosttyBubbleSegment>> bubbles;
+  final Color color;
+
+  /// Outline stroke width, in logical px.
+  static const double _stroke = 1.5;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _stroke
+      ..color = color
+      ..isAntiAlias = true;
+    for (final segments in bubbles) {
+      for (final segment in segments) {
+        canvas.drawRRect(segment.toRRect(), paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _GhosttyBubblePainter old) {
+    if (old.color != color) return true;
+    if (old.bubbles.length != bubbles.length) return true;
+    for (var i = 0; i < bubbles.length; i++) {
+      final a = bubbles[i];
+      final b = old.bubbles[i];
+      if (a.length != b.length) return true;
+      for (var j = 0; j < a.length; j++) {
+        if (a[j] != b[j]) return true;
+      }
+    }
+    return false;
+  }
+}

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -1256,6 +1256,30 @@ bool ghosttyLongPressShowsPathMenu(StructuredMatch? matchAtCell) =>
 bool ghosttyMatchHasCopyablePayload(StructuredMatch match) =>
     '${match.payload}'.trim().isNotEmpty;
 
+/// #988: the single-TAP action for a detected structured match — COPY the exact
+/// anchor payload (wrap-joined, indent-aware; the #925/#928 extraction) for
+/// URLs AND file paths. The bubble is the visual preview of exactly this text,
+/// so what you see is what a tap copies. Open lives on the long-press menu and
+/// the gutter mark (a path tap used to open the SFTP explorer, #778 — #988
+/// unifies tap=copy across pattern kinds per the owner's spec).
+///
+/// Returns the success toast label, or null when nothing was copied (empty
+/// payload — the #810 guard — or the [copy] sink failed). [copy] is injected
+/// (production: `copyToClipboard`) so the dispatch is unit-testable headless.
+Future<String?> ghosttyTapCopyMatch(
+  StructuredMatch match, {
+  required Future<bool> Function(String text) copy,
+}) async {
+  // #810: never report a successful copy for an EMPTY payload. An empty-URI
+  // OSC-8 link could surface a non-null match with no payload; copying ""
+  // while toasting success is the "copied but empty" bug. Bail silently (no
+  // clipboard write, no toast) so the tap is a no-op rather than a lie.
+  if (!ghosttyMatchHasCopyablePayload(match)) return null;
+  final ok = await copy('${match.payload}');
+  if (!ok) return null;
+  return match.patternId == kGhosttyPathPatternId ? 'Copied path' : 'Copied URL';
+}
+
 /// Map a vertical swipe DELTA (logical px the finger moved this update) to a
 /// scrollback pixel delta to apply to the [TerminalScrollController] (#690).
 ///
@@ -2591,14 +2615,14 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// maintains the ANCHORS across scroll / wrap / resize / eviction — no app-side
   /// detect or push. Re-registering with the same id replaces the pattern.
   ///
-  /// #767 Slice B / #955: the pattern carries NO highlight background. The URL's
-  /// visual is now the right-edge GUTTER mark ([GhosttyGutterLayer]) — NOT an
-  /// inline fill/bubble painted over the glyphs (retired #955; it drifted off its
-  /// text during scroll). The fork's [HighlightPainter] only fills when a range
-  /// opts in with a background, so a no-background URL anchor leaves the glyphs
-  /// untouched; the gutter mark draws the affordance instead. The mark colour
-  /// comes from the gutter layer ([_lastHighlightColor]); this registration is
-  /// theme-independent.
+  /// #767 Slice B / #955 / #988: the pattern carries NO highlight background.
+  /// The visuals are WIDGET-layer decorators — the restored inline BUBBLE
+  /// ([GhosttyBubbleLayer], #988, on the post-#985 painted-offset geometry) and
+  /// the right-edge GUTTER mark ([GhosttyGutterLayer]) — never a per-glyph
+  /// fill. The fork's [HighlightPainter] only fills when a range opts in with a
+  /// background, so a no-background anchor leaves the glyphs untouched. The
+  /// decorator colour comes from the layers ([_lastHighlightColor]); this
+  /// registration is theme-independent.
   void _registerUrlPattern(TerminalController controller) {
     // #888 Part A: detection is gated on the GLOBAL detection settings. Read
     // them HERE so registration reflects the current toggles; a live change
@@ -3469,22 +3493,13 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   }
 
   /// Handle a single-TAP that landed on a detected structured match (the tap is
-  /// swallowed by the router). #726: a `url`/`osc8` match COPIES the URL + shows
-  /// a top-toast. #778: a `path` match OPENS the SFTP explorer at that path
-  /// instead (the primary affordance for a file path is "go there", not copy —
-  /// Copy path lives on the long-press menu). Routed by [StructuredMatch.patternId].
+  /// swallowed by the router). #726/#988: the tap COPIES the exact anchor
+  /// payload for URLs AND file paths — the bubble the tap landed on is the
+  /// visual preview of exactly this text ([ghosttyTapCopyMatch]). Open (browser
+  /// / SFTP explorer) lives on the long-press menu and the gutter mark.
   Future<void> _copyUrl(StructuredMatch match) async {
-    if (match.patternId == _kPathPatternId) {
-      _openPath('${match.payload}');
-      return;
-    }
-    // #810: never report a successful copy for an EMPTY payload. An empty-URI
-    // OSC-8 link could surface a non-null match with no payload; copying ""
-    // while toasting "Copied URL" is the "copied but empty" bug. Bail silently
-    // (no clipboard write, no toast) so the tap is a no-op rather than a lie.
-    if (!ghosttyMatchHasCopyablePayload(match)) return;
-    final ok = await copyToClipboard('${match.payload}');
-    if (ok && mounted) showTopToast(context, 'Copied URL');
+    final toast = await ghosttyTapCopyMatch(match, copy: copyToClipboard);
+    if (toast != null && mounted) showTopToast(context, toast);
   }
 
   /// #778 paths Slice 1: open the SFTP file explorer AT [path] (the tapped /
@@ -3752,13 +3767,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // #971 (test-only): publish the measured cell size so the gesture test can
     // convert a status-bar label column to the exact tap pixel.
     GhosttyTerminalView.debugCellSizes[widget.sessionId] = cellSize;
-    // #755/#767/#955: URLs + paths are DETECTED + ANCHORED inside the terminal
-    // (the `url`/`path` structured-text patterns over its own cells). The VISUAL
-    // is the right-edge GUTTER mark ([GhosttyGutterLayer]) coloured with the live
-    // session selection colour — no inline fill, no host re-detect. The
-    // colourless pattern registration never needs re-registering on a theme
-    // change; we just track the colour the mark paints in, so cycling the session
-    // theme recolours the mark on the next build.
+    // #755/#767/#955/#988: URLs + paths are DETECTED + ANCHORED inside the
+    // terminal (the `url`/`path` structured-text patterns over its own cells).
+    // The VISUALS are the inline BUBBLE ([GhosttyBubbleLayer], restored #988 on
+    // the post-#985 painted-offset geometry) and the right-edge GUTTER mark
+    // ([GhosttyGutterLayer]), both coloured with the live session selection
+    // colour — no per-glyph fill, no host re-detect. The colourless pattern
+    // registration never needs re-registering on a theme change; we just track
+    // the colour the decorators paint in, so cycling the session theme
+    // recolours them on the next build.
     final highlightColor = palette.theme.selection;
     if (highlightColor != _lastHighlightColor) {
       _lastHighlightColor = highlightColor;
@@ -4023,6 +4040,19 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             // parent builds the on-screen highlight rects + anchor from the match
             // and hands them to the overlay.
             onUrlLongPress: _showUrlMenu,
+          ),
+        ),
+        // #988: the restored inline BUBBLE layer — a paint-only, wrap-aware
+        // outline over each detected URL/OSC-8/path anchor, resolved via
+        // `controller.anchorRects` on the post-#985 painted-offset geometry
+        // (the SAME source the router's `matchAt` hit-tests with, #863, so the
+        // bubble IS the tappable region). IgnorePointer: taps fall through to
+        // the router below (single-tap copy). Hides mid-scroll, re-shows on
+        // settle — never drifts (#930 guard). Coexists with the gutter marks.
+        Positioned.fill(
+          child: GhosttyBubbleLayer(
+            controller: controller,
+            color: highlightColor,
           ),
         ),
         // #962: right-edge LINE-SELECT layer. Drag the gutter to select WHOLE

--- a/native/test/ui/ghostty_bubble_layer_test.dart
+++ b/native/test/ui/ghostty_bubble_layer_test.dart
@@ -1,0 +1,417 @@
+// #988 — the restored inline URL/path BUBBLE + single-tap copy (wrap-aware),
+// rebuilt on the post-#985 painted-offset geometry (no damage-consuming
+// RenderState reads; anchorRects/matchAt share ONE offset, #863).
+//
+// Three layers, all headless (no flterm native .so):
+//   1. PURE, end-to-end geometry: the REAL StructuredTextScanner over a fake
+//      CellReader holding a GENERATED long URL wrapped across 3 rows behind a
+//      space-painted left margin (#925/#928 shape) → per-row ranges →
+//      AnchorGeometry.rectsFor → ghosttyBubbleSegments. One segment per row,
+//      first-row start col honored, continuation rows exclude the painted
+//      margin, capsule ends ONLY on the first/last segments (reads as ONE
+//      object across the wrap).
+//   2. WIDGET: GhosttyBubbleLayer renders for an on-screen anchor, hides while
+//      scrolling (hidden is acceptable, DRIFT is not — #930 guard), re-shows on
+//      settle, and renders nothing for an off-screen anchor.
+//   3. TAP-COPY: a tap routed by the gesture router at a bubble cell resolves
+//      the match and ghosttyTapCopyMatch copies the EXACT wrap-joined URL (no
+//      injected whitespace) — for URLs AND file paths (#988 goal).
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+/// A pure, headless [CellReader] built from per-row text. A space cell reads
+/// back as a LITERAL ' ' glyph (the #928 space-painted-margin case — the
+/// scanner must treat it as blank, not content).
+class _SpacePaintedReader implements CellReader {
+  _SpacePaintedReader(List<String> rowTexts, {required this.cols})
+    : _rows = [
+        for (final t in rowTexts)
+          List<String>.generate(cols, (c) => c < t.length ? t[c] : ' '),
+      ];
+
+  final List<List<String>> _rows;
+
+  @override
+  final int cols;
+
+  @override
+  int get baseAbsRow => 0;
+
+  @override
+  int get rows => _rows.length;
+
+  @override
+  String cellContent(int row, int col) => _rows[row][col];
+
+  @override
+  bool rowWrap(int row) => false;
+
+  @override
+  String? hyperlinkAt(int row, int col) => null;
+}
+
+/// Fake controller exposing scripted [anchors] + a real-geometry [anchorRects]
+/// (AnchorGeometry over fixed metrics) — the only surface [GhosttyBubbleLayer]
+/// reads.
+class _FakeController extends ChangeNotifier implements TerminalController {
+  static const CellMetrics metrics = CellMetrics(
+    cellWidth: 8,
+    cellHeight: 16,
+    baseline: 12,
+  );
+  static const Offset origin = Offset(4, 4);
+
+  final int viewportRows = 24;
+  final int gridCols = 50;
+  int viewportOffset = 0;
+
+  List<StructuredAnchor> _anchors = const [];
+  bool _scrolling = false;
+
+  void setAnchors(List<StructuredAnchor> value) {
+    _anchors = value;
+    notifyListeners();
+  }
+
+  void setScrolling(bool value) {
+    if (_scrolling == value) return;
+    _scrolling = value;
+    notifyListeners();
+  }
+
+  @override
+  List<StructuredAnchor> get anchors => _anchors;
+
+  @override
+  bool get isScrolling => _scrolling;
+
+  @override
+  Listenable get decorationListenable => this;
+
+  @override
+  List<Rect> anchorRects(HighlightRange range) => AnchorGeometry.rectsFor(
+    range,
+    metrics: metrics,
+    viewportOffset: viewportOffset,
+    cols: gridCols,
+    viewportRows: viewportRows,
+    origin: origin,
+  );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  const scanner = StructuredTextScanner();
+  const cols = 50;
+  const indent = 2;
+  const cellW = 8.0;
+  const cellH = 16.0;
+  const origin = Offset(4, 4);
+
+  // GENERATED long URL that wraps across exactly 3 rows at a 48-char content
+  // width behind a 2-col space-painted margin: 48 + 48 + 20 = 116 chars.
+  final url = 'https://example.com/${'x' * 96}';
+  List<String> wrappedRows() => [
+    '  ${url.substring(0, 48)}',
+    '  ${url.substring(48, 96)}',
+    '  ${url.substring(96)}',
+  ];
+
+  StructuredMatch scanWrapped() {
+    final reader = _SpacePaintedReader(wrappedRows(), cols: cols);
+    final matches = scanner.scan(reader, [TextPattern.url()]);
+    expect(matches, hasLength(1), reason: 'one wrapped URL match expected');
+    return matches.single;
+  }
+
+  List<Rect> rectsFor(StructuredMatch match) => [
+    for (final range in match.ranges)
+      ...AnchorGeometry.rectsFor(
+        range,
+        metrics: _FakeController.metrics,
+        viewportOffset: 0,
+        cols: cols,
+        viewportRows: 24,
+        origin: origin,
+      ),
+  ];
+
+  group('#988 wrap-aware bubble geometry (pure, real scanner)', () {
+    test('the joined payload is the EXACT URL — no injected whitespace', () {
+      final match = scanWrapped();
+      expect(match.payload, url);
+      expect('${match.payload}'.contains(' '), isFalse);
+      expect(match.ranges, hasLength(3), reason: 'one range per wrapped row');
+    });
+
+    test('one rect per wrapped row, hugging content on every row', () {
+      final rects = rectsFor(scanWrapped());
+      expect(rects, hasLength(3), reason: 'one rect per wrapped row');
+      // First row starts at the MATCH's start col (the 2-col indent).
+      expect(rects[0].left, origin.dx + indent * cellW);
+      // Continuation rows start at CONTENT, not padded col 0 — the painted
+      // margin (space glyphs, #928) is excluded.
+      expect(rects[1].left, origin.dx + indent * cellW);
+      expect(rects[2].left, origin.dx + indent * cellW);
+      expect(
+        rects[1].left,
+        greaterThan(origin.dx),
+        reason: 'continuation row must NOT start at padded col 0',
+      );
+      // Rows stack: one rect per successive row.
+      expect(rects[0].top, origin.dy);
+      expect(rects[1].top, origin.dy + cellH);
+      expect(rects[2].top, origin.dy + 2 * cellH);
+      // Full rows end at the wrap col; the last row ends at CONTENT end.
+      expect(rects[0].right, origin.dx + cols * cellW);
+      expect(rects[2].right, origin.dx + (indent + 20) * cellW);
+    });
+
+    test('capsule ends ONLY on the first/last segments (one visual object)', () {
+      final segments = ghosttyBubbleSegments(rectsFor(scanWrapped()));
+      expect(segments, hasLength(3));
+      expect(segments[0].roundLeft, isTrue);
+      expect(segments[0].roundRight, isFalse);
+      expect(segments[1].roundLeft, isFalse);
+      expect(segments[1].roundRight, isFalse);
+      expect(segments[2].roundLeft, isFalse);
+      expect(segments[2].roundRight, isTrue);
+      // Each segment stays on its own row band (hugs its row's cells).
+      final rects = rectsFor(scanWrapped());
+      for (var i = 0; i < 3; i++) {
+        expect(segments[i].rect.center.dy, greaterThan(rects[i].top));
+        expect(segments[i].rect.center.dy, lessThan(rects[i].bottom));
+        expect(segments[i].rect.left, lessThanOrEqualTo(rects[i].left));
+        expect(segments[i].rect.right, greaterThanOrEqualTo(rects[i].right));
+      }
+    });
+
+    test('a single-row match gets a FULL capsule (both ends rounded)', () {
+      final segments = ghosttyBubbleSegments(const [
+        Rect.fromLTWH(20, 4, 160, 16),
+      ]);
+      expect(segments, hasLength(1));
+      expect(segments.single.roundLeft, isTrue);
+      expect(segments.single.roundRight, isTrue);
+    });
+
+    test('degenerate rects are skipped', () {
+      final segments = ghosttyBubbleSegments(const [
+        Rect.fromLTWH(20, 4, 0, 16),
+        Rect.fromLTWH(20, 20, 160, 16),
+      ]);
+      expect(segments, hasLength(1));
+      expect(segments.single.roundLeft, isTrue);
+      expect(segments.single.roundRight, isTrue);
+    });
+  });
+
+  group('#988 GhosttyBubbleLayer widget', () {
+    Future<_FakeController> pumpLayer(WidgetTester tester) async {
+      final controller = _FakeController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                Positioned.fill(
+                  child: GhosttyBubbleLayer(
+                    controller: controller,
+                    color: const Color(0xFF5B9BD5),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return controller;
+    }
+
+    StructuredAnchor urlAnchor({int row = 2}) => StructuredAnchor(
+      patternId: kGhosttyUrlPatternId,
+      payload: 'https://example.com',
+      ranges: [
+        HighlightRange(
+          startRow: row,
+          startCol: 4,
+          endRow: row,
+          endCol: 23,
+          payload: 'https://example.com',
+        ),
+      ],
+    );
+
+    testWidgets('renders the bubble paint for an on-screen anchor', (
+      tester,
+    ) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([urlAnchor()]);
+      await tester.pump();
+      expect(find.byKey(const Key('ghostty-bubble-paint')), findsOneWidget);
+    });
+
+    testWidgets('renders nothing when the anchor is fully off-screen', (
+      tester,
+    ) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([urlAnchor(row: 99)]);
+      await tester.pump();
+      expect(find.byKey(const Key('ghostty-bubble-paint')), findsNothing);
+    });
+
+    testWidgets('HIDES while scrolling, re-shows on settle (never drifts)', (
+      tester,
+    ) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([urlAnchor()]);
+      await tester.pump();
+      expect(find.byKey(const Key('ghostty-bubble-paint')), findsOneWidget);
+
+      controller.setScrolling(true);
+      await tester.pump();
+      expect(
+        find.byKey(const Key('ghostty-bubble-paint')),
+        findsNothing,
+        reason: 'mid-scroll the bubble hides — hidden is acceptable, '
+            'a drifting bubble is not (#930/#812)',
+      );
+
+      controller.setScrolling(false);
+      await tester.pump();
+      expect(find.byKey(const Key('ghostty-bubble-paint')), findsOneWidget);
+    });
+
+    testWidgets('a PATH anchor bubbles too (shared mechanism)', (tester) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([
+        StructuredAnchor(
+          patternId: kGhosttyPathPatternId,
+          payload: '/etc/hosts',
+          ranges: const [
+            HighlightRange(startRow: 3, startCol: 0, endRow: 3, endCol: 10),
+          ],
+        ),
+      ]);
+      await tester.pump();
+      expect(find.byKey(const Key('ghostty-bubble-paint')), findsOneWidget);
+    });
+  });
+
+  group('#988 single-tap copies the exact anchor text', () {
+    test('a URL match copies its exact wrap-joined payload', () async {
+      final match = scanWrapped();
+      final copied = <String>[];
+      final toast = await ghosttyTapCopyMatch(
+        match,
+        copy: (text) async {
+          copied.add(text);
+          return true;
+        },
+      );
+      expect(copied, [url], reason: 'the EXACT joined URL, nothing injected');
+      expect(toast, 'Copied URL');
+    });
+
+    test('a PATH match copies too (tap = copy for BOTH kinds, #988)', () async {
+      const match = StructuredMatch(
+        patternId: kGhosttyPathPatternId,
+        payload: '/etc/ssh/sshd_config',
+        ranges: [
+          HighlightRange(startRow: 2, startCol: 4, endRow: 2, endCol: 24),
+        ],
+      );
+      final copied = <String>[];
+      final toast = await ghosttyTapCopyMatch(
+        match,
+        copy: (text) async {
+          copied.add(text);
+          return true;
+        },
+      );
+      expect(copied, ['/etc/ssh/sshd_config']);
+      expect(toast, 'Copied path');
+    });
+
+    test('an empty payload neither copies nor toasts (#810 guard)', () async {
+      const match = StructuredMatch(
+        patternId: kGhosttyOsc8PatternId,
+        payload: '',
+        ranges: [
+          HighlightRange(startRow: 2, startCol: 4, endRow: 2, endCol: 8),
+        ],
+      );
+      var copyCalls = 0;
+      final toast = await ghosttyTapCopyMatch(
+        match,
+        copy: (_) async {
+          copyCalls++;
+          return true;
+        },
+      );
+      expect(copyCalls, 0);
+      expect(toast, isNull);
+    });
+
+    testWidgets(
+      'a tap routed at a CONTINUATION-row bubble cell resolves the match and '
+      'copies the full URL',
+      (tester) async {
+        final match = scanWrapped();
+        final copied = <String>[];
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Align(
+                alignment: Alignment.topLeft,
+                child: SizedBox(
+                  width: 400,
+                  height: 400,
+                  child: GhosttyPointerGestureRouter(
+                    active: false,
+                    scrollController: TerminalScrollController(),
+                    cols: cols,
+                    rows: 24,
+                    lastSentCols: cols,
+                    lastSentRows: 24,
+                    cellWidth: cellW,
+                    cellHeight: cellH,
+                    mouseTrackingLabel: 'any',
+                    onTap: () {},
+                    onFocus: () {},
+                    onMouseReport: (_) {},
+                    onSelectionStart: (_, _) {},
+                    onSelectionExtend: (_, _) {},
+                    hasSelection: () => false,
+                    onSelectionClear: () {},
+                    urlAtCell: (col, row) =>
+                        match.contains(row, col) ? match : null,
+                    onUrlTap: (m) => ghosttyTapCopyMatch(
+                      m,
+                      copy: (text) async {
+                        copied.add(text);
+                        return true;
+                      },
+                    ),
+                    onUrlLongPress: (_, _) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        // Row 1 (a continuation row), col 10 — inside the wrapped match. The
+        // router maps px→cell with cellW=8/cellH=16: (10*8+4, 1*16+8).
+        await tester.tapAt(const Offset(84, 24));
+        await tester.pumpAndSettle();
+        expect(copied, [url], reason: 'tap on a continuation row copies the FULL URL');
+      },
+    );
+  });
+}

--- a/native/test/ui/ghostty_terminal_decorators_test.dart
+++ b/native/test/ui/ghostty_terminal_decorators_test.dart
@@ -1,8 +1,9 @@
-// #955 — what survives of ghostty_terminal_decorators.dart after the inline
-// decorations (URL bubble / path underline painters + GhosttyTerminalDecoratorLayer)
-// were RETIRED in favour of the right-edge gutter (ghostty_gutter_layer.dart):
-// the shared pattern ids and the (empty) URL highlight style. The gutter widget
-// behaviour is covered in ghostty_gutter_layer_test.dart.
+// #955/#988 — the shared decorator contract in ghostty_terminal_decorators.dart:
+// the pattern ids and the (empty) URL highlight style. The style stays EMPTY
+// even with the inline bubble RESTORED (#988): the bubble is a WIDGET-layer
+// decorator (GhosttyBubbleLayer, covered in ghostty_bubble_layer_test.dart),
+// never a per-glyph fill; the gutter widget behaviour is covered in
+// ghostty_gutter_layer_test.dart.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
@@ -18,8 +19,8 @@ void main() {
 
   group('#864 URL highlight style', () {
     test('drops the underline AND the fill (no app ink over the glyphs)', () {
-      // With the inline bubble retired (#955), the URL affordance is the gutter
-      // mark; the pattern must paint NO inline fill/underline of its own.
+      // The URL affordances (bubble #988 + gutter mark #955) are widget-layer
+      // decorators; the pattern must paint NO per-glyph fill/underline of its own.
       expect(kGhosttyUrlHighlightStyle.underline, isNull);
       expect(kGhosttyUrlHighlightStyle.background, isNull);
     });

--- a/native/third_party/flterm/lib/flterm.dart
+++ b/native/third_party/flterm/lib/flterm.dart
@@ -21,6 +21,10 @@ export 'package:libghostty/libghostty.dart'
         UnderlineStyle,
         initializeForWeb;
 
+// #988: the pure anchor→viewport-rect resolver is part of the public geometry
+// seam — the app's bubble decorator (and its headless tests) resolve per-row
+// rects with the SAME math `anchorRects` uses.
+export 'src/foundation/anchor_geometry.dart' show AnchorGeometry;
 export 'src/foundation/callbacks.dart' show OnResize;
 export 'src/foundation/cell_metrics.dart' show CellMetrics;
 export 'src/foundation/color_palette.dart' show ColorPalette;


### PR DESCRIPTION
## Summary
- Restores the inline URL/path BUBBLE (#955 retirement reversed) on the post-#985 painted-offset geometry: a wrap-aware outline that hugs actual content per row — first row starts at the match's start col, continuation rows start at content (painted-margin whitespace excluded, #925/#928), last row ends at content end. Capsule ends only on the first/last row segments so a wrapped URL reads as ONE object.
- Single TAP on the bubble copies the exact wrap-joined anchor text for BOTH URLs and file paths (`ghosttyTapCopyMatch`; path tap previously opened the explorer — Open stays on the long-press menu and the gutter mark, per the issue's owner goals).
- Verified the #985 premise first: `anchorRects` is pure `AnchorGeometry` over the PAINTED offset (`screenViewportTop`), the SAME source `matchAt` hit-tests with (#863) — paint and tap cannot diverge. The bubble hides mid-scroll and re-shows on settle (#812 stance: hidden is acceptable, drift is not). Gutter marks coexist unchanged (`ghostty_gutter_layer.dart` untouched).

## What changed
- `native/lib/ui/ghostty_terminal_decorators.dart` — `ghosttyBubbleSegments` (pure per-row segment computation, capsule flags) + `GhosttyBubbleLayer` (paint-only, IgnorePointer; listens to the narrow `decorationListenable`).
- `native/lib/ui/ghostty_terminal_view.dart` — mounts the layer in the terminal Stack; `_copyUrl` → `ghosttyTapCopyMatch` (tap = copy for url/osc8/path); stale #955 comments updated.
- `native/third_party/flterm/lib/flterm.dart` — exports `AnchorGeometry` (the public geometry seam the layer + tests resolve rects with).
- `kGhosttyUrlHighlightStyle` stays EMPTY — the bubble is a widget-layer decorator, never a per-glyph fill.

## TDD Analysis
- Type: feature (restore + redesign)
- Behavior change: yes (bubble visible; path tap copies instead of opening)
- TDD approach: full (red baseline confirmed before implementation)

## Test coverage
- New `native/test/ui/ghostty_bubble_layer_test.dart` (13 tests, fail→pass):
  - REAL scanner over a generated 3-row wrapped URL behind a space-painted margin → per-row ranges → `AnchorGeometry.rectsFor` → segments: one rect per row, first-row start col honored, continuation rows exclude the painted margin, capsule ends only on first/last, single-row = full capsule, degenerate rects skipped.
  - Widget: layer renders for an on-screen anchor (url AND path), renders nothing off-screen, hides while scrolling / re-shows on settle.
  - Tap: router-routed tap on a CONTINUATION row resolves the match; `ghosttyTapCopyMatch` copies the exact joined URL; path copies with "Copied path"; empty payload copies nothing (#810 guard).
- New `native/integration_test/url_bubble_wrap_988_test.dart` (emulator, real session to test-sshd): 197-char URL soft-wraps across 4 rows → one anchor with the EXACT payload; bubble paints; per-row rects stack; single tap at a continuation-row bubble rect → system clipboard == exact URL; `seq 200` scroll: bubble hidden while scrolling and gone once the anchor is off-screen (no stale outline); scroll back → tap the re-resolved rect → exact copy again (#930 drift guard: a drifted rect would miss).
- Updated: `ghostty_terminal_decorators_test.dart` comments only (assertions unchanged — the empty style is still the contract).

## Test results
- flutter analyze: PASS
- flutter test (fast gate): PASS (1680 tests, 13 new)
- Emulator integration: PASS (url_bubble_wrap_988_test.dart, cycle details below)

## Screenshot
`test-results/emulator-shots/20260708T133902+0000-bubble-988-wrapped_.png` — the 4-row wrapped URL bubbled as one object (capsule start on row 1, square wrap edges, capsule close at content end), MOTD URL + `/etc/motd` path capsules, gutter marks coexisting.

## Emulator cycles (honest log)
1. Fixture bug: base64 payload lacked the trailing newline (prompt printed on the URL's row and was swallowed into the payload) and 200 chars is a multiple of the 50-col grid (flush last row → width-join onto the prompt line). Fixed: encode `url\n`, PRIME length 197.
2. Assertion raced the BY-DESIGN one-frame hide latency (isScrolling flips during paint; the layer hides on the post-frame decoration notify, #812 rising edge). Assertion now grants exactly that frame.
3. GREEN.

## What only the owner's device can verify
- Visual feel of the capsule on real DPI/fonts and against the owner's tmux/TUI content (emulator screenshot looks physical).
- Cross-app paste remains the separate open issue #924 (in-app clipboard readback is what the test asserts).

Closes #988

## Cycles used
3/3 (1 headless + 2 emulator-fixture refinements; no implementation churn after cycle 1)