### PR TITLE
feat(native): detected vs VERIFIED path shades (SFTP stat) + single-segment visibility gate (#990)

### DIFF
--- a/native/integration_test/path_verified_shade_test.dart
+++ b/native/integration_test/path_verified_shade_test.dart
@@ -1,0 +1,211 @@
+// On-emulator smoke for #990 — detected vs VERIFIED path shades, plus the
+// single-segment VISIBILITY gate (owner report on +121: `/config` bubbled).
+//
+// Connects to test-sshd and prints four references:
+//   /etc/hosts        — REAL multi-segment  → detected shade, upgrades to bold
+//   /no/such/path990  — FAKE multi-segment  → stays detected (fail-open)
+//   /etc              — REAL single-segment → suppressed until its stat lands,
+//                       then visible (verified)
+//   /config           — FAKE single-segment (a TUI slash-command shape) →
+//                       stat resolves MISSING → suppressed forever
+// The session's SessionPathVerifier (GhosttyTerminalView.debugPathVerifiers)
+// is the production instance the layers read; its status() drives both the
+// shade and the visibility gate. This exercises the WHOLE production chain the
+// headless tests fake: anchor rescan → notePaths → debounce → sftpStat IPC →
+// task-side stat over the live SftpSession → SftpStatResultEvent → cache →
+// shade/visibility predicates.
+//
+// After the assertions the test HOLDS the terminal on screen so the
+// orchestrator can run `scripts/emu-shot.sh path-verified` and review that the
+// two shades are distinguishable at phone density (bold ring on the verified
+// row's gutter chip; thicker stroke + fill wash on its bubble).
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/path_verified_shade_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/path_verifier.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'a REAL printed path upgrades to the verified shade; a FAKE one stays '
+    'detected (#990)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller for session');
+
+      // Wait for a live shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      const realPath = '/etc/hosts';
+      const fakePath = '/no/such/path990';
+      const realSingle = '/etc';
+      const fakeSingle = '/config';
+      entry.proxy.sendInput(
+        Uint8List.fromList(
+          utf8.encode(
+            'echo REAL990 $realPath; echo FAKE990 $fakePath; '
+            'echo DIR990 $realSingle; echo CMD990 $fakeSingle\n',
+          ),
+        ),
+      );
+
+      // Both paths must be DETECTED (path anchors) regardless of existence.
+      bool bothDetected() =>
+          controller!.anchors.any(
+            (a) => a.patternId == 'path' && '${a.payload}' == realPath,
+          ) &&
+          controller.anchors.any(
+            (a) => a.patternId == 'path' && '${a.payload}' == fakePath,
+          );
+      for (var i = 0; i < 40 && !bothDetected(); i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(
+        bothDetected(),
+        isTrue,
+        reason: 'both printed paths must be DETECTED as path anchors '
+            '(detection is syntactic — existence only affects the shade)',
+      );
+
+      // The session's verifier is the production instance the layers read.
+      final verifier = GhosttyTerminalView.debugPathVerifiers[sessionId];
+      expect(verifier, isNotNull, reason: 'no path verifier for session');
+
+      // The REAL path upgrades to verified once its SFTP stat lands (debounce
+      // + stat round-trip — give it a generous window).
+      var realVerified = false;
+      for (var i = 0; i < 40 && !realVerified; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        realVerified = verifier!.isVerified(realPath);
+      }
+      expect(
+        realVerified,
+        isTrue,
+        reason: '$realPath exists on test-sshd — its anchor must upgrade to '
+            'the VERIFIED shade',
+      );
+
+      // By now the fake path's stat has also resolved (same batch) — it must
+      // read NOT verified (fail-open keeps the plain detected shade).
+      expect(
+        verifier!.isVerified(fakePath),
+        isFalse,
+        reason: '$fakePath does not exist — it must stay in the detected shade',
+      );
+
+      // #990 visibility gate — REAL single-segment (`/etc`): suppressed until
+      // its stat lands, then VISIBLE (status verified drives the gate).
+      var singleVerified = false;
+      for (var i = 0; i < 40 && !singleVerified; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        singleVerified =
+            verifier.status(realSingle) == PathVerification.verified;
+      }
+      expect(
+        singleVerified,
+        isTrue,
+        reason: '$realSingle exists on test-sshd — its affordance must appear '
+            'after verification',
+      );
+
+      // FAKE single-segment (`/config`, the slash-command shape): if the
+      // scanner anchored it at all, its stat must resolve MISSING — the
+      // visibility gate keeps it affordance-free forever (pending and missing
+      // are both suppressed; the rendering side is asserted headlessly in the
+      // gutter/bubble layer widget tests).
+      final configAnchored = controller!.anchors.any(
+        (a) => a.patternId == 'path' && '${a.payload}' == fakeSingle,
+      );
+      if (configAnchored) {
+        var configResolved = false;
+        for (var i = 0; i < 40 && !configResolved; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+          configResolved =
+              verifier.status(fakeSingle) == PathVerification.missing;
+        }
+        expect(
+          configResolved,
+          isTrue,
+          reason: '$fakeSingle must resolve MISSING (stat fails) so the '
+              'visibility gate never shows its affordance',
+        );
+        expect(verifier.isVerified(fakeSingle), isFalse);
+      }
+
+      // Screenshot HOLD: keep both shades on screen for the external emu-shot.
+      debugPrint('PATH990_SHOT_WINDOW_OPEN');
+      for (var i = 0; i < 90; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      debugPrint('PATH990_SHOT_WINDOW_CLOSED');
+    },
+  );
+}

--- a/native/lib/services/path_verifier.dart
+++ b/native/lib/services/path_verifier.dart
@@ -1,0 +1,198 @@
+// path_verifier.dart — per-session detected-path VERIFICATION cache (#990).
+//
+// A detected file-path anchor renders in the plain "detected" shade; once this
+// verifier confirms the path EXISTS ON THE CONNECTED HOST (one SFTP stat via
+// the session's `sftpStat` probe) the anchor upgrades to the bolder VERIFIED
+// shade. The presentation layers never see WHY a path is verified — they get
+// an opaque predicate + this ChangeNotifier — so the meaning of "verified"
+// can later change (e.g. "downloaded locally") without touching paint code.
+//
+// Contract (issue #990):
+//   - per-session: one verifier per session; state is keyed (session, path).
+//     A path valid on host A says nothing about host B.
+//   - debounced: a burst of anchor updates collapses into one batched drain.
+//   - cached with a short TTL: a fresh answer (either way) is never re-probed;
+//     an expired one lapses back to "detected" until re-confirmed.
+//   - capped: at most [maxInFlight] outstanding stats; the rest queue.
+//   - fail-open: a negative/errored/timed-out stat leaves the path in the
+//     "detected" shade. Never blocks rendering (pure lookups, async fills).
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Sends one stat probe. Production wires `SshSessionProxy.sftpStat`; tests
+/// record the calls.
+typedef PathStatSender =
+    void Function({required String requestId, required String path});
+
+/// The tri-state a consumer can read for a path (#990 visibility gate):
+///   - [pending]  — no FRESH answer (never probed, awaiting one, or expired).
+///   - [verified] — a fresh stat confirmed the path exists on this host.
+///   - [missing]  — a fresh stat failed (no such path / denied / errored /
+///                  timed out — all fail-open equivalents).
+/// The SHADE predicate only cares about [verified]; the single-segment
+/// VISIBILITY gate suppresses both [pending] and [missing].
+enum PathVerification { pending, verified, missing }
+
+/// One cached stat answer: [exists] until [expiresAt].
+class _CacheEntry {
+  _CacheEntry({required this.exists, required this.expiresAt});
+
+  final bool exists;
+  final DateTime expiresAt;
+}
+
+/// One outstanding probe, so a result/timeout can resolve back to its path.
+class _InFlight {
+  _InFlight({required this.path, required this.timeout});
+
+  final String path;
+  final Timer timeout;
+}
+
+/// Per-session verification cache for detected path anchors (#990).
+///
+/// Feed it the currently-anchored paths via [notePaths] (cheap, debounced);
+/// read [isVerified] from paint code (synchronous map lookup); listen for
+/// upgrades (it notifies when any path's verified state changes).
+class SessionPathVerifier extends ChangeNotifier {
+  SessionPathVerifier({
+    required this.sessionId,
+    required this.sendStat,
+    this.ttl = const Duration(seconds: 30),
+    this.debounce = const Duration(milliseconds: 250),
+    this.requestTimeout = const Duration(seconds: 6),
+    this.maxInFlight = 4,
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  /// The session this verifier is scoped to. Also namespaces request ids so a
+  /// cross-routed result can never land in another session's cache.
+  final String sessionId;
+
+  /// How long a stat answer (either way) stays fresh. Short by design: a path
+  /// can be created/deleted at any time; the anchor set re-notes on every
+  /// decoration change so a hot path re-probes soon after expiry.
+  final Duration ttl;
+
+  /// The batching window for [notePaths] bursts (anchors arrive per detection
+  /// rescan — several notifies per output burst).
+  final Duration debounce;
+
+  /// Fail-open deadline for one probe: an unanswered stat is treated as
+  /// "not verified" and its slot freed.
+  final Duration requestTimeout;
+
+  /// Cap on outstanding probes; the rest queue until a slot frees.
+  final int maxInFlight;
+
+  /// Fires one stat probe (production: `SshSessionProxy.sftpStat`).
+  final PathStatSender sendStat;
+
+  final DateTime Function() _now;
+
+  final Map<String, _CacheEntry> _cache = {};
+  final Set<String> _pending = {};
+  final Map<String, _InFlight> _inFlight = {};
+  Timer? _debounceTimer;
+  int _seq = 0;
+  bool _disposed = false;
+
+  /// Whether [path] is currently verified (exists on this session's host, per
+  /// a FRESH stat answer). Pure lookup — never triggers I/O, safe from paint.
+  bool isVerified(String path) => status(path) == PathVerification.verified;
+
+  /// The full tri-state for [path] (#990 visibility gate). Pure lookup.
+  PathVerification status(String path) {
+    final entry = _cache[path];
+    if (entry == null) return PathVerification.pending;
+    if (!entry.expiresAt.isAfter(_now())) return PathVerification.pending;
+    return entry.exists ? PathVerification.verified : PathVerification.missing;
+  }
+
+  /// Note the currently-anchored detected paths. Cheap and idempotent: paths
+  /// with a fresh cached answer or an outstanding probe are skipped; the rest
+  /// are probed after the debounce window, at most [maxInFlight] at a time.
+  void notePaths(Iterable<String> paths) {
+    if (_disposed) return;
+    var added = false;
+    for (final path in paths) {
+      if (path.isEmpty) continue;
+      added = _pending.add(path) || added;
+    }
+    if (!added && _debounceTimer != null) return;
+    _debounceTimer ??= Timer(debounce, () {
+      _debounceTimer = null;
+      _drain();
+    });
+  }
+
+  /// Deliver one probe answer. Wire this to the session proxy's
+  /// [SftpStatResultEvent]s. Unknown/stale request ids are ignored.
+  void onStatResult({required String requestId, required bool exists}) {
+    if (_disposed) return;
+    final inFlight = _inFlight.remove(requestId);
+    if (inFlight == null) return;
+    inFlight.timeout.cancel();
+    _store(inFlight.path, exists);
+    _drain();
+  }
+
+  void _store(String path, bool exists) {
+    // Notify on ANY status change (pending→missing included): the #990
+    // visibility gate suppresses pending single-segment matches, so a missing
+    // verdict is as paint-relevant as an upgrade.
+    final was = status(path);
+    _cache[path] = _CacheEntry(exists: exists, expiresAt: _now().add(ttl));
+    if (status(path) != was) notifyListeners();
+  }
+
+  void _drain() {
+    if (_disposed) return;
+    final now = _now();
+    // Evict expired cache entries so the map stays bounded by live anchors.
+    _cache.removeWhere((_, e) => !e.expiresAt.isAfter(now));
+    final drained = <String>[];
+    for (final path in _pending) {
+      if (_inFlight.length >= maxInFlight) break;
+      if (_cache.containsKey(path)) {
+        drained.add(path);
+        continue;
+      }
+      if (_inFlight.values.any((f) => f.path == path)) {
+        drained.add(path);
+        continue;
+      }
+      final requestId = 'pathstat-$sessionId-${_seq++}';
+      _inFlight[requestId] = _InFlight(
+        path: path,
+        // Fail-open: an unanswered probe resolves to "not verified" and frees
+        // its slot so the queue keeps moving. The negative is CACHED (normal
+        // TTL) so a dead SFTP channel isn't hammered every rescan.
+        timeout: Timer(requestTimeout, () {
+          final timedOut = _inFlight.remove(requestId);
+          if (timedOut == null) return;
+          _store(timedOut.path, false);
+          _drain();
+        }),
+      );
+      drained.add(path);
+      sendStat(requestId: requestId, path: path);
+    }
+    _pending.removeAll(drained);
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    for (final f in _inFlight.values) {
+      f.timeout.cancel();
+    }
+    _inFlight.clear();
+    _pending.clear();
+    super.dispose();
+  }
+}

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -371,6 +371,8 @@ class SessionHost {
         _handleSftpUpload(cmd);
       case SftpUploadFileCommand():
         _handleSftpUploadFile(cmd);
+      case SftpStatCommand():
+        _handleSftpStat(cmd);
       case SshControlCommand():
         _handleControlCommand(cmd);
       case SshTmuxGestureCommand():
@@ -1588,6 +1590,36 @@ class SessionHost {
       ctrace('task.host', 'sftp uploadFile FAILED remote=${cmd.remotePath} — $e');
       _emitSftpError(cmd.sessionId, cmd.requestId, 'Upload failed: $e');
     }
+  }
+
+  /// #990: existence probe for a detected path anchor. ONE stat over the
+  /// session's SftpSession ([SftpSession.sizeOf] — a stat under the hood; no
+  /// new session-abstraction method so the existing fakes stay valid). ALWAYS
+  /// replies with a [SftpStatResultEvent]; every failure mode (missing path,
+  /// permission denied, session not connected, channel error) collapses to
+  /// `exists=false` — fail-open per the #990 contract, so the UI never blocks
+  /// or surfaces an error banner for a probe.
+  Future<void> _handleSftpStat(SftpStatCommand cmd) async {
+    var exists = false;
+    try {
+      final sftp = await _ensureSftp(cmd.sessionId);
+      if (sftp != null) {
+        await sftp.sizeOf(cmd.path);
+        exists = true;
+      }
+    } catch (e) {
+      ctrace('task.host', 'sftp stat MISS path=${cmd.path} — $e');
+      exists = false;
+    }
+    if (_disposed) return;
+    _gateway.send(
+      SftpStatResultEvent(
+        sessionId: cmd.sessionId,
+        requestId: cmd.requestId,
+        path: cmd.path,
+        exists: exists,
+      ).toJson(),
+    );
   }
 
   void _emitSftpError(String sessionId, String requestId, String message) {

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -75,6 +75,14 @@ enum SshTaskCommandKind {
   /// [SftpUploadProgressEvent]s + a terminal [SftpUploadDoneEvent].
   sftpUploadFile,
 
+  /// Lightweight existence probe for ONE remote path (#990). The task stats
+  /// the path over the session's SftpSession and replies with a
+  /// [SftpStatResultEvent] (`exists` bool) — ALWAYS a result, never an error
+  /// event: a failed/denied stat is `exists=false` (fail-open — the UI keeps
+  /// the plain "detected" shade). Used by the path-anchor verifier; NEVER a
+  /// directory listing (that's [sftpList], too heavy for a probe).
+  sftpStat,
+
   // --- tmux control mode (#911, Part C) ---
 
   /// UI → task: a FULL tmux `-CC` control-command LINE, delivered ATOMICALLY
@@ -154,6 +162,11 @@ enum SshTaskEventKind {
   /// browser renders a determinate bar; resume reports its starting offset via
   /// the first event.
   sftpUploadProgress,
+
+  /// The reply to an [SshTaskCommandKind.sftpStat] probe (#990): whether the
+  /// path exists on the connected host. Errors collapse to `exists=false`
+  /// (fail-open) so the verifier needs no error branch.
+  sftpStatResult,
 
   /// An SFTP operation failed (list, download, or upload). Carries the request
   /// id so the UI can match it to the in-flight op without tearing down the
@@ -322,6 +335,12 @@ sealed class SshTaskCommand {
           localPath: json['localPath'] as String,
           remotePath: json['remotePath'] as String,
         );
+      case SshTaskCommandKind.sftpStat:
+        return SftpStatCommand(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          path: json['path'] as String,
+        );
       case SshTaskCommandKind.controlCommand:
         return SshControlCommand(
           sessionId: sessionId,
@@ -461,6 +480,33 @@ class SftpUploadFileCommand extends SshTaskCommand {
     'requestId': requestId,
     'localPath': localPath,
     'remotePath': remotePath,
+  };
+}
+
+/// UI → task: does the remote path exist? (#990). The task stats [path] over
+/// the session's SftpSession and replies with a [SftpStatResultEvent] keyed by
+/// [requestId]. Mirrors [SftpListCommand]'s envelope; deliberately NOT a
+/// listing — a probe must stay cheap (one stat) because the verifier fires it
+/// for every currently-anchored detected path.
+class SftpStatCommand extends SshTaskCommand {
+  const SftpStatCommand({
+    required String sessionId,
+    required this.requestId,
+    required this.path,
+  }) : super(sessionId);
+
+  final String requestId;
+  final String path;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.sftpStat;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'requestId': requestId,
+    'path': path,
   };
 }
 
@@ -900,6 +946,13 @@ sealed class SshTaskEvent {
           sent: json['sent'] as int,
           totalBytes: json['totalBytes'] as int,
         );
+      case SshTaskEventKind.sftpStatResult:
+        return SftpStatResultEvent(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          path: json['path'] as String,
+          exists: json['exists'] as bool,
+        );
       case SshTaskEventKind.sftpError:
         return SftpErrorEvent(
           sessionId: sessionId,
@@ -1304,6 +1357,37 @@ class SftpUploadProgressEvent extends SshTaskEvent {
     'requestId': requestId,
     'sent': sent,
     'totalBytes': totalBytes,
+  };
+}
+
+/// Task → UI: the reply to an [SftpStatCommand] probe (#990). [exists] is true
+/// iff the stat succeeded on the connected host; ANY failure (missing path,
+/// permission denied, session not connected) is `exists=false` — fail-open,
+/// the path anchor keeps the plain "detected" shade. Echoes [path] so the
+/// UI-side verifier can cache by path without holding request state beyond the
+/// id.
+class SftpStatResultEvent extends SshTaskEvent {
+  const SftpStatResultEvent({
+    required String sessionId,
+    required this.requestId,
+    required this.path,
+    required this.exists,
+  }) : super(sessionId);
+
+  final String requestId;
+  final String path;
+  final bool exists;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.sftpStatResult;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'requestId': requestId,
+    'path': path,
+    'exists': exists,
   };
 }
 

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -388,6 +388,20 @@ class SshSessionProxy {
     );
   }
 
+  /// Probe whether a remote path exists over SFTP (#990). The
+  /// [SftpStatResultEvent] arrives on [sftpEvents] keyed by [requestId] —
+  /// ALWAYS a result (errors collapse to `exists=false`, fail-open). Used by
+  /// the path-anchor verifier to upgrade a detected path to the verified shade.
+  void sftpStat({required String requestId, required String path}) {
+    gateway.send(
+      SftpStatCommand(
+        sessionId: sessionId,
+        requestId: requestId,
+        path: path,
+      ).toJson(),
+    );
+  }
+
   /// Send a PTY resize to the remote.
   ///
   /// #848 — NO-OP GUARD: a resize whose (cols, rows) are IDENTICAL to the last
@@ -526,6 +540,7 @@ class SshSessionProxy {
       case SftpDownloadDoneEvent():
       case SftpUploadDoneEvent():
       case SftpUploadProgressEvent():
+      case SftpStatResultEvent():
       case SftpErrorEvent():
         // SFTP results (#559/#892/#960) — forward to the file browser / writer
         // seam, which match by request id. They never touch the SSH lifecycle.

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -55,13 +55,25 @@ class GutterMarkStyle {
     required this.chipSize,
     required this.glyphSize,
     required this.minTapExtent,
+    this.ringWidth = 0.0,
   });
 
-  /// The standard mark style. (#990 adds a `bold` verified-path variant here.)
+  /// The standard mark style — the plain "detected" shade.
   static const GutterMarkStyle normal = GutterMarkStyle(
     chipSize: 24.0,
     glyphSize: 16.0,
     minTapExtent: 40.0,
+  );
+
+  /// The BOLD variant (#990): the VERIFIED-path shade. Same geometry and tap
+  /// semantics as [normal] plus a contrast RING around the chip (stroked in
+  /// [onChipColor], so it stays monochrome + theme-compliant and reads at
+  /// phone density where a subtle fill change would not).
+  static const GutterMarkStyle bold = GutterMarkStyle(
+    chipSize: 24.0,
+    glyphSize: 16.0,
+    minTapExtent: 40.0,
+    ringWidth: 2.5,
   );
 
   /// Diameter of the filled chip behind the glyph.
@@ -74,6 +86,10 @@ class GutterMarkStyle {
   /// The mark's HIT box is expanded to this even though the painted chip is
   /// smaller — the extra area is invisible and centred on the row.
   final double minTapExtent;
+
+  /// Width of the contrast ring around the chip — 0 for the plain detected
+  /// shade, >0 for the bold VERIFIED shade (#990).
+  final double ringWidth;
 
   /// The chip fill: the theme accent forced OPAQUE. The session selection
   /// colour is often translucent (e.g. `0x33` alpha) — a see-through chip has
@@ -311,6 +327,10 @@ class GhosttyGutterLayer extends StatelessWidget {
     this.padding = 4.0,
     this.stripWidth = kGutterStripWidth,
     this.style = GutterMarkStyle.normal,
+    this.isVerified,
+    this.isVisible,
+    this.verifiedStyle = GutterMarkStyle.bold,
+    this.verificationListenable,
   });
 
   /// The SAME controller handed to the flterm `TerminalView`.
@@ -336,17 +356,47 @@ class GhosttyGutterLayer extends StatelessWidget {
   /// Chip sizing + colour derivation for the marks (#989).
   final GutterMarkStyle style;
 
+  /// #990: OPAQUE verification predicate. True → the anchor's row renders in
+  /// [verifiedStyle] (the bold shade). Null → every mark stays [style]. The
+  /// layer deliberately doesn't know WHY an anchor is verified (today:
+  /// exists-on-host via the session's SFTP stat) so the predicate's meaning
+  /// can change without paint rework.
+  final bool Function(StructuredAnchor anchor)? isVerified;
+
+  /// #990 visibility gate: OPAQUE suppression predicate — false means the
+  /// anchor gets NO gutter mark at all (a low-confidence single-segment match
+  /// awaiting verification, or confirmed missing). A suppressed anchor also
+  /// drops out of a multi-match row's count. Null → everything shows.
+  final bool Function(StructuredAnchor anchor)? isVisible;
+
+  /// The bold shade for verified anchors (#990).
+  final GutterMarkStyle verifiedStyle;
+
+  /// #990: fires when a verification result lands (no anchor change involved)
+  /// so the marks repaint. Merged with the controller's decoration listenable.
+  final Listenable? verificationListenable;
+
   @override
   Widget build(BuildContext context) {
+    final verification = verificationListenable;
     return ListenableBuilder(
-      listenable: controller.decorationListenable,
+      listenable: verification == null
+          ? controller.decorationListenable
+          : Listenable.merge([controller.decorationListenable, verification]),
       builder: (context, _) {
         // #812: don't draw mid-scroll — the marks reappear on settle. (Tap
         // routing via the gesture router's matchAt is unaffected.)
         if (controller.isScrolling) return const SizedBox.shrink();
         if (cellHeight <= 0) return const SizedBox.shrink();
         final byRow = groupAnchorsByGutterRow(
-          controller.anchors,
+          // #990 visibility gate: suppressed anchors never reach the grouping,
+          // so a suppressed match neither marks its row nor inflates a count.
+          isVisible == null
+              ? controller.anchors
+              : [
+                  for (final a in controller.anchors)
+                    if (isVisible!(a)) a,
+                ],
           gutterRowOf: controller.anchorGutterRow,
           hasPresentation: (id) => registry.forPattern(id) != null,
         );
@@ -387,7 +437,11 @@ class GhosttyGutterLayer extends StatelessWidget {
                   anchors: entry.value,
                   registry: registry,
                   color: color,
-                  style: style,
+                  // #990: a row with ANY verified anchor renders the bold
+                  // shade (a multi-match row's badge inherits it too).
+                  style: (isVerified != null && entry.value.any(isVerified!))
+                      ? verifiedStyle
+                      : style,
                   stripWidth: stripWidth,
                 ),
               ),
@@ -480,6 +534,11 @@ class _GutterMarkState extends State<_GutterMark> {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 color: chipFill,
+                // #990: the VERIFIED shade — a contrast ring (bold), absent on
+                // the plain detected chip.
+                border: style.ringWidth > 0
+                    ? Border.all(color: onChip, width: style.ringWidth)
+                    : null,
                 boxShadow: [
                   BoxShadow(
                     color: Colors.black.withValues(alpha: 0.35),

--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -139,6 +139,45 @@ List<GhosttyBubbleSegment> ghosttyBubbleSegments(List<Rect> rowRects) {
   ];
 }
 
+/// #990 visibility gate: whether a detected path payload is a LOW-CONFIDENCE
+/// match that must be VERIFIED (SFTP stat confirms existence) before ANY
+/// affordance shows. True for SINGLE-SEGMENT root-level matches (`/config`,
+/// `/rc` — no second slash): in terminal output those are overwhelmingly TUI
+/// slash-commands (the +121 owner report), not paths. Multi-segment paths
+/// (`/etc/hosts`) return false — they show immediately at the detected shade.
+/// Degenerate payloads (`/`, empty) are conservatively true (suppressed).
+bool ghosttyPathRequiresVerification(String payload) {
+  var p = payload;
+  while (p.endsWith('/')) {
+    p = p.substring(0, p.length - 1);
+  }
+  if (p.length < 2 || !p.startsWith('/')) return true; // degenerate
+  return !p.substring(1).contains('/');
+}
+
+/// Stroke width of the plain "detected" bubble outline, logical px.
+const double kGhosttyBubbleStrokeWidth = 1.5;
+
+/// Stroke width of the bolder VERIFIED bubble outline (#990) — a detected
+/// file path confirmed to exist on the connected host.
+const double kGhosttyBubbleVerifiedStrokeWidth = 2.5;
+
+/// Fill-wash alpha inside a VERIFIED bubble (#990). A faint tint (the text
+/// stays fully readable) that, with the thicker stroke, makes the verified
+/// shade legible at phone density.
+const double kGhosttyBubbleVerifiedFillAlpha = 0.15;
+
+/// One anchor's renderable bubble (#990): its per-row [segments] plus whether
+/// it renders in the bolder VERIFIED shade. Public (with the painter) so the
+/// widget test can assert shade selection without reaching into paint calls.
+@immutable
+class GhosttyBubbleSpec {
+  const GhosttyBubbleSpec({required this.segments, required this.verified});
+
+  final List<GhosttyBubbleSegment> segments;
+  final bool verified;
+}
+
 /// The restored inline bubble layer (#988) — a paint-only overlay drawing one
 /// wrap-aware outline bubble per detected URL / OSC-8 link / file path.
 ///
@@ -159,6 +198,9 @@ class GhosttyBubbleLayer extends StatelessWidget {
     super.key,
     required this.controller,
     required this.color,
+    this.isVerified,
+    this.isVisible,
+    this.verificationListenable,
   });
 
   /// The SAME controller handed to the flterm `TerminalView`. Its `anchors` /
@@ -168,6 +210,23 @@ class GhosttyBubbleLayer extends StatelessWidget {
   /// The theme accent the bubbles are stroked in (the session selection
   /// colour). Rebuilds when the parent re-creates the layer with a new colour.
   final Color color;
+
+  /// #990: OPAQUE verification predicate — true renders the anchor's bubble in
+  /// the bolder VERIFIED shade (thicker stroke + faint fill). Null → every
+  /// bubble stays the plain detected shade. The layer doesn't know WHY an
+  /// anchor is verified (today: exists-on-host via the session's SFTP stat),
+  /// so the predicate's meaning can change without paint rework.
+  final bool Function(StructuredAnchor anchor)? isVerified;
+
+  /// #990 visibility gate: OPAQUE suppression predicate — false means the
+  /// anchor paints NO bubble at all (a low-confidence single-segment match
+  /// awaiting verification, or confirmed missing). Null → everything paints.
+  final bool Function(StructuredAnchor anchor)? isVisible;
+
+  /// #990: fires when a verification result lands (no anchor change involved)
+  /// so the bubbles repaint. Merged with the controller's decoration
+  /// listenable.
+  final Listenable? verificationListenable;
 
   /// The pattern ids that render a bubble. URL, OSC-8 and path share the ONE
   /// mechanism (#988); a per-pattern shade difference is a separate issue.
@@ -179,26 +238,36 @@ class GhosttyBubbleLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final verification = verificationListenable;
     return ListenableBuilder(
-      listenable: controller.decorationListenable,
+      listenable: verification == null
+          ? controller.decorationListenable
+          : Listenable.merge([controller.decorationListenable, verification]),
       builder: (context, _) {
         if (controller.isScrolling) return const SizedBox.shrink();
-        final bubbles = <List<GhosttyBubbleSegment>>[];
+        final specs = <GhosttyBubbleSpec>[];
         for (final anchor in controller.anchors) {
           if (!_bubblePatternIds.contains(anchor.patternId)) continue;
+          // #990 visibility gate: suppressed anchors paint nothing.
+          if (!(isVisible?.call(anchor) ?? true)) continue;
           final rects = <Rect>[];
           for (final range in anchor.ranges) {
             rects.addAll(controller.anchorRects(range));
           }
           final segments = ghosttyBubbleSegments(rects);
           if (segments.isEmpty) continue; // fully off-screen
-          bubbles.add(segments);
+          specs.add(
+            GhosttyBubbleSpec(
+              segments: segments,
+              verified: isVerified?.call(anchor) ?? false,
+            ),
+          );
         }
-        if (bubbles.isEmpty) return const SizedBox.shrink();
+        if (specs.isEmpty) return const SizedBox.shrink();
         return IgnorePointer(
           child: CustomPaint(
             key: const Key('ghostty-bubble-paint'),
-            painter: _GhosttyBubblePainter(bubbles: bubbles, color: color),
+            painter: GhosttyBubblePainter(specs: specs, color: color),
             size: Size.infinite,
           ),
         );
@@ -209,40 +278,51 @@ class GhosttyBubbleLayer extends StatelessWidget {
 
 /// Strokes one outline per bubble segment — an OUTLINE (never an opaque fill
 /// over the glyphs) so the text stays readable and the capsule reads as a
-/// physical chip around it.
-class _GhosttyBubblePainter extends CustomPainter {
-  _GhosttyBubblePainter({required this.bubbles, required this.color});
+/// physical chip around it. A VERIFIED spec (#990) strokes thicker and adds a
+/// faint fill wash. Public (with final fields) so the widget test can assert
+/// the detected/verified shade selection.
+class GhosttyBubblePainter extends CustomPainter {
+  GhosttyBubblePainter({required this.specs, required this.color});
 
-  final List<List<GhosttyBubbleSegment>> bubbles;
+  final List<GhosttyBubbleSpec> specs;
   final Color color;
-
-  /// Outline stroke width, in logical px.
-  static const double _stroke = 1.5;
 
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
+    final stroke = Paint()
       ..style = PaintingStyle.stroke
-      ..strokeWidth = _stroke
+      ..strokeWidth = kGhosttyBubbleStrokeWidth
       ..color = color
       ..isAntiAlias = true;
-    for (final segments in bubbles) {
-      for (final segment in segments) {
-        canvas.drawRRect(segment.toRRect(), paint);
+    final verifiedStroke = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = kGhosttyBubbleVerifiedStrokeWidth
+      ..color = color
+      ..isAntiAlias = true;
+    final verifiedFill = Paint()
+      ..style = PaintingStyle.fill
+      ..color = color.withValues(alpha: kGhosttyBubbleVerifiedFillAlpha)
+      ..isAntiAlias = true;
+    for (final spec in specs) {
+      for (final segment in spec.segments) {
+        final rrect = segment.toRRect();
+        if (spec.verified) canvas.drawRRect(rrect, verifiedFill);
+        canvas.drawRRect(rrect, spec.verified ? verifiedStroke : stroke);
       }
     }
   }
 
   @override
-  bool shouldRepaint(covariant _GhosttyBubblePainter old) {
+  bool shouldRepaint(covariant GhosttyBubblePainter old) {
     if (old.color != color) return true;
-    if (old.bubbles.length != bubbles.length) return true;
-    for (var i = 0; i < bubbles.length; i++) {
-      final a = bubbles[i];
-      final b = old.bubbles[i];
-      if (a.length != b.length) return true;
-      for (var j = 0; j < a.length; j++) {
-        if (a[j] != b[j]) return true;
+    if (old.specs.length != specs.length) return true;
+    for (var i = 0; i < specs.length; i++) {
+      final a = specs[i];
+      final b = old.specs[i];
+      if (a.verified != b.verified) return true;
+      if (a.segments.length != b.segments.length) return true;
+      for (var j = 0; j < a.segments.length; j++) {
+        if (a.segments[j] != b.segments[j]) return true;
       }
     }
     return false;

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -176,7 +176,9 @@ import '../diagnostics/gesture_trace.dart';
 import '../diagnostics/paint_stats.dart';
 import '../diagnostics/session_byte_recorder.dart';
 import '../services/clipboard.dart';
-import '../services/session_messages.dart' show TmuxWindowGesture;
+import '../services/path_verifier.dart';
+import '../services/session_messages.dart'
+    show SftpStatResultEvent, SshTaskEvent, TmuxWindowGesture;
 import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../terminal/tmux_control_mode_flag.dart';
@@ -2200,6 +2202,14 @@ class GhosttyTerminalView extends ConsumerStatefulWidget {
   @visibleForTesting
   static final Map<String, List<int>> debugGrids = <String, List<int>>{};
 
+  /// #990: the live per-session path verifier, exposed so the on-emulator
+  /// integration test can assert a printed REAL path upgrades to verified while
+  /// a FAKE one stays detected (`isVerified(path)`). Mirrors the other debug
+  /// seams: set in initState, cleared on dispose. Test-only.
+  @visibleForTesting
+  static final Map<String, SessionPathVerifier> debugPathVerifiers =
+      <String, SessionPathVerifier>{};
+
   @override
   ConsumerState<GhosttyTerminalView> createState() =>
       _GhosttyTerminalViewState();
@@ -2420,6 +2430,18 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// doesn't spam the scroll ring with identical offsets.
   int _lastRecordedScrollOffset = -1;
 
+  /// #990: the per-session detected-path VERIFICATION cache. Feeds the bolder
+  /// "verified" shade on the gutter chip + inline bubble for a path anchor
+  /// that exists on the CONNECTED host (one SFTP stat per path, debounced,
+  /// TTL-cached, fail-open). Scoped to this view == this session, so a path
+  /// verified on host A never bleeds onto host B. Null when the proxy failed
+  /// to resolve.
+  SessionPathVerifier? _pathVerifier;
+
+  /// #990: subscription routing [SftpStatResultEvent]s (broadcast, shared with
+  /// the file browser's listener) into [_pathVerifier]. Cancelled on dispose.
+  StreamSubscription<SshTaskEvent>? _sftpStatSub;
+
   @override
   void initState() {
     super.initState();
@@ -2532,6 +2554,27 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // visual is the widget-layer bubble decorator, coloured per the live
       // session theme in [build].
       _registerUrlPattern(controller);
+      // #990: per-session path verification. The verifier probes each detected
+      // path anchor ONCE (debounced, capped, TTL-cached) over the session's
+      // SFTP and the gutter/bubble layers read `isVerified` for the bolder
+      // shade. Anchors are noted off the SAME narrow decoration listenable the
+      // layers repaint on; results arrive on the broadcast sftpEvents stream.
+      _pathVerifier = SessionPathVerifier(
+        sessionId: widget.sessionId,
+        sendStat: proxy.sftpStat,
+      );
+      _sftpStatSub = proxy.sftpEvents.listen((event) {
+        if (event is SftpStatResultEvent) {
+          _pathVerifier?.onStatResult(
+            requestId: event.requestId,
+            exists: event.exists,
+          );
+        }
+      });
+      controller.decorationListenable.addListener(_notePathAnchors);
+      // #990 (test-only): expose the verifier so the on-emulator integration
+      // test can assert the real-path/fake-path shade split.
+      GhosttyTerminalView.debugPathVerifiers[widget.sessionId] = _pathVerifier!;
       // Paint replay harness: let the stats snapshot probe the live render-box
       // boundary counters (notifies / paints / frame syncs) at read time.
       _paintStats.boxProbe = _probePaintBox;
@@ -2597,6 +2640,50 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // #748/#750/#751/#764 drift root cause (external re-sync on every notify) is
     // gone.
   }
+
+  /// #990: feed the CURRENTLY-ANCHORED detected paths to the per-session
+  /// verifier. Runs on the controller's narrow decoration listenable (fires on
+  /// anchor-set / painted-offset changes only). Cheap: the verifier debounces,
+  /// dedupes against its TTL cache, and caps in-flight stats — so this can
+  /// fire freely on every rescan. Gated on a connected session: probing a
+  /// dead session is pure noise (its stats would fail-open anyway).
+  void _notePathAnchors() {
+    final controller = _controller;
+    final verifier = _pathVerifier;
+    if (controller == null || verifier == null) return;
+    final proxy = _proxy;
+    if (proxy == null || proxy.data.state != SshSessionState.connected) return;
+    verifier.notePaths([
+      for (final anchor in controller.anchors)
+        if (anchor.patternId == kGhosttyPathPatternId) '${anchor.payload}',
+    ]);
+  }
+
+  /// #990: the OPAQUE verification predicate handed to the gutter + bubble
+  /// layers. True only for a PATH anchor whose payload the session verifier
+  /// confirmed (exists on the connected host, fresh in its TTL cache). The
+  /// layers never learn WHY — the predicate could later mean "downloaded
+  /// locally" without any paint change.
+  bool _isAnchorVerified(StructuredAnchor anchor) {
+    if (anchor.patternId != kGhosttyPathPatternId) return false;
+    return _pathVerifier?.isVerified('${anchor.payload}') ?? false;
+  }
+
+  /// #990 visibility gate (owner report on +121: `/config`, `/rc` bubbled): a
+  /// SINGLE-SEGMENT root-level path match is a low-confidence detection —
+  /// overwhelmingly a TUI slash-command — so it shows NO affordance (no
+  /// bubble, no gutter chip, no tap-copy) unless the verifier CONFIRMED it
+  /// exists on this host. `pending` and `missing` are both suppressed.
+  /// Multi-segment paths (and every non-path pattern) are always visible.
+  bool _isPayloadVisible(String patternId, String payload) {
+    if (patternId != kGhosttyPathPatternId) return true;
+    if (!ghosttyPathRequiresVerification(payload)) return true;
+    return _pathVerifier?.status(payload) == PathVerification.verified;
+  }
+
+  /// Anchor-shaped adapter of [_isPayloadVisible] for the gutter/bubble layers.
+  bool _isAnchorVisible(StructuredAnchor anchor) =>
+      _isPayloadVisible(anchor.patternId, '${anchor.payload}');
 
   /// #767: read the flterm viewport scroll offset, defensively (an FFI hiccup
   /// must never crash the session) — 0 if the controller can't report it. Used
@@ -3654,6 +3741,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     GhosttyTerminalView.debugByteRecorders.remove(widget.sessionId);
     GhosttyTerminalView.debugCellSizes.remove(widget.sessionId);
     GhosttyTerminalView.debugGrids.remove(widget.sessionId);
+    // #990: tear down the path verifier with its session view.
+    if (GhosttyTerminalView.debugPathVerifiers[widget.sessionId] ==
+        _pathVerifier) {
+      GhosttyTerminalView.debugPathVerifiers.remove(widget.sessionId);
+    }
+    _controller?.decorationListenable.removeListener(_notePathAnchors);
+    _sftpStatSub?.cancel();
+    _pathVerifier?.dispose();
+    _pathVerifier = null;
     _controller?.removeListener(_onControllerChanged);
     _controller?.onOutput = null;
     _controller?.onResize = null;
@@ -4032,8 +4128,17 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             onSelectionClear: _clearSelection,
             // #726/#767: resolve a tapped cell (0-based viewport) to a detected
             // structured match. Detection lives INSIDE the terminal now, so we
-            // ask the controller directly — no app-side URL list.
-            urlAtCell: (col, row) => controller.matchAt(row: row, col: col),
+            // ask the controller directly — no app-side URL list. #990: a
+            // SUPPRESSED match (unverified single-segment path) shows NO
+            // affordance — including the tap-copy — so it doesn't hit-test.
+            urlAtCell: (col, row) {
+              final match = controller.matchAt(row: row, col: col);
+              if (match == null) return null;
+              if (!_isPayloadVisible(match.patternId, '${match.payload}')) {
+                return null;
+              }
+              return match;
+            },
             onUrlTap: _copyUrl,
             // #734: a long-press on a detected URL shows the Copy/Open action
             // menu (the same `showUrlActions` overlay the xterm path uses). The
@@ -4053,6 +4158,12 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
           child: GhosttyBubbleLayer(
             controller: controller,
             color: highlightColor,
+            // #990: verified paths (exist on the connected host, per the
+            // session verifier's SFTP stat) paint the bolder bubble shade;
+            // unverified SINGLE-SEGMENT matches are suppressed entirely.
+            isVerified: _isAnchorVerified,
+            isVisible: _isAnchorVisible,
+            verificationListenable: _pathVerifier,
           ),
         ),
         // #962: right-edge LINE-SELECT layer. Drag the gutter to select WHOLE
@@ -4090,6 +4201,12 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             color: highlightColor,
             cellHeight: cellSize.height,
             padding: kGhosttyTerminalPadding,
+            // #990: a row with a verified path anchor renders the bold chip;
+            // unverified SINGLE-SEGMENT matches get no mark (and drop out of
+            // multi-match counts).
+            isVerified: _isAnchorVerified,
+            isVisible: _isAnchorVisible,
+            verificationListenable: _pathVerifier,
           ),
         ),
         // Selection affordances (bottom-right). #712: shown ONLY while a

--- a/native/test/services/path_verifier_test.dart
+++ b/native/test/services/path_verifier_test.dart
@@ -1,0 +1,235 @@
+// #990 — SessionPathVerifier: the per-session "does this detected path exist
+// on the CONNECTED host" cache that upgrades a path anchor from the plain
+// "detected" shade to the bolder VERIFIED shade.
+//
+// Pure unit level: the verifier talks to a fake `sendStat` seam (production
+// wires `SshSessionProxy.sftpStat`) and results are injected via
+// `onStatResult` — no gateway, no widget. Timing (debounce, TTL, request
+// timeout) runs under FakeAsync.
+//
+// Covered per the issue's test plan:
+//   - debounce: a burst of noted paths → ONE batched drain after the window
+//   - cache TTL: fresh results are not re-requested; expired ones are
+//   - fail-open: a stat error/timeout leaves the path in the "detected" state
+//   - per-session isolation: two verifiers never share state
+//   - in-flight cap: at most maxInFlight outstanding stats; queue drains as
+//     results free slots
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/path_verifier.dart';
+
+void main() {
+  const debounce = Duration(milliseconds: 250);
+  const ttl = Duration(seconds: 30);
+  const requestTimeout = Duration(seconds: 6);
+
+  /// Build a verifier wired to a recording sendStat seam.
+  ({SessionPathVerifier verifier, List<({String requestId, String path})> sent})
+  build(
+    FakeAsync async, {
+    String sessionId = 'host:22:user:1',
+    int maxInFlight = 4,
+  }) {
+    final sent = <({String requestId, String path})>[];
+    final verifier = SessionPathVerifier(
+      sessionId: sessionId,
+      sendStat: ({required String requestId, required String path}) =>
+          sent.add((requestId: requestId, path: path)),
+      ttl: ttl,
+      debounce: debounce,
+      requestTimeout: requestTimeout,
+      maxInFlight: maxInFlight,
+      // FakeAsync fakes Timers but NOT DateTime.now — drive the TTL clock off
+      // the same virtual timeline via the injectable `now` seam.
+      now: () => async.getClock(DateTime(2026)).now(),
+    );
+    return (verifier: verifier, sent: sent);
+  }
+
+  test('a burst of noted paths is DEBOUNCED into one batched drain', () {
+    fakeAsync((async) {
+      final t = build(async);
+      t.verifier.notePaths(['/etc/hosts']);
+      t.verifier.notePaths(['/etc/hosts', '/tmp/a']);
+      t.verifier.notePaths(['/tmp/b']);
+      // Inside the debounce window nothing is sent yet.
+      expect(t.sent, isEmpty);
+      async.elapse(debounce + const Duration(milliseconds: 1));
+      // One drain, each unique path exactly once.
+      expect(t.sent.map((s) => s.path).toList()..sort(), [
+        '/etc/hosts',
+        '/tmp/a',
+        '/tmp/b',
+      ]);
+      t.verifier.dispose();
+    });
+  });
+
+  test('a positive result upgrades the path to VERIFIED and notifies', () {
+    fakeAsync((async) {
+      final t = build(async);
+      var notified = 0;
+      t.verifier.addListener(() => notified++);
+      t.verifier.notePaths(['/etc/hosts']);
+      async.elapse(debounce * 2);
+      expect(t.verifier.isVerified('/etc/hosts'), isFalse);
+      t.verifier.onStatResult(requestId: t.sent.single.requestId, exists: true);
+      expect(t.verifier.isVerified('/etc/hosts'), isTrue);
+      expect(notified, 1);
+      t.verifier.dispose();
+    });
+  });
+
+  test('fail-open: a NEGATIVE/errored stat leaves the path detected', () {
+    fakeAsync((async) {
+      final t = build(async);
+      t.verifier.notePaths(['/no/such/path']);
+      async.elapse(debounce * 2);
+      t.verifier.onStatResult(requestId: t.sent.single.requestId, exists: false);
+      expect(t.verifier.isVerified('/no/such/path'), isFalse);
+      t.verifier.dispose();
+    });
+  });
+
+  test('a fresh cached result is NOT re-requested; an expired one is', () {
+    fakeAsync((async) {
+      final t = build(async);
+      t.verifier.notePaths(['/etc/hosts']);
+      async.elapse(debounce * 2);
+      t.verifier.onStatResult(requestId: t.sent.single.requestId, exists: true);
+
+      // Re-noting inside the TTL sends nothing new.
+      t.verifier.notePaths(['/etc/hosts']);
+      async.elapse(debounce * 2);
+      expect(t.sent, hasLength(1));
+      expect(t.verifier.isVerified('/etc/hosts'), isTrue);
+
+      // After TTL expiry the verified state lapses and a re-note re-stats.
+      async.elapse(ttl + const Duration(seconds: 1));
+      expect(
+        t.verifier.isVerified('/etc/hosts'),
+        isFalse,
+        reason: 'an expired entry must not keep claiming verified',
+      );
+      t.verifier.notePaths(['/etc/hosts']);
+      async.elapse(debounce * 2);
+      expect(t.sent, hasLength(2));
+      t.verifier.dispose();
+    });
+  });
+
+  test('fail-open on TIMEOUT: an unanswered stat frees its slot and the path '
+      'stays detected', () {
+    fakeAsync((async) {
+      final t = build(async, maxInFlight: 1);
+      t.verifier.notePaths(['/a', '/b']);
+      async.elapse(debounce * 2);
+      // Cap 1: only the first is in flight.
+      expect(t.sent, hasLength(1));
+      // Never answer it — after the request timeout the slot frees and the
+      // queued path goes out; the timed-out path reads as NOT verified.
+      async.elapse(requestTimeout + const Duration(seconds: 1));
+      expect(t.sent, hasLength(2));
+      expect(t.verifier.isVerified(t.sent.first.path), isFalse);
+      t.verifier.dispose();
+    });
+  });
+
+  test('in-flight cap: at most maxInFlight outstanding; results drain the '
+      'queue', () {
+    fakeAsync((async) {
+      final t = build(async, maxInFlight: 2);
+      t.verifier.notePaths(['/a', '/b', '/c', '/d']);
+      async.elapse(debounce * 2);
+      expect(t.sent, hasLength(2), reason: 'cap must bound outstanding stats');
+      t.verifier.onStatResult(requestId: t.sent[0].requestId, exists: true);
+      expect(t.sent, hasLength(3), reason: 'a result frees a slot → next sent');
+      t.verifier.onStatResult(requestId: t.sent[1].requestId, exists: false);
+      expect(t.sent, hasLength(4));
+      t.verifier.dispose();
+    });
+  });
+
+  test('per-session isolation: the same path verified on host A is NOT '
+      'verified on host B', () {
+    fakeAsync((async) {
+      final a = build(async, sessionId: 'hostA:22:user:1');
+      final b = build(async, sessionId: 'hostB:22:user:1');
+      a.verifier.notePaths(['/etc/hosts']);
+      b.verifier.notePaths(['/etc/hosts']);
+      async.elapse(debounce * 2);
+      a.verifier.onStatResult(requestId: a.sent.single.requestId, exists: true);
+      b.verifier.onStatResult(requestId: b.sent.single.requestId, exists: false);
+      expect(a.verifier.isVerified('/etc/hosts'), isTrue);
+      expect(
+        b.verifier.isVerified('/etc/hosts'),
+        isFalse,
+        reason: 'verification state must be scoped per (session, path)',
+      );
+      // Request ids are namespaced per session so a cross-routed result can
+      // never be attributed to the wrong session's cache.
+      expect(a.sent.single.requestId, isNot(b.sent.single.requestId));
+      a.verifier.dispose();
+      b.verifier.dispose();
+    });
+  });
+
+  // #990 visibility gate (owner report on +121): single-segment root matches
+  // (`/config`) are SUPPRESSED until verified, so consumers need the full
+  // tri-state — pending (no fresh answer) / verified / missing — not just the
+  // isVerified bool.
+  group('status() tri-state', () {
+    test('pending before any result, verified/missing after, pending again '
+        'after TTL expiry', () {
+      fakeAsync((async) {
+        final t = build(async);
+        expect(t.verifier.status('/etc'), PathVerification.pending);
+        t.verifier.notePaths(['/etc', '/config']);
+        async.elapse(debounce * 2);
+        expect(t.verifier.status('/etc'), PathVerification.pending);
+        t.verifier.onStatResult(requestId: t.sent[0].requestId, exists: true);
+        t.verifier.onStatResult(requestId: t.sent[1].requestId, exists: false);
+        expect(t.verifier.status('/etc'), PathVerification.verified);
+        expect(t.verifier.status('/config'), PathVerification.missing);
+        async.elapse(ttl + const Duration(seconds: 1));
+        expect(t.verifier.status('/etc'), PathVerification.pending);
+        expect(t.verifier.status('/config'), PathVerification.pending);
+        t.verifier.dispose();
+      });
+    });
+
+    test('a MISSING result notifies listeners (suppression consumers must '
+        'repaint on it, not only on upgrades)', () {
+      fakeAsync((async) {
+        final t = build(async);
+        var notified = 0;
+        t.verifier.addListener(() => notified++);
+        t.verifier.notePaths(['/config']);
+        async.elapse(debounce * 2);
+        t.verifier.onStatResult(
+          requestId: t.sent.single.requestId,
+          exists: false,
+        );
+        expect(
+          notified,
+          greaterThanOrEqualTo(1),
+          reason: 'pending → missing is a status change a visibility gate '
+              'depends on',
+        );
+        t.verifier.dispose();
+      });
+    });
+  });
+
+  test('a stale/unknown requestId is ignored (no crash, no state change)', () {
+    fakeAsync((async) {
+      final t = build(async);
+      t.verifier.notePaths(['/etc/hosts']);
+      async.elapse(debounce * 2);
+      t.verifier.onStatResult(requestId: 'pathstat-bogus-99', exists: true);
+      expect(t.verifier.isVerified('/etc/hosts'), isFalse);
+      t.verifier.dispose();
+    });
+  });
+}

--- a/native/test/services/sftp_host_test.dart
+++ b/native/test/services/sftp_host_test.dart
@@ -53,6 +53,11 @@ class FakeSftpSession implements SftpSession {
   String? lastListedPath;
   String? lastDownloadedPath;
 
+  /// #990: when set, [sizeOf] (the stat seam the host's sftpStat handler uses)
+  /// succeeds ONLY for paths in this set and throws for anything else —
+  /// modelling a real server's "No such file" stat error.
+  Set<String>? statExisting;
+
   /// Records what the host wrote (#892): the resolved-or-literal path and the
   /// exact bytes, so a test can assert the upload reached the wrapper intact.
   String? lastUploadedPath;
@@ -74,7 +79,13 @@ class FakeSftpSession implements SftpSession {
   }
 
   @override
-  Future<int?> sizeOf(String path) async => fileBytes.length;
+  Future<int?> sizeOf(String path) async {
+    final existing = statExisting;
+    if (existing != null && !existing.contains(path)) {
+      throw Exception('No such file: $path');
+    }
+    return fileBytes.length;
+  }
 
   @override
   Future<int> download(
@@ -236,6 +247,96 @@ void main() {
     expect(done, isNotNull);
     expect(done!.requestId, 'sid-up#write0');
     expect(done!.totalBytes, payload.length);
+
+    await sub.cancel();
+  });
+
+  test('sftpStat replies exists=true for a path the server can stat (#990)',
+      () async {
+    final fake = FakeSftpSession()..statExisting = {'/etc/hosts'};
+    final ctx = await setUpConnected('sid-st', fake);
+    addTearDown(ctx.pair.dispose);
+    addTearDown(ctx.host.dispose);
+    addTearDown(ctx.proxy.dispose);
+
+    final results = <SftpStatResultEvent>[];
+    final sub = ctx.proxy.sftpEvents.listen((e) {
+      if (e is SftpStatResultEvent) results.add(e);
+    });
+
+    ctx.proxy.sftpStat(requestId: 'sid-st#0', path: '/etc/hosts');
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(results, hasLength(1));
+    expect(results.single.requestId, 'sid-st#0');
+    expect(results.single.path, '/etc/hosts');
+    expect(results.single.exists, isTrue);
+
+    await sub.cancel();
+  });
+
+  test('sftpStat replies exists=false (fail-open) when the stat errors (#990)',
+      () async {
+    final fake = FakeSftpSession()..statExisting = {'/etc/hosts'};
+    final ctx = await setUpConnected('sid-st2', fake);
+    addTearDown(ctx.pair.dispose);
+    addTearDown(ctx.host.dispose);
+    addTearDown(ctx.proxy.dispose);
+
+    final results = <SftpStatResultEvent>[];
+    final errors = <SftpErrorEvent>[];
+    final sub = ctx.proxy.sftpEvents.listen((e) {
+      if (e is SftpStatResultEvent) results.add(e);
+      if (e is SftpErrorEvent) errors.add(e);
+    });
+
+    ctx.proxy.sftpStat(requestId: 'sid-st2#0', path: '/no/such/path990');
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(results, hasLength(1));
+    expect(results.single.exists, isFalse);
+    // Fail-open is a RESULT, not an error — a missing path must not surface
+    // an SFTP error banner anywhere.
+    expect(errors, isEmpty);
+
+    await sub.cancel();
+  });
+
+  test('sftpStat replies exists=false for a session with no live client (#990)',
+      () async {
+    final fake = FakeSftpSession();
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: _stubControllerFactory,
+      // Opener returning null = "session not connected" (matches production).
+      sftpOpener: (_) async => null,
+      snapshotInterval: const Duration(hours: 1),
+    );
+    addTearDown(host.dispose);
+    final proxy = SshSessionProxy(sessionId: 'sid-st3', gateway: pair.uiSide);
+    addTearDown(proxy.dispose);
+    proxy.connect(const SshConnectParams(
+      host: 'h',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    ));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    final results = <SftpStatResultEvent>[];
+    final sub = proxy.sftpEvents.listen((e) {
+      if (e is SftpStatResultEvent) results.add(e);
+    });
+
+    proxy.sftpStat(requestId: 'sid-st3#0', path: '/etc/hosts');
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(results, hasLength(1));
+    expect(results.single.exists, isFalse,
+        reason: 'no client → fail-open result, never a hang or an error event');
+    expect(fake.closed, isFalse);
 
     await sub.cancel();
   });

--- a/native/test/services/task_ipc_test.dart
+++ b/native/test/services/task_ipc_test.dart
@@ -171,6 +171,19 @@ void main() {
       }
     });
 
+    test('SftpStatCommand round-trips requestId + path (#990)', () {
+      const cmd = SftpStatCommand(
+        sessionId: 'host:22:user:1',
+        requestId: 'pathstat-1',
+        path: '/etc/hosts',
+      );
+      final restored = SshTaskCommand.fromJson(cmd.toJson()) as SftpStatCommand;
+      expect(restored.kind, SshTaskCommandKind.sftpStat);
+      expect(restored.sessionId, 'host:22:user:1');
+      expect(restored.requestId, 'pathstat-1');
+      expect(restored.path, '/etc/hosts');
+    });
+
     test('unknown kind throws FormatException', () {
       expect(
         () => SshTaskCommand.fromJson({'kind': 'bogus', 'sessionId': 'sid'}),
@@ -246,6 +259,24 @@ void main() {
       // Task-global: empty sentinel sessionId (mirrors SshLifecycleEvent).
       expect(restored.sessionId, '');
       expect(restored.kind, SshTaskEventKind.controlModeTrace);
+    });
+
+    test('SftpStatResultEvent round-trips exists both ways (#990)', () {
+      for (final exists in [true, false]) {
+        final ev = SftpStatResultEvent(
+          sessionId: 'host:22:user:1',
+          requestId: 'pathstat-1',
+          path: '/etc/hosts',
+          exists: exists,
+        );
+        final restored =
+            SshTaskEvent.fromJson(ev.toJson()) as SftpStatResultEvent;
+        expect(restored.kind, SshTaskEventKind.sftpStatResult);
+        expect(restored.sessionId, 'host:22:user:1');
+        expect(restored.requestId, 'pathstat-1');
+        expect(restored.path, '/etc/hosts');
+        expect(restored.exists, exists);
+      }
     });
   });
 

--- a/native/test/ui/ghostty_bubble_layer_test.dart
+++ b/native/test/ui/ghostty_bubble_layer_test.dart
@@ -106,6 +106,12 @@ class _FakeController extends ChangeNotifier implements TerminalController {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// A test-owned verification signal (#990) — stands in for the
+/// SessionPathVerifier's ChangeNotifier surface.
+class _TestSignal extends ChangeNotifier {
+  void fire() => notifyListeners();
+}
+
 void main() {
   const scanner = StructuredTextScanner();
   const cols = 50;
@@ -301,6 +307,162 @@ void main() {
       ]);
       await tester.pump();
       expect(find.byKey(const Key('ghostty-bubble-paint')), findsOneWidget);
+    });
+  });
+
+  // #990 — detected vs VERIFIED path shades on the inline bubble. A verified
+  // path (exists on the connected host per the session's SFTP stat) paints a
+  // BOLDER bubble: thicker stroke + a translucent fill wash. The layer only
+  // consumes an opaque `isVerified` predicate.
+  group('#990 verified path bubble shade', () {
+    StructuredAnchor pathAnchor(String path, {int row = 3}) => StructuredAnchor(
+      patternId: kGhosttyPathPatternId,
+      payload: path,
+      ranges: [
+        HighlightRange(
+          startRow: row,
+          startCol: 0,
+          endRow: row,
+          endCol: path.length,
+          payload: path,
+        ),
+      ],
+    );
+
+    Future<_FakeController> pumpVerifiable(
+      WidgetTester tester, {
+      required bool Function(StructuredAnchor anchor) isVerified,
+      bool Function(StructuredAnchor anchor)? isVisible,
+      Listenable? verificationListenable,
+    }) async {
+      final controller = _FakeController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                Positioned.fill(
+                  child: GhosttyBubbleLayer(
+                    controller: controller,
+                    color: const Color(0xFF5B9BD5),
+                    isVerified: isVerified,
+                    isVisible: isVisible,
+                    verificationListenable: verificationListenable,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return controller;
+    }
+
+    GhosttyBubblePainter painterOf(WidgetTester tester) {
+      final paint = tester.widget<CustomPaint>(
+        find.byKey(const Key('ghostty-bubble-paint')),
+      );
+      return paint.painter! as GhosttyBubblePainter;
+    }
+
+    test('the verified stroke is BOLDER than the detected stroke', () {
+      expect(
+        kGhosttyBubbleVerifiedStrokeWidth,
+        greaterThan(kGhosttyBubbleStrokeWidth),
+      );
+    });
+
+    testWidgets('a verified path bubble is marked verified; an unverified one '
+        'is not', (tester) async {
+      final controller = await pumpVerifiable(
+        tester,
+        isVerified: (a) => a.payload == '/etc/hosts',
+      );
+      controller.setAnchors([
+        pathAnchor('/etc/hosts', row: 3),
+        pathAnchor('/no/such/path990', row: 5),
+      ]);
+      await tester.pump();
+      final painter = painterOf(tester);
+      expect(painter.specs, hasLength(2));
+      final byPayload = {
+        for (var i = 0; i < painter.specs.length; i++) i: painter.specs[i],
+      };
+      // Anchor order is preserved: [verified, unverified].
+      expect(byPayload[0]!.verified, isTrue);
+      expect(byPayload[1]!.verified, isFalse);
+    });
+
+    testWidgets('a URL bubble is never bold — the predicate decides, the layer '
+        'obeys', (tester) async {
+      final controller = await pumpVerifiable(
+        tester,
+        // The production predicate only ever returns true for path anchors.
+        isVerified: (a) => a.patternId == kGhosttyPathPatternId,
+      );
+      controller.setAnchors([
+        StructuredAnchor(
+          patternId: kGhosttyUrlPatternId,
+          payload: 'https://example.com',
+          ranges: const [
+            HighlightRange(startRow: 2, startCol: 4, endRow: 2, endCol: 23),
+          ],
+        ),
+      ]);
+      await tester.pump();
+      expect(painterOf(tester).specs.single.verified, isFalse);
+    });
+
+    // #990 visibility gate: a SUPPRESSED anchor (single-segment root match not
+    // yet verified) paints NO bubble; it appears once verified.
+    testWidgets('a suppressed anchor paints NO bubble until it becomes visible',
+        (tester) async {
+      final visible = <String>{};
+      final signal = _TestSignal();
+      addTearDown(signal.dispose);
+      final controller = await pumpVerifiable(
+        tester,
+        isVerified: (_) => false,
+        isVisible: (a) => visible.contains('${a.payload}'),
+        verificationListenable: signal,
+      );
+      controller.setAnchors([pathAnchor('/config')]);
+      await tester.pump();
+      expect(
+        find.byKey(const Key('ghostty-bubble-paint')),
+        findsNothing,
+        reason: 'an unverified single-segment match must show NO affordance',
+      );
+
+      visible.add('/config');
+      signal.fire();
+      await tester.pump();
+      expect(find.byKey(const Key('ghostty-bubble-paint')), findsOneWidget);
+    });
+
+    testWidgets('a verification arriving LATER repaints the bubble bold',
+        (tester) async {
+      final verified = <String>{};
+      final signal = _TestSignal();
+      addTearDown(signal.dispose);
+      final controller = await pumpVerifiable(
+        tester,
+        isVerified: (a) => verified.contains('${a.payload}'),
+        verificationListenable: signal,
+      );
+      controller.setAnchors([pathAnchor('/etc/hosts')]);
+      await tester.pump();
+      expect(painterOf(tester).specs.single.verified, isFalse);
+
+      verified.add('/etc/hosts');
+      signal.fire();
+      await tester.pump();
+      expect(
+        painterOf(tester).specs.single.verified,
+        isTrue,
+        reason: 'the bubble must repaint on verification results, not only '
+            'on anchor changes',
+      );
     });
   });
 

--- a/native/test/ui/ghostty_gutter_layer_test.dart
+++ b/native/test/ui/ghostty_gutter_layer_test.dart
@@ -95,6 +95,12 @@ class _FakeController extends ChangeNotifier implements TerminalController {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// A test-owned verification signal (#990) — stands in for the
+/// SessionPathVerifier's ChangeNotifier surface.
+class _TestSignal extends ChangeNotifier {
+  void fire() => notifyListeners();
+}
+
 void main() {
   group('groupAnchorsByGutterRow (pure)', () {
     test('groups several matches on the SAME row under one key', () {
@@ -380,6 +386,193 @@ void main() {
         expect(tester.widget<AnimatedScale>(scaleFinder).scale, 1.0);
         // The tap-up fired the single-URL action overlay — tear it down.
         debugDismissUrlActions();
+      });
+    });
+
+    // #990 — detected vs VERIFIED path shades. A path anchor whose payload the
+    // per-session verifier confirmed (exists on the CONNECTED host via SFTP
+    // stat) renders its chip in the BOLD style (a contrast ring); an unverified
+    // one keeps the plain detected chip. The layer only consumes an OPAQUE
+    // `isVerified` predicate — WHY a path is verified is the caller's business.
+    group('verified path shade (#990)', () {
+      BoxDecoration chipDecorationOf(WidgetTester tester, int row) {
+        final boxes = tester.widgetList<DecoratedBox>(
+          find.descendant(
+            of: find.byKey(Key('gutter-mark-$row')),
+            matching: find.byType(DecoratedBox),
+          ),
+        );
+        return boxes
+            .map((b) => b.decoration)
+            .whereType<BoxDecoration>()
+            .firstWhere((d) => d.color != null);
+      }
+
+      Future<_FakeController> pumpVerifiable(
+        WidgetTester tester, {
+        required bool Function(StructuredAnchor anchor) isVerified,
+        bool Function(StructuredAnchor anchor)? isVisible,
+        Listenable? verificationListenable,
+      }) async {
+        final controller = _FakeController();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  Positioned.fill(
+                    child: GhosttyGutterLayer(
+                      controller: controller,
+                      registry: GutterPatternRegistry.standard(
+                        openPath: (_) async => true,
+                      ),
+                      color: const Color(0xFF5B9BD5),
+                      cellHeight: 20,
+                      isVerified: isVerified,
+                      isVisible: isVisible,
+                      verificationListenable: verificationListenable,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        return controller;
+      }
+
+      test('GutterMarkStyle.bold is a BOLDER variant of normal (ring)', () {
+        expect(GutterMarkStyle.normal.ringWidth, 0.0);
+        expect(
+          GutterMarkStyle.bold.ringWidth,
+          greaterThan(0.0),
+          reason: 'the verified chip must be visually bolder than detected',
+        );
+        expect(
+          GutterMarkStyle.bold.minTapExtent,
+          GutterMarkStyle.normal.minTapExtent,
+          reason: 'verification never changes tap semantics',
+        );
+      });
+
+      testWidgets('an UNVERIFIED path keeps the plain detected chip (no ring)',
+          (tester) async {
+        final controller = await pumpVerifiable(tester, isVerified: (_) => false);
+        controller.setAnchors([_pathAnchor('/no/such/path990', row: 3)]);
+        await tester.pump();
+        final deco = chipDecorationOf(tester, 3);
+        expect(deco.border, isNull);
+      });
+
+      testWidgets('a VERIFIED path renders the bold chip (contrast ring)',
+          (tester) async {
+        final controller = await pumpVerifiable(
+          tester,
+          isVerified: (a) => a.payload == '/etc/hosts',
+        );
+        controller.setAnchors([
+          _pathAnchor('/etc/hosts', row: 3),
+          _pathAnchor('/no/such/path990', row: 5),
+        ]);
+        await tester.pump();
+        final verified = chipDecorationOf(tester, 3);
+        expect(verified.border, isNotNull);
+        expect(
+          verified.border!.top.width,
+          GutterMarkStyle.bold.ringWidth,
+          reason: 'verified chip carries the bold ring',
+        );
+        final detected = chipDecorationOf(tester, 5);
+        expect(detected.border, isNull,
+            reason: 'the fake path on the SAME layer stays detected');
+      });
+
+      testWidgets(
+          'a verification arriving LATER upgrades the chip (listenable-driven)',
+          (tester) async {
+        final verified = <String>{};
+        final signal = _TestSignal();
+        addTearDown(signal.dispose);
+        final controller = await pumpVerifiable(
+          tester,
+          isVerified: (a) => verified.contains('${a.payload}'),
+          verificationListenable: signal,
+        );
+        controller.setAnchors([_pathAnchor('/etc/hosts', row: 4)]);
+        await tester.pump();
+        expect(chipDecorationOf(tester, 4).border, isNull);
+
+        // The async SFTP stat lands: the verifier notifies, no anchor change.
+        verified.add('/etc/hosts');
+        signal.fire();
+        await tester.pump();
+        expect(
+          chipDecorationOf(tester, 4).border,
+          isNotNull,
+          reason: 'the layer must repaint on verification results, not only '
+              'on anchor changes',
+        );
+      });
+
+      // #990 visibility gate: a SUPPRESSED anchor (single-segment root match
+      // not yet verified — pending or missing) renders NO chip at all; it
+      // appears once the verifier confirms existence.
+      testWidgets('a suppressed anchor renders NO mark until it becomes '
+          'visible (listenable-driven)', (tester) async {
+        final visible = <String>{};
+        final signal = _TestSignal();
+        addTearDown(signal.dispose);
+        final controller = await pumpVerifiable(
+          tester,
+          isVerified: (_) => false,
+          isVisible: (a) => visible.contains('${a.payload}'),
+          verificationListenable: signal,
+        );
+        controller.setAnchors([_pathAnchor('/config', row: 4)]);
+        await tester.pump();
+        expect(
+          find.byKey(const Key('gutter-mark-4')),
+          findsNothing,
+          reason: 'an unverified single-segment match must show NO affordance',
+        );
+
+        // The stat confirms it exists → the chip appears.
+        visible.add('/config');
+        signal.fire();
+        await tester.pump();
+        expect(find.byKey(const Key('gutter-mark-4')), findsOneWidget);
+      });
+
+      testWidgets('a multi-match row drops a suppressed anchor from its count',
+          (tester) async {
+        final controller = await pumpVerifiable(
+          tester,
+          isVerified: (_) => false,
+          isVisible: (a) => '${a.payload}' != '/config',
+        );
+        controller.setAnchors([
+          _urlAnchor('https://example.com', row: 6),
+          _pathAnchor('/config', row: 6),
+        ]);
+        await tester.pump();
+        // Only the URL remains → a single-pattern glyph mark, no count badge.
+        expect(find.byKey(const Key('gutter-mark-6')), findsOneWidget);
+        expect(find.text('2'), findsNothing);
+      });
+
+      testWidgets('a multi-match row with ONE verified anchor uses the bold chip',
+          (tester) async {
+        final controller = await pumpVerifiable(
+          tester,
+          isVerified: (a) => a.payload == '/etc/hosts',
+        );
+        controller.setAnchors([
+          _urlAnchor('https://example.com', row: 6),
+          _pathAnchor('/etc/hosts', row: 6),
+        ]);
+        await tester.pump();
+        expect(chipDecorationOf(tester, 6).border, isNotNull);
+        expect(find.text('2'), findsOneWidget);
       });
     });
 

--- a/native/test/ui/ghostty_terminal_decorators_test.dart
+++ b/native/test/ui/ghostty_terminal_decorators_test.dart
@@ -25,4 +25,29 @@ void main() {
       expect(kGhosttyUrlHighlightStyle.background, isNull);
     });
   });
+
+  // #990 visibility gate: single-segment root-level matches (`/word`) are
+  // overwhelmingly TUI slash-commands (`/config`, `/rc` — the +121 owner
+  // report), not paths. They get NO affordance until an SFTP stat confirms
+  // they exist. Multi-segment paths never require verification to SHOW.
+  group('#990 ghosttyPathRequiresVerification', () {
+    test('single-segment root matches require verification', () {
+      expect(ghosttyPathRequiresVerification('/config'), isTrue);
+      expect(ghosttyPathRequiresVerification('/rc'), isTrue);
+      expect(ghosttyPathRequiresVerification('/etc'), isTrue);
+      // Trailing slash doesn't add a segment.
+      expect(ghosttyPathRequiresVerification('/etc/'), isTrue);
+    });
+
+    test('multi-segment paths do NOT require verification to show', () {
+      expect(ghosttyPathRequiresVerification('/etc/hosts'), isFalse);
+      expect(ghosttyPathRequiresVerification('/no/such/path990'), isFalse);
+      expect(ghosttyPathRequiresVerification('/a/b/'), isFalse);
+    });
+
+    test('degenerate payloads are conservative (suppressed until verified)', () {
+      expect(ghosttyPathRequiresVerification('/'), isTrue);
+      expect(ghosttyPathRequiresVerification(''), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
Implements #990: detected file-path anchors get TWO shades — plain "detected" vs bolder VERIFIED — where verified means the path EXISTS ON THE CONNECTED HOST, confirmed via one SFTP stat over the session's channel. Also implements the mid-flight spec refinement (owner report on +121: `/config`, `/rc` false positives): a visibility gate for low-confidence single-segment matches.

## Policy (per the issue + refinement comment)
- MULTI-SEGMENT paths (`/etc/hosts`): visible immediately at the detected shade; upgrade to the bold shade when verified; fail-open on stat error/timeout (stay detected).
- SINGLE-SEGMENT root-level matches (`/config`, `/etc` — no second slash): overwhelmingly TUI slash-commands, so they show NO affordance (no bubble, no gutter chip, no tap-copy) while verification is `pending` or `missing`; a confirmed stat makes them visible with the normal treatment.
- Per-session scoping: one verifier per session view, request ids namespaced by session — a path verified on host A never bleeds onto host B.
- Presentation layers consume an OPAQUE `isVerified` / `isVisible` predicate + a `Listenable`; they never learn WHY a path is verified, so the predicate could later mean "downloaded locally" with zero paint rework.

## What changed
- IPC: new `sftpStat` command + `sftpStatResult` event (`native/lib/services/session_messages.dart`), mirroring the `sftpList` envelope. The host handler (`session_host.dart`) stats via the existing `SftpSession.sizeOf` (a stat under the hood — no new abstract method, so the 10 existing `implements SftpSession` fakes stay valid) and ALWAYS replies; every failure mode collapses to `exists=false` (fail-open, never an error banner).
- UI proxy: `SshSessionProxy.sftpStat` + routing `SftpStatResultEvent` onto the broadcast `sftpEvents` stream.
- New `native/lib/services/path_verifier.dart` — `SessionPathVerifier` (ChangeNotifier): per-path TTL cache (30s), debounced batching (250ms), in-flight cap (4), per-request timeout (6s) fail-open; tri-state `status()` (`pending`/`verified`/`missing`) for the visibility gate.
- Gutter (`ghostty_gutter_layer.dart`): `GutterMarkStyle.bold` slots into the #989 seam — same geometry/tap semantics + a 2.5px contrast ring (monochrome, luminance-picked). A row with ANY verified anchor renders bold; suppressed anchors drop out of marks AND multi-match counts.
- Bubble (`ghostty_terminal_decorators.dart`): verified bubbles stroke thicker (2.5 vs 1.5) + a faint fill wash; painter made public (`GhosttyBubblePainter` + `GhosttyBubbleSpec`) so the widget test asserts shade selection. Pure `ghosttyPathRequiresVerification()` classifies single-segment matches.
- View (`ghostty_terminal_view.dart`): creates the verifier per session, notes path anchors off the narrow decoration listenable, gates `urlAtCell` (tap-copy) with the same visibility predicate, exposes `debugPathVerifiers` for the emulator test, disposes cleanly.

## Red → green
- Red baseline: all 5 new/extended test files failed to compile/pass against the missing API (captured before implementation).
- Green: `scripts/native-fast-gate.sh` PASSED in the worktree — analyze clean, 1715 tests.
- Unit (`path_verifier_test.dart`, FakeAsync + injected clock): debounce batching, TTL expiry → re-request, fail-open on negative/timeout, in-flight cap drains on results, per-session isolation (two verifiers, same path, independent), tri-state status incl. missing-notifies.
- IPC round-trips (`task_ipc_test.dart`) + host handler cases (`sftp_host_test.dart`): exists=true, stat-error → exists=false with NO SftpErrorEvent, no-client → exists=false.
- Widget: gutter chip ring present/absent + listenable-driven upgrade + suppressed-anchor no-mark + count-drop; bubble verified spec + suppressed no-paint + late-verification repaint.
- Emulator (`integration_test/path_verified_shade_test.dart`, run via `scripts/native-connect-test.sh`): TEST PASSED — `/etc/hosts` upgrades to verified, `/no/such/path990` stays detected, `/etc` (single-segment, real) becomes visible after verification, `/config` resolves MISSING (suppressed).

## Screenshot (reviewed at phone density)
- `test-results/emulator-shots/20260708T142924+0000-path-verified_.png`
- Verified rows (`/etc/hosts`, `/etc`): bubble with fill wash + 2.5px stroke, gutter chip with the contrast ring. Detected row (`/no/such/path990`): thin 1.5px outline bubble, flat chip, no ring. `CMD990 /config` line: NO bubble, NO chip — the visibility gate visible on screen.

## Caveats (honest)
- The chip ring is `onChip`-colored (luminance-picked → black on the default green accent). On a dark theme it reads as a crisp OUTLINED chip vs the flat detected chip — clearly distinct at phone density (zoomed crop reviewed), but whether the ring reads "bolder" (vs merely distinct) is an owner taste call; the bubble treatment (fill + thick stroke) unambiguously reads bolder. Tuning is one static const (`GutterMarkStyle.bold`).
- A verified single-segment chip can flicker off for ~debounce+RTT when its 30s TTL expires mid-session (the same notify cycle re-notes and re-verifies it). Accepted as a transient; a "stale-while-revalidate" cache is a follow-up if it shows on device.
- Long-press URL/path menu routing (`onUrlLongPress`) is gated by the same `urlAtCell` seam, so suppression covers it too; the fork's internal `matchAt` itself is unchanged.
- The detected-shade chip/bubble visuals for multi-segment paths are unchanged from #988/#989 — only the bold variant and the suppression gate are new.

Closes #990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa