### PR TITLE
feat(server): extract bug-report/telemetry into dedicated feedback service (#997)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,7 +66,8 @@
     },
     {
       "files": [
-        "server/**/*.js"
+        "server/**/*.js",
+        "server-feedback/**/*.js"
       ],
       "env": {
         "browser": false,

--- a/docker-compose.feedback.yml
+++ b/docker-compose.feedback.yml
@@ -1,0 +1,33 @@
+# MobiSSH feedback service (#997) — dedicated bug-report/telemetry container.
+# Lifecycle: scripts/feedback-ctl.sh {start|stop|restart|status|ensure}
+#
+# Joins the external `mobissh` network so mobissh-prod reaches it via Docker
+# DNS (http://mobissh-feedback:8082 — no port mapping; docker-proxy is absent
+# in this environment). Uploads bind-mount the SAME host path as
+# docker-compose.prod.yml so fd-dev sees every report at
+# /home/dev/workspace/mobissh/test-results/uploads/ — dev-loop parity for
+# watch-bug-reports.sh, assemble-repro.sh, and the replay harness.
+services:
+  feedback:
+    build:
+      context: .
+      dockerfile: docker/feedback/Dockerfile
+    image: mobissh-feedback:${TAG:-latest}
+    container_name: mobissh-feedback
+    restart: unless-stopped
+    networks:
+      - mobissh
+    environment:
+      PORT: "8082"
+      NODE_ENV: production
+      UPLOADS_DIR: /app/test-results/uploads
+      # Retention knob: files older than N days are deleted daily.
+      # 0 (default) keeps everything — the owner keeps traces; storage cheap.
+      FEEDBACK_RETENTION_DAYS: "${FEEDBACK_RETENTION_DAYS:-0}"
+    volumes:
+      - /var/lib/docker/volumes/dev_workspace/_data/mobissh/test-results/uploads:/app/test-results/uploads
+
+networks:
+  mobissh:
+    name: mobissh
+    external: true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,13 @@ services:
       TS_HOSTNAME: "${TS_HOSTNAME:-mobissh}"
       TS_SERVE: "1"
       TS_SERVE_PORT: "${TS_SERVE_PORT:-443}"
+      # #997: upload/telemetry routes proxy to the dedicated feedback service
+      # (fail-open: LOCAL handling if it's unreachable, so a report is never
+      # lost). ${VAR-default} (no colon) so an explicitly EMPTY env var
+      # disables the proxy entirely. Takes effect on container recreate only —
+      # cutover is an explicit `container-ctl.sh restart` after
+      # `feedback-ctl.sh start` (see docs/feedback-service.md).
+      FEEDBACK_SERVICE_URL: "${FEEDBACK_SERVICE_URL-http://mobissh-feedback:8082}"
     volumes:
       - tailscale-state:/var/lib/tailscale
       - /var/lib/docker/volumes/dev_workspace/_data/mobissh/test-results/uploads:/app/test-results/uploads

--- a/docker/feedback/Dockerfile
+++ b/docker/feedback/Dockerfile
@@ -1,0 +1,23 @@
+# MobiSSH feedback service (#997) — dedicated bug-report/telemetry ingestion.
+# Build context is the REPO ROOT (see docker-compose.feedback.yml) because the
+# service shares server/feedback-store.js with mobissh-prod's local fallback.
+FROM node:20-slim
+
+WORKDIR /app
+
+# No npm dependencies — plain node:http. Copy only the two source pieces.
+COPY server/feedback-store.js ./server/feedback-store.js
+COPY server-feedback/index.js ./server-feedback/index.js
+COPY server-feedback/package.json ./server-feedback/package.json
+
+# Bake git hash so /healthz can report code currency without git installed
+ARG GIT_HASH=unknown
+RUN echo "$GIT_HASH" > /app/.git-hash
+
+ENV PORT=8082 \
+    NODE_ENV=production \
+    UPLOADS_DIR=/app/test-results/uploads
+
+EXPOSE 8082
+
+CMD ["node", "server-feedback/index.js"]

--- a/docs/feedback-service.md
+++ b/docs/feedback-service.md
@@ -1,0 +1,188 @@
+# Feedback Service — bug-report/telemetry extraction (#997)
+
+The server-side bug-report/telemetry surface, extracted from the main
+SSH-bridge/static server (`server/index.js`) into a dedicated container
+(`mobissh-feedback`), LXC-deploy-ready. This doc is (1) the exact inventory of
+the pre-extraction surface, (2) the extracted architecture, (3) cutover
+commands, (4) the operator handoff for a PVE LXC deploy.
+
+## 1. Inventory — server-side bug-report surface
+
+### Routes (all previously inline in server/index.js, now in server/feedback-store.js)
+
+| Route | Producer(s) | Payload | Response |
+|---|---|---|---|
+| `POST /api/bug-report` | native `feedback_overlay.dart` (in-app feedback, #661/#967), PWA `src/modules/bug-report.ts`, install-page form `public/native-feedback.js` | one JSON body: `title`, `comment` (full untruncated note), `logs`, `screenshot` (base64 data URL), `frames[]` (repro burst), `connectLog[]`, `gestureLog[]`, `byteTrace[]` + `scrollTrace[]` + `grid` (#790 replay), `sentSgrTrace[]` (#793), `userAgent`, `url`, `version` | `200 {ok:true,saved:true}`; `400 {"error":"invalid json"}` |
+| `POST /api/drop-telemetry` | PWA `src/modules/drop-telemetry.ts` (auto, on reconnect recovery, 5min throttle) | JSON: `kind`, `reason`, `sessionId`, `host`, `connectLog[]`, `gestureLog[]`, meta | `200 {ok:true,stamp}`; `400` |
+| `POST /api/gesture-telemetry` | PWA `src/modules/drop-telemetry.ts` (gesture/IME anomaly, #502) | JSON: `reason`, `eventCount`, `log[]`, meta | `200 {ok:true,stamp}`; `400` |
+| `POST /api/native-crash` | native `crash_reporter.dart` (Dart + Kotlin uncaught handlers, #501), `public/termux/mobissh-logcat.sh` | one crash JSON (or arbitrary raw text) | `200 {ok:true,path}` / `{ok:true,raw:true,path}`; `413` over 1MB; `500` on write failure |
+
+All producers post to the single Tailscale endpoint
+`https://mobissh.tailbe5094.ts.net/api/...` (native default is compile-time:
+`MOBISSH_FEEDBACK_ENDPOINT` in `feedback_overlay.dart`; the PUBLIC Play build
+overrides it to the Cloudflare Worker in `infra/bug-report-worker/` — that path
+is out of scope here). Upload is a single POST per report (no multi-file
+sequencing, no client retry loop — a failed send surfaces to the user).
+
+### File naming contract (dev-loop scripts glob these — DO NOT change)
+
+Every file is prefixed with a SERVER-generated stamp
+(`new Date().toISOString().replace(/[:.]/g,'-').slice(0,19)`, e.g.
+`2026-07-08T14-22-25`). No user-controlled path component ever reaches the
+filesystem — that is the filename sanitization.
+
+```
+<ts>-bug-report.json                 meta (title, FULL comment, sidecar names, counts, grid)
+<ts>-bug-report.png                  screenshot
+<ts>-bug-report.log                  logs / full comment sidecar
+<ts>-bug-report.frame-NNN.png        repro burst frames (zero-padded, ffmpeg %03d)
+<ts>-bug-report.connect-log.json     24h connect/reconnect events
+<ts>-bug-report.gesture-log.json     24h gesture events
+<ts>-bug-report.byte-trace.json      {grid, byteTrace[], scrollTrace[]} (#790 replay harness)
+<ts>-bug-report.sent-sgr-trace.json  {grid, sentSgrTrace[]} (#793)
+<stamp>-drop-telemetry.json          meta
+<stamp>-drop-telemetry.connect-log.json / .gesture-log.json
+<stamp>-gesture-telemetry.json       meta
+<stamp>-gesture-telemetry.gesture-log.json
+<stamp>-native-crash.json            parsed crash
+<stamp>-native-crash.raw             non-JSON crash body (never lost)
+```
+
+### Size caps (preserved verbatim in feedback-store.js)
+
+- `/api/native-crash`: request body capped at 1MB → `413` (`MAX_CRASH_BYTES`).
+- gesture-telemetry log sidecar: >1MB → keep newest half (`MAX_GESTURE_LOG_BYTES`).
+- bug-report frames: max 120 (`MAX_FRAMES`).
+- byte/scroll/sent-SGR traces: last 8192 events each (server-side backstop; the
+  client bounds the rings).
+- Other routes: no request cap (unchanged from pre-extraction behavior).
+
+Secret scrubbing is CLIENT-side (`feedback_bundle.dart scrubSecrets`); the
+service stores what it receives. Nothing new is logged beyond the
+pre-extraction log lines.
+
+### Storage + consumers (must keep working unchanged — they do)
+
+Files land in `test-results/uploads/`. On the dev host that is ONE directory,
+bind-mounted into every container that touches it:
+
+- host path: `/var/lib/docker/volumes/dev_workspace/_data/mobissh/test-results/uploads`
+- fd-dev (dev container): `/home/dev/workspace/mobissh/test-results/uploads/`
+- mobissh-prod: `/app/test-results/uploads` (docker-compose.prod.yml)
+- mobissh-feedback: `/app/test-results/uploads` (docker-compose.feedback.yml)
+
+Consumers (all read the fd-dev path; none change):
+
+- `scripts/watch-bug-reports.sh` — polls `*-bug-report.json` / `*-drop-telemetry.json`
+- `scripts/assemble-repro.sh` — `*-bug-report.frame-%03d.png` → mp4/gif
+- replay harness / `scripts/paint-replay.sh` — `*-bug-report.byte-trace.json`
+- `scripts/pull-feedback.sh` — docker-cp fallback from prod (belt-and-braces; still works)
+- SSE events (`bug-report`, `drop-telemetry`, …): emitted by prod's LOCAL path
+  only; audit found NO client listens to them, so the proxied path drops them
+  (prod still logs `[feedback-proxy] ...` per relayed upload).
+
+## 2. Extracted architecture
+
+```
+app ── POST https://mobissh.tailbe5094.ts.net/api/bug-report (unchanged)
+        │ (tailscale serve → localhost:8081 inside mobissh-prod)
+        ▼
+mobissh-prod server/index.js
+        │ FEEDBACK_SERVICE_URL set?
+        ├─ yes → buffer body → relay verbatim → http://mobissh-feedback:8082 ──▶ feedback-store → uploads bind mount
+        │         └─ transport error/timeout → LOG + fall back ↓   (fail-open)
+        └─ no/fallback → server/feedback-store.js locally ─────────────────────▶ same uploads bind mount
+```
+
+- `server/feedback-store.js` — single source of truth for persistence (naming,
+  caps, response bodies). Used by BOTH prod's local/fallback path and the
+  service, so semantics cannot drift.
+- `server-feedback/index.js` — the dedicated service. Plain `node:http`, zero
+  dependencies. Routes above + `GET /healthz`. Retention knob
+  `FEEDBACK_RETENTION_DAYS` (default 0 = keep everything; sweep on boot + daily).
+- `docker/feedback/Dockerfile` — build context is the repo root (shares
+  feedback-store.js). `docker-compose.feedback.yml` joins the external
+  `mobissh` network (Docker DNS; no port mapping — docker-proxy is absent).
+- Proxy in `server/index.js` (`handleFeedbackUpload`): buffers the raw body
+  (the old handlers buffered too), forwards it unmodified with a 10s timeout
+  (`FEEDBACK_PROXY_TIMEOUT_MS`), relays the service's response verbatim
+  (including 413/400 — the caps live in the shared store either way). Only
+  TRANSPORT errors fall back to local handling, so a report is never lost when
+  the telemetry container is down. Duplicate risk on a timeout-after-write is
+  accepted (duplicate > lost).
+- Security: nothing is exposed beyond the tailnet. The service listens only on
+  the internal `mobissh` bridge network; the app still talks to the single
+  Tailscale endpoint. No new auth surface; no secrets in code or logs.
+
+### Tests
+
+- `server-feedback/test.js` (`npm test` in `server-feedback/`) — round-trip of
+  all four routes against a temp dir, exact filename contract, 1MB crash cap,
+  raw-crash preservation, retention sweep, healthz.
+- `server/test.js` (`npm test` in `server/`) — proxy pass-through (stub service
+  receives the raw body, response relayed verbatim), fail-open fallback
+  (unreachable service → local file written), pre-cutover local default.
+
+## 3. Cutover (explicit, owner-run; nothing flips silently)
+
+Pre-cutover state after merging this PR: NOTHING changes on the live
+mobissh-prod container (it runs the old image until rebuilt).
+
+```
+scripts/feedback-ctl.sh start        # build + start mobissh-feedback on the mobissh network
+scripts/feedback-ctl.sh status       # healthz + code-currency check
+scripts/container-ctl.sh restart     # rebuild prod: picks up the proxy code + FEEDBACK_SERVICE_URL default
+```
+
+Verification: file a test report from the app (or `curl -X POST .../api/bug-report`
+over the tailnet), then check `docker logs mobissh-prod` for
+`[feedback-proxy] /api/bug-report -> http://mobissh-feedback:8082 (200)` and the
+file in `/home/dev/workspace/mobissh/test-results/uploads/`.
+
+Rollback / disable proxying (keep the new prod image, handle locally):
+recreate prod with the env EXPLICITLY empty — `FEEDBACK_SERVICE_URL=` (the
+compose default uses `${FEEDBACK_SERVICE_URL-…}`, no colon, so an empty value
+disables). Fallback also engages automatically whenever the service is down —
+`scripts/feedback-ctl.sh stop` alone never loses reports.
+
+Retention: default keeps everything. To enable pruning, recreate the service
+with e.g. `FEEDBACK_RETENTION_DAYS=90`.
+
+## 4. Operator handoff — PVE LXC deploy (raserver-home-it)
+
+Modeled on the emulator-container arc (docker-compose file in repo root +
+docker/ build dir; fd-dev drives docker against the shared daemon; the operator
+does host-side provisioning). Two supported shapes:
+
+**A. Same Docker daemon as today (no host work needed).** The service is just
+another sibling container on the `mobissh` bridge network. Everything in
+section 3 works as-is. Nothing to provision.
+
+**B. Dedicated LXC on PVE (this issue's ask).** Provision like the emulator
+LXC, but far lighter — this is a tiny stateless-ish Node HTTP service plus a
+data directory:
+
+- Unprivileged LXC, 1 vCPU / 512MB is plenty. No GPU, no KVM, no TUN needed
+  (the service itself does NOT run Tailscale; mobissh-prod remains the single
+  Tailscale endpoint and proxies over the internal network).
+- Runtime: either `docker compose -f docker-compose.feedback.yml up -d` inside
+  the LXC (needs nesting for Docker) or bare `node server-feedback/index.js`
+  with Node >= 18 (zero npm deps — copy `server-feedback/` +
+  `server/feedback-store.js`, keep the relative layout).
+- Storage: bind-mount the uploads directory into the LXC and export it to the
+  dev environment. The HARD requirement is that fd-dev keeps seeing the files
+  at `/home/dev/workspace/mobissh/test-results/uploads/` — today that is the
+  host path `/var/lib/docker/volumes/dev_workspace/_data/mobissh/test-results/uploads`.
+  If the LXC lives on the same PVE host, an LXC mountpoint (`mpN:`) to that
+  path preserves dev-loop parity with zero changes. If it lives elsewhere, an
+  NFS/SSHFS export back to that path is required before cutover.
+- Network: mobissh-prod must reach the service at port 8082. Same host: attach
+  the LXC to the bridge and set `FEEDBACK_SERVICE_URL=http://<lxc-ip-or-name>:8082`
+  on mobissh-prod (compose env). The service needs NO inbound exposure beyond
+  that one consumer — do not publish it on the tailnet or LAN-wide.
+- Env: `PORT=8082`, `UPLOADS_DIR=<mounted dir>`, `FEEDBACK_RETENTION_DAYS=0`.
+- Health: `GET http://<service>:8082/healthz` → `{ok:true,service:"mobissh-feedback",...}`.
+  `scripts/feedback-ctl.sh status` covers the Docker shape; for a bare-node LXC
+  use the healthz URL directly.
+- Fail-open means the LXC can be provisioned/rebooted at leisure: while it is
+  down, mobissh-prod handles uploads locally into the same directory.

--- a/scripts/feedback-ctl.sh
+++ b/scripts/feedback-ctl.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# scripts/feedback-ctl.sh — Feedback service container lifecycle (#997)
+#
+# Manages the dedicated bug-report/telemetry container (mobissh-feedback)
+# mirroring container-ctl.sh conventions: idempotent network create, build
+# verification, health check via /healthz, code-currency check.
+#
+# Usage:
+#   scripts/feedback-ctl.sh start       # build + start (or restart if stale)
+#   scripts/feedback-ctl.sh stop        # stop container
+#   scripts/feedback-ctl.sh restart     # force rebuild + restart
+#   scripts/feedback-ctl.sh status      # health + version check
+#   scripts/feedback-ctl.sh ensure      # idempotent: rebuild only if stale
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MOBISSH_TMPDIR="${MOBISSH_TMPDIR:-/tmp/mobissh}"
+MOBISSH_LOGDIR="${MOBISSH_LOGDIR:-/tmp/mobissh/logs}"
+mkdir -p "$MOBISSH_TMPDIR" "$MOBISSH_LOGDIR"
+LOGFILE="${MOBISSH_LOGDIR}/feedback-ctl.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+COMPOSE_FILE="docker-compose.feedback.yml"
+CONTAINER="mobissh-feedback"
+HEALTH_TIMEOUT=30
+
+log() { echo "> $*"; }
+err() { echo "! $*" >&2; }
+ok()  { echo "+ $*"; }
+
+head_hash() {
+  git rev-parse --short HEAD 2>/dev/null || echo "unknown"
+}
+
+is_running() {
+  docker ps --filter "name=${CONTAINER}" --format '{{.Names}}' 2>/dev/null | grep -q "^${CONTAINER}$"
+}
+
+container_version() {
+  docker exec "$CONTAINER" cat /app/.git-hash 2>/dev/null | tr -d '[:space:]' || echo ""
+}
+
+# Wait for /healthz inside the container (curl/wget not in slim image)
+wait_healthy() {
+  local elapsed=0
+  while (( elapsed < HEALTH_TIMEOUT )); do
+    if docker exec "$CONTAINER" node -e "
+      const h=require('http');
+      const r=h.get('http://localhost:8082/healthz',res=>{
+        process.exit(res.statusCode===200?0:1);
+      });
+      r.on('error',()=>process.exit(1));
+      r.setTimeout(2000,()=>{r.destroy();process.exit(1)});
+    " 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+    (( elapsed++ ))
+  done
+  return 1
+}
+
+is_current() {
+  local serving head
+  serving=$(container_version)
+  head=$(head_hash)
+  [[ -n "$serving" && "$serving" == "$head" ]]
+}
+
+cmd_stop() {
+  if ! is_running; then
+    log "Container ${CONTAINER} not running."
+    return 0
+  fi
+  log "Stopping ${CONTAINER}..."
+  docker compose -f "$COMPOSE_FILE" stop
+  ok "Container stopped."
+}
+
+cmd_build() {
+  local hash
+  hash=$(head_hash)
+
+  # Pre-build gate: plain syntax check (the service has no TS and no deps).
+  if [[ "${SKIP_GATE:-0}" != "1" ]]; then
+    log "Pre-build gate: node --check..."
+    if ! node --check server-feedback/index.js; then
+      err "node --check server-feedback/index.js failed — aborting build."
+      exit 1
+    fi
+    if ! node --check server/feedback-store.js; then
+      err "node --check server/feedback-store.js failed — aborting build."
+      exit 1
+    fi
+    ok "Pre-build gate passed."
+  else
+    log "Pre-build gate: SKIPPED (SKIP_GATE=1)"
+  fi
+
+  log "Building ${CONTAINER} at ${hash}..."
+  GIT_HASH="$hash" docker compose -f "$COMPOSE_FILE" build --build-arg "GIT_HASH=${hash}" 2>&1
+  ok "Image built."
+}
+
+cmd_up() {
+  log "Starting ${CONTAINER}..."
+  # Ensure shared Docker network exists (external: true requires pre-creation)
+  docker network create mobissh 2>/dev/null || true
+  docker compose -f "$COMPOSE_FILE" up -d 2>&1
+
+  if wait_healthy; then
+    ok "Container healthy (version $(container_version))."
+  else
+    err "Container failed to become healthy within ${HEALTH_TIMEOUT}s."
+    err "Logs:"
+    docker logs --tail 20 "$CONTAINER"
+    return 1
+  fi
+}
+
+cmd_start() {
+  if is_running && is_current; then
+    ok "Container already running at HEAD ($(head_hash))."
+    return 0
+  fi
+  if is_running; then
+    log "Container running but stale (serving $(container_version), HEAD is $(head_hash)). Rebuilding..."
+  fi
+  cmd_build
+  cmd_up
+}
+
+cmd_restart() {
+  cmd_build
+  cmd_up
+}
+
+cmd_status() {
+  local head
+  head=$(head_hash)
+
+  if ! is_running; then
+    err "Container ${CONTAINER} is NOT running."
+    return 1
+  fi
+
+  local uptime
+  uptime=$(docker ps --filter "name=${CONTAINER}" --format '{{.Status}}')
+  log "Status: ${uptime}"
+
+  if wait_healthy; then
+    ok "Healthz OK."
+  else
+    err "Healthz FAILED."
+    return 1
+  fi
+
+  local serving
+  serving=$(container_version)
+  if [[ "$serving" == "$head" ]]; then
+    ok "Code current: ${serving} (matches HEAD)."
+  else
+    err "STALE: serving ${serving:-empty}, HEAD is ${head}. Run: scripts/feedback-ctl.sh restart"
+    return 1
+  fi
+}
+
+cmd_ensure() {
+  if is_running && is_current; then
+    ok "Container healthy at HEAD ($(head_hash))."
+    return 0
+  fi
+  cmd_start
+}
+
+case "${1:-}" in
+  start)   cmd_start ;;
+  stop)    cmd_stop ;;
+  restart) cmd_restart ;;
+  status)  cmd_status ;;
+  ensure)  cmd_ensure ;;
+  *)
+    echo "Usage: scripts/feedback-ctl.sh {start|stop|restart|status|ensure}"
+    echo ""
+    echo "  start    Build + start (rebuild if stale)"
+    echo "  stop     Stop container"
+    echo "  restart  Force rebuild + restart"
+    echo "  status   Health + version check"
+    echo "  ensure   Idempotent: rebuild only if code is stale"
+    exit 1
+    ;;
+esac

--- a/scripts/test-lint.sh
+++ b/scripts/test-lint.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 LOGFILE=/tmp/test-lint.log
 exec > >(tee "$LOGFILE") 2>&1
 
-npx eslint src/ public/ server/ tests/
+npx eslint src/ public/ server/ server-feedback/ tests/
 
 # SFTP message type sync check (catches missing router entries)
 scripts/test-sftp-sync.sh

--- a/server-feedback/index.js
+++ b/server-feedback/index.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * MobiSSH feedback service (#997) — dedicated bug-report/telemetry ingestion.
+ *
+ * Minimal Node HTTP server (no dependencies) extracted from server/index.js.
+ * Handles ONLY the upload/telemetry routes; the SSH bridge / static server
+ * (mobissh-prod) proxies these routes here so the app keeps posting to the
+ * single Tailscale endpoint. Persistence semantics (file naming, size caps,
+ * response bodies) live in server/feedback-store.js, shared with prod's
+ * fail-open local fallback.
+ *
+ * Routes:
+ *   POST /api/bug-report
+ *   POST /api/drop-telemetry
+ *   POST /api/gesture-telemetry
+ *   POST /api/native-crash
+ *   GET  /healthz              — liveness + config for feedback-ctl.sh
+ *
+ * Env:
+ *   PORT                    listen port (default 8082)
+ *   HOST                    bind address (default 0.0.0.0)
+ *   UPLOADS_DIR             storage dir (default ../test-results/uploads)
+ *   FEEDBACK_RETENTION_DAYS retention knob; 0/unset = keep everything
+ *                           (default — the owner keeps traces, storage is cheap)
+ */
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const store = require('../server/feedback-store');
+
+const PORT = process.env.PORT || 8082;
+const HOST = process.env.HOST || '0.0.0.0';
+const UPLOADS_DIR = process.env.UPLOADS_DIR
+  ? path.resolve(process.env.UPLOADS_DIR)
+  : path.resolve(__dirname, '..', 'test-results', 'uploads');
+const RETENTION_DAYS = parseInt(process.env.FEEDBACK_RETENTION_DAYS || '', 10) || 0;
+const APP_VERSION = require('./package.json').version || '0.0.0';
+
+let GIT_HASH = 'unknown';
+try { GIT_HASH = fs.readFileSync(path.join(__dirname, '..', '.git-hash'), 'utf8').trim(); } catch (_) {}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/healthz') {
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+    res.end(JSON.stringify({
+      ok: true,
+      service: 'mobissh-feedback',
+      version: APP_VERSION,
+      hash: GIT_HASH,
+      uploadsDir: UPLOADS_DIR,
+      retentionDays: RETENTION_DAYS,
+    }));
+    return;
+  }
+
+  if (req.method === 'POST' && store.FEEDBACK_ROUTES.includes(req.url)) {
+    const route = req.url;
+    const maxBytes = route === '/api/native-crash' ? store.MAX_CRASH_BYTES : 0;
+    let body;
+    try {
+      body = await store.readBody(req, maxBytes);
+    } catch (err) {
+      if (err.code === 'TOO_LARGE') {
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end('{"error":"crash report exceeds 1MB"}');
+      }
+      return;
+    }
+    const result = store.handleFeedbackRequest(route, body, UPLOADS_DIR);
+    res.writeHead(result.status, { 'Content-Type': 'application/json' });
+    res.end(result.body);
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end('{"error":"not found"}');
+});
+
+if (require.main === module) {
+  server.listen(PORT, HOST, () => {
+    console.log(`[feedback-service] listening on ${HOST}:${PORT} uploads=${UPLOADS_DIR} retention=${RETENTION_DAYS || 'keep-everything'}`);
+    fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+    // Retention sweep: on boot + daily. No-op at the default 0 (keep all).
+    store.sweepRetention(UPLOADS_DIR, RETENTION_DAYS);
+    setInterval(() => store.sweepRetention(UPLOADS_DIR, RETENTION_DAYS), 24 * 60 * 60 * 1000).unref();
+  });
+}
+
+module.exports = { server, UPLOADS_DIR };

--- a/server-feedback/package.json
+++ b/server-feedback/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mobissh-feedback",
+  "version": "1.0.0",
+  "description": "Dedicated bug-report/telemetry ingestion service for MobiSSH (#997)",
+  "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node --test test.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/server-feedback/test.js
+++ b/server-feedback/test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+/**
+ * server-feedback/test.js — round-trip tests for the feedback service (#997)
+ *
+ * Run with: npm test  (from the server-feedback/ directory)
+ *
+ * Uploads land in a temp dir (UPLOADS_DIR is read at require time, so it is
+ * set before the service module loads). Asserts the exact filename contract
+ * the dev-loop consumers (watch-bug-reports.sh, assemble-repro.sh, the replay
+ * harness) depend on.
+ */
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+
+const TMP_UPLOADS = fs.mkdtempSync(path.join(os.tmpdir(), 'mobissh-feedback-test-'));
+process.env.UPLOADS_DIR = TMP_UPLOADS;
+
+const { server } = require('./index.js');
+const store = require('../server/feedback-store.js');
+
+let baseUrl = '';
+
+before(async () => {
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  fs.rmSync(TMP_UPLOADS, { recursive: true, force: true });
+});
+
+function post(route, body, headers) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(baseUrl + route, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(headers || {}) },
+    }, (res) => {
+      let out = '';
+      res.on('data', (c) => { out += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body: out }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function get(route) {
+  return new Promise((resolve, reject) => {
+    http.get(baseUrl + route, (res) => {
+      let out = '';
+      res.on('data', (c) => { out += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body: out }));
+    }).on('error', reject);
+  });
+}
+
+function uploadsWith(suffix) {
+  return fs.readdirSync(TMP_UPLOADS).filter((n) => n.endsWith(suffix));
+}
+
+// 1x1 transparent PNG as a data URL
+const PNG_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+test('healthz reports service identity and uploads dir', async () => {
+  const res = await get('/healthz');
+  assert.equal(res.status, 200);
+  const j = JSON.parse(res.body);
+  assert.equal(j.ok, true);
+  assert.equal(j.service, 'mobissh-feedback');
+  assert.equal(j.uploadsDir, TMP_UPLOADS);
+});
+
+test('bug-report round-trip writes the full sidecar set', async () => {
+  const payload = {
+    title: '[1.0 abc123] terminal froze',
+    comment: 'terminal froze\nafter switching tmux windows\nline three',
+    logs: 'terminal froze\nafter switching tmux windows\nline three',
+    userAgent: 'test-agent',
+    url: 'https://mobissh.example/app',
+    version: '[1.0 abc123]',
+    screenshot: PNG_DATA_URL,
+    frames: [PNG_DATA_URL, PNG_DATA_URL],
+    connectLog: [{ t: 1, ev: 'connect' }],
+    gestureLog: [{ t: 2, ev: 'swipe' }],
+    byteTrace: [{ tMs: 1, b64: 'aGk=' }],
+    scrollTrace: [{ tMs: 2, offset: 3 }],
+    sentSgrTrace: [{ tMs: 3, b64: 'c2dy' }],
+    grid: { cols: 80, rows: 24 },
+  };
+  const res = await post('/api/bug-report', JSON.stringify(payload));
+  assert.equal(res.status, 200);
+  assert.deepEqual(JSON.parse(res.body), { ok: true, saved: true });
+
+  const metaName = uploadsWith('-bug-report.json')[0];
+  assert.ok(metaName, 'meta json written');
+  const ts = metaName.replace('-bug-report.json', '');
+  const meta = JSON.parse(fs.readFileSync(path.join(TMP_UPLOADS, metaName), 'utf8'));
+  assert.equal(meta.comment, payload.comment);
+  assert.equal(meta.title, payload.title);
+  assert.equal(meta.frameCount, 2);
+  assert.equal(meta.framesPattern, `${ts}-bug-report.frame-%03d.png`);
+  assert.deepEqual(meta.grid, { cols: 80, rows: 24 });
+
+  // Exact filename contract the dev-loop scripts glob for.
+  for (const f of [
+    `${ts}-bug-report.png`,
+    `${ts}-bug-report.log`,
+    `${ts}-bug-report.frame-001.png`,
+    `${ts}-bug-report.frame-002.png`,
+    `${ts}-bug-report.connect-log.json`,
+    `${ts}-bug-report.gesture-log.json`,
+    `${ts}-bug-report.byte-trace.json`,
+    `${ts}-bug-report.sent-sgr-trace.json`,
+  ]) {
+    assert.ok(fs.existsSync(path.join(TMP_UPLOADS, f)), `${f} written`);
+  }
+
+  // Byte-trace sidecar shape consumed by the replay harness (#790).
+  const bt = JSON.parse(fs.readFileSync(path.join(TMP_UPLOADS, `${ts}-bug-report.byte-trace.json`), 'utf8'));
+  assert.deepEqual(bt.grid, { cols: 80, rows: 24 });
+  assert.equal(bt.byteTrace.length, 1);
+  assert.equal(bt.scrollTrace.length, 1);
+});
+
+test('bug-report rejects invalid json with 400', async () => {
+  const res = await post('/api/bug-report', 'not json {');
+  assert.equal(res.status, 400);
+  assert.deepEqual(JSON.parse(res.body), { error: 'invalid json' });
+});
+
+test('drop-telemetry round-trip', async () => {
+  const res = await post('/api/drop-telemetry', JSON.stringify({
+    kind: 'drop-recovery',
+    reason: 'ws-close',
+    host: 'fd-dev',
+    connectLog: [{ t: 1, ev: 'reconnect' }],
+  }));
+  assert.equal(res.status, 200);
+  const j = JSON.parse(res.body);
+  assert.equal(j.ok, true);
+  assert.ok(j.stamp);
+  const meta = JSON.parse(fs.readFileSync(path.join(TMP_UPLOADS, `${j.stamp}-drop-telemetry.json`), 'utf8'));
+  assert.equal(meta.reason, 'ws-close');
+  assert.equal(meta.host, 'fd-dev');
+  assert.ok(fs.existsSync(path.join(TMP_UPLOADS, `${j.stamp}-drop-telemetry.connect-log.json`)));
+});
+
+test('gesture-telemetry round-trip', async () => {
+  const res = await post('/api/gesture-telemetry', JSON.stringify({
+    reason: 'ime-anomaly',
+    eventCount: 2,
+    log: [{ t: 1 }, { t: 2 }],
+  }));
+  assert.equal(res.status, 200);
+  const j = JSON.parse(res.body);
+  const meta = JSON.parse(fs.readFileSync(path.join(TMP_UPLOADS, `${j.stamp}-gesture-telemetry.json`), 'utf8'));
+  assert.equal(meta.reason, 'ime-anomaly');
+  assert.equal(meta.logEventCount, 2);
+  assert.ok(fs.existsSync(path.join(TMP_UPLOADS, `${j.stamp}-gesture-telemetry.gesture-log.json`)));
+});
+
+test('native-crash JSON body persists as .json', async () => {
+  const res = await post('/api/native-crash', JSON.stringify({ kind: 'dart', error: 'boom' }));
+  assert.equal(res.status, 200);
+  const j = JSON.parse(res.body);
+  assert.equal(j.ok, true);
+  assert.match(j.path, /-native-crash\.json$/);
+  const saved = JSON.parse(fs.readFileSync(path.join(TMP_UPLOADS, j.path), 'utf8'));
+  assert.equal(saved.error, 'boom');
+});
+
+test('native-crash non-JSON body preserved as .raw', async () => {
+  const res = await post('/api/native-crash', 'FATAL EXCEPTION: main\n  at ...');
+  assert.equal(res.status, 200);
+  const j = JSON.parse(res.body);
+  assert.equal(j.raw, true);
+  assert.match(j.path, /-native-crash\.raw$/);
+  assert.ok(fs.existsSync(path.join(TMP_UPLOADS, j.path)));
+});
+
+test('native-crash over 1MB answers 413', async () => {
+  const big = JSON.stringify({ kind: 'dart', error: 'x'.repeat(1024 * 1024 + 64) });
+  const res = await post('/api/native-crash', big).catch((err) => ({ status: 413, aborted: true, err }));
+  // The server destroys the request after responding; depending on timing the
+  // client sees the 413 or a socket reset. Either way nothing was persisted.
+  if (!res.aborted) assert.equal(res.status, 413);
+  const before413 = uploadsWith('-native-crash.json').length + uploadsWith('-native-crash.raw').length;
+  assert.equal(before413, 2); // only the two crash files from the tests above
+});
+
+test('unknown route answers 404', async () => {
+  const res = await post('/api/nope', '{}');
+  assert.equal(res.status, 404);
+});
+
+test('retention sweep deletes only files older than the knob', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mobissh-retention-test-'));
+  const oldFile = path.join(dir, 'old-bug-report.json');
+  const newFile = path.join(dir, 'new-bug-report.json');
+  fs.writeFileSync(oldFile, '{}');
+  fs.writeFileSync(newFile, '{}');
+  const tenDaysAgo = (Date.now() - 10 * 24 * 60 * 60 * 1000) / 1000;
+  fs.utimesSync(oldFile, tenDaysAgo, tenDaysAgo);
+
+  // Default (0) keeps everything.
+  assert.equal(store.sweepRetention(dir, 0), 0);
+  assert.ok(fs.existsSync(oldFile));
+
+  // 7-day knob deletes only the old file.
+  assert.equal(store.sweepRetention(dir, 7), 1);
+  assert.ok(!fs.existsSync(oldFile));
+  assert.ok(fs.existsSync(newFile));
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/server/feedback-store.js
+++ b/server/feedback-store.js
@@ -1,0 +1,441 @@
+'use strict';
+
+/**
+ * server/feedback-store.js — bug-report/telemetry persistence (#997).
+ *
+ * Single source of truth for the four feedback ingestion routes:
+ *
+ *   POST /api/bug-report         user-filed report (screenshot, frames, logs, traces)
+ *   POST /api/drop-telemetry     auto-upload on connection-drop recovery
+ *   POST /api/gesture-telemetry  auto-upload on gesture/IME anomaly (#502)
+ *   POST /api/native-crash       native APK crash reports (#501)
+ *
+ * Extracted VERBATIM from server/index.js so the dedicated feedback-service
+ * container (server-feedback/index.js) and mobissh-prod's fail-open local
+ * fallback share identical file-naming contracts, size caps, and response
+ * bodies. The dev-loop consumers (scripts/watch-bug-reports.sh,
+ * scripts/assemble-repro.sh, the replay harness, scripts/paint-replay.sh)
+ * depend on the exact filenames written here — do not change them.
+ *
+ * Filename contract: every file is named from a server-generated ISO stamp
+ * (`2026-07-08T14-15-16`) plus a fixed suffix. No user-controlled path
+ * components ever reach the filesystem — that IS the sanitization.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Request-body cap for /api/native-crash (stack traces are far smaller).
+const MAX_CRASH_BYTES = 1024 * 1024;
+// Per-file cap for the gesture-telemetry log sidecar.
+const MAX_GESTURE_LOG_BYTES = 1024 * 1024;
+// Frame-burst guard for bug-report repro recordings.
+const MAX_FRAMES = 120;
+// Server-side backstop caps for replay traces (client already bounds the rings).
+const MAX_BYTE_EVENTS = 8192;
+const MAX_SCROLL_EVENTS = 8192;
+const MAX_SENT_SGR_EVENTS = 8192;
+
+/** The routes this store handles (also used by the prod proxy gate). */
+const FEEDBACK_ROUTES = [
+  '/api/bug-report',
+  '/api/drop-telemetry',
+  '/api/gesture-telemetry',
+  '/api/native-crash',
+];
+
+/** Server-generated timestamp used as the filename prefix for every artifact. */
+function stampNow() {
+  return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+}
+
+/**
+ * Buffer a request body, optionally enforcing a byte cap. Resolves with the
+ * body as a utf8 string. Rejects with err.code === 'TOO_LARGE' (after
+ * destroying the request) when the cap is exceeded — the caller answers 413.
+ */
+function readBody(req, maxBytes) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    let aborted = false;
+    req.on('data', (chunk) => {
+      if (aborted) return;
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buf.length;
+      if (maxBytes && total > maxBytes) {
+        aborted = true;
+        try { req.destroy(); } catch (_) {}
+        const err = new Error(`body exceeds ${maxBytes} bytes`);
+        err.code = 'TOO_LARGE';
+        reject(err);
+        return;
+      }
+      chunks.push(buf);
+    });
+    req.on('end', () => {
+      if (!aborted) resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+    req.on('error', (err) => {
+      if (!aborted) reject(err);
+    });
+  });
+}
+
+/** Save a drop-telemetry payload. Returns the meta object written to disk. */
+function saveDropTelemetry(data, reportDir) {
+  const { kind, reason, sessionId, host, ts, userAgent, url, version, connectLog, gestureLog } = data;
+  const stamp = stampNow();
+  fs.mkdirSync(reportDir, { recursive: true });
+
+  let connectLogFile = '';
+  if (Array.isArray(connectLog) && connectLog.length > 0) {
+    connectLogFile = `${stamp}-drop-telemetry.connect-log.json`;
+    fs.writeFileSync(
+      path.join(reportDir, connectLogFile),
+      JSON.stringify(connectLog, null, 2),
+    );
+  }
+
+  let gestureLogFile = '';
+  if (Array.isArray(gestureLog) && gestureLog.length > 0) {
+    gestureLogFile = `${stamp}-drop-telemetry.gesture-log.json`;
+    fs.writeFileSync(
+      path.join(reportDir, gestureLogFile),
+      JSON.stringify(gestureLog, null, 2),
+    );
+  }
+
+  const meta = {
+    kind: kind || 'drop-recovery',
+    reason: reason || '',
+    sessionId: sessionId || '',
+    host: host || '',
+    ts: ts || Date.now(),
+    stamp,
+    userAgent: userAgent || '',
+    url: url || '',
+    version: version || '',
+    connectLogFile,
+    connectLogEventCount: Array.isArray(connectLog) ? connectLog.length : 0,
+    gestureLogFile,
+    gestureLogEventCount: Array.isArray(gestureLog) ? gestureLog.length : 0,
+  };
+  fs.writeFileSync(path.join(reportDir, `${stamp}-drop-telemetry.json`), JSON.stringify(meta, null, 2));
+  console.log(`[drop-telemetry] ${stamp} reason="${meta.reason}" host="${meta.host}" connectEvents=${meta.connectLogEventCount} gestureEvents=${meta.gestureLogEventCount}`);
+  return meta;
+}
+
+/** Save a gesture-telemetry payload. Returns the meta object written to disk. */
+function saveGestureTelemetry(data, reportDir) {
+  const { kind, reason, eventCount, ts, userAgent, url, version, log } = data;
+  const stamp = stampNow();
+  fs.mkdirSync(reportDir, { recursive: true });
+
+  let logFile = '';
+  if (Array.isArray(log) && log.length > 0) {
+    logFile = `${stamp}-gesture-telemetry.gesture-log.json`;
+    const logPath = path.join(reportDir, logFile);
+    const logBody = JSON.stringify(log, null, 2);
+    // Cap individual log files at ~1MB to bound disk usage.
+    const safeBody = Buffer.byteLength(logBody, 'utf8') > MAX_GESTURE_LOG_BYTES
+      ? JSON.stringify(log.slice(-Math.floor(log.length / 2)), null, 2)
+      : logBody;
+    fs.writeFileSync(logPath, safeBody);
+  }
+
+  const meta = {
+    kind: kind || 'gesture-anomaly',
+    reason: reason || '',
+    eventCount: typeof eventCount === 'number' ? eventCount : 0,
+    ts: ts || Date.now(),
+    stamp,
+    userAgent: userAgent || '',
+    url: url || '',
+    version: version || '',
+    logFile,
+    logEventCount: Array.isArray(log) ? log.length : 0,
+  };
+  fs.writeFileSync(
+    path.join(reportDir, `${stamp}-gesture-telemetry.json`),
+    JSON.stringify(meta, null, 2),
+  );
+  console.log(`[gesture-telemetry] ${stamp} reason="${meta.reason}" events=${meta.eventCount} logEvents=${meta.logEventCount}`);
+  return meta;
+}
+
+/**
+ * Save a native crash report from the RAW request body. Non-JSON bodies are
+ * preserved as `.raw` so a crash report is never lost. Returns
+ * { raw, file, kind, stamp } — `raw` true when the body did not parse.
+ */
+function saveNativeCrash(rawBody, reportDir) {
+  const stamp = stampNow();
+  fs.mkdirSync(reportDir, { recursive: true });
+  let parsed = null;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch (parseErr) {
+    const rawFile = path.join(reportDir, `${stamp}-native-crash.raw`);
+    fs.writeFileSync(rawFile, rawBody);
+    console.warn(`[native-crash] non-JSON body saved to ${rawFile}: ${parseErr.message}`);
+    return { raw: true, file: path.basename(rawFile), kind: 'unknown', stamp };
+  }
+  const kind = (parsed && parsed.kind) || 'unknown';
+  const outFile = path.join(reportDir, `${stamp}-native-crash.json`);
+  fs.writeFileSync(outFile, JSON.stringify(parsed, null, 2));
+  const errMsg = (parsed && parsed.error) || '';
+  console.log(`[native-crash] ${stamp} kind="${kind}" error="${String(errMsg).slice(0, 120)}"`);
+  return { raw: false, file: path.basename(outFile), kind, stamp };
+}
+
+/** Save a bug-report payload. Returns the meta object written to disk. */
+function saveBugReport(data, reportDir) {
+  const { screenshot, frames, logs, title, comment, userAgent, url, version, connectLog, gestureLog, byteTrace, scrollTrace, sentSgrTrace, grid } = data;
+  const ts = stampNow();
+  fs.mkdirSync(reportDir, { recursive: true });
+
+  // Save screenshot
+  let screenshotFile = '';
+  if (screenshot) {
+    const imgData = screenshot.replace(/^data:image\/\w+;base64,/, '');
+    screenshotFile = `${ts}-bug-report.png`;
+    fs.writeFileSync(path.join(reportDir, screenshotFile), Buffer.from(imgData, 'base64'));
+    console.log(`[bug-report] screenshot: ${screenshotFile}`);
+  }
+
+  // #repro: a recorded burst of frames (in-app 10s "video"). Save each as a
+  // zero-padded PNG so the orchestrator can assemble them with ffmpeg
+  // (`ffmpeg -framerate 5 -i ${ts}-bug-report.frame-%03d.png out.mp4`).
+  let frameCount = 0;
+  let framesPattern = '';
+  if (Array.isArray(frames) && frames.length > 0) {
+    const n = Math.min(frames.length, MAX_FRAMES);
+    for (let i = 0; i < n; i++) {
+      const f = frames[i];
+      if (typeof f !== 'string' || !f) continue;
+      const fData = f.replace(/^data:image\/\w+;base64,/, '');
+      const name = `${ts}-bug-report.frame-${String(i + 1).padStart(3, '0')}.png`;
+      fs.writeFileSync(path.join(reportDir, name), Buffer.from(fData, 'base64'));
+      frameCount++;
+    }
+    framesPattern = `${ts}-bug-report.frame-%03d.png`;
+    console.log(`[bug-report] frames: ${frameCount} (${framesPattern})`);
+  }
+
+  // Full free-text body. The native in-app feedback (#661) sends the ENTIRE
+  // multi-line note as `comment` (no truncation). The web form
+  // (public/native-feedback.js) sends the full note as `logs` and only a
+  // first-line `title`. Resolve the full body from `comment` first, falling
+  // back to `logs`, and persist it into the .json meta so the orchestrator's
+  // watcher — which reads the .json — gets the complete note.
+  const fullComment = (typeof comment === 'string' && comment.length > 0)
+    ? comment
+    : (typeof logs === 'string' ? logs : '');
+
+  // Save logs / full comment as a sidecar text file too.
+  const logBody = (typeof logs === 'string' && logs.length > 0) ? logs : fullComment;
+  if (logBody) {
+    fs.writeFileSync(path.join(reportDir, `${ts}-bug-report.log`), logBody);
+    console.log(`[bug-report] logs: ${ts}-bug-report.log`);
+  }
+
+  // 24h connect log — every connect/reconnect/state-transition event.
+  let connectLogFile = '';
+  if (Array.isArray(connectLog) && connectLog.length > 0) {
+    connectLogFile = `${ts}-bug-report.connect-log.json`;
+    fs.writeFileSync(
+      path.join(reportDir, connectLogFile),
+      JSON.stringify(connectLog, null, 2),
+    );
+    console.log(`[bug-report] connect log: ${connectLogFile} (${connectLog.length} events)`);
+  }
+
+  // 24h gesture log — every swipe / pinch / long-press / drag-select.
+  let gestureLogFile = '';
+  if (Array.isArray(gestureLog) && gestureLog.length > 0) {
+    gestureLogFile = `${ts}-bug-report.gesture-log.json`;
+    fs.writeFileSync(
+      path.join(reportDir, gestureLogFile),
+      JSON.stringify(gestureLog, null, 2),
+    );
+    console.log(`[bug-report] gesture log: ${gestureLogFile} (${gestureLog.length} events)`);
+  }
+
+  // #790: the replay-harness trace — raw bytes that reached the terminal
+  // (byteTrace) + scroll-offset events (scrollTrace) + the viewport grid.
+  let byteTraceFile = '';
+  let byteTraceEventCount = 0;
+  let scrollTraceEventCount = 0;
+  const hasByteTrace = Array.isArray(byteTrace) && byteTrace.length > 0;
+  const hasScrollTrace = Array.isArray(scrollTrace) && scrollTrace.length > 0;
+  if (hasByteTrace || hasScrollTrace) {
+    const cappedBytes = hasByteTrace ? byteTrace.slice(-MAX_BYTE_EVENTS) : [];
+    const cappedScroll = hasScrollTrace ? scrollTrace.slice(-MAX_SCROLL_EVENTS) : [];
+    byteTraceEventCount = cappedBytes.length;
+    scrollTraceEventCount = cappedScroll.length;
+    byteTraceFile = `${ts}-bug-report.byte-trace.json`;
+    fs.writeFileSync(
+      path.join(reportDir, byteTraceFile),
+      JSON.stringify({
+        grid: (grid && typeof grid === 'object') ? grid : null,
+        byteTrace: cappedBytes,
+        scrollTrace: cappedScroll,
+      }, null, 2),
+    );
+    console.log(`[bug-report] byte trace: ${byteTraceFile} (${byteTraceEventCount} byte events, ${scrollTraceEventCount} scroll events)`);
+  }
+
+  // #793: the sent-SGR trace — synthesized mouse/wheel SGR reports the app
+  // SENT to the remote. Filtered client-side to SGR-mouse reports ONLY.
+  let sentSgrTraceFile = '';
+  let sentSgrTraceEventCount = 0;
+  const hasSentSgrTrace = Array.isArray(sentSgrTrace) && sentSgrTrace.length > 0;
+  if (hasSentSgrTrace) {
+    const cappedSentSgr = sentSgrTrace.slice(-MAX_SENT_SGR_EVENTS);
+    sentSgrTraceEventCount = cappedSentSgr.length;
+    sentSgrTraceFile = `${ts}-bug-report.sent-sgr-trace.json`;
+    fs.writeFileSync(
+      path.join(reportDir, sentSgrTraceFile),
+      JSON.stringify({
+        grid: (grid && typeof grid === 'object') ? grid : null,
+        sentSgrTrace: cappedSentSgr,
+      }, null, 2),
+    );
+    console.log(`[bug-report] sent-SGR trace: ${sentSgrTraceFile} (${sentSgrTraceEventCount} events)`);
+  }
+
+  // Save metadata
+  const meta = {
+    title: title || `Bug report ${ts}`,
+    // #661: persist the FULL comment (untruncated) into the meta JSON.
+    comment: fullComment,
+    version,
+    url,
+    userAgent,
+    ts,
+    screenshotFile,
+    frameCount,
+    framesPattern,
+    connectLogFile,
+    connectLogEventCount: Array.isArray(connectLog) ? connectLog.length : 0,
+    gestureLogFile,
+    gestureLogEventCount: Array.isArray(gestureLog) ? gestureLog.length : 0,
+    byteTraceFile,
+    byteTraceEventCount,
+    scrollTraceEventCount,
+    sentSgrTraceFile,
+    sentSgrTraceEventCount,
+    grid: (grid && typeof grid === 'object') ? grid : null,
+  };
+  fs.writeFileSync(path.join(reportDir, `${ts}-bug-report.json`), JSON.stringify(meta, null, 2));
+  console.log(`[bug-report] saved: "${meta.title}"`);
+  return meta;
+}
+
+/**
+ * Dispatch a buffered feedback request body. Route must be one of
+ * FEEDBACK_ROUTES. Returns { status, body, sse } where `body` is the exact
+ * JSON response string and `sse` is an optional { event, data } for callers
+ * that broadcast (mobissh-prod's local path; the standalone service has no
+ * SSE clients and ignores it). Response bodies match the pre-extraction
+ * server/index.js handlers byte-for-byte.
+ */
+function handleFeedbackRequest(route, rawBody, reportDir) {
+  if (route === '/api/native-crash') {
+    try {
+      const r = saveNativeCrash(rawBody, reportDir);
+      const body = r.raw
+        ? JSON.stringify({ ok: true, raw: true, path: r.file })
+        : JSON.stringify({ ok: true, path: r.file });
+      return { status: 200, body, sse: { event: 'native-crash', data: { kind: r.kind, stamp: r.stamp, path: r.file } } };
+    } catch (err) {
+      console.error('[native-crash] write error:', err.message);
+      return { status: 500, body: '{"error":"failed to persist crash"}' };
+    }
+  }
+
+  // Parse + save under one catch, matching the pre-extraction handlers: any
+  // failure (bad JSON or a write error) answered 400 "invalid json". Kept
+  // byte-identical so existing clients/tests see no behavior change.
+  try {
+    return dispatchJsonRoute(route, JSON.parse(rawBody), reportDir);
+  } catch (err) {
+    const tag = route.replace('/api/', '');
+    console.error(`[${tag}] parse error:`, err.message);
+    return { status: 400, body: '{"error":"invalid json"}' };
+  }
+}
+
+function dispatchJsonRoute(route, data, reportDir) {
+  switch (route) {
+    case '/api/drop-telemetry': {
+      const meta = saveDropTelemetry(data, reportDir);
+      return {
+        status: 200,
+        body: JSON.stringify({ ok: true, stamp: meta.stamp }),
+        sse: { event: 'drop-telemetry', data: { reason: meta.reason, host: meta.host, stamp: meta.stamp } },
+      };
+    }
+    case '/api/gesture-telemetry': {
+      const meta = saveGestureTelemetry(data, reportDir);
+      return {
+        status: 200,
+        body: JSON.stringify({ ok: true, stamp: meta.stamp }),
+        sse: { event: 'gesture-telemetry', data: { reason: meta.reason, eventCount: meta.eventCount, stamp: meta.stamp } },
+      };
+    }
+    case '/api/bug-report': {
+      const meta = saveBugReport(data, reportDir);
+      return {
+        status: 200,
+        body: JSON.stringify({ ok: true, saved: true }),
+        sse: { event: 'bug-report', data: { title: meta.title, saved: true } },
+      };
+    }
+    default:
+      return { status: 404, body: '{"error":"unknown feedback route"}' };
+  }
+}
+
+/**
+ * Retention sweep: delete files in reportDir older than `days` (by mtime).
+ * days <= 0 means keep everything (the default — the owner keeps traces;
+ * storage is cheap). Returns the number of files deleted.
+ */
+function sweepRetention(reportDir, days) {
+  if (!days || days <= 0) return 0;
+  let deleted = 0;
+  let names;
+  try {
+    names = fs.readdirSync(reportDir);
+  } catch (_) {
+    return 0; // dir not created yet — nothing to sweep
+  }
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  for (const name of names) {
+    const p = path.join(reportDir, name);
+    try {
+      const st = fs.statSync(p);
+      if (st.isFile() && st.mtimeMs < cutoff) {
+        fs.unlinkSync(p);
+        deleted++;
+      }
+    } catch (_) { /* raced or unreadable — skip */ }
+  }
+  if (deleted > 0) console.log(`[retention] deleted ${deleted} file(s) older than ${days}d from ${reportDir}`);
+  return deleted;
+}
+
+module.exports = {
+  FEEDBACK_ROUTES,
+  MAX_CRASH_BYTES,
+  readBody,
+  stampNow,
+  saveDropTelemetry,
+  saveGestureTelemetry,
+  saveNativeCrash,
+  saveBugReport,
+  handleFeedbackRequest,
+  sweepRetention,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -63,6 +63,7 @@ const { Client } = require('ssh2');
 const { isOriginAllowed } = require('./origin');
 const TRACE_TRANSFER = process.env.MOBISSH_TRACE_TRANSFER === '1' || true; // default on for data gathering
 const { rewriteManifest } = require('./manifest');
+const feedbackStore = require('./feedback-store');
 
 const PORT = process.env.PORT || 8081;
 const HOST = process.env.HOST || '0.0.0.0';
@@ -207,6 +208,82 @@ function sseBroadcast(event, data) {
   for (const client of sseClients) {
     client.write(msg);
   }
+}
+
+// ─── Bug-report / telemetry ingestion (#997) ─────────────────────────────────
+// Persistence for /api/bug-report, /api/drop-telemetry, /api/gesture-telemetry
+// and /api/native-crash lives in server/feedback-store.js, shared with the
+// dedicated feedback-service container (server-feedback/). When
+// FEEDBACK_SERVICE_URL is set (docker-compose.prod.yml defaults it to
+// http://mobissh-feedback:8082) the raw body is relayed to that service so the
+// app keeps posting to the single Tailscale endpoint. If the service is
+// unreachable the report is handled LOCALLY (fail-open — a bug report must
+// never be lost because the telemetry container is down). Both sides write to
+// the same host bind mount, so dev-loop consumers see the files either way.
+
+const FEEDBACK_PROXY_TIMEOUT_MS = parseInt(process.env.FEEDBACK_PROXY_TIMEOUT_MS || '', 10) || 10_000;
+
+/**
+ * Relay a buffered feedback body to the feedback service and return its
+ * response. The body is buffered (the local handlers always buffered too)
+ * rather than piped so a transport failure can still fall back to local
+ * handling with the full body. Service HTTP responses (4xx/5xx included) are
+ * relayed verbatim; only transport errors (DNS/connect/timeout) reject.
+ */
+function proxyFeedbackBody(serviceUrl, route, body, contentType) {
+  return new Promise((resolve, reject) => {
+    const proxyReq = http.request(new URL(serviceUrl + route), {
+      method: 'POST',
+      headers: {
+        'Content-Type': contentType || 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+      timeout: FEEDBACK_PROXY_TIMEOUT_MS,
+    }, (proxyRes) => {
+      let out = '';
+      proxyRes.on('data', (c) => { out += c; });
+      proxyRes.on('end', () => resolve({ status: proxyRes.statusCode || 502, body: out }));
+    });
+    proxyReq.on('timeout', () => proxyReq.destroy(new Error('feedback service timeout')));
+    proxyReq.on('error', reject);
+    proxyReq.end(body);
+  });
+}
+
+async function handleFeedbackUpload(req, res) {
+  const route = req.url;
+  const maxBytes = route === '/api/native-crash' ? feedbackStore.MAX_CRASH_BYTES : 0;
+  let body;
+  try {
+    body = await feedbackStore.readBody(req, maxBytes);
+  } catch (err) {
+    if (err.code === 'TOO_LARGE') {
+      res.writeHead(413, { 'Content-Type': 'application/json' });
+      res.end('{"error":"crash report exceeds 1MB"}');
+    }
+    return;
+  }
+  // Read per-request (not at boot) so tests can toggle it; the deployed value
+  // comes from docker-compose.prod.yml env — activating it is an explicit
+  // container recreate, never a silent flip.
+  const serviceUrl = (process.env.FEEDBACK_SERVICE_URL || '').replace(/\/+$/, '');
+  if (serviceUrl) {
+    try {
+      const relayed = await proxyFeedbackBody(serviceUrl, route, body, req.headers['content-type']);
+      console.log(`[feedback-proxy] ${route} -> ${serviceUrl} (${relayed.status})`);
+      res.writeHead(relayed.status, { 'Content-Type': 'application/json' });
+      res.end(relayed.body);
+      return;
+    } catch (err) {
+      // Fail-open: never lose a report because the telemetry container is down.
+      console.error(`[feedback-proxy] ${route} -> ${serviceUrl} unreachable (${err.message}) — falling back to LOCAL handling`);
+    }
+  }
+  const reportDir = path.join(__dirname, '..', 'test-results', 'uploads');
+  const result = feedbackStore.handleFeedbackRequest(route, body, reportDir);
+  if (result.sse) sseBroadcast(result.sse.event, result.sse.data);
+  res.writeHead(result.status, { 'Content-Type': 'application/json' });
+  res.end(result.body);
 }
 
 const MIME = {
@@ -722,362 +799,12 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // POST /api/drop-telemetry — auto-upload of connection-drop telemetry
-  // (connect log + gesture log + metadata, no screenshot). Client fires this
-  // on every recovery from a `reconnecting` state, throttled to 5min/device.
-  // Lands in test-results/uploads/ alongside bug reports so the watcher
-  // surfaces it the same way; distinguished by the filename prefix.
-  if (req.method === 'POST' && req.url === '/api/drop-telemetry') {
-    let body = '';
-    req.on('data', (chunk) => { body += chunk; });
-    req.on('end', () => {
-      try {
-        const data = JSON.parse(body);
-        const { kind, reason, sessionId, host, ts, userAgent, url, version, connectLog, gestureLog } = data;
-        const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-        const reportDir = path.join(__dirname, '..', 'test-results', 'uploads');
-        fs.mkdirSync(reportDir, { recursive: true });
-
-        let connectLogFile = '';
-        if (Array.isArray(connectLog) && connectLog.length > 0) {
-          connectLogFile = `${stamp}-drop-telemetry.connect-log.json`;
-          fs.writeFileSync(
-            path.join(reportDir, connectLogFile),
-            JSON.stringify(connectLog, null, 2),
-          );
-        }
-
-        let gestureLogFile = '';
-        if (Array.isArray(gestureLog) && gestureLog.length > 0) {
-          gestureLogFile = `${stamp}-drop-telemetry.gesture-log.json`;
-          fs.writeFileSync(
-            path.join(reportDir, gestureLogFile),
-            JSON.stringify(gestureLog, null, 2),
-          );
-        }
-
-        const meta = {
-          kind: kind || 'drop-recovery',
-          reason: reason || '',
-          sessionId: sessionId || '',
-          host: host || '',
-          ts: ts || Date.now(),
-          stamp,
-          userAgent: userAgent || '',
-          url: url || '',
-          version: version || '',
-          connectLogFile,
-          connectLogEventCount: Array.isArray(connectLog) ? connectLog.length : 0,
-          gestureLogFile,
-          gestureLogEventCount: Array.isArray(gestureLog) ? gestureLog.length : 0,
-        };
-        fs.writeFileSync(path.join(reportDir, `${stamp}-drop-telemetry.json`), JSON.stringify(meta, null, 2));
-        console.log(`[drop-telemetry] ${stamp} reason="${meta.reason}" host="${meta.host}" connectEvents=${meta.connectLogEventCount} gestureEvents=${meta.gestureLogEventCount}`);
-        sseBroadcast('drop-telemetry', { reason: meta.reason, host: meta.host, stamp });
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, stamp }));
-      } catch (err) {
-        console.error('[drop-telemetry] parse error:', err.message);
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end('{"error":"invalid json"}');
-      }
-    });
-    return;
-  }
-
-  // POST /api/gesture-telemetry — auto-upload of gesture-anomaly telemetry
-  // (#502 diagnostic). Fires when selection.ts detects a focus/IME anomaly
-  // during a gesture window. Independent throttle from drop-telemetry.
-  // Lands in test-results/uploads/ with prefix gesture-telemetry.
-  if (req.method === 'POST' && req.url === '/api/gesture-telemetry') {
-    let body = '';
-    req.on('data', (chunk) => { body += chunk; });
-    req.on('end', () => {
-      try {
-        const data = JSON.parse(body);
-        const { kind, reason, eventCount, ts, userAgent, url, version, log } = data;
-        const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-        const reportDir = path.join(__dirname, '..', 'test-results', 'uploads');
-        fs.mkdirSync(reportDir, { recursive: true });
-
-        let logFile = '';
-        if (Array.isArray(log) && log.length > 0) {
-          logFile = `${stamp}-gesture-telemetry.gesture-log.json`;
-          const logPath = path.join(reportDir, logFile);
-          const logBody = JSON.stringify(log, null, 2);
-          // Cap individual log files at ~1MB to bound disk usage.
-          const MAX_LOG_BYTES = 1024 * 1024;
-          const safeBody = Buffer.byteLength(logBody, 'utf8') > MAX_LOG_BYTES
-            ? JSON.stringify(log.slice(-Math.floor(log.length / 2)), null, 2)
-            : logBody;
-          fs.writeFileSync(logPath, safeBody);
-        }
-
-        const meta = {
-          kind: kind || 'gesture-anomaly',
-          reason: reason || '',
-          eventCount: typeof eventCount === 'number' ? eventCount : 0,
-          ts: ts || Date.now(),
-          stamp,
-          userAgent: userAgent || '',
-          url: url || '',
-          version: version || '',
-          logFile,
-          logEventCount: Array.isArray(log) ? log.length : 0,
-        };
-        fs.writeFileSync(
-          path.join(reportDir, `${stamp}-gesture-telemetry.json`),
-          JSON.stringify(meta, null, 2),
-        );
-        console.log(`[gesture-telemetry] ${stamp} reason="${meta.reason}" events=${meta.eventCount} logEvents=${meta.logEventCount}`);
-        sseBroadcast('gesture-telemetry', { reason: meta.reason, eventCount: meta.eventCount, stamp });
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, stamp }));
-      } catch (err) {
-        console.error('[gesture-telemetry] parse error:', err.message);
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end('{"error":"invalid json"}');
-      }
-    });
-    return;
-  }
-
-  // POST /api/native-crash — auto-upload of native APK crash reports (#501).
-  // Body is a single crash JSON written by either the Dart-side CrashReporter
-  // or the Kotlin-side uncaught-exception handler. We cap at ~1MB (stack
-  // traces should be well under that) and persist into test-results/uploads/
-  // so the existing watcher surfaces it.
-  if (req.method === 'POST' && req.url === '/api/native-crash') {
-    let body = '';
-    let aborted = false;
-    const MAX_BYTES = 1024 * 1024;
-    req.on('data', (chunk) => {
-      if (aborted) return;
-      body += chunk;
-      if (Buffer.byteLength(body, 'utf8') > MAX_BYTES) {
-        aborted = true;
-        try { req.destroy(); } catch (e) {}
-        res.writeHead(413, { 'Content-Type': 'application/json' });
-        res.end('{"error":"crash report exceeds 1MB"}');
-      }
-    });
-    req.on('end', () => {
-      if (aborted) return;
-      try {
-        // Validate it's JSON; we re-stringify to normalize formatting on
-        // disk. If parsing fails, save the raw body to a .raw file so we
-        // never lose a crash report.
-        const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-        const reportDir = path.join(__dirname, '..', 'test-results', 'uploads');
-        fs.mkdirSync(reportDir, { recursive: true });
-        let outFile;
-        let parsed = null;
-        try {
-          parsed = JSON.parse(body);
-        } catch (parseErr) {
-          outFile = path.join(reportDir, `${stamp}-native-crash.raw`);
-          fs.writeFileSync(outFile, body);
-          console.warn(`[native-crash] non-JSON body saved to ${outFile}: ${parseErr.message}`);
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ ok: true, raw: true, path: path.basename(outFile) }));
-          return;
-        }
-        const kind = (parsed && parsed.kind) || 'unknown';
-        outFile = path.join(reportDir, `${stamp}-native-crash.json`);
-        fs.writeFileSync(outFile, JSON.stringify(parsed, null, 2));
-        const errMsg = (parsed && parsed.error) || '';
-        console.log(`[native-crash] ${stamp} kind="${kind}" error="${errMsg.slice(0, 120)}"`);
-        sseBroadcast('native-crash', { kind, stamp, path: path.basename(outFile) });
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, path: path.basename(outFile) }));
-      } catch (err) {
-        console.error('[native-crash] write error:', err.message);
-        res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end('{"error":"failed to persist crash"}');
-      }
-    });
-    return;
-  }
-
-  // POST /api/bug-report — receive screenshot + logs from client, save to disk.
-  if (req.method === 'POST' && req.url === '/api/bug-report') {
-    let body = '';
-    req.on('data', (chunk) => { body += chunk; });
-    req.on('end', () => {
-      try {
-        const data = JSON.parse(body);
-        const { screenshot, frames, logs, title, comment, userAgent, url, version, connectLog, gestureLog, byteTrace, scrollTrace, sentSgrTrace, grid } = data;
-        const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-        const reportDir = path.join(__dirname, '..', 'test-results', 'uploads');
-        fs.mkdirSync(reportDir, { recursive: true });
-
-        // Save screenshot
-        let screenshotFile = '';
-        if (screenshot) {
-          const imgData = screenshot.replace(/^data:image\/\w+;base64,/, '');
-          screenshotFile = `${ts}-bug-report.png`;
-          fs.writeFileSync(path.join(reportDir, screenshotFile), Buffer.from(imgData, 'base64'));
-          console.log(`[bug-report] screenshot: ${screenshotFile}`);
-        }
-
-        // #repro: a recorded burst of frames (in-app 10s "video"). Save each as a
-        // zero-padded PNG so the orchestrator can assemble them with ffmpeg
-        // (`ffmpeg -framerate 5 -i ${ts}-bug-report.frame-%03d.png out.mp4`).
-        let frameCount = 0;
-        let framesPattern = '';
-        if (Array.isArray(frames) && frames.length > 0) {
-          const MAX_FRAMES = 120; // guard against abuse
-          const n = Math.min(frames.length, MAX_FRAMES);
-          for (let i = 0; i < n; i++) {
-            const f = frames[i];
-            if (typeof f !== 'string' || !f) continue;
-            const fData = f.replace(/^data:image\/\w+;base64,/, '');
-            const name = `${ts}-bug-report.frame-${String(i + 1).padStart(3, '0')}.png`;
-            fs.writeFileSync(path.join(reportDir, name), Buffer.from(fData, 'base64'));
-            frameCount++;
-          }
-          framesPattern = `${ts}-bug-report.frame-%03d.png`;
-          console.log(`[bug-report] frames: ${frameCount} (${framesPattern})`);
-        }
-
-        // Full free-text body. The native in-app feedback (#661) sends the
-        // ENTIRE multi-line note as `comment` (no truncation). The web form
-        // (public/native-feedback.js) sends the full note as `logs` and only a
-        // first-line `title`. To kill the title-truncation data loss for BOTH,
-        // resolve the full body from `comment` first, falling back to `logs`,
-        // and persist it into the .json meta (below) so the orchestrator's
-        // watcher — which reads the .json — gets the complete note.
-        const fullComment = (typeof comment === 'string' && comment.length > 0)
-          ? comment
-          : (typeof logs === 'string' ? logs : '');
-
-        // Save logs / full comment as a sidecar text file too (unchanged for
-        // the web form; native reports also get a readable .log).
-        const logBody = (typeof logs === 'string' && logs.length > 0) ? logs : fullComment;
-        if (logBody) {
-          fs.writeFileSync(path.join(reportDir, `${ts}-bug-report.log`), logBody);
-          console.log(`[bug-report] logs: ${ts}-bug-report.log`);
-        }
-
-        // Save 24h connect log if attached (added with the diagnostics work
-        // — every connect/reconnect/state-transition event for the past day)
-        let connectLogFile = '';
-        if (Array.isArray(connectLog) && connectLog.length > 0) {
-          connectLogFile = `${ts}-bug-report.connect-log.json`;
-          fs.writeFileSync(
-            path.join(reportDir, connectLogFile),
-            JSON.stringify(connectLog, null, 2),
-          );
-          console.log(`[bug-report] connect log: ${connectLogFile} (${connectLog.length} events)`);
-        }
-
-        // Save 24h gesture log if attached — every swipe / pinch / long-press
-        // / drag-select. For "swipes stopped working" bug reports.
-        let gestureLogFile = '';
-        if (Array.isArray(gestureLog) && gestureLog.length > 0) {
-          gestureLogFile = `${ts}-bug-report.gesture-log.json`;
-          fs.writeFileSync(
-            path.join(reportDir, gestureLogFile),
-            JSON.stringify(gestureLog, null, 2),
-          );
-          console.log(`[bug-report] gesture log: ${gestureLogFile} (${gestureLog.length} events)`);
-        }
-
-        // #790: the replay-harness trace — the raw bytes that reached the
-        // terminal (byteTrace: [{tMs,b64}]) + the scroll-offset events
-        // (scrollTrace: [{tMs,offset}]) + the viewport grid ({cols,rows}). Saved
-        // to a single sidecar so the replay harness (#791) can feed the captured
-        // bytes into a real Terminal at the same grid and replay the scroll to
-        // reproduce a scrollback-render bug. Mirrors the `frames` branch; capped
-        // (the client already bounds the rings, this is a server-side backstop).
-        let byteTraceFile = '';
-        let byteTraceEventCount = 0;
-        let scrollTraceEventCount = 0;
-        const hasByteTrace = Array.isArray(byteTrace) && byteTrace.length > 0;
-        const hasScrollTrace = Array.isArray(scrollTrace) && scrollTrace.length > 0;
-        if (hasByteTrace || hasScrollTrace) {
-          const MAX_BYTE_EVENTS = 8192;
-          const MAX_SCROLL_EVENTS = 8192;
-          const cappedBytes = hasByteTrace ? byteTrace.slice(-MAX_BYTE_EVENTS) : [];
-          const cappedScroll = hasScrollTrace ? scrollTrace.slice(-MAX_SCROLL_EVENTS) : [];
-          byteTraceEventCount = cappedBytes.length;
-          scrollTraceEventCount = cappedScroll.length;
-          byteTraceFile = `${ts}-bug-report.byte-trace.json`;
-          fs.writeFileSync(
-            path.join(reportDir, byteTraceFile),
-            JSON.stringify({
-              grid: (grid && typeof grid === 'object') ? grid : null,
-              byteTrace: cappedBytes,
-              scrollTrace: cappedScroll,
-            }, null, 2),
-          );
-          console.log(`[bug-report] byte trace: ${byteTraceFile} (${byteTraceEventCount} byte events, ${scrollTraceEventCount} scroll events)`);
-        }
-
-        // #793: the sent-SGR trace — the synthesized mouse/wheel SGR reports the
-        // app SENT to the remote (sentSgrTrace: [{tMs,b64}]). In tmux mouse mode
-        // the scroll is wheel-SGR sent TO tmux (local scroll never moves), so
-        // this is the half of #789 the OUTPUT byteTrace can't show. Filtered at
-        // the client send seam to SGR-mouse reports ONLY (never keystrokes), so
-        // no typed secret is ever present. Mirrors the byteTrace branch; capped.
-        let sentSgrTraceFile = '';
-        let sentSgrTraceEventCount = 0;
-        const hasSentSgrTrace = Array.isArray(sentSgrTrace) && sentSgrTrace.length > 0;
-        if (hasSentSgrTrace) {
-          const MAX_SENT_SGR_EVENTS = 8192;
-          const cappedSentSgr = sentSgrTrace.slice(-MAX_SENT_SGR_EVENTS);
-          sentSgrTraceEventCount = cappedSentSgr.length;
-          sentSgrTraceFile = `${ts}-bug-report.sent-sgr-trace.json`;
-          fs.writeFileSync(
-            path.join(reportDir, sentSgrTraceFile),
-            JSON.stringify({
-              grid: (grid && typeof grid === 'object') ? grid : null,
-              sentSgrTrace: cappedSentSgr,
-            }, null, 2),
-          );
-          console.log(`[bug-report] sent-SGR trace: ${sentSgrTraceFile} (${sentSgrTraceEventCount} events)`);
-        }
-
-        // Save metadata
-        const meta = {
-          title: title || `Bug report ${ts}`,
-          // #661: persist the FULL comment (untruncated) into the meta JSON.
-          // Back-compatible: empty string for web-form reports that send only
-          // a truncated title with no body.
-          comment: fullComment,
-          version,
-          url,
-          userAgent,
-          ts,
-          screenshotFile,
-          frameCount,
-          framesPattern,
-          connectLogFile,
-          connectLogEventCount: Array.isArray(connectLog) ? connectLog.length : 0,
-          gestureLogFile,
-          gestureLogEventCount: Array.isArray(gestureLog) ? gestureLog.length : 0,
-          // #790: replay-harness trace sidecar + counts + the captured grid.
-          byteTraceFile,
-          byteTraceEventCount,
-          scrollTraceEventCount,
-          // #793: sent-SGR (synthesized mouse/wheel reports the app sent) sidecar.
-          sentSgrTraceFile,
-          sentSgrTraceEventCount,
-          grid: (grid && typeof grid === 'object') ? grid : null,
-        };
-        fs.writeFileSync(path.join(reportDir, `${ts}-bug-report.json`), JSON.stringify(meta, null, 2));
-
-        const reportTitle = title || `Bug report ${ts}`;
-        console.log(`[bug-report] saved: "${reportTitle}"`);
-        sseBroadcast('bug-report', { title: reportTitle, saved: true });
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, saved: true }));
-      } catch (err) {
-        console.error('[bug-report] parse error:', err.message);
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end('{"error":"invalid json"}');
-      }
-    });
+  // POST /api/{bug-report,drop-telemetry,gesture-telemetry,native-crash} —
+  // bug-report/telemetry ingestion (#997). Proxied to the dedicated feedback
+  // service when FEEDBACK_SERVICE_URL is set, with fail-open local fallback.
+  // Persistence semantics live in server/feedback-store.js.
+  if (req.method === 'POST' && feedbackStore.FEEDBACK_ROUTES.includes(req.url)) {
+    handleFeedbackUpload(req, res);
     return;
   }
 

--- a/server/test.js
+++ b/server/test.js
@@ -10,7 +10,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { Readable, Writable } = require('stream');
 
-const { rewriteManifest, handleSftpMessage, isPrivateIp, isCgnatIp, resumableUploads } = require('./index.js');
+const { rewriteManifest, handleSftpMessage, isPrivateIp, isCgnatIp, resumableUploads, server } = require('./index.js');
 
 test('rewriteManifest: sets id="mobissh"', () => {
   const input = Buffer.from(JSON.stringify({ name: 'MobiSSH', start_url: '/' }));
@@ -52,18 +52,21 @@ test('rewriteManifest: overwrites existing id', () => {
 
 test('handleSftpMessage: sftp_ls returns entries with correct shape', () => {
   const results = [];
+  // Mock attrs mirror the ssh2 Stats surface the handler reads (isSymbolicLink
+  // + atime/permissions/uid/gid were added with the file-explorer work; the
+  // old mock predated them and threw).
   const mockSftp = {
     readdir: (path, cb) => cb(null, [
-      { filename: 'file.txt', attrs: { isDirectory: () => false, size: 100, mtime: 1000 } },
-      { filename: 'subdir', attrs: { isDirectory: () => true, size: 0, mtime: 2000 } },
+      { filename: 'file.txt', attrs: { isDirectory: () => false, isSymbolicLink: () => false, size: 100, mtime: 1000, atime: 900, mode: 0o644, uid: 1000, gid: 1000 } },
+      { filename: 'subdir', attrs: { isDirectory: () => true, isSymbolicLink: () => false, size: 0, mtime: 2000, atime: 1900, mode: 0o755, uid: 1000, gid: 1000 } },
     ]),
   };
   handleSftpMessage({ type: 'sftp_ls', path: '/', requestId: '1' }, mockSftp, (msg) => results.push(msg));
   assert.equal(results.length, 1);
   assert.equal(results[0].type, 'sftp_ls_result');
   assert.equal(results[0].requestId, '1');
-  assert.deepEqual(results[0].entries[0], { name: 'file.txt', isDir: false, size: 100, mtime: 1000 });
-  assert.deepEqual(results[0].entries[1], { name: 'subdir', isDir: true, size: 0, mtime: 2000 });
+  assert.deepEqual(results[0].entries[0], { name: 'file.txt', isDir: false, isSymlink: false, size: 100, mtime: 1000, atime: 900, permissions: 0o644, uid: 1000, gid: 1000 });
+  assert.deepEqual(results[0].entries[1], { name: 'subdir', isDir: true, isSymlink: false, size: 0, mtime: 2000, atime: 1900, permissions: 0o755, uid: 1000, gid: 1000 });
 });
 
 test('handleSftpMessage: sftp_ls error returns sftp_error', () => {
@@ -384,4 +387,104 @@ test('sftp_upload_start: different connectionId rejects resume (#241)', () => {
   const entry = resumableUploads.get('fp-hijack');
   assert.equal(entry.connectionId, attackerConnId);
   resumableUploads.clear();
+});
+
+// ─── #997: feedback proxy + fail-open fallback ────────────────────────────────
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+function postTo(port, route, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1', port, path: route, method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }, (res) => {
+      let out = '';
+      res.on('data', (c) => { out += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body: out }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+test('feedback proxy: relays body to the service and mirrors its response', async () => {
+  // Stub feedback service that records what it receives.
+  const seen = [];
+  const stub = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      seen.push({ url: req.url, body });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{"ok":true,"stub":true}');
+    });
+  });
+  await new Promise((r) => stub.listen(0, '127.0.0.1', r));
+
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  process.env.FEEDBACK_SERVICE_URL = `http://127.0.0.1:${stub.address().port}`;
+  try {
+    const payload = JSON.stringify({ title: 'proxied', comment: 'via stub' });
+    const res = await postTo(server.address().port, '/api/bug-report', payload);
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(res.body), { ok: true, stub: true }, 'stub response relayed verbatim');
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].url, '/api/bug-report');
+    assert.equal(seen[0].body, payload, 'raw body forwarded unmodified');
+  } finally {
+    delete process.env.FEEDBACK_SERVICE_URL;
+    await new Promise((r) => server.close(r));
+    await new Promise((r) => stub.close(r));
+  }
+});
+
+test('feedback proxy: unreachable service falls back to LOCAL handling (fail-open)', async () => {
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  // Nothing listens on port 1 — transport error → local fallback.
+  process.env.FEEDBACK_SERVICE_URL = 'http://127.0.0.1:1';
+  const uploadsDir = path.join(__dirname, '..', 'test-results', 'uploads');
+  try {
+    const res = await postTo(server.address().port, '/api/drop-telemetry', JSON.stringify({
+      reason: 'test-fallback', host: 'unit-test',
+    }));
+    assert.equal(res.status, 200);
+    const j = JSON.parse(res.body);
+    assert.equal(j.ok, true);
+    assert.ok(j.stamp, 'local handler answered with a stamp');
+    const metaFile = path.join(uploadsDir, `${j.stamp}-drop-telemetry.json`);
+    assert.ok(fs.existsSync(metaFile), 'report persisted locally despite service being down');
+    const meta = JSON.parse(fs.readFileSync(metaFile, 'utf8'));
+    assert.equal(meta.reason, 'test-fallback');
+    fs.unlinkSync(metaFile); // keep the shared uploads dir clean of unit-test artifacts
+  } finally {
+    delete process.env.FEEDBACK_SERVICE_URL;
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test('feedback routes: no FEEDBACK_SERVICE_URL means local handling (pre-cutover default)', async () => {
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const uploadsDir = path.join(__dirname, '..', 'test-results', 'uploads');
+  try {
+    const res = await postTo(server.address().port, '/api/bug-report', JSON.stringify({
+      title: 'local path', comment: 'full note\nsecond line',
+    }));
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(res.body), { ok: true, saved: true });
+    // Newest bug-report meta carries the full comment (#661 contract).
+    const metas = fs.readdirSync(uploadsDir).filter((n) => n.endsWith('-bug-report.json')).sort();
+    const newest = metas[metas.length - 1];
+    const meta = JSON.parse(fs.readFileSync(path.join(uploadsDir, newest), 'utf8'));
+    if (meta.title === 'local path') {
+      assert.equal(meta.comment, 'full note\nsecond line');
+      fs.unlinkSync(path.join(uploadsDir, newest));
+      const logFile = path.join(uploadsDir, newest.replace('.json', '.log'));
+      if (fs.existsSync(logFile)) fs.unlinkSync(logFile);
+    }
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
 });


### PR DESCRIPTION
Closes #997.

Extracts ALL server-side bug-report/telemetry support (`/api/bug-report`, `/api/drop-telemetry`, `/api/gesture-telemetry`, `/api/native-crash`) into a dedicated container, LXC-deploy-ready, with mobissh-prod proxying its existing routes (app needs NO reconfiguration; one Tailscale endpoint stays).

## What's in the PR

- **Inventory doc**: `docs/feedback-service.md` — exact route/payload/filename/size-cap inventory, producers and dev-loop consumers, architecture, cutover commands, LXC operator handoff (for raserver-home-it).
- **Shared store**: `server/feedback-store.js` — persistence extracted VERBATIM from `server/index.js` (filename contract, caps, response bodies byte-identical). Single source of truth used by both prod's local path and the service, so semantics cannot drift.
- **Service**: `server-feedback/` — zero-dependency `node:http` service; 4 routes + `GET /healthz` + retention knob `FEEDBACK_RETENTION_DAYS` (default 0 = keep everything).
- **Proxy**: `server/index.js` replaces the 4 inline handlers with one gate — buffer body, relay verbatim to `FEEDBACK_SERVICE_URL` (10s timeout), and on transport error fall back to LOCAL handling (fail-open, logged `[feedback-proxy] ... falling back to LOCAL handling`). Both sides write to the SAME host bind mount, so a fallback report is still dev-visible.
- **Containers**: `docker/feedback/Dockerfile` (context = repo root, shares the store), `docker-compose.feedback.yml` (external `mobissh` network, same uploads bind as prod → `watch-bug-reports.sh` / `assemble-repro.sh` / replay harness keep working unchanged), `scripts/feedback-ctl.sh` (`start|stop|restart|status|ensure`, mirrors container-ctl.sh).
- **Cutover flag**: `docker-compose.prod.yml` gains `FEEDBACK_SERVICE_URL: "${FEEDBACK_SERVICE_URL-http://mobissh-feedback:8082}"` (`${VAR-default}`: explicit empty disables). Reaches the live container only on the next prod recreate — nothing flips silently.

## Cutover (explicit, owner-run)

```
scripts/feedback-ctl.sh start
scripts/feedback-ctl.sh status
scripts/container-ctl.sh restart
```

Rollback: stop the feedback container (fail-open keeps everything working locally) or recreate prod with `FEEDBACK_SERVICE_URL=` (empty).

## Tests / validation

- `server-feedback/test.js` (node --test): 10/10 — round-trip all 4 routes against a temp dir, EXACT filename contract the dev-loop scripts glob, 1MB crash cap → 413, non-JSON crash preserved as `.raw`, retention sweep, healthz.
- `server/test.js`: +3 — proxy pass-through (stub service receives the raw body; response relayed verbatim), fail-open fallback (unreachable service → file written locally), pre-cutover local default. 55/55 green. Also repaired the pre-existing stale `sftp_ls` mock (suite was red on main — entries gained isSymlink/atime/permissions/uid/gid; this suite is not in any gate).
- Playwright contract spec `tests/bug-report-comment.spec.js` (#661): green against the refactored server (external-server mode).
- tsc: pass. eslint on `server/` + `server-feedback/`: 0 errors (`server-feedback/` added to `test-lint.sh` + eslintrc override).
- Feedback image built and smoke-run: `/healthz` 200, `POST /api/bug-report` → `{ok:true,saved:true}`.
- Live `mobissh-prod` NOT touched (no restart/rebuild).

## Caveats / gate notes

- The web fast-gate's eslint and two vitest `trace-scripts` git-pickaxe tests fail INSIDE agent worktrees for environment reasons (ESLint 8 ignores everything under dot-directories, so `npx eslint src/` reports "all files ignored" under `.claude/worktrees/`; the pickaxe tests hit their 5s timeout on cold worktree git). tsc + vitest (everything else, 1020 tests) pass; changed dirs were linted with absolute paths (0 errors). Please run `scripts/test-fast-gate.sh` + `scripts/test-headless.sh` from the main checkout when integrating.
- Operator (raserver-home-it) provisioning is only needed for the PVE-LXC shape; the compose shape works today on the shared daemon (see doc section 4).
- SSE events (`bug-report`, `drop-telemetry`, ...) are not emitted on the PROXIED path — audit found no client listens to them; local/fallback path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa