### PR TITLE
feat(native): bubble v2 — translucent wash, more bottom padding, gutter-keyed hue (#1000)

### DIFF
--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -8,9 +8,11 @@
 // `anchorRects` resolves per-row rects purely from the resize-seam grid cache +
 // the PAINTED viewport offset, the SAME source `matchAt` hit-tests with (#863).
 // #988 restores the bubble on that stable geometry as the primary affordance:
-// a rounded outline that visibly respects line wraps and omits injected margin
-// whitespace, so the bubble IS the preview of what a single tap will copy. The
-// right-edge gutter marks (`ghostty_gutter_layer.dart`) coexist unchanged.
+// it visibly respects line wraps and omits injected margin whitespace, so the
+// bubble IS the preview of what a single tap will copy. #1000 re-skins it as a
+// translucent background WASH (no outline — the stroke crowded neighbors) in
+// the gutter chip's hue at a luminance-tuned alpha. The right-edge gutter
+// marks (`ghostty_gutter_layer.dart`) coexist unchanged.
 //
 // This file keeps the shared contract (pattern ids + the EMPTY highlight style
 // — the bubble is a WIDGET-layer decorator per the #767 Slice B design, never a
@@ -67,7 +69,7 @@ class GhosttyBubbleSegment {
   final bool roundLeft;
   final bool roundRight;
 
-  /// The rounded rect to stroke: capsule radius (half the segment height) on
+  /// The rounded rect to fill: capsule radius (half the segment height) on
   /// the rounded end(s), square corners on a cut (wrap-continuation) end.
   RRect toRRect() {
     final radius = Radius.circular(rect.height / 2);
@@ -96,14 +98,17 @@ class GhosttyBubbleSegment {
 /// feedback, carried over from the retired bubble's polish).
 const double _kBubblePadX = 3.0;
 
-/// VERTICAL inset: flterm's cell rect spans the full typographic line height
-/// (ascender + descender slack), so an uninset outline sits top-heavy over the
-/// glyphs (#864). Insetting shrinks that slack.
-const double _kBubblePadY = 1.0;
+/// TOP inset: flterm's cell rect spans the full typographic line height with
+/// its empty slack band at the TOP (#864), so the wash trims most of that band
+/// — but keeps a hair of it as breathing room above the glyph caps (#1000).
+const double _kBubbleTopInset = 2.0;
 
-/// DOWNWARD shift: after insetting, nudge the outline down so it is vertically
-/// CENTERED on the glyph ink (the cell's empty band is at the TOP, #864).
-const double _kBubbleShiftY = 1.5;
+/// BOTTOM outset (#1000): the glyph ink (descenders) runs close to the cell
+/// rect's bottom, so the wash EXPANDS downward past it — the #988 outline sat
+/// only 0.5px below and read cramped under descenders. The next row's top
+/// slack band (see [_kBubbleTopInset]) absorbs the overhang, so neighbors stay
+/// uncrowded.
+const double _kBubbleBottomOutset = 2.0;
 
 /// Compute the per-row bubble segments for an anchor's on-screen row rects
 /// (#988). Pure and headless-testable.
@@ -122,9 +127,9 @@ List<GhosttyBubbleSegment> ghosttyBubbleSegments(List<Rect> rowRects) {
     if (rect.width <= 0 || rect.height <= 0) continue;
     final bubble = Rect.fromLTRB(
       rect.left - _kBubblePadX,
-      rect.top + _kBubblePadY + _kBubbleShiftY,
+      rect.top + _kBubbleTopInset,
       rect.right + _kBubblePadX,
-      rect.bottom - _kBubblePadY + _kBubbleShiftY,
+      rect.bottom + _kBubbleBottomOutset,
     );
     if (bubble.width <= 0 || bubble.height <= 0) continue;
     padded.add(bubble);
@@ -155,17 +160,46 @@ bool ghosttyPathRequiresVerification(String payload) {
   return !p.substring(1).contains('/');
 }
 
-/// Stroke width of the plain "detected" bubble outline, logical px.
-const double kGhosttyBubbleStrokeWidth = 1.5;
+/// #1000 wash alphas — the bubble is a translucent background FILL (no
+/// stroke), tuned per terminal-BACKGROUND luminance: a dark terminal needs
+/// less pigment for the wash to register than a light one (where ambient
+/// screen brightness washes out faint tints). Detected < verified by a
+/// clearly-visible margin at phone density, and every value stays inside the
+/// readable band (glyphs legible in the wash; the wash still distinct from
+/// flterm's ~0x33-alpha native selection fill).
+const double kGhosttyBubbleDetectedWashAlphaOnDark = 0.26;
 
-/// Stroke width of the bolder VERIFIED bubble outline (#990) — a detected
-/// file path confirmed to exist on the connected host.
-const double kGhosttyBubbleVerifiedStrokeWidth = 2.5;
+/// Detected wash alpha over a LIGHT terminal background (#1000).
+const double kGhosttyBubbleDetectedWashAlphaOnLight = 0.32;
 
-/// Fill-wash alpha inside a VERIFIED bubble (#990). A faint tint (the text
-/// stays fully readable) that, with the thicker stroke, makes the verified
-/// shade legible at phone density.
-const double kGhosttyBubbleVerifiedFillAlpha = 0.15;
+/// VERIFIED wash alpha over a dark terminal background (#990 shade, #1000
+/// wash language): a detected file path confirmed to exist on the host.
+const double kGhosttyBubbleVerifiedWashAlphaOnDark = 0.42;
+
+/// Verified wash alpha over a LIGHT terminal background (#1000).
+const double kGhosttyBubbleVerifiedWashAlphaOnLight = 0.50;
+
+/// The bubble wash colour (#1000): the SAME opaque hue as the gutter chip —
+/// `GutterMarkStyle.chipColor` forces the accent's alpha to 1.0, mirrored here
+/// (the gutter file imports this one, so the derivation lives here and the
+/// chip's is kept in sync by the shared-hue widget test) — at the
+/// luminance-tuned wash alpha. One hue family for the whole detection
+/// affordance: chip green → pale green wash.
+Color ghosttyBubbleWashColor(
+  Color accent, {
+  required bool verified,
+  required Brightness backgroundBrightness,
+}) {
+  final dark = backgroundBrightness == Brightness.dark;
+  final alpha = verified
+      ? (dark
+            ? kGhosttyBubbleVerifiedWashAlphaOnDark
+            : kGhosttyBubbleVerifiedWashAlphaOnLight)
+      : (dark
+            ? kGhosttyBubbleDetectedWashAlphaOnDark
+            : kGhosttyBubbleDetectedWashAlphaOnLight);
+  return accent.withValues(alpha: alpha);
+}
 
 /// One anchor's renderable bubble (#990): its per-row [segments] plus whether
 /// it renders in the bolder VERIFIED shade. Public (with the painter) so the
@@ -198,6 +232,7 @@ class GhosttyBubbleLayer extends StatelessWidget {
     super.key,
     required this.controller,
     required this.color,
+    required this.backgroundBrightness,
     this.isVerified,
     this.isVisible,
     this.verificationListenable,
@@ -207,12 +242,17 @@ class GhosttyBubbleLayer extends StatelessWidget {
   /// `anchorRects` drive the bubbles; its notifications drive repaint.
   final TerminalController controller;
 
-  /// The theme accent the bubbles are stroked in (the session selection
-  /// colour). Rebuilds when the parent re-creates the layer with a new colour.
+  /// The theme accent the wash is tinted in (the session selection colour —
+  /// the gutter chip's hue family, #1000). Rebuilds when the parent re-creates
+  /// the layer with a new colour.
   final Color color;
 
+  /// The TERMINAL background's luminance (#1000): the wash alpha is tuned per
+  /// theme brightness ([ghosttyBubbleWashColor]), not one fixed constant.
+  final Brightness backgroundBrightness;
+
   /// #990: OPAQUE verification predicate — true renders the anchor's bubble in
-  /// the bolder VERIFIED shade (thicker stroke + faint fill). Null → every
+  /// the bolder VERIFIED shade (the stronger-alpha wash, #1000). Null → every
   /// bubble stays the plain detected shade. The layer doesn't know WHY an
   /// anchor is verified (today: exists-on-host via the session's SFTP stat),
   /// so the predicate's meaning can change without paint rework.
@@ -267,7 +307,11 @@ class GhosttyBubbleLayer extends StatelessWidget {
         return IgnorePointer(
           child: CustomPaint(
             key: const Key('ghostty-bubble-paint'),
-            painter: GhosttyBubblePainter(specs: specs, color: color),
+            painter: GhosttyBubblePainter(
+              specs: specs,
+              color: color,
+              backgroundBrightness: backgroundBrightness,
+            ),
             size: Size.infinite,
           ),
         );
@@ -276,38 +320,48 @@ class GhosttyBubbleLayer extends StatelessWidget {
   }
 }
 
-/// Strokes one outline per bubble segment — an OUTLINE (never an opaque fill
-/// over the glyphs) so the text stays readable and the capsule reads as a
-/// physical chip around it. A VERIFIED spec (#990) strokes thicker and adds a
-/// faint fill wash. Public (with final fields) so the widget test can assert
-/// the detected/verified shade selection.
+/// Fills one translucent background WASH per bubble segment (#1000) — never a
+/// stroke: the #988 outline visually crowded the lines above/below and the
+/// characters just outside the capsule, while a low-alpha fill stays inside
+/// the glyph rows. The wash colour is the gutter chip's hue at a
+/// luminance-tuned alpha ([ghosttyBubbleWashColor]); a VERIFIED spec (#990)
+/// fills the SAME hue at a clearly stronger alpha. Public (with final fields)
+/// so the widget test can assert the detected/verified shade selection.
 class GhosttyBubblePainter extends CustomPainter {
-  GhosttyBubblePainter({required this.specs, required this.color});
+  GhosttyBubblePainter({
+    required this.specs,
+    required this.color,
+    required this.backgroundBrightness,
+  });
 
   final List<GhosttyBubbleSpec> specs;
   final Color color;
+  final Brightness backgroundBrightness;
 
   @override
   void paint(Canvas canvas, Size size) {
-    final stroke = Paint()
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = kGhosttyBubbleStrokeWidth
-      ..color = color
-      ..isAntiAlias = true;
-    final verifiedStroke = Paint()
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = kGhosttyBubbleVerifiedStrokeWidth
-      ..color = color
-      ..isAntiAlias = true;
-    final verifiedFill = Paint()
+    final detectedWash = Paint()
       ..style = PaintingStyle.fill
-      ..color = color.withValues(alpha: kGhosttyBubbleVerifiedFillAlpha)
+      ..color = ghosttyBubbleWashColor(
+        color,
+        verified: false,
+        backgroundBrightness: backgroundBrightness,
+      )
+      ..isAntiAlias = true;
+    final verifiedWash = Paint()
+      ..style = PaintingStyle.fill
+      ..color = ghosttyBubbleWashColor(
+        color,
+        verified: true,
+        backgroundBrightness: backgroundBrightness,
+      )
       ..isAntiAlias = true;
     for (final spec in specs) {
       for (final segment in spec.segments) {
-        final rrect = segment.toRRect();
-        if (spec.verified) canvas.drawRRect(rrect, verifiedFill);
-        canvas.drawRRect(rrect, spec.verified ? verifiedStroke : stroke);
+        canvas.drawRRect(
+          segment.toRRect(),
+          spec.verified ? verifiedWash : detectedWash,
+        );
       }
     }
   }
@@ -315,6 +369,7 @@ class GhosttyBubblePainter extends CustomPainter {
   @override
   bool shouldRepaint(covariant GhosttyBubblePainter old) {
     if (old.color != color) return true;
+    if (old.backgroundBrightness != backgroundBrightness) return true;
     if (old.specs.length != specs.length) return true;
     for (var i = 0; i < specs.length; i++) {
       final a = specs[i];

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -3938,6 +3938,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     if (highlightColor != _lastHighlightColor) {
       _lastHighlightColor = highlightColor;
     }
+    // #1000: the bubble WASH tunes its alpha per the TERMINAL background's
+    // luminance (a dark theme needs less pigment than a light one), so derive
+    // the brightness from the live session palette alongside the accent.
+    final backgroundBrightness =
+        ThemeData.estimateBrightnessForColor(palette.theme.background);
     // #922: wrap in a LayoutBuilder so we read the terminal box's ACTUAL
     // constraints — the height the Scaffold has ALREADY shrunk for the soft
     // keyboard (terminal_screen.dart keeps `resizeToAvoidBottomInset:true`, so
@@ -3956,6 +3961,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
           theme: theme,
           cellSize: cellSize,
           highlightColor: highlightColor,
+          backgroundBrightness: backgroundBrightness,
         );
       },
     );
@@ -4008,6 +4014,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     required TerminalTheme theme,
     required Size cellSize,
     required Color highlightColor,
+    required Brightness backgroundBrightness,
   }) {
     // #975 (test-only): publish the grid the router will map gestures with this
     // frame so the keyboard-race repro can see the SGR target vs the visible box.
@@ -4221,6 +4228,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
           child: GhosttyBubbleLayer(
             controller: controller,
             color: highlightColor,
+            backgroundBrightness: backgroundBrightness,
             // #990: verified paths (exist on the connected host, per the
             // session verifier's SFTP stat) paint the bolder bubble shade;
             // unverified SINGLE-SEGMENT matches are suppressed entirely.

--- a/native/test/ui/ghostty_bubble_layer_test.dart
+++ b/native/test/ui/ghostty_bubble_layer_test.dart
@@ -114,6 +114,31 @@ class _TestSignal extends ChangeNotifier {
   void fire() => notifyListeners();
 }
 
+/// One recorded drawRRect call: the Paint's style + color SNAPSHOT at call
+/// time (Paint is mutable; the values must be copied when recorded).
+class _RRectCall {
+  _RRectCall(this.rrect, Paint paint)
+    : style = paint.style,
+      color = paint.color;
+
+  final RRect rrect;
+  final PaintingStyle style;
+  final Color color;
+}
+
+/// A [Canvas] that records drawRRect calls so a test can assert the #1000
+/// wash paints FILLS only (no stroke) in the derived wash color. Every other
+/// canvas op is a no-op via noSuchMethod.
+class _RecordingCanvas implements Canvas {
+  final List<_RRectCall> rrects = [];
+
+  @override
+  void drawRRect(RRect rrect, Paint paint) => rrects.add(_RRectCall(rrect, paint));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
 void main() {
   const scanner = StructuredTextScanner();
   const cols = 50;
@@ -232,6 +257,7 @@ void main() {
                   child: GhosttyBubbleLayer(
                     controller: controller,
                     color: const Color(0xFF5B9BD5),
+                    backgroundBrightness: Brightness.dark,
                   ),
                 ),
               ],
@@ -347,6 +373,7 @@ void main() {
                   child: GhosttyBubbleLayer(
                     controller: controller,
                     color: const Color(0xFF5B9BD5),
+                    backgroundBrightness: Brightness.dark,
                     isVerified: isVerified,
                     isVisible: isVisible,
                     verificationListenable: verificationListenable,
@@ -366,13 +393,6 @@ void main() {
       );
       return paint.painter! as GhosttyBubblePainter;
     }
-
-    test('the verified stroke is BOLDER than the detected stroke', () {
-      expect(
-        kGhosttyBubbleVerifiedStrokeWidth,
-        greaterThan(kGhosttyBubbleStrokeWidth),
-      );
-    });
 
     testWidgets('a verified path bubble is marked verified; an unverified one '
         'is not', (tester) async {
@@ -465,6 +485,195 @@ void main() {
         reason: 'the bubble must repaint on verification results, not only '
             'on anchor changes',
       );
+    });
+  });
+
+  // #1000 — bubble v2: a translucent background WASH replaces the outline.
+  // No stroke paints anywhere; the fill expands DOWNWARD inside the row box so
+  // descenders get room; the hue is the SAME opaque accent hue as the gutter
+  // chip (GutterMarkStyle.chipColor forces alpha 1.0); the alpha is tuned per
+  // terminal-background luminance and the VERIFIED shade is a clearly stronger
+  // wash of the same hue. Shape semantics from #988 are UNCHANGED.
+  group('#1000 translucent wash bubble', () {
+    const accent = Color(0x335B9BD5); // typical translucent selection accent
+
+    group('geometry: more bottom padding (descender room)', () {
+      // The cell rect's empty band sits at the TOP (#864): glyph ink runs from
+      // roughly rect.top + this slack down to rect.bottom (descenders).
+      const inkTopSlack = 2.5;
+
+      test('the fill expands DOWNWARD past the row-box bottom for descenders',
+          () {
+        const row = Rect.fromLTWH(20, 4, 160, 16);
+        final seg = ghosttyBubbleSegments(const [row]).single;
+        expect(
+          seg.rect.bottom - row.bottom,
+          greaterThanOrEqualTo(1.5),
+          reason: 'descenders were cramped at the #988 +0.5 — the wash must '
+              'extend further down within the row box',
+        );
+      });
+
+      test('bottom padding around the glyph ink >= top padding (centered)', () {
+        const row = Rect.fromLTWH(20, 4, 160, 16);
+        final seg = ghosttyBubbleSegments(const [row]).single;
+        final topPad = (row.top + inkTopSlack) - seg.rect.top;
+        final bottomPad = seg.rect.bottom - row.bottom;
+        expect(
+          bottomPad,
+          greaterThanOrEqualTo(topPad),
+          reason: 'text must sit centered-or-lower in the wash, never '
+              'cramped at the bottom',
+        );
+      });
+
+      test('the fill never invades the row ABOVE (neighbors uncrowded)', () {
+        const row = Rect.fromLTWH(20, 4, 160, 16);
+        final seg = ghosttyBubbleSegments(const [row]).single;
+        expect(seg.rect.top, greaterThanOrEqualTo(row.top));
+      });
+    });
+
+    group('wash color derivation (shared hue with the gutter chip)', () {
+      test('the wash hue is the accent hue — the gutter chip hue family', () {
+        for (final verified in [false, true]) {
+          for (final brightness in Brightness.values) {
+            final wash = ghosttyBubbleWashColor(
+              accent,
+              verified: verified,
+              backgroundBrightness: brightness,
+            );
+            // Same RGB as the chip (accent forced opaque, per
+            // GutterMarkStyle.chipColor) — only the alpha differs.
+            expect(wash.r, accent.r);
+            expect(wash.g, accent.g);
+            expect(wash.b, accent.b);
+          }
+        }
+      });
+
+      test('alpha sits in the readable band on BOTH theme luminances', () {
+        for (final verified in [false, true]) {
+          for (final brightness in Brightness.values) {
+            final wash = ghosttyBubbleWashColor(
+              accent,
+              verified: verified,
+              backgroundBrightness: brightness,
+            );
+            expect(wash.a, greaterThanOrEqualTo(0.15),
+                reason: 'too faint to read as an affordance');
+            expect(wash.a, lessThanOrEqualTo(0.55),
+                reason: 'too strong — glyphs must stay readable in the wash');
+          }
+        }
+      });
+
+      test('alpha is tuned PER background luminance, not one fixed constant',
+          () {
+        final dark = ghosttyBubbleWashColor(
+          accent,
+          verified: false,
+          backgroundBrightness: Brightness.dark,
+        );
+        final light = ghosttyBubbleWashColor(
+          accent,
+          verified: false,
+          backgroundBrightness: Brightness.light,
+        );
+        expect(dark.a, isNot(equals(light.a)));
+      });
+
+      test('the VERIFIED wash is clearly stronger than the detected wash', () {
+        for (final brightness in Brightness.values) {
+          final detected = ghosttyBubbleWashColor(
+            accent,
+            verified: false,
+            backgroundBrightness: brightness,
+          );
+          final verified = ghosttyBubbleWashColor(
+            accent,
+            verified: true,
+            backgroundBrightness: brightness,
+          );
+          expect(
+            verified.a - detected.a,
+            greaterThanOrEqualTo(0.12),
+            reason: 'the two shades must be distinct at phone density',
+          );
+        }
+      });
+    });
+
+    group('painter: fill-not-stroke', () {
+      List<GhosttyBubbleSpec> specsFor({required bool verified}) => [
+        GhosttyBubbleSpec(
+          segments: ghosttyBubbleSegments(const [
+            Rect.fromLTWH(20, 4, 160, 16),
+          ]),
+          verified: verified,
+        ),
+      ];
+
+      test('the detected bubble paints ONLY translucent fills — no stroke', () {
+        final canvas = _RecordingCanvas();
+        GhosttyBubblePainter(
+          specs: specsFor(verified: false),
+          color: accent,
+          backgroundBrightness: Brightness.dark,
+        ).paint(canvas, const Size(400, 400));
+        expect(canvas.rrects, hasLength(1),
+            reason: 'exactly one draw per segment — a wash, not fill+stroke');
+        for (final call in canvas.rrects) {
+          expect(call.style, PaintingStyle.fill,
+              reason: 'no hard border: the outline visually crowds neighbors');
+          // Paint.color roundtrips through the engine — compare ARGB32.
+          expect(
+            call.color.toARGB32(),
+            ghosttyBubbleWashColor(
+              accent,
+              verified: false,
+              backgroundBrightness: Brightness.dark,
+            ).toARGB32(),
+          );
+        }
+      });
+
+      test('the VERIFIED bubble is also a pure wash, at the stronger alpha',
+          () {
+        final canvas = _RecordingCanvas();
+        GhosttyBubblePainter(
+          specs: specsFor(verified: true),
+          color: accent,
+          backgroundBrightness: Brightness.light,
+        ).paint(canvas, const Size(400, 400));
+        expect(canvas.rrects, hasLength(1));
+        for (final call in canvas.rrects) {
+          expect(call.style, PaintingStyle.fill);
+          expect(
+            call.color.toARGB32(),
+            ghosttyBubbleWashColor(
+              accent,
+              verified: true,
+              backgroundBrightness: Brightness.light,
+            ).toARGB32(),
+          );
+        }
+      });
+
+      test('a background-brightness change repaints (alpha retune)', () {
+        final specs = specsFor(verified: false);
+        final dark = GhosttyBubblePainter(
+          specs: specs,
+          color: accent,
+          backgroundBrightness: Brightness.dark,
+        );
+        final light = GhosttyBubblePainter(
+          specs: specs,
+          color: accent,
+          backgroundBrightness: Brightness.light,
+        );
+        expect(light.shouldRepaint(dark), isTrue);
+      });
     });
   });
 


### PR DESCRIPTION
Closes #1000 — bubble v2: the #988/#990 outline bubble becomes a translucent background WASH.

## What changed
- **No stroke anywhere.** `GhosttyBubblePainter` fills each per-row segment with `ghosttyBubbleWashColor` — the gutter chip's hue family (the same accent `GutterMarkStyle.chipColor` forces opaque) at a luminance-tuned alpha. Shape semantics from #988 (content-hugging per-row segments, capsule rounding only on true first/last ends) are unchanged.
- **Alpha per background luminance, not one constant:** detected 0.26 dark / 0.32 light; verified 0.42 dark / 0.50 light. Verified is the SAME hue at a clearly stronger alpha (delta >= 0.12 asserted) — no thicker stroke. Detected sits above flterm's ~0x33 native selection fill so the two stay distinguishable, below 0.55 so glyphs stay readable.
- **More bottom padding:** the fill now expands 2.0px DOWNWARD past the row box (was +0.5 — descenders sat cramped); top inset eased 2.5 → 2.0. The next row's top slack band absorbs the overhang, so neighbors stay uncrowded.
- `GhosttyBubbleLayer`/`Painter` take `backgroundBrightness`; `ghostty_terminal_view.dart` derives it from the live session palette background (`estimateBrightnessForColor`), so theme cycling retunes the wash. `ghostty_gutter_layer.dart` untouched (parallel #993 agent owns it).

## Red → green
New `#1000 translucent wash bubble` test group failed on the outline implementation (compile-level red on the new API + geometry assertions that fail on the old +0.5 bottom), passes on the wash:
- fill-not-stroke via a recording `Canvas` (exactly one fill per segment, no `PaintingStyle.stroke`)
- descender expansion >= 1.5px; bottom padding >= top padding; fill never invades the row above
- alpha in the readable band [0.15, 0.55] on BOTH luminances; dark != light; verified-detected delta >= 0.12
- wash RGB == accent RGB (gutter chip hue family)
- brightness change triggers repaint

`scripts/native-fast-gate.sh` PASSED in the worktree (analyze + 1737 tests).

## Emulator evidence (dark theme, on-device)
- `integration_test/path_verified_shade_test.dart` PASSED live (detect → SFTP stat → shade/visibility): screenshot `test-results/emulator-shots/20260708T152227+0000-path-wash-1000_.png` — `/etc/hosts` + `/etc` verified (stronger wash), `/no/such/path990` detected (paler wash, same hue), `/config` suppressed, wrapped `https://wiki.alpinelinux.org/` URL washed with no outline; glyphs readable, neighbors uncrowded, descenders comfortable.
- `integration_test/url_bubble_wrap_988_test.dart` PASSED live (wrapped ~200-char URL, tap-copy exact payload on the new wash geometry, #930 scroll no-drift guard): screenshot `test-results/emulator-shots/20260708T152527+0000-url-wrap-wash-1000_.png` — the 4-row wrapped URL reads as ONE continuous wash (rows fuse at the seam), capsule rounding only on the true first/last ends.

## Honest caveats
- Light-theme wash is validated headlessly (alpha band + luminance-tuned constants) but not screenshotted — no light-theme emulator fixture; owner device check recommended when cycling themes.
- Wash-vs-native-selection distinguishability rests on the alpha offset (0.26/0.42 vs the theme's ~0x33 selection) + capsule shape; not exercised side-by-side on the emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa