### PR TITLE
fix(native): gutter chips TRACK their line while scrolling (#993)

### DIFF
--- a/native/integration_test/gutter_track_scroll_993_test.dart
+++ b/native/integration_test/gutter_track_scroll_993_test.dart
@@ -1,0 +1,350 @@
+// On-emulator check for #993: gutter chips must TRACK their line while the
+// user scrolls — never sit pinned to a fixed viewport row while the text moves
+// under them.
+//
+// Flow (real SSH → shell → flterm chain):
+//   1. connect to test-sshd, print one URL line (VISIT993 …/track993),
+//   2. `seq 200` → the URL line scrolls ~200 rows up into scrollback,
+//   3. SWIPE-scroll back up in steps; at every sampled frame assert that every
+//      RENDERED gutter mark row is one the controller itself resolves for a
+//      live anchor at the current (or immediately previous — one-frame notify
+//      lag) painted offset. A mark at any other row = pinned to a wrong line.
+//   4. assert the URL's mark was observed at >= 2 DISTINCT viewport rows while
+//      scrolling (it tracked), and at least one sample was mid-scroll
+//      (isScrolling) with marks visible (tracking, not hide-on-scroll),
+//   5. settle and assert the mark sits exactly on the re-resolved row.
+//
+// Screenshot windows (the orchestrator runs `scripts/emu-shot.sh` during each
+// hold and reviews the PNGs): GUTTER993_MIDSCROLL_WINDOW_OPEN (slow continuous
+// oscillating scroll — chips must ride their lines) and
+// GUTTER993_SETTLED_WINDOW_OPEN (stationary, chips on the correct lines).
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/gutter_track_scroll_993_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+const _url = 'https://example.com/track993';
+
+/// The viewport rows the gutter is CURRENTLY rendering a mark on (parsed from
+/// the `gutter-mark-<row>` keys).
+Set<int> _renderedRows(WidgetTester tester) {
+  final rows = <int>{};
+  final marks = find.byWidgetPredicate((w) {
+    final k = w.key;
+    return k is ValueKey<String> && k.value.startsWith('gutter-mark-');
+  });
+  for (final e in marks.evaluate()) {
+    final v = (e.widget.key! as ValueKey<String>).value;
+    final row = int.tryParse(v.substring('gutter-mark-'.length));
+    if (row != null) rows.add(row);
+  }
+  return rows;
+}
+
+/// The rows the controller resolves for every live anchor at the CURRENT
+/// painted offset — the ground truth a rendered mark must belong to.
+Set<int> _expectedRows(TerminalController c) {
+  final rows = <int>{};
+  for (final a in c.anchors) {
+    for (final r in a.ranges) {
+      final row = c.anchorGutterRow(r);
+      if (row != null) {
+        rows.add(row);
+        break;
+      }
+    }
+  }
+  return rows;
+}
+
+/// The URL anchor's current viewport row (null when off-screen/undetected).
+/// CONTAINS-match: the detector may capture trailing shell-line characters or
+/// normalize the payload, so equality against the echoed URL is too strict.
+int? _urlRow(TerminalController c) {
+  for (final a in c.anchors) {
+    if (!'${a.payload}'.contains('track993')) continue;
+    for (final r in a.ranges) {
+      final row = c.anchorGutterRow(r);
+      if (row != null) return row;
+    }
+  }
+  return null;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'gutter chips track their line while scrolling — never pinned (#993)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? ctrlOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && ctrlOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final maybeController = ctrlOf();
+      expect(
+        maybeController,
+        isNotNull,
+        reason: 'no ghostty controller for session',
+      );
+      final controller = maybeController!;
+
+      // Wait for a live shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // The URL line SANDWICHED mid-history (100 lines either side): scrolled
+      // back to it, it can occupy ANY viewport row — required for observing the
+      // mark at several distinct rows. (At the very top of the buffer it could
+      // only ever render at row 0 — the run-6 dead end.)
+      entry.proxy.sendInput(
+        Uint8List.fromList(
+          utf8.encode('clear; seq 100; echo VISIT993 $_url; seq 200\n'),
+        ),
+      );
+      var tailSeen = false;
+      for (var i = 0; i < 80; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        if (utf8.decode(out, allowMalformed: true).contains('\n200')) {
+          tailSeen = true;
+          break;
+        }
+      }
+      expect(tailSeen, isTrue, reason: 'seq 200 output never arrived');
+      // Let detection + paint settle at the tail. (The URL is now ~200 rows up
+      // in scrollback — outside the bounded detection window, so its anchor may
+      // have been evicted; scrolling back up re-detects it via the debounced
+      // rescan once it re-enters the window.)
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+
+      final termFinder = find.byKey(Key('ghostty-terminal-$sessionId'));
+      expect(termFinder, findsOneWidget, reason: 'no ghostty terminal view');
+      final rect = tester.getRect(termFinder);
+      final bodyX = rect.left + rect.width * 0.35;
+
+      // Sample ground truth vs rendered marks. Called only when the painted
+      // offset is QUIESCENT (finger held still, or post-release micro-settle):
+      // the decoration notify lands post-frame, so two pumps after the last
+      // move guarantee the rendered marks reflect the current offset. The
+      // PREVIOUS sample's expected rows stay legal as slack for a stray vsync.
+      var prevExpected = _expectedRows(controller);
+      final urlRowsSeenRendered = <int>{};
+      var sawMarksMidScroll = false;
+      Future<void> sample(String phase) async {
+        await tester.pump(const Duration(milliseconds: 16));
+        await tester.pump(const Duration(milliseconds: 16));
+        final expected = _expectedRows(controller);
+        final rendered = _renderedRows(tester);
+        final legal = {...expected, ...prevExpected};
+        final rogue = rendered.difference(legal);
+        expect(
+          rogue,
+          isEmpty,
+          reason: '[$phase] gutter mark(s) PINNED to wrong line(s) $rogue — '
+              'rendered=$rendered expected=$expected prev=$prevExpected '
+              'oPaint=${controller.paintedViewportOffset} '
+              'isScrolling=${controller.isScrolling} (#993)',
+        );
+        final u = _urlRow(controller);
+        if (u != null && rendered.contains(u)) urlRowsSeenRendered.add(u);
+        if (controller.isScrolling && rendered.isNotEmpty) {
+          sawMarksMidScroll = true;
+        }
+        prevExpected = expected;
+      }
+
+      // PHASE 1: swipe-scroll back up until the URL line re-enters the
+      // detection window and its anchor resolves on-screen. Every step still
+      // runs the pinned-mark subset assertion.
+      var urlOnScreen = false;
+      for (var s = 0; s < 30 && !urlOnScreen; s++) {
+        final g = await tester.startGesture(
+          Offset(bodyX, rect.top + rect.height * 0.30),
+        );
+        for (var i = 1; i <= 6; i++) {
+          await g.moveTo(
+            Offset(bodyX, rect.top + rect.height * (0.30 + 0.09 * i)),
+          );
+          await sample('swipe$s.move$i');
+        }
+        await g.up();
+        // Post-release: let any fling coast + the debounced rescan (~120ms)
+        // re-anchor before checking.
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 60));
+        }
+        await sample('swipe$s.up');
+        urlOnScreen = _urlRow(controller) != null;
+        debugPrint(
+          'GUTTER993 swipe$s: oPaint=${controller.paintedViewportOffset} '
+          'oScroll=${controller.scrollbar.offset} '
+          'anchors=${controller.anchors.length} urlRow=${_urlRow(controller)} '
+          'rendered=${_renderedRows(tester)} '
+          'payloads=${[for (final a in controller.anchors) '${a.patternId}:${a.payload}']}',
+        );
+      }
+      expect(
+        urlOnScreen,
+        isTrue,
+        reason: 'never scrolled the VISIT993 URL line back on-screen / '
+            're-detected — cannot assert tracking',
+      );
+
+      // PHASE 2: with the URL on-screen, HELD small drag steps: after each
+      // move the finger stays down and the offset holds, but isScrolling stays
+      // true for its 140ms settle window — the exact mid-scroll state. The URL
+      // row must be observed RENDERED at several distinct rows.
+      for (var s = 0; s < 6 && urlRowsSeenRendered.length < 3; s++) {
+        final down = s.isEven; // alternate so the URL stays near mid-screen
+        final startY = rect.top + rect.height * (down ? 0.30 : 0.70);
+        final g = await tester.startGesture(Offset(bodyX, startY));
+        for (var i = 1; i <= 5; i++) {
+          final dy = rect.height * 0.06 * i * (down ? 1 : -1);
+          await g.moveTo(Offset(bodyX, startY + dy));
+          await sample('track$s.move$i');
+        }
+        await g.up();
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 60));
+        }
+        await sample('track$s.up');
+      }
+
+      debugPrint(
+        'GUTTER993 scroll pass: urlRowsSeenRendered=$urlRowsSeenRendered '
+        'sawMarksMidScroll=$sawMarksMidScroll '
+        'oPaint=${controller.paintedViewportOffset}',
+      );
+      expect(
+        sawMarksMidScroll,
+        isTrue,
+        reason: 'marks must stay VISIBLE and track mid-scroll (#993 tracking '
+            'mode) — never rendered while isScrolling means hide-on-scroll',
+      );
+      expect(
+        urlRowsSeenRendered.length,
+        greaterThanOrEqualTo(2),
+        reason: 'the URL mark must be observed at >=2 distinct viewport rows '
+            'across the scroll (it TRACKS its line, #993) — saw '
+            '$urlRowsSeenRendered',
+      );
+
+      // MID-SCROLL screenshot window: keep the content slowly oscillating so
+      // the external emu-shot lands on an in-flight scroll with chips riding
+      // their lines. Assertions keep running throughout.
+      debugPrint('GUTTER993_MIDSCROLL_WINDOW_OPEN');
+      for (var o = 0; o < 24; o++) {
+        final down = o.isEven;
+        final startY = rect.top + rect.height * (down ? 0.35 : 0.65);
+        final g = await tester.startGesture(Offset(bodyX, startY));
+        for (var i = 1; i <= 5; i++) {
+          final dy = rect.height * 0.05 * i * (down ? 1 : -1);
+          await g.moveTo(Offset(bodyX, startY + dy));
+          await sample('osc$o.move$i');
+        }
+        await g.up();
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 60));
+        }
+        await sample('osc$o.rest');
+      }
+      debugPrint('GUTTER993_MIDSCROLL_WINDOW_CLOSED');
+
+      // SETTLE: the marks must sit exactly on the re-resolved rows.
+      for (var i = 0; i < 15; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(controller.isScrolling, isFalse, reason: 'never settled');
+      final settledExpected = _expectedRows(controller);
+      final settledRendered = _renderedRows(tester);
+      final settledUrlRow = _urlRow(controller);
+      debugPrint(
+        'GUTTER993 settled: rendered=$settledRendered '
+        'expected=$settledExpected urlRow=$settledUrlRow',
+      );
+      expect(
+        settledRendered.difference(settledExpected),
+        isEmpty,
+        reason: 'settled marks must all sit on controller-resolved rows — '
+            'rendered=$settledRendered expected=$settledExpected',
+      );
+      if (settledUrlRow != null) {
+        expect(
+          settledRendered,
+          contains(settledUrlRow),
+          reason: 'the on-screen URL line must carry its mark once settled',
+        );
+      }
+
+      // SETTLED screenshot window.
+      debugPrint('GUTTER993_SETTLED_WINDOW_OPEN');
+      for (var i = 0; i < 48; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      debugPrint('GUTTER993_SETTLED_WINDOW_CLOSED');
+    },
+  );
+}

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -8,8 +8,12 @@
 // the #803/#812/#863/#864 saga. A GUTTER indicator needs only a ROW + a fixed
 // edge X, so that whole drift class is GONE: there is no text under the mark to
 // drift away from. It tracks scroll by row index alone (`anchorGutterRow`, now
-// resolved against the PAINTED offset #955), and hides mid-scroll like the old
-// decorator did (the controller's `isScrolling` gate).
+// resolved against the PAINTED offset #955). #993: it TRACKS mid-scroll too —
+// the decoration listenable fires post-frame on every painted-offset change, so
+// each notify re-resolves every mark's viewport row in lockstep with the
+// painted glyphs (the old `isScrolling` hide was the bubble's sub-pixel-drift
+// contract; a row-indexed chip has nothing to drift, and hiding left the chips
+// visibly pinned on scroll paths where `isScrolling` never engages).
 //
 // The layer reads the controller's live `anchors`, resolves each to a VIEWPORT
 // row via `anchorGutterRow` (dropping off-screen/null), GROUPS anchors by row,
@@ -311,12 +315,16 @@ Map<int, List<StructuredAnchor>> groupAnchorsByGutterRow(
 /// viewport row (#955). Replaces the inline `GhosttyTerminalDecoratorLayer`.
 ///
 /// Listens to the controller's NARROW [TerminalController.decorationListenable]
-/// (#805) and HIDES while [TerminalController.isScrolling] (#812) — the marks
-/// reappear, in lockstep with the painted rows, once the scroll settles. Reads
-/// `controller.anchors`, resolves each row via `controller.anchorGutterRow`, and
-/// places a mark at `padding + row * cellHeight` on the right edge. Sits ABOVE
-/// the gesture router so a tap on a mark is consumed by the mark (everywhere
-/// else is transparent and falls through).
+/// (#805), which fires post-frame on every painted-offset change while anchors
+/// exist — so during a scroll the marks TRACK their line (#993): every notify
+/// re-resolves each anchor's viewport row via `controller.anchorGutterRow`
+/// (painted-offset, frame-synced) and repositions the mark at
+/// `padding + row * cellHeight` on the right edge, in lockstep with the painted
+/// glyphs. No mid-scroll hide (that is the bubble's #812 sub-pixel contract);
+/// taps ARE ignored while [TerminalController.isScrolling], since a chip can
+/// change rows between tapDown and tapUp. Sits ABOVE the gesture router so a
+/// tap on a mark is consumed by the mark (everywhere else is transparent and
+/// falls through).
 class GhosttyGutterLayer extends StatelessWidget {
   const GhosttyGutterLayer({
     super.key,
@@ -384,9 +392,12 @@ class GhosttyGutterLayer extends StatelessWidget {
           ? controller.decorationListenable
           : Listenable.merge([controller.decorationListenable, verification]),
       builder: (context, _) {
-        // #812: don't draw mid-scroll — the marks reappear on settle. (Tap
-        // routing via the gesture router's matchAt is unaffected.)
-        if (controller.isScrolling) return const SizedBox.shrink();
+        // #993: no isScrolling hide here — each painted-offset notify lands
+        // post-frame and `anchorGutterRow` resolves against that same painted
+        // offset, so re-grouping below moves every chip to its line's new
+        // viewport row in lockstep with the painted glyphs. (The notify only
+        // fires when the offset actually changed, so a settled terminal never
+        // rebuilds this.) Taps are gated on isScrolling inside _GutterMark.
         if (cellHeight <= 0) return const SizedBox.shrink();
         final byRow = groupAnchorsByGutterRow(
           // #990 visibility gate: suppressed anchors never reach the grouping,
@@ -434,6 +445,7 @@ class GhosttyGutterLayer extends StatelessWidget {
                 height: boxHeight,
                 child: _GutterMark(
                   key: Key('gutter-mark-${entry.key}'),
+                  controller: controller,
                   anchors: entry.value,
                   registry: registry,
                   color: color,
@@ -461,12 +473,17 @@ class GhosttyGutterLayer extends StatelessWidget {
 class _GutterMark extends StatefulWidget {
   const _GutterMark({
     super.key,
+    required this.controller,
     required this.anchors,
     required this.registry,
     required this.color,
     required this.style,
     required this.stripWidth,
   });
+
+  /// #993: consulted at tap time — while the painted offset is still moving a
+  /// chip can change rows between tapDown and tapUp, so taps are ignored.
+  final TerminalController controller;
 
   final List<StructuredAnchor> anchors;
   final GutterPatternRegistry registry;
@@ -487,6 +504,11 @@ class _GutterMarkState extends State<_GutterMark> {
   }
 
   void _onTap(BuildContext context, Offset markGlobal) {
+    // #993: mid-scroll the chip under the finger is not a stable target — the
+    // row it marks may have changed since tapDown. Firing here could invoke a
+    // DIFFERENT line's action, so ignore the tap (pre-#993 this state was
+    // unreachable: the whole layer hid while scrolling).
+    if (widget.controller.isScrolling) return;
     final anchors = widget.anchors;
     if (anchors.length == 1) {
       final presentation = widget.registry.forPattern(anchors.first.patternId);

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -4254,7 +4254,8 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         // painted rows — #955), GROUPS them by row, and renders ONE small
         // monochrome mark per matched row at the right edge. No glyph-cell
         // geometry → no scroll drift (the #930/#803/#812/#863/#864 inline-bubble
-        // saga). Hides mid-scroll (`isScrolling`), re-shows on settle. Mounted
+        // saga). #993: TRACKS mid-scroll (rows re-resolve on every painted-
+        // offset notify; taps ignored while scrolling). Mounted
         // ABOVE the gesture router so a tap on a mark is consumed by the mark
         // (everywhere else is transparent and falls through to the router below).
         Positioned.fill(

--- a/native/test/terminal/replay_hide_on_scroll_test.dart
+++ b/native/test/terminal/replay_hide_on_scroll_test.dart
@@ -9,11 +9,14 @@ library;
 // it doesn't draw mid-scroll. Tap-to-copy (`controller.matchAt`) must keep
 // working THROUGHOUT.
 //
-// #955 retired the inline decorator layer; the right-edge GUTTER ([GhosttyGutterLayer])
-// inherits the SAME contract (it gates on `controller.isScrolling`). This replay
-// tier mounts the REAL flterm `TerminalView` (so the render box paints and reports
-// its painted offset, which drives `isScrolling`) ALONG with a gutter-equivalent
-// PROBE that consumes the exact controller surface the gutter reads
+// #955 retired the inline decorator layer. The hide-on-scroll contract now
+// belongs to the BUBBLE ([GhosttyBubbleLayer], #988 — sub-pixel rect precision
+// drifts mid-scroll); the GUTTER ([GhosttyGutterLayer]) TRACKS the scroll since
+// #993 (row-indexed chips re-resolve per painted-offset notify — see
+// test/ui/ghostty_gutter_layer_test.dart). This replay tier keeps exercising
+// the hide contract against the REAL flterm `TerminalView` (so the render box
+// paints and reports its painted offset, which drives `isScrolling`) via a
+// bubble-equivalent PROBE that consumes the same controller surface
 // (`decorationListenable` + `isScrolling` + `anchors` + `anchorGutterRow`), and
 // asserts:
 //   1. while the painted offset is changing the gutter renders NO mark;
@@ -36,10 +39,11 @@ class _PaintCounter {
   int paints = 0;
 }
 
-/// A gutter-equivalent probe: listens to the narrow decoration signal, GATES on
-/// `isScrolling` (renders nothing mid-scroll, exactly like [GhosttyGutterLayer]),
-/// and counts a "paint" on any settled build that resolves at least one on-screen
-/// gutter row. Mirrors the layer's consumption without depending on its widgets.
+/// A bubble-equivalent probe: listens to the narrow decoration signal, GATES on
+/// `isScrolling` (renders nothing mid-scroll, like [GhosttyBubbleLayer]; the
+/// gutter tracks instead since #993), and counts a "paint" on any settled build
+/// that resolves at least one on-screen gutter row. Mirrors the hide-contract
+/// consumption without depending on the layer widgets.
 class _GutterProbe extends StatelessWidget {
   const _GutterProbe({required this.controller, required this.counter});
 

--- a/native/test/ui/ghostty_gutter_layer_test.dart
+++ b/native/test/ui/ghostty_gutter_layer_test.dart
@@ -1,6 +1,8 @@
 // #955 — the right-edge GUTTER layer that replaced the inline URL bubble / path
 // underline. Covers (1) the PURE grouping of anchors → gutter rows, and (2) the
-// WIDGET behaviour: marks appear only on matched rows, hide while scrolling, a
+// WIDGET behaviour: marks appear only on matched rows, TRACK the scroll by
+// re-resolving their viewport row on every decoration notify (#993 — no
+// mid-scroll hide; that is the bubble's contract, not the gutter's), a
 // single-match mark taps straight to the action overlay, and a multi-match mark
 // opens the list sheet whose items dispatch to the right action (a path item
 // opens the SFTP browser at its path).
@@ -58,10 +60,13 @@ StructuredAnchor _wrappedUrl(String url, List<int> rows) => StructuredAnchor(
 
 /// Fake controller exposing scripted [anchors] + an [anchorGutterRow] that maps a
 /// range's top row to a viewport row (null when off [viewportRows]). The only
-/// surface [GhosttyGutterLayer] reads.
+/// surface [GhosttyGutterLayer] reads. #993: [setOffset] models a painted-offset
+/// change mid-scroll — the real controller's decorationListenable fires post-frame
+/// on every painted-offset change and anchorGutterRow re-resolves against it.
 class _FakeController extends ChangeNotifier implements TerminalController {
   List<StructuredAnchor> _anchors = const [];
   bool _scrolling = false;
+  int _offset = 0;
   int viewportRows = 24;
 
   void setAnchors(List<StructuredAnchor> value) {
@@ -72,6 +77,14 @@ class _FakeController extends ChangeNotifier implements TerminalController {
   void setScrolling(bool value) {
     if (_scrolling == value) return;
     _scrolling = value;
+    notifyListeners();
+  }
+
+  /// A painted-offset step: rows re-resolve as `topRow - offset`; the scroll
+  /// flag defaults ON (this is what happens DURING a scroll, #993).
+  void setOffset(int value, {bool scrolling = true}) {
+    _offset = value;
+    _scrolling = scrolling;
     notifyListeners();
   }
 
@@ -86,7 +99,7 @@ class _FakeController extends ChangeNotifier implements TerminalController {
 
   @override
   int? anchorGutterRow(HighlightRange range) {
-    final row = range.topRow;
+    final row = range.topRow - _offset;
     if (row < 0 || row >= viewportRows) return null;
     return row;
   }
@@ -196,23 +209,142 @@ void main() {
       expect(find.byKey(const Key('gutter-mark-2')), findsNothing);
     });
 
-    testWidgets('HIDES marks while scrolling, re-shows on settle', (tester) async {
-      final controller = await pumpLayer(tester);
-      controller.setAnchors([_urlAnchor('https://example.com', row: 4)]);
-      await tester.pump();
-      expect(find.byKey(const Key('gutter-mark-4')), findsOneWidget);
+    // #993 — the chips TRACK their line during a scroll instead of hiding
+    // (the owner saw them pinned to fixed viewport rows while the text moved).
+    // Every painted-offset notify re-resolves each anchor's viewport row via
+    // anchorGutterRow, so the mark moves in lockstep with the painted glyphs.
+    group('scroll tracking (#993)', () {
+      testWidgets('marks stay VISIBLE and move to the re-resolved row while '
+          'the painted offset changes mid-scroll', (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([_urlAnchor('https://example.com', row: 10)]);
+        await tester.pump();
+        expect(find.byKey(const Key('gutter-mark-10')), findsOneWidget);
 
-      controller.setScrolling(true);
-      await tester.pump();
-      expect(
-        find.byKey(const Key('gutter-mark-4')),
-        findsNothing,
-        reason: 'marks hide while the painted offset is changing (#812/#955)',
-      );
+        // The scroll starts: the offset moves 3 rows, isScrolling is true.
+        controller.setOffset(3);
+        await tester.pump();
+        expect(
+          find.byKey(const Key('gutter-mark-7')),
+          findsOneWidget,
+          reason: 'the mark must TRACK its line to the new viewport row (#993)',
+        );
+        expect(
+          find.byKey(const Key('gutter-mark-10')),
+          findsNothing,
+          reason: 'the mark must not stay pinned to the old viewport row',
+        );
 
-      controller.setScrolling(false);
-      await tester.pump();
-      expect(find.byKey(const Key('gutter-mark-4')), findsOneWidget);
+        // A further step mid-scroll keeps tracking.
+        controller.setOffset(6);
+        await tester.pump();
+        expect(find.byKey(const Key('gutter-mark-4')), findsOneWidget);
+      });
+
+      testWidgets('a mark scrolled OFF-screen disappears and returns when '
+          'scrolled back on-screen', (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([_urlAnchor('https://example.com', row: 2)]);
+        await tester.pump();
+        expect(find.byKey(const Key('gutter-mark-2')), findsOneWidget);
+
+        controller.setOffset(5); // row 2 - 5 → above the viewport
+        await tester.pump();
+        expect(find.byKey(const Key('gutter-mark--3')), findsNothing);
+        expect(find.byKey(const Key('gutter-mark-2')), findsNothing);
+
+        controller.setOffset(0);
+        await tester.pump();
+        expect(find.byKey(const Key('gutter-mark-2')), findsOneWidget);
+      });
+
+      testWidgets('settle keeps the mark at the settled offset row',
+          (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([_urlAnchor('https://example.com', row: 9)]);
+        await tester.pump();
+
+        controller.setOffset(4); // scrolling
+        await tester.pump();
+        expect(find.byKey(const Key('gutter-mark-5')), findsOneWidget);
+
+        controller.setScrolling(false); // trailing-edge settle notify
+        await tester.pump();
+        expect(find.byKey(const Key('gutter-mark-5')), findsOneWidget);
+      });
+
+      testWidgets('taps are IGNORED while scrolling (a chip can change rows '
+          'between tapDown and tapUp)', (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([_urlAnchor('https://example.com', row: 10)]);
+        controller.setOffset(3);
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('gutter-mark-7')));
+        await tester.pump();
+        expect(
+          find.byKey(const Key('url-action-menu')),
+          findsNothing,
+          reason: 'mid-scroll the chip under the finger is not a stable '
+              'target — no action may fire (#993)',
+        );
+
+        controller.setScrolling(false);
+        await tester.pump();
+        await tester.tap(find.byKey(const Key('gutter-mark-7')));
+        await tester.pump();
+        expect(find.byKey(const Key('url-action-menu')), findsOneWidget);
+        debugDismissUrlActions();
+      });
+
+      testWidgets('#990 verified shade and visibility gating hold mid-scroll',
+          (tester) async {
+        final controller = _FakeController();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  Positioned.fill(
+                    child: GhosttyGutterLayer(
+                      controller: controller,
+                      registry: GutterPatternRegistry.standard(
+                        openPath: (_) async => true,
+                      ),
+                      color: const Color(0xFF5B9BD5),
+                      cellHeight: 20,
+                      isVerified: (a) => a.payload == '/etc/hosts',
+                      isVisible: (a) => '${a.payload}' != '/config',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        controller.setAnchors([
+          _pathAnchor('/etc/hosts', row: 8),
+          _pathAnchor('/config', row: 12),
+        ]);
+        controller.setOffset(2); // scrolling
+        await tester.pump();
+
+        // The verified path tracks to row 6 and keeps the bold ring.
+        final boxes = tester.widgetList<DecoratedBox>(
+          find.descendant(
+            of: find.byKey(const Key('gutter-mark-6')),
+            matching: find.byType(DecoratedBox),
+          ),
+        );
+        final deco = boxes
+            .map((b) => b.decoration)
+            .whereType<BoxDecoration>()
+            .firstWhere((d) => d.color != null);
+        expect(deco.border, isNotNull,
+            reason: 'the verified bold ring must survive scroll tracking');
+        // The suppressed anchor renders nothing at its tracked row either.
+        expect(find.byKey(const Key('gutter-mark-10')), findsNothing);
+      });
     });
 
     testWidgets('a multi-match row shows a count mark', (tester) async {


### PR DESCRIPTION
Fixes #993 — gutter chips now TRACK their line while scrolling (preferred mode from the issue), instead of sitting pinned to fixed viewport rows while the text moves under them.

## Mode shipped: TRACKING (not hide-on-scroll)

Root cause: `GhosttyGutterLayer` rebuilt on `decorationListenable` — which already fires post-frame on EVERY painted-offset change while anchors exist — but the `if (controller.isScrolling) return SizedBox.shrink()` gate (inherited from the bubble's #812 sub-pixel-drift contract) threw that signal away. A row-indexed chip has no sub-pixel geometry to drift, so the hide was unnecessary; on scroll paths where `isScrolling` never engages the stale build sat visibly pinned.

The fix removes that gate: each painted-offset notify re-resolves every anchor's viewport row via `controller.anchorGutterRow` (the same frame-synced painted offset the glyph painter uses), so chips move in lockstep with the painted text. Allocation-light: the notify only fires when the offset actually changed — a settled terminal never rebuilds the layer.

Safety addition: taps are now IGNORED while `isScrolling` (one line in `_GutterMark._onTap`). Mid-scroll a chip can change rows between tapDown and tapUp, so firing could invoke a different line's action. Pre-#993 this state was unreachable (the layer hid), so this preserves the previous action semantics exactly.

`#990` verified-shade + visibility gating are untouched and covered by mid-scroll tests.

## Red → green

- 5 new widget tests in `native/test/ui/ghostty_gutter_layer_test.dart` (scroll tracking group): marks stay visible and move to the re-resolved row mid-scroll; off-screen drop + return; settled correctness; taps ignored while scrolling; #990 bold ring + suppression hold mid-scroll. All 5 FAILED against the old hide-on-scroll code; green after the fix. All 23 pre-existing gutter tests unchanged and green (28/28).
- `replay_hide_on_scroll_test.dart` comments updated: its probe models the BUBBLE's hide contract (#988, kept), no code change.

## Emulator evidence (real SSH → shell → flterm)

New `native/integration_test/gutter_track_scroll_993_test.dart`:
- connects to test-sshd, prints a URL sandwiched mid-history (`seq 100; echo URL; seq 200`), swipe-scrolls back;
- at every quiescent sample, asserts every RENDERED `gutter-mark-<row>` is a row the controller itself resolves for a live anchor at the current painted offset — a mark anywhere else = pinned to a wrong line (fails the test);
- asserts the URL's mark is observed RENDERED at >= 2 distinct viewport rows across the scroll (it tracks) and that marks are visible while `isScrolling` (tracking, not hide);
- settled state asserted exact; screenshots taken mid-scroll and settled.

Run result (emulator, real device-class scroll): PASSED.
- `GUTTER993 scroll pass: urlRowsSeenRendered={1, 2, 4, 5, 7} sawMarksMidScroll=true` — the URL chip was observed RENDERED at 5 distinct viewport rows while `isScrolling` was true; zero pinned-mark violations across every sampled frame of an 18-swipe scrollback descent + tracking passes.
- `GUTTER993 settled: rendered={7} expected={7} urlRow=7` — settled row exact.
- Screenshots (chip riding the VISIT993 URL line, mid-scroll and settled):
  `test-results/emulator-shots/20260708T153906+0000-gutter993-midscroll-a_.png`
  `test-results/emulator-shots/20260708T153911+0000-gutter993-midscroll-b_.png`
  `test-results/emulator-shots/20260708T153927+0000-gutter993-settled_.png`
- Native fast gate: PASSED (1732 tests). One unrelated pre-existing flake (`reconnect_shell_revive_test`, #590 timing) failed once under CPU contention from a parallel agent's run and passes in isolation and in the final full gate.
- Observed detector quirk while testing (NOT this PR): the URL scanner wrap-joined the URL line with the NEXT line's content — payload came back `…/track9931` (glued `1` from the following `seq` line) on an unwrapped 38-char line. Candidate follow-up issue for the #925 wrap-join heuristic.

## Notes / caveats

- Tracking lands one frame behind the glyphs (post-frame notify) — at row granularity this is invisible; it is the same lockstep the bubble/matchAt geometry uses.
- On alt-screen (tmux) redraw scrolls the painted offset does not move; chips there follow anchor relocations (prune/rescan), which is as live as flterm's anchor model allows.
- Per-frame cost during scroll: one grouping pass over the (small) anchor list per actual offset change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa