### PR TITLE
fix(flterm): wrap-join head must plausibly reach a wrap boundary (#1007)

### DIFF
--- a/native/test/terminal/replay_url_short_row_join_1007_test.dart
+++ b/native/test/terminal/replay_url_short_row_join_1007_test.dart
@@ -1,0 +1,68 @@
+@Tags(['ffi'])
+library;
+
+// REPLAY regression for #1007 — the width-heuristic wrap-join glued the next
+// line's leading `1` onto a URL whose row NEVER reached a wrap boundary.
+//
+// Found by the #993 agent's emulator run: `SOMETEXT https://example.com/track993`
+// is 38 cols in a 55-col grid — provably NOT soft-wrapped (17 cols of headroom)
+// — yet the anchor payload came back `…/track9931`. Root cause: `_inferWrapCol`
+// takes the MODE of content-end columns among long rows, and with this row as
+// the ONLY sample its own end (38) became the "inferred wrap column", making the
+// `end >= wrapCol - 1` reach test vacuously true (self-corroboration). The #1007
+// guard demands the boundary be corroborated by a SECOND row (a consistent app
+// content width) or sit at the grid edge (the terminal itself wraps there).
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const url = 'https://example.com/track993';
+
+  group('REPLAY #1007 — short row must not width-join', () {
+    test(
+      'a 38-col URL line in a 55-col grid followed by a line starting with `1` '
+      'anchors EXACTLY the URL (no glued `1` from the next line)',
+      () async {
+        final controller = TerminalController(
+          config: const TerminalConfig(cols: 55, rows: 20),
+        );
+        addTearDown(controller.dispose);
+        controller.registerTextPattern(TextPattern.url());
+
+        // The exact #993 shape: a 38-col line — far short of both the terminal
+        // width (55) and any real app wrap column — hard-terminated by CRLF,
+        // followed by a line whose first glyph is a bare `1` (not a bullet, not
+        // a scheme, same col-0 margin: every pre-#1007 join gate passed).
+        controller.write(
+          Uint8List.fromList(
+            utf8.encode('SOMETEXT $url\r\n1 more output line\r\n'),
+          ),
+        );
+        // Detection re-scan is debounced (~120ms); mirror the sibling replay
+        // tests' 250ms settle.
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        final urlAnchors = controller.anchors
+            .where((a) => a.patternId == 'url')
+            .toList();
+        expect(
+          urlAnchors,
+          hasLength(1),
+          reason: 'exactly one URL anchor on the grid',
+        );
+        expect(
+          urlAnchors.single.payload,
+          url,
+          reason: 'the payload must be EXACTLY the printed URL — the #1007 bug '
+              'wrap-joined the next line and produced …/track9931',
+        );
+      },
+    );
+  });
+}

--- a/native/third_party/flterm/lib/src/foundation/structured_text.dart
+++ b/native/third_party/flterm/lib/src/foundation/structured_text.dart
@@ -684,7 +684,7 @@ class StructuredTextScanner {
     // CLI's ~53-col content width in a 55-col terminal only bubbled/copied its
     // first row). Joining must key off where wrapped rows ACTUALLY end, not the
     // terminal edge.
-    final wrapCol = _inferWrapCol(reader, rows, cols);
+    final (wrapCol, wrapColCount) = _inferWrapCol(reader, rows, cols);
     final lines = <_LogicalLine>[];
     var r = 0;
     while (r < rows) {
@@ -748,7 +748,8 @@ class StructuredTextScanner {
           glyphs.add(_Glyph(content.isEmpty ? ' ' : content, absRow, c));
         }
         if (r < rows - 1 &&
-            _continuesOnto(reader, r, cols, wrapCol, blockIndent)) {
+            _continuesOnto(
+                reader, r, cols, wrapCol, wrapColCount, blockIndent)) {
           viaWidthJoin = !reader.rowWrap(r);
           r++;
           continue;
@@ -828,6 +829,7 @@ class StructuredTextScanner {
     int r,
     int cols,
     int wrapCol,
+    int wrapColCount,
     int blockIndent,
   ) {
     if (reader.rowWrap(r)) return true;
@@ -854,7 +856,46 @@ class StructuredTextScanner {
     // paragraph/block, not a wrap of this one — keeps #764 two-match behavior
     // for a complete URL followed by a differently-indented line.
     if (nextStart != blockIndent) return false;
-    return !_startsNewBlock(reader, next, cols, blockIndent);
+    if (_startsNewBlock(reader, next, cols, blockIndent)) return false;
+    // #1007: the wrap column must be a PLAUSIBLE wrap boundary, not the head
+    // row's own content-end echoed back. [_inferWrapCol] takes the MODE of long
+    // rows' end columns, so with exactly ONE long row in the buffer that row
+    // self-corroborates: a 38-col `SOMETEXT https://example.com/track993` line
+    // in a 55-col grid — provably not wrapped, 17 cols of headroom — "reached"
+    // its own wrapCol=38 and glued the next line's leading `1` onto the URL
+    // (`…/track9931`, the #993 emulator find). The boundary is trusted as-is
+    // when:
+    //   * CORROBORATED — at least TWO long rows end there (wrapColCount >= 2):
+    //     independent evidence of a consistent app content width (the #767
+    //     padded-app device fixture has 3 sibling rows ending at col 12 in a
+    //     20-col grid; a URL wrapping across 3+ rows corroborates itself with
+    //     its own full continuation rows); OR
+    //   * AT/NEAR THE GRID EDGE (wrapCol >= cols - 2) — the terminal itself
+    //     wraps there, so even a lone full-width row is a plausible wrap head
+    //     (the tmux hard-wrap class). The 2-col tolerance is the widest right
+    //     margin any green fixture requires: the REAL captured Claude-TUI
+    //     trace (`claude_wrapped_url_55col.cast.json`, the +22..+28
+    //     regression) hard-breaks its lone URL head at col 53 in a 55-col
+    //     grid — a TUI reserves a small FIXED right margin — and the reach
+    //     test's own wide-char/pad slack is 1. Do NOT widen without a real
+    //     captured trace: every extra col re-admits #1007-class false joins.
+    // Otherwise (a lone long row well short of the grid edge) fall back to the
+    // #996-class LOCAL token evidence: the head row must end in an
+    // unterminated-looking URL token AND the continuation's head token must
+    // look like a URL tail (`.` `/` `:`). This keeps the true single-sample
+    // join — the SAME 53-col capture replayed into a REMOUNTED ~94-col grid
+    // (#863's widget-tier harness) has no sibling rows and sits far from the
+    // new grid's edge, yet its halves carry the URL evidence — while the #993
+    // bug's bare `1` continuation fails it. Residual accepted risk (same class
+    // as #996's): a lone short COMPLETE-URL row followed at the same margin by
+    // a line whose first token carries `.`/`/`/`:` still glues that token.
+    final plausibleBoundary = wrapColCount >= 2 || wrapCol >= cols - 2;
+    if (!plausibleBoundary &&
+        !(_endsWithUrlToken(reader, r, cols) &&
+            _headLooksLikeUrlTail(reader, next, cols, nextStart))) {
+      return false;
+    }
+    return true;
   }
 
   /// Whether local [row]'s LAST whitespace-delimited token looks like a split
@@ -935,7 +976,17 @@ class StructuredTextScanner {
   /// full-terminal-width row that MAX would wrongly latch onto. Returns 0 when
   /// there are no wrap candidates (nothing to join by width).
   ///
-  int _inferWrapCol(CellReader reader, int rows, int cols) {
+  /// #1007: alongside the column, returns HOW MANY long rows end there (the
+  /// mode's count) so [_continuesOnto] can tell a CORROBORATED wrap column (a
+  /// consistent app content width shared by >= 2 rows) from a SELF-DEFINED one.
+  /// With exactly ONE long row in the buffer, that row's own content-end IS the
+  /// mode, making the join gate's `end >= wrapCol - 1` reach test vacuously
+  /// true — a 38-col line in a 55-col grid (provably not wrapped: 17 cols of
+  /// headroom) self-corroborated and glued the next line's leading `1` onto its
+  /// URL (`…/track9931`). The count lets the join demand extra evidence in that
+  /// degenerate case without losing the true single-sample joins (see
+  /// [_continuesOnto]).
+  (int, int) _inferWrapCol(CellReader reader, int rows, int cols) {
     final counts = <int, int>{};
     final threshold = cols ~/ 2;
     for (var r = 0; r < rows - 1; r++) {
@@ -952,7 +1003,7 @@ class StructuredTextScanner {
         bestCount = n;
       }
     });
-    return best;
+    return (best, bestCount);
   }
 
   /// Whether row [row] STARTS a new block rather than continuing the prior row:


### PR DESCRIPTION
Fixes #1007.

## Guard rule (one sentence)
A row can only be a width-heuristic JOIN HEAD if its content reaches a wrap boundary that is corroborated by a second long row or sits within 2 cols of the grid edge — otherwise the join additionally requires the #996-class local token evidence (head row ends in a scheme-bearing token AND the continuation's head token carries URL structure).

## Root cause
`_inferWrapCol` takes the MODE of long rows' content-end columns. With exactly one long row in the buffer, that row's own end becomes the "inferred wrap column", so the join gate's `end >= wrapCol - 1` reach test is vacuously true (self-corroboration). The 38-col `SOMETEXT https://example.com/track993` line in a 55-col grid — 17 cols of headroom, provably not wrapped — defined wrapCol=38, "reached" it, and glued the next line's leading `1` (payload `…/track9931`, found by the #993 emulator run).

## Fix
`native/third_party/flterm/lib/src/foundation/structured_text.dart`:
- `_inferWrapCol` now also returns the mode's COUNT (how many long rows end at that column).
- `_continuesOnto` trusts the boundary as-is when it is corroborated (count >= 2 — e.g. the padded-app fixture's 3 sibling rows at col 12 in a 20-col grid) or at/near the grid edge (within 2 cols — the widest right margin any green fixture requires: the real Claude-TUI capture hard-breaks its lone URL head at col 53 in 55). An uncorroborated boundary far from the edge falls back to the existing #996 token evidence (`_endsWithUrlToken` && `_headLooksLikeUrlTail`).

The tolerance rationale and the residual accepted risk (a lone short complete-URL row followed at the same margin by a token carrying `.`/`/`/`:` still glues, same class as #996's documented residual) are in the code comment.

## Red → green evidence
New `native/test/terminal/replay_url_short_row_join_1007_test.dart` (real TerminalController, 55 cols, exact issue repro):
- RED before fix: `Expected: 'https://example.com/track993' Actual: 'https://example.com/track9931'`
- GREEN after fix.

## Why not the simpler hard gate
Cycle 1 gated `_inferWrapCol` itself (count >= 2 or grid edge). That broke the #863 widget-tier replay: the SAME real 53-col capture remounted into a ~94-col grid is a TRUE single-sample join far from the grid edge. The token-evidence fallback keeps it green while still rejecting the #993 bare-`1` glue.

## Regression net (all foreground)
- flterm fork suite (`scripts/native-fork-test.sh`): 781 tests, all passed.
- `scripts/native-fast-gate.sh`: analyze clean + full test pass, including the #925/#928/#996 wrap fixtures, the +22..+28 real-capture regression, and the #863 paint/hit replays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa