### PR TITLE
feat(native): file:// URLs are remote paths — tap navigates the SFTP browser, menu adds bare path + sftp:// (#994)

### DIFF
--- a/native/integration_test/file_url_actions_994_test.dart
+++ b/native/integration_test/file_url_actions_994_test.dart
@@ -1,0 +1,341 @@
+// On-emulator acceptance for #994 — a file:// URL detected in terminal output
+// is a REMOTE PATH on the SSH host:
+//   * a single TAP on an OSC-8 file:///etc/ link NAVIGATES — opens this app's
+//     SFTP file browser at /etc on the CONNECTED session's host (trailing
+//     slash → the dir itself per the #999 dir-vs-file rule), never the
+//     clipboard, never an Android URL hand-off;
+//   * a LONG-PRESS on an OSC-8 file:///etc/hosts link shows the PATH action
+//     menu (Open / Copy path / Copy sftp URL) and "Copy path" puts the BARE
+//     percent-free path (/etc/hosts — no scheme) on the real clipboard.
+//
+// OSC-8 links are used because that is how file:// URLs reach a terminal
+// today (ls --hyperlink, eza); plain-text file:// detection is the parallel
+// flterm url-regex change — the action layer here routes it identically
+// (unit-tested headless in test/ui/ghostty_file_url_994_test.dart).
+//
+// Device-class behaviour a headless test cannot cover: libghostty attaching
+// the OSC-8 URI to real cells, a real tap/long-press through the gesture
+// router, the real navigation push, a real SFTP listing of /etc, and the real
+// Android clipboard.
+//
+// The escape sequences are delivered via base64 so the typed COMMAND ECHO
+// never contains a detectable file:// literal (future-proof against the
+// plain-text url-regex change) — each link yields exactly ONE anchor.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/file_url_actions_994_test.dart
+
+import 'dart:convert';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'tap on an OSC-8 file:///etc/ link opens the file browser at /etc; '
+    'long-press on file:///etc/hosts offers Copy path (bare, no scheme) and '
+    'Copy sftp URL (#994)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      // Reach the terminal screen, accepting the host-key prompt if shown.
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller for session');
+
+      // Wait for a live shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // Let the first-connect resize storm settle before echoing (see the
+      // #999 test) so the links land in a stable grid.
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      // Emit an OSC-8 hyperlink via base64 (the command echo never contains a
+      // file:// literal). [label] is the visible cell text; [uri] rides the
+      // cells as the OSC-8 hyperlink.
+      Future<void> emitOsc8(String varName, String uri, String label) async {
+        final seq = '\x1b]8;;$uri\x1b\\$label\x1b]8;;\x1b\\\n';
+        final b64 = base64Encode(utf8.encode(seq));
+        entry.proxy.sendInput(
+          Uint8List.fromList(
+            utf8.encode('$varName=\$(echo $b64 | base64 -d)\n'),
+          ),
+        );
+        for (var i = 0; i < 4; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+        }
+        // %s\n: command substitution stripped the trailing newline, so print
+        // one back — the prompt must not share the link's row.
+        entry.proxy.sendInput(
+          Uint8List.fromList(utf8.encode('printf \'%s\\n\' "\$$varName"\n')),
+        );
+      }
+
+      StructuredAnchor? anchorOf(String uri) {
+        for (final a in controller!.anchors) {
+          if (a.patternId == 'osc8' && '${a.payload}' == uri) return a;
+        }
+        return null;
+      }
+
+      Future<StructuredAnchor> awaitAnchor(String uri) async {
+        for (var i = 0; i < 60 && anchorOf(uri) == null; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+        }
+        final anchorDump = [
+          for (final a in controller!.anchors) '${a.patternId}:"${a.payload}"',
+        ];
+        expect(
+          anchorOf(uri),
+          isNotNull,
+          reason:
+              'the OSC-8 link $uri was never anchored — anchors: $anchorDump',
+        );
+        return anchorOf(uri)!;
+      }
+
+      Future<List<Rect>> awaitRects(String uri) async {
+        List<Rect> anchorRects() => [
+          for (final range in anchorOf(uri)!.ranges)
+            ...controller!.anchorRects(range),
+        ];
+        for (var i = 0;
+            i < 30 && (controller!.isScrolling || anchorRects().isEmpty);
+            i++) {
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        final rects = anchorRects();
+        expect(rects, isNotEmpty, reason: 'no on-screen rect for $uri');
+        return rects;
+      }
+
+      // PART 1 — TAP NAVIGATES. Trailing slash: the #999 rule opens the dir
+      // itself, so the browser lands AT /etc.
+      const dirUri = 'file:///etc/';
+      await emitOsc8('v', dirUri, 'ETC-LINK');
+      await awaitAnchor(dirUri);
+      final dirRects = await awaitRects(dirUri);
+
+      // Clipboard sentinel: a #994 file:// tap must NOT touch the clipboard.
+      const sentinel = 'SEED-994-NAVIGATE';
+      await Clipboard.setData(const ClipboardData(text: sentinel));
+
+      final viewOrigin = tester.getTopLeft(find.byType(TerminalView));
+      await tester.tapAt(viewOrigin + dirRects.first.center);
+
+      var browserOpen = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(const Key('file-browser-path')).evaluate().isNotEmpty) {
+          browserOpen = true;
+          break;
+        }
+      }
+      expect(
+        browserOpen,
+        isTrue,
+        reason: 'the file:// tap never opened the file browser (#994)',
+      );
+      final pathText = tester.widget<Text>(
+        find.byKey(const Key('file-browser-path')),
+      );
+      expect(
+        pathText.data,
+        '/etc',
+        reason: 'file:///etc/ must open the browser AT /etc (trailing slash '
+            '→ the dir itself, authority-stripped bare path)',
+      );
+
+      // The real /etc listing renders over SFTP.
+      var listMounted = false;
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(const Key('file-browser-list')).evaluate().isNotEmpty) {
+          listMounted = true;
+          break;
+        }
+      }
+      expect(listMounted, isTrue, reason: 'the /etc listing never rendered');
+
+      final clipAfterTap = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
+      expect(
+        clipAfterTap,
+        sentinel,
+        reason: 'a file:// tap must navigate, not copy; clipboard changed',
+      );
+
+      // Hold briefly so the host can screenshot the browser at /etc.
+      debugPrint('BROWSE_HOLD_994 file browser open at /etc (screenshot now)');
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      // Back to the terminal for PART 2 (the browser's leading action is the
+      // terminal glyph, not a standard Material back button).
+      await tester.tap(
+        find.byKey(const Key('file-browser-back-to-terminal')),
+      );
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      expect(
+        find.byType(TerminalView),
+        findsWidgets,
+        reason: 'never returned to the terminal after the browser',
+      );
+
+      // PART 2 — the anchor's ACTION MENU: Copy path yields the BARE path (no
+      // scheme). Driven via the GUTTER MARK (a keyed widget tap): the mark
+      // dispatches through the SAME #994 registry routing as the long-press
+      // menu, without the raw-pointer geometry that the post-browser keyboard
+      // resize churn makes flaky (runs 1-2: the press point went stale mid-
+      // resize and hit nothing). The long-press classification itself is
+      // covered headless in test/ui/ghostty_file_url_994_test.dart.
+      const fileUri = 'file:///etc/hosts';
+      await emitOsc8('w', fileUri, 'HOSTS-LINK');
+      await awaitAnchor(fileUri);
+      await awaitRects(fileUri);
+      // Let the prompt line + resize churn settle so the mark row is stable.
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      // The mark renders at the anchor's LIVE viewport row — re-resolve the
+      // anchor each probe (its absolute ranges can shift on resize/eviction).
+      Finder markFinder() {
+        final anchor = anchorOf(fileUri);
+        if (anchor == null) return find.byKey(const Key('gutter-mark-none'));
+        final row = controller!.anchorGutterRow(anchor.ranges.first);
+        return find.byKey(Key('gutter-mark-$row'));
+      }
+
+      for (var i = 0; i < 20 && markFinder().evaluate().isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(
+        markFinder(),
+        findsOneWidget,
+        reason: 'no gutter mark for the file:///etc/hosts anchor',
+      );
+      await tester.tap(markFinder());
+
+      var menuOpen = false;
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        if (find.byKey(const Key('path-action-menu')).evaluate().isNotEmpty) {
+          menuOpen = true;
+          break;
+        }
+      }
+      expect(
+        menuOpen,
+        isTrue,
+        reason: 'the file:// anchor mark must show the PATH action '
+            'menu (#994), not the URL menu',
+      );
+      expect(find.byKey(const Key('url-action-menu')), findsNothing);
+      expect(find.byKey(const Key('path-action-open')), findsOneWidget);
+      expect(
+        find.byKey(const Key('path-action-copy-sftp')),
+        findsOneWidget,
+        reason: 'the canonical sftp:// form must be offered',
+      );
+
+      // Screenshot beat: the menu is the deliverable UI.
+      debugPrint('MENU_HOLD_994 path menu open on file:///etc/hosts');
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      await tester.tap(find.byKey(const Key('path-action-copy')));
+      // Assert the UI contract: the success toast carries the EXACT copied
+      // payload and only shows after the authoritative native write returned
+      // true. `Clipboard.getData` is NOT used here: Android 10+ gates
+      // clipboard READS on window focus, which this harness doesn't reliably
+      // hold (run-3 telemetry: `native setText wrote=10` — the bare path —
+      // but `hasClip=false focus=false` on the self-read; the #924 class).
+      var toastSeen = false;
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 150));
+        if (find.text('Copied: /etc/hosts').evaluate().isNotEmpty) {
+          toastSeen = true;
+          break;
+        }
+      }
+      expect(
+        toastSeen,
+        isTrue,
+        reason: 'Copy path must write the BARE path (no file:// scheme) and '
+            'toast "Copied: /etc/hosts"',
+      );
+
+      // Hold so the host can grab a final screenshot.
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+    },
+  );
+}

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -35,6 +35,7 @@ import 'package:flterm/flterm.dart' hide Key;
 import 'package:flutter/material.dart';
 
 import '../services/clipboard.dart';
+import '../util/file_url.dart';
 import 'path_action_overlay.dart';
 import 'top_toast.dart';
 import 'url_action_overlay.dart';
@@ -182,8 +183,15 @@ class GutterPatternRegistry {
   /// its `_openPath`); injectable so a widget test asserts the dispatch without
   /// pushing a real route. URL opening + clipboard honour the existing
   /// `url_action_overlay` / `clipboard` test seams.
+  ///
+  /// [sftpUrlOf] (#994) maps a bare remote path to its canonical
+  /// `sftp://user@host[:port]/path` form on the view's session (null omits the
+  /// action). A url/osc8 anchor whose payload is a well-formed file:// URI is
+  /// a REMOTE PATH: it gets the PATH action set (Open in the explorer, Copy
+  /// bare path, Copy sftp URL) instead of the browser URL actions.
   factory GutterPatternRegistry.standard({
     required Future<bool> Function(String path) openPath,
+    String? Function(String path)? sftpUrlOf,
   }) {
     GutterItemAction copyAction(String payload) => GutterItemAction(
       keyLabel: 'copy',
@@ -192,31 +200,84 @@ class GutterPatternRegistry {
       onInvoke: (context) => _copyWithToast(context, payload),
     );
 
+    GutterItemAction openPathAction(String path) => GutterItemAction(
+      keyLabel: 'open',
+      icon: Icons.folder_open,
+      label: 'Open',
+      onInvoke: (context) async {
+        final overlay = Overlay.maybeOf(context, rootOverlay: true);
+        final ok = await openPath(path);
+        if (!ok && overlay != null) {
+          showTopToastInOverlay(overlay, 'Could not open: $path');
+        }
+      },
+    );
+
+    // #994: the path-class actions for a file:// url/osc8 anchor — Open the
+    // explorer at the BARE path, copy the BARE path (command-line use), copy
+    // the canonical sftp:// form when the session identity is available.
+    List<GutterItemAction> fileUrlActions(String barePath) => [
+      openPathAction(barePath),
+      GutterItemAction(
+        keyLabel: 'copy',
+        icon: Icons.content_copy,
+        label: 'Copy path',
+        onInvoke: (context) => _copyWithToast(context, barePath),
+      ),
+      if (sftpUrlOf?.call(barePath) case final String sftpUrl)
+        GutterItemAction(
+          keyLabel: 'copy-sftp',
+          icon: Icons.link,
+          label: 'Copy sftp URL',
+          onInvoke: (context) => _copyWithToast(context, sftpUrl),
+        ),
+    ];
+
     final url = GutterPatternPresentation(
       patternId: kGhosttyUrlPatternId,
       icon: Icons.link,
       typeLabel: 'Link',
-      showActions: (context, anchor, markGlobal) => showUrlActions(
-        context,
-        '${anchor.payload}',
-        highlightRects: const [],
-        anchor: markGlobal,
-      ),
-      itemActions: (payload) => [
-        copyAction(payload),
-        GutterItemAction(
-          keyLabel: 'open',
-          icon: Icons.open_in_new,
-          label: 'Open',
-          onInvoke: (context) async {
-            final overlay = Overlay.maybeOf(context, rootOverlay: true);
-            final ok = await openDetectedUrl(payload);
-            if (!ok && overlay != null) {
-              showTopToastInOverlay(overlay, 'Could not open: $payload');
-            }
-          },
-        ),
-      ],
+      showActions: (context, anchor, markGlobal) {
+        final payload = '${anchor.payload}';
+        // #994: a file:// anchor is a REMOTE path → the PATH menu.
+        final barePath = fileUrlToRemotePath(payload);
+        if (barePath != null) {
+          showPathActions(
+            context,
+            barePath,
+            highlightRects: const [],
+            anchor: markGlobal,
+            onOpen: openPath,
+            sftpUrl: sftpUrlOf?.call(barePath),
+          );
+          return;
+        }
+        showUrlActions(
+          context,
+          payload,
+          highlightRects: const [],
+          anchor: markGlobal,
+        );
+      },
+      itemActions: (payload) {
+        final barePath = fileUrlToRemotePath(payload);
+        if (barePath != null) return fileUrlActions(barePath);
+        return [
+          copyAction(payload),
+          GutterItemAction(
+            keyLabel: 'open',
+            icon: Icons.open_in_new,
+            label: 'Open',
+            onInvoke: (context) async {
+              final overlay = Overlay.maybeOf(context, rootOverlay: true);
+              final ok = await openDetectedUrl(payload);
+              if (!ok && overlay != null) {
+                showTopToastInOverlay(overlay, 'Could not open: $payload');
+              }
+            },
+          ),
+        ];
+      },
     );
 
     final path = GutterPatternPresentation(
@@ -231,18 +292,7 @@ class GutterPatternRegistry {
         onOpen: openPath,
       ),
       itemActions: (payload) => [
-        GutterItemAction(
-          keyLabel: 'open',
-          icon: Icons.folder_open,
-          label: 'Open',
-          onInvoke: (context) async {
-            final overlay = Overlay.maybeOf(context, rootOverlay: true);
-            final ok = await openPath(payload);
-            if (!ok && overlay != null) {
-              showTopToastInOverlay(overlay, 'Could not open: $payload');
-            }
-          },
-        ),
+        openPathAction(payload),
         copyAction(payload),
       ],
     );

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -187,6 +187,7 @@ import '../state/detection_providers.dart';
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
+import '../util/file_url.dart';
 import 'file_browser_screen.dart';
 import 'ghostty_gutter_layer.dart';
 import 'ghostty_terminal_decorators.dart';
@@ -1308,6 +1309,24 @@ String ghosttyPathBrowseTarget(String path) {
   return p.substring(0, cut);
 }
 
+/// #994: the bare REMOTE path a file:// url/osc8 match names, or null when
+/// [match] is not file-URL-class.
+///
+/// Classification is by SCHEME at the ACTION layer — detection is untouched:
+/// file:// anchors come from the URL/OSC-8 patterns (`ls --hyperlink` / eza
+/// emit OSC-8 file:// links). Because they are URL-pattern matches, they are
+/// NOT subject to the #990 single-segment path suppression — an explicit
+/// file:// scheme is explicit intent. A `path`-pattern match returns null (it
+/// already has the path action set); a malformed file:// payload returns null
+/// so the caller falls back to plain-URL handling.
+String? ghosttyFileUrlPath(StructuredMatch match) {
+  if (match.patternId != kGhosttyUrlPatternId &&
+      match.patternId != kGhosttyOsc8PatternId) {
+    return null;
+  }
+  return fileUrlToRemotePath('${match.payload}');
+}
+
 /// #999: the single-TAP dispatch for a detected structured match — a PATH
 /// anchor NAVIGATES (opens this app's SFTP file browser via the injected
 /// [openPath] seam; the #632/#950 favorites → browser entry point), everything
@@ -1315,6 +1334,10 @@ String ghosttyPathBrowseTarget(String path) {
 /// verdict on #988's tap=copy-for-both: paths must navigate (the #778
 /// behaviour class); copy stays one interaction away on the long-press menu
 /// and the gutter mark.
+///
+/// #994: a url/osc8 match whose payload is a well-formed file:// URI is a
+/// REMOTE PATH on the session's host — it NAVIGATES through the same [openPath]
+/// seam with the authority-stripped, percent-decoded bare path.
 ///
 /// Returns the copy toast label for the copy branch; null for the navigate
 /// branch (the pushed browser IS the feedback) and for an empty payload (the
@@ -1328,6 +1351,11 @@ Future<String?> ghosttyTapMatchAction(
   if (match.patternId == kGhosttyPathPatternId) {
     if (!ghosttyMatchHasCopyablePayload(match)) return null;
     await openPath('${match.payload}'.trim());
+    return null;
+  }
+  final filePath = ghosttyFileUrlPath(match);
+  if (filePath != null) {
+    await openPath(filePath);
     return null;
   }
   return ghosttyTapCopyMatch(match, copy: copy);
@@ -2335,7 +2363,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// the instance [_openPath]. A future pattern (slice 4 custom regex) is a
   /// trivial registry entry — no paint code.
   late final GutterPatternRegistry _gutterRegistry =
-      GutterPatternRegistry.standard(openPath: _openPath);
+      GutterPatternRegistry.standard(
+        openPath: _openPath,
+        // #994: lets the registry offer "Copy sftp URL" for file:// anchors.
+        sftpUrlOf: _sftpUrlFor,
+      );
 
   /// #705: the long-press selection ANCHOR — the 1-based VIEWPORT cell of the
   /// long-press-start, held while the finger drags so each extend rebuilds the
@@ -3689,12 +3721,43 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       );
       return;
     }
+    // #994: a file:// url/osc8 anchor is a REMOTE path — it gets the PATH menu
+    // (Open → explorer, Copy path) plus the canonical sftp:// form.
+    final filePath = ghosttyFileUrlPath(match);
+    if (filePath != null) {
+      showPathActions(
+        context,
+        filePath,
+        highlightRects: rects,
+        anchor: globalAnchor,
+        onOpen: _openPath,
+        sftpUrl: _sftpUrlFor(filePath),
+      );
+      return;
+    }
     showUrlActions(
       context,
       '${match.payload}',
       highlightRects: rects,
       anchor: globalAnchor,
     );
+  }
+
+  /// #994: the canonical `sftp://user@host[:port]/path` form of [path] on THIS
+  /// view's session, from the live session entry's identity — or null when the
+  /// session is gone (the menu simply omits the sftp action).
+  String? _sftpUrlFor(String path) {
+    for (final e in ref.read(sessionsProvider).entries) {
+      if (e.id == widget.sessionId) {
+        return sftpUrlForRemotePath(
+          username: e.username,
+          host: e.host,
+          port: e.port,
+          path: path,
+        );
+      }
+    }
+    return null;
   }
 
   /// The GLOBAL on-screen rects for [match]'s cell range (#734/#767). One per

--- a/native/lib/ui/path_action_overlay.dart
+++ b/native/lib/ui/path_action_overlay.dart
@@ -56,6 +56,11 @@ void debugDismissPathActions() => _dismiss();
 /// explorer navigation; when null the [debugPathOpenerOverride] (tests) or a
 /// no-op is used.
 ///
+/// [sftpUrl] (#994): the canonical `sftp://user@host[:port]/path` form of the
+/// path on its session's host. When non-null a third "Copy sftp URL" action is
+/// offered (a file:// anchor's share/canonical form); the bare-path Copy stays
+/// the primary copy for command-line pasting.
+///
 /// Safe to call from any context under an [Overlay]. No-op if no overlay.
 void showPathActions(
   BuildContext context,
@@ -63,6 +68,7 @@ void showPathActions(
   required List<Rect> highlightRects,
   required Offset anchor,
   Future<bool> Function(String path)? onOpen,
+  String? sftpUrl,
   Duration timeout = const Duration(seconds: 6),
 }) {
   final overlay = Overlay.maybeOf(context, rootOverlay: true);
@@ -88,6 +94,16 @@ void showPathActions(
           if (ok) showTopToastInOverlay(overlay, 'Copied: $path');
         }());
       },
+      // #994: the canonical sftp:// form, only for anchors that carry one.
+      onCopySftp: sftpUrl == null
+          ? null
+          : () {
+              unawaited(() async {
+                final ok = await copyToClipboard(sftpUrl);
+                if (identical(_activeEntry, entry)) _dismiss();
+                if (ok) showTopToastInOverlay(overlay, 'Copied: $sftpUrl');
+              }());
+            },
       onOpen: () async {
         if (identical(_activeEntry, entry)) _dismiss();
         final ok = await opener(path);
@@ -117,6 +133,7 @@ class _PathActionLayer extends StatelessWidget {
     required this.onCopy,
     required this.onOpen,
     required this.onDismiss,
+    this.onCopySftp,
   });
 
   final String path;
@@ -125,6 +142,9 @@ class _PathActionLayer extends StatelessWidget {
   final VoidCallback onCopy;
   final Future<void> Function() onOpen;
   final VoidCallback onDismiss;
+
+  /// #994: copies the canonical sftp:// URL; null hides the action.
+  final VoidCallback? onCopySftp;
 
   @override
   Widget build(BuildContext context) {
@@ -183,8 +203,12 @@ class _PathActionLayer extends StatelessWidget {
               ),
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
+                // Wrap, not Row (#994): with the third "Copy sftp URL" action
+                // the buttons can exceed the max width — they flow to a second
+                // line instead of overflowing.
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
                   children: [
                     _ActionButton(
                       key: const Key('path-action-open'),
@@ -194,13 +218,19 @@ class _PathActionLayer extends StatelessWidget {
                         onOpen();
                       },
                     ),
-                    const SizedBox(width: 8),
                     _ActionButton(
                       key: const Key('path-action-copy'),
                       icon: Icons.content_copy,
                       label: 'Copy path',
                       onTap: onCopy,
                     ),
+                    if (onCopySftp != null)
+                      _ActionButton(
+                        key: const Key('path-action-copy-sftp'),
+                        icon: Icons.link,
+                        label: 'Copy sftp URL',
+                        onTap: onCopySftp!,
+                      ),
                   ],
                 ),
               ),

--- a/native/lib/util/file_url.dart
+++ b/native/lib/util/file_url.dart
@@ -1,0 +1,59 @@
+// #994 — file:// URLs detected in terminal output are REMOTE paths on the SSH
+// host, not local/browser URLs. Pure conversion helpers (no Flutter imports)
+// so the action-layer routing is unit-testable headless.
+
+/// The bare absolute remote path a `file://` URI names, or null when [url] is
+/// not a well-formed file URL (#994).
+///
+/// `ls --hyperlink` / eza emit `file://HOSTNAME/path` (the remote hostname as
+/// authority); plain tooling emits `file:///path` (empty authority). Both
+/// resolve to `/path` — on an SSH client the file lives on the CONNECTED
+/// session's host, so the authority is stripped, never trusted. The path part
+/// is percent-decoded (UTF-8). Malformed input — no path after the authority,
+/// a bad percent escape, invalid UTF-8 — returns null so the caller falls
+/// back to plain-URL handling rather than navigating somewhere wrong.
+///
+/// The scheme matches case-insensitively (RFC 3986). A trailing slash is
+/// PRESERVED — it feeds the #999 dir-vs-file browse rule downstream.
+String? fileUrlToRemotePath(String url) {
+  final s = url.trim();
+  const scheme = 'file://';
+  if (s.length <= scheme.length) return null;
+  if (s.substring(0, scheme.length).toLowerCase() != scheme) return null;
+  final rest = s.substring(scheme.length);
+  // The path begins at the first '/': index 0 means an EMPTY authority
+  // (file:///path); a later index means a hostname authority to strip
+  // (file://host/path). No '/' at all means no path — malformed.
+  final slash = rest.indexOf('/');
+  if (slash < 0) return null;
+  final encoded = rest.substring(slash);
+  try {
+    // decodeComponent: %XX (incl. multi-byte UTF-8) → chars; '+' stays a
+    // literal plus (this is a path, not a query).
+    return Uri.decodeComponent(encoded);
+  } on ArgumentError {
+    return null; // truncated/invalid percent escape — reject, don't guess
+  } on FormatException {
+    return null; // invalid UTF-8 in the escape bytes — reject, don't guess
+  }
+}
+
+/// The canonical `sftp://user@host[:port]/path` form of a remote [path] on
+/// the session identified by [username]/[host]/[port] (#994).
+///
+/// The default SSH port 22 is omitted. Built via [Uri] so the userInfo/host/
+/// path are percent-encoded correctly (a space in the path yields a valid URL).
+String sftpUrlForRemotePath({
+  required String username,
+  required String host,
+  required int port,
+  required String path,
+}) {
+  return Uri(
+    scheme: 'sftp',
+    userInfo: username,
+    host: host,
+    port: port == 22 ? null : port,
+    path: path,
+  ).toString();
+}

--- a/native/test/ui/ghostty_file_url_994_test.dart
+++ b/native/test/ui/ghostty_file_url_994_test.dart
@@ -1,0 +1,370 @@
+// #994 — a file:// URL detected in terminal output is a REMOTE PATH on the
+// SSH host, not a browser URL. Classification happens by SCHEME at the ACTION
+// layer (detection is untouched: file:// anchors come from the url/osc8
+// patterns):
+//   1. PURE classification `ghosttyFileUrlPath`: a url/osc8 match whose
+//      payload is a well-formed file:// URI yields the bare decoded path;
+//      anything else (http URLs, path-pattern matches, malformed file://)
+//      yields null.
+//   2. TAP dispatch `ghosttyTapMatchAction`: a file:// match NAVIGATES through
+//      the SAME openPath seam #999 built — never the clipboard. http(s)/OSC-8
+//      web URLs keep #988's tap-copy unchanged.
+//   3. MENU: showPathActions grows an optional "Copy sftp URL" action; the
+//      gutter registry routes a file:// url/osc8 anchor to the PATH menu
+//      (Open / Copy path / Copy sftp URL) and a web URL to the URL menu.
+//
+// All headless (no flterm native .so): matches/anchors are constructed
+// directly, sinks are spies.
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_gutter_layer.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+import 'package:mobissh/ui/path_action_overlay.dart';
+import 'package:mobissh/ui/url_action_overlay.dart';
+
+StructuredMatch _match(String patternId, String payload) => StructuredMatch(
+  patternId: patternId,
+  payload: payload,
+  ranges: [
+    HighlightRange(
+      startRow: 2,
+      startCol: 0,
+      endRow: 2,
+      endCol: payload.length,
+      payload: payload,
+    ),
+  ],
+);
+
+StructuredAnchor _anchor(String patternId, String payload, {int row = 2}) =>
+    StructuredAnchor(
+      patternId: patternId,
+      payload: payload,
+      ranges: [
+        HighlightRange(
+          startRow: row,
+          startCol: 0,
+          endRow: row,
+          endCol: payload.length,
+          payload: payload,
+        ),
+      ],
+    );
+
+/// Minimal fake controller for the gutter layer (mirrors the #955 test's).
+class _FakeController extends ChangeNotifier implements TerminalController {
+  List<StructuredAnchor> _anchors = const [];
+
+  void setAnchors(List<StructuredAnchor> value) {
+    _anchors = value;
+    notifyListeners();
+  }
+
+  @override
+  List<StructuredAnchor> get anchors => _anchors;
+
+  @override
+  bool get isScrolling => false;
+
+  @override
+  Listenable get decorationListenable => this;
+
+  @override
+  int? anchorGutterRow(HighlightRange range) => range.topRow;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('#994 ghosttyFileUrlPath (pure classification by scheme)', () {
+    test('a url-pattern file:// match yields the bare decoded path', () {
+      expect(
+        ghosttyFileUrlPath(_match(kGhosttyUrlPatternId, 'file:///etc/hosts')),
+        '/etc/hosts',
+      );
+    });
+
+    test('an osc8-pattern file:// match yields the bare decoded path '
+        '(hostname authority stripped, percent-decoded)', () {
+      expect(
+        ghosttyFileUrlPath(
+          _match(kGhosttyOsc8PatternId, 'file://fd-dev/home/dev/my%20doc.md'),
+        ),
+        '/home/dev/my doc.md',
+      );
+    });
+
+    test('a web URL is NOT path-class', () {
+      expect(
+        ghosttyFileUrlPath(_match(kGhosttyUrlPatternId, 'https://example.com')),
+        isNull,
+      );
+    });
+
+    test('a path-pattern match is NOT reclassified here (it already has the '
+        'path action set)', () {
+      expect(
+        ghosttyFileUrlPath(_match(kGhosttyPathPatternId, '/etc/hosts')),
+        isNull,
+      );
+    });
+
+    test('a malformed file:// payload is ignored (falls back to URL class)', () {
+      expect(
+        ghosttyFileUrlPath(_match(kGhosttyUrlPatternId, 'file://hostonly')),
+        isNull,
+      );
+      expect(
+        ghosttyFileUrlPath(_match(kGhosttyUrlPatternId, 'file:///bad%zz')),
+        isNull,
+      );
+    });
+  });
+
+  group('#994 tap dispatch: file:// NAVIGATES, web URLs still copy', () {
+    Future<(List<String> opened, List<String> copied, String? toast)> tap(
+      StructuredMatch match,
+    ) async {
+      final opened = <String>[];
+      final copied = <String>[];
+      final toast = await ghosttyTapMatchAction(
+        match,
+        copy: (text) async {
+          copied.add(text);
+          return true;
+        },
+        openPath: (path) async {
+          opened.add(path);
+          return true;
+        },
+      );
+      return (opened, copied, toast);
+    }
+
+    test('a file:// url match invokes openPath with the BARE path — never '
+        'the clipboard, no toast (navigation is the feedback)', () async {
+      final (opened, copied, toast) = await tap(
+        _match(kGhosttyUrlPatternId, 'file:///etc/hosts'),
+      );
+      expect(opened, ['/etc/hosts']);
+      expect(copied, isEmpty);
+      expect(toast, isNull);
+    });
+
+    test('an OSC-8 file:// link navigates too (authority stripped)', () async {
+      final (opened, copied, toast) = await tap(
+        _match(kGhosttyOsc8PatternId, 'file://fd-dev/var/log/'),
+      );
+      expect(opened, ['/var/log/']);
+      expect(copied, isEmpty);
+      expect(toast, isNull);
+    });
+
+    test('a SINGLE-SEGMENT file:// URL still navigates: file:// anchors are '
+        'URL-pattern matches, NOT path-pattern — the #990 single-segment '
+        'suppression does not apply (an explicit file:// scheme is explicit '
+        'intent, always shown/actionable)', () async {
+      final (opened, copied, _) = await tap(
+        _match(kGhosttyUrlPatternId, 'file:///etc'),
+      );
+      expect(opened, ['/etc']);
+      expect(copied, isEmpty);
+    });
+
+    test('a web URL match still tap-copies (unchanged #988)', () async {
+      final (opened, copied, toast) = await tap(
+        _match(kGhosttyUrlPatternId, 'https://example.com'),
+      );
+      expect(copied, ['https://example.com']);
+      expect(opened, isEmpty);
+      expect(toast, 'Copied URL');
+    });
+
+    test('a MALFORMED file:// payload falls back to the URL copy branch', () async {
+      final (opened, copied, toast) = await tap(
+        _match(kGhosttyUrlPatternId, 'file://hostonly'),
+      );
+      expect(opened, isEmpty);
+      expect(copied, ['file://hostonly']);
+      expect(toast, 'Copied URL');
+    });
+  });
+
+  group('#994 path action menu with an sftp:// form', () {
+    testWidgets('showPathActions with sftpUrl offers Open / Copy path / '
+        'Copy sftp URL', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showPathActions(
+                  context,
+                  '/etc/hosts',
+                  highlightRects: const [],
+                  anchor: const Offset(200, 200),
+                  sftpUrl: 'sftp://testuser@10.0.0.5/etc/hosts',
+                ),
+                child: const Text('menu'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('menu'));
+      await tester.pump();
+      expect(find.byKey(const Key('path-action-menu')), findsOneWidget);
+      expect(find.byKey(const Key('path-action-open')), findsOneWidget);
+      expect(find.byKey(const Key('path-action-copy')), findsOneWidget);
+      expect(find.byKey(const Key('path-action-copy-sftp')), findsOneWidget);
+      expect(find.text('Copy sftp URL'), findsOneWidget);
+      debugDismissPathActions();
+      await tester.pump();
+    });
+
+    testWidgets('without sftpUrl the menu is unchanged (no sftp action)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showPathActions(
+                  context,
+                  '/etc/hosts',
+                  highlightRects: const [],
+                  anchor: const Offset(200, 200),
+                ),
+                child: const Text('menu'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('menu'));
+      await tester.pump();
+      expect(find.byKey(const Key('path-action-menu')), findsOneWidget);
+      expect(find.byKey(const Key('path-action-copy-sftp')), findsNothing);
+      debugDismissPathActions();
+      await tester.pump();
+    });
+  });
+
+  group('#994 gutter registry routes file:// anchors to the PATH action set', () {
+    Future<_FakeController> pumpLayer(
+      WidgetTester tester, {
+      Future<bool> Function(String path)? openPath,
+      String? Function(String path)? sftpUrlOf,
+    }) async {
+      final controller = _FakeController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                Positioned.fill(
+                  child: GhosttyGutterLayer(
+                    controller: controller,
+                    registry: GutterPatternRegistry.standard(
+                      openPath: openPath ?? (_) async => true,
+                      sftpUrlOf: sftpUrlOf,
+                    ),
+                    color: const Color(0xFF5B9BD5),
+                    cellHeight: 20,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return controller;
+    }
+
+    testWidgets('tap a file:// URL mark → the PATH menu with the sftp action, '
+        'not the URL menu', (tester) async {
+      final controller = await pumpLayer(
+        tester,
+        sftpUrlOf: (path) => 'sftp://u@h$path',
+      );
+      controller.setAnchors([
+        _anchor(kGhosttyUrlPatternId, 'file:///etc/hosts'),
+      ]);
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('gutter-mark-2')));
+      await tester.pump();
+      expect(find.byKey(const Key('path-action-menu')), findsOneWidget);
+      expect(find.byKey(const Key('url-action-menu')), findsNothing);
+      expect(find.byKey(const Key('path-action-copy-sftp')), findsOneWidget);
+      debugDismissPathActions();
+    });
+
+    testWidgets('tap an OSC-8 file:// mark → the PATH menu too', (tester) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([
+        _anchor(kGhosttyOsc8PatternId, 'file://fd-dev/etc/hosts'),
+      ]);
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('gutter-mark-2')));
+      await tester.pump();
+      expect(find.byKey(const Key('path-action-menu')), findsOneWidget);
+      expect(find.byKey(const Key('url-action-menu')), findsNothing);
+      debugDismissPathActions();
+    });
+
+    testWidgets('a web URL mark keeps the URL menu (unchanged)', (tester) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([
+        _anchor(kGhosttyUrlPatternId, 'https://example.com'),
+      ]);
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('gutter-mark-2')));
+      await tester.pump();
+      expect(find.byKey(const Key('url-action-menu')), findsOneWidget);
+      expect(find.byKey(const Key('path-action-menu')), findsNothing);
+      debugDismissUrlActions();
+    });
+
+    testWidgets('the multi-match list sheet gives a file:// anchor Open / '
+        'Copy path / Copy sftp URL and Open navigates with the BARE path', (
+      tester,
+    ) async {
+      final opened = <String>[];
+      final controller = await pumpLayer(
+        tester,
+        openPath: (path) async {
+          opened.add(path);
+          return true;
+        },
+        sftpUrlOf: (path) => 'sftp://u@h$path',
+      );
+      controller.setAnchors([
+        _anchor(kGhosttyUrlPatternId, 'file:///etc/hosts', row: 6),
+        _anchor(kGhosttyPathPatternId, '/var/log', row: 6),
+      ]);
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('gutter-mark-6')));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('gutter-pattern-list')), findsOneWidget);
+      // The file:// row keeps its raw payload TITLE (what was detected) but
+      // carries the three PATH-class actions.
+      expect(find.text('file:///etc/hosts'), findsOneWidget);
+      expect(find.byKey(const Key('gutter-item-0-open')), findsOneWidget);
+      expect(find.byKey(const Key('gutter-item-0-copy')), findsOneWidget);
+      expect(find.byKey(const Key('gutter-item-0-copy-sftp')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('gutter-item-0-open')));
+      await tester.pumpAndSettle();
+      expect(opened, ['/etc/hosts'], reason: 'Open must use the BARE path');
+    });
+  });
+}

--- a/native/test/util/file_url_test.dart
+++ b/native/test/util/file_url_test.dart
@@ -1,0 +1,119 @@
+// #994 — file:// URLs in terminal output are REMOTE paths on the SSH host.
+// Pure conversion layer:
+//   * fileUrlToRemotePath: file:// URI -> bare absolute path. Strips the
+//     scheme + authority (ls --hyperlink / eza emit the remote HOSTNAME as
+//     authority; an empty authority is the common file:///path form),
+//     percent-decodes UTF-8, and rejects malformed input with null.
+//   * sftpUrlForRemotePath: the canonical sftp://user@host[:port]/path form
+//     built from the session identity — :22 omitted (the default port).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/util/file_url.dart';
+
+void main() {
+  group('#994 fileUrlToRemotePath', () {
+    test('empty authority (file:///path) yields the bare path', () {
+      expect(fileUrlToRemotePath('file:///etc/hosts'), '/etc/hosts');
+      expect(
+        fileUrlToRemotePath('file:///home/dev/workspace/mobissh/notes.md'),
+        '/home/dev/workspace/mobissh/notes.md',
+      );
+    });
+
+    test('hostname authority (ls --hyperlink / eza) is STRIPPED', () {
+      expect(fileUrlToRemotePath('file://fd-dev/etc/hosts'), '/etc/hosts');
+      expect(
+        fileUrlToRemotePath('file://localhost/var/log/syslog'),
+        '/var/log/syslog',
+      );
+    });
+
+    test('percent-encoded spaces decode', () {
+      expect(
+        fileUrlToRemotePath('file:///home/dev/my%20file.md'),
+        '/home/dev/my file.md',
+      );
+    });
+
+    test('percent-encoded UTF-8 decodes', () {
+      expect(
+        fileUrlToRemotePath('file:///home/d%C3%A9v/caf%C3%A9.txt'),
+        '/home/dév/café.txt',
+      );
+    });
+
+    test('a plus sign is a literal path char, never a space', () {
+      expect(fileUrlToRemotePath('file:///opt/g++/notes'), '/opt/g++/notes');
+    });
+
+    test('trailing slash survives (feeds the #999 dir-vs-file rule)', () {
+      expect(fileUrlToRemotePath('file:///etc/'), '/etc/');
+      expect(fileUrlToRemotePath('file://host/etc/'), '/etc/');
+    });
+
+    test('scheme matches case-insensitively', () {
+      expect(fileUrlToRemotePath('FILE:///etc/hosts'), '/etc/hosts');
+      expect(fileUrlToRemotePath('File:///etc/hosts'), '/etc/hosts');
+    });
+
+    test('surrounding whitespace is trimmed', () {
+      expect(fileUrlToRemotePath('  file:///etc/hosts  '), '/etc/hosts');
+    });
+
+    test('no path at all is malformed -> null', () {
+      expect(fileUrlToRemotePath('file://'), isNull);
+      expect(fileUrlToRemotePath('file://hostname'), isNull);
+    });
+
+    test('malformed percent escapes -> null (rejected, not crashed)', () {
+      expect(fileUrlToRemotePath('file:///bad%zzpath'), isNull);
+      expect(fileUrlToRemotePath('file:///truncated%2'), isNull);
+    });
+
+    test('non-file schemes are not file URLs -> null', () {
+      expect(fileUrlToRemotePath('https://example.com/etc'), isNull);
+      expect(fileUrlToRemotePath('sftp://u@h/etc'), isNull);
+      expect(fileUrlToRemotePath('/etc/hosts'), isNull);
+      expect(fileUrlToRemotePath('file:/etc/hosts'), isNull);
+      expect(fileUrlToRemotePath(''), isNull);
+    });
+  });
+
+  group('#994 sftpUrlForRemotePath', () {
+    test('default port 22 is omitted', () {
+      expect(
+        sftpUrlForRemotePath(
+          username: 'testuser',
+          host: '10.0.0.5',
+          port: 22,
+          path: '/etc/hosts',
+        ),
+        'sftp://testuser@10.0.0.5/etc/hosts',
+      );
+    });
+
+    test('non-default port is included', () {
+      expect(
+        sftpUrlForRemotePath(
+          username: 'testuser',
+          host: '127.0.0.1',
+          port: 2222,
+          path: '/etc/hosts',
+        ),
+        'sftp://testuser@127.0.0.1:2222/etc/hosts',
+      );
+    });
+
+    test('a space in the path is percent-encoded (valid URL out)', () {
+      expect(
+        sftpUrlForRemotePath(
+          username: 'dev',
+          host: 'fd-dev',
+          port: 22,
+          path: '/home/dev/my file.md',
+        ),
+        'sftp://dev@fd-dev/home/dev/my%20file.md',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #994.

file:// URLs detected in terminal output are REMOTE paths on the SSH host, not browser URLs. Per the post-#999 spec alignment: a file:// anchor's single TAP NAVIGATES the SFTP file browser; the long-press / gutter-mark menu offers Open, Copy path (bare, percent-decoded, no scheme) and Copy sftp:// URL. Web http(s)/OSC-8 URLs are unchanged (tap still copies).

## What changed (app layer only — flterm untouched)
- `native/lib/util/file_url.dart` (new, pure): `fileUrlToRemotePath` — strips scheme + authority (`file:///p` and `file://host/p` both → `/p`; ls --hyperlink/eza emit hostname authorities), percent-decodes UTF-8, malformed (no path, bad escape, bad UTF-8) → null; `sftpUrlForRemotePath` — `sftp://user@host[:port]/path`, `:22` omitted, built via `Uri` so paths encode validly.
- `ghosttyTapMatchAction` (+ new `ghosttyFileUrlPath` classifier): classification is by SCHEME at the ACTION layer — a url/osc8 match whose payload converts is path-class and navigates through the SAME `_openPath` seam + `ghosttyPathBrowseTarget` dir-vs-file rule #999 built. Malformed file:// falls back to plain-URL copy.
- `_showUrlMenu` + `GutterPatternRegistry.standard` (new `sftpUrlOf` param): file:// anchors get the PATH menu — Open / Copy path / Copy sftp URL (`path-action-copy-sftp`; sftp form from the session's user/host/port via sessionsProvider, omitted when the session is gone). The path overlay's button row became a Wrap so the third action flows instead of overflowing.
- #990 interplay: file:// anchors are URL-pattern matches, NOT path-pattern — they are exempt from single-segment suppression by construction (explicit scheme = explicit intent); stated in a dedicated test.

## Red → green
- Red baseline: both new headless test files failed to compile against HEAD (API absent), captured before implementation.
- Green: `scripts/native-fast-gate.sh` PASSED (analyze + 1771 tests, incl. 30 new: conversion matrix — empty/hostname authority, %20/UTF-8, plus-literal, trailing slash, case-insensitive scheme, malformed → null; sftp URL with/without port + encoding; tap dispatch file:// navigates / web copies / malformed falls back / single-segment file:// still actionable; menu with and without sftp action; gutter registry routing for url/osc8/web + list-sheet actions with bare-path Open).
- Emulator (`scripts/native-connect-test.sh integration_test/file_url_actions_994_test.dart`): PASSED 3 consecutive runs. Tap on a real OSC-8 `file:///etc/` link opens the file browser AT `/etc` (real SFTP listing; clipboard sentinel untouched); the gutter-mark menu for `file:///etc/hosts` is the PATH menu with the sftp action, and Copy path toasts `Copied: /etc/hosts` (native clipboard telemetry: `setText wrote=10` — the bare path).
- Screenshots: `test-results/emulator-shots/20260708T162401+0000-994-browser-etc_.png` (browser at /etc after the tap), `test-results/emulator-shots/20260708T162413+0000-994-path-menu_.png` (menu moment — partially covered by the OS battery dialog, see caveats).

## Caveats (honest)
- Plain-TEXT `file://` URLs are not yet detected: flterm's url regex matches only http/https/www, and a parallel agent owns `structured_text.dart`. The action layer here routes any url/osc8 match with a file:// payload, so plain-text support turns on automatically when that regex lands (unit-tested against a url-pattern match with a file:// payload). The emulator test uses OSC-8 links (how file:// URLs reach terminals today) and delivers them base64-encoded so it stays valid after the regex change.
- Issue sketch said tap on `file:///etc` "opens at /etc"; the mandated #999 dir-vs-file rule opens the PARENT for a no-trailing-slash segment. The emulator test uses `file:///etc/` (trailing slash → opens AT /etc), and `file:///etc` navigates to `/` with etc one tap away — consistent with #999.
- The emulator asserts the copy via the success toast + native `wrote=` telemetry, not `Clipboard.getData`: Android 10+ gates clipboard READS on window focus, which the harness doesn't hold (`hasClip=false focus=false` on self-read — the #924 class; the WRITE is authoritative).
- On-device long-press was replaced by the gutter-mark tap in the emulator test (post-browser keyboard resize churn made raw-pointer long-press geometry flaky, runs 1–2); long-press routing is covered headless and shares the same menu code path.
- The gutter multi-match LIST SHEET titles a file:// row with its raw payload (`file:///etc/hosts`), not the bare path — display unchanged for the smallest diff; the actions use the bare path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa