### PR TITLE
feat(fork): pattern tiering — block anchors contain span anchors (#998 slice A)

### DIFF
--- a/native/third_party/flterm/lib/src/foundation/structured_text.dart
+++ b/native/third_party/flterm/lib/src/foundation/structured_text.dart
@@ -51,6 +51,21 @@ final class HighlightStyle {
           underline == other.underline;
 }
 
+/// The anchoring TIER of a [TextPattern] (#998 slice A).
+///
+/// Tiers let a BLOCK-level anchor (a whole command line) CONTAIN span-level
+/// anchors (the URLs/paths inside it) with NEITHER suppressing the other:
+///   * [span] — an inline token (URL, path, OSC-8 link). The default; every
+///     pre-tier pattern keeps today's behavior with zero registration changes.
+///   * [block] — a whole-logical-line construct (a command line, #998 B). A
+///     block match may OVERLAP span matches and OSC-8 hyperlinked cells; the
+///     span-tier OSC-8-wins de-dup does not apply to it.
+/// Hit-testing prefers the INNERMOST tier: [StructuredTextScanner] emits both,
+/// and `TerminalController.matchAt` resolves a cell covered by both tiers to
+/// the span match (inline taps never route to the containing block), with the
+/// block match still resolvable via `matchAt(tier: TextTier.block)`.
+enum TextTier { span, block }
+
 /// A detectable structured-text pattern (#767).
 ///
 /// A pattern names a class of structured text (URL, path, …) with a [regex]
@@ -93,6 +108,27 @@ final class TextPattern {
   /// match always WINS over an overlapping [regex] match (see [StructuredTextScanner.scan]).
   final bool isOsc8Source;
 
+  /// The anchoring tier (#998 slice A). Defaults to [TextTier.span] — every
+  /// existing pattern keeps today's behavior with no registration change. A
+  /// [TextTier.block] pattern (a whole command line, #998 B) may CONTAIN span
+  /// matches / OSC-8 links without the span-tier de-dup suppressing it, and
+  /// loses hit-test ties to any covering span match (innermost wins).
+  final TextTier tier;
+
+  /// When set, emitted ranges cover THIS capture group's span instead of the
+  /// full match (#998 slice A) — e.g. a command pattern `^\$ (.+)$` with
+  /// `rangeGroup: 1` anchors only the command, so the prompt stays un-anchored
+  /// ink. GEOMETRY only: [normalize] still receives the FULL raw match (a
+  /// command scorer needs the prompt) and produces the payload as today. An
+  /// EMPTY or absent group suppresses the match (nothing to anchor).
+  ///
+  /// Dart's [Match] exposes no per-group offsets, so the group's span is
+  /// located as the LAST occurrence of the group text within the match — exact
+  /// whenever the group extends to the END of the match (the prompt-strip
+  /// shape this exists for); groups repeated elsewhere in the match resolve to
+  /// their final occurrence.
+  final int? rangeGroup;
+
   const TextPattern({
     required this.id,
     required this.regex,
@@ -100,6 +136,8 @@ final class TextPattern {
     this.normalize,
     this.trailingTrim = '',
     this.isOsc8Source = false,
+    this.tier = TextTier.span,
+    this.rangeGroup,
   });
 
   /// The built-in URL pattern (#726/#764 moved in-fork, #767).
@@ -350,10 +388,16 @@ final class StructuredMatch {
   /// The opaque value the match represents (e.g. the normalized URL string).
   final Object payload;
 
+  /// The producing pattern's [TextPattern.tier] (#998 slice A), stamped by the
+  /// scanner so hit-testing can prefer the innermost (span) match at a cell
+  /// covered by both tiers. Defaults to [TextTier.span].
+  final TextTier tier;
+
   const StructuredMatch({
     required this.patternId,
     required this.ranges,
     required this.payload,
+    this.tier = TextTier.span,
   });
 
   /// Returns true if the cell at ABSOLUTE ([row], [col]) falls in any range.
@@ -548,11 +592,15 @@ class StructuredTextScanner {
             end--;
           }
           if (end <= start) continue;
-          // De-dup: OSC-8 wins. Drop a regex match that overlaps ANY OSC-8
-          // hyperlinked cell, so a hyperlinked URL (whose visible text is also
-          // URL-shaped) yields only the exact OSC-8 anchor. A plain-text URL
-          // (no OSC-8) is unaffected — the map is empty, so this never fires.
-          if (hyperlinkedCells.isNotEmpty &&
+          // De-dup: OSC-8 wins WITHIN the span tier (#998 A). Drop a SPAN-tier
+          // regex match that overlaps ANY OSC-8 hyperlinked cell, so a
+          // hyperlinked URL (whose visible text is also URL-shaped) yields only
+          // the exact OSC-8 anchor. A BLOCK-tier match (a command line, #998 B)
+          // legitimately CONTAINS links — cross-tier containment is allowed, so
+          // it is exempt. A plain-text URL (no OSC-8) is unaffected — the map
+          // is empty, so this never fires.
+          if (pattern.tier == TextTier.span &&
+              hyperlinkedCells.isNotEmpty &&
               _overlapsHyperlink(line.glyphs, start, end, hyperlinkedCells)) {
             continue;
           }
@@ -564,10 +612,29 @@ class StructuredTextScanner {
           final Object? payload =
               pattern.normalize != null ? pattern.normalize!(raw) : raw;
           if (payload == null) continue;
+          // #998 A: rangeGroup narrows the ANCHORED span to the capture group
+          // (the prompt stays un-anchored ink). Geometry only — [raw]/[payload]
+          // above keep the full match. Dart's Match has no per-group offsets,
+          // so locate the group text's LAST occurrence within the match (exact
+          // for the suffix-group shape this exists for). The group span is
+          // clamped to the trailing-trimmed end.
+          var rangeStart = start;
+          var rangeEnd = end;
+          final rangeGroup = pattern.rangeGroup;
+          if (rangeGroup != null) {
+            final group =
+                rangeGroup <= m.groupCount ? m.group(rangeGroup) : null;
+            if (group == null || group.isEmpty) continue;
+            final matched = text.substring(m.start, m.end);
+            rangeStart = m.start + matched.lastIndexOf(group);
+            rangeEnd = rangeStart + group.length;
+            if (rangeEnd > end) rangeEnd = end;
+            if (rangeEnd <= rangeStart) continue;
+          }
           final ranges = _rangesFor(
             line.glyphs,
-            start,
-            end,
+            rangeStart,
+            rangeEnd,
             pattern.style,
             payload,
           );
@@ -577,6 +644,7 @@ class StructuredTextScanner {
               patternId: pattern.id,
               ranges: ranges,
               payload: payload,
+              tier: pattern.tier,
             ),
           );
         }
@@ -664,6 +732,7 @@ class StructuredTextScanner {
             patternId: pattern.id,
             ranges: ranges,
             payload: uri,
+            tier: pattern.tier,
           ),
         );
       }

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
@@ -151,9 +151,17 @@ abstract class TerminalController extends ChangeNotifier
   /// drawn bubble, so a tap anywhere on a painted URL (incl. a `:port` URL or a
   /// wrapped multi-row URL) resolves to its match instead of landing a row off
   /// (#863). The returned [StructuredMatch.payload] recovers what the cells
-  /// represent (e.g. the URL behind a tap/long-press). When matches overlap, the
-  /// last detected one wins.
-  StructuredMatch? matchAt({required int row, required int col});
+  /// represent (e.g. the URL behind a tap/long-press).
+  ///
+  /// TIER preference (#998 slice A): when the cell is covered by both a
+  /// SPAN-tier match (url/path/OSC-8) and a BLOCK-tier match containing it (a
+  /// command line, #998 B), the SPAN match wins — an inline tap never routes
+  /// to the containing block. Pass [tier] to scope the query to one tier (e.g.
+  /// `tier: TextTier.block` resolves the containing command at a cell whose
+  /// default answer is the inner URL); null on a scoped query means no match
+  /// of that tier covers the cell. WITHIN a tier, overlapping matches keep
+  /// today's rule: the last detected one wins.
+  StructuredMatch? matchAt({required int row, required int col, TextTier? tier});
 
   /// The current detected structured-text ANCHORS (#767 Slice B).
   ///

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -343,7 +343,8 @@ class TerminalControllerImpl extends TerminalController
   }
 
   @override
-  StructuredMatch? matchAt({required int row, required int col}) {
+  StructuredMatch? matchAt(
+      {required int row, required int col, TextTier? tier}) {
     if (_detectionMatches.isEmpty) return null;
     // #863: UNIFY hit-test with paint. The widget-layer URL bubble PAINTS its
     // anchor rects via [anchorRects] -> [AnchorGeometry.rectsFor], which resolves
@@ -366,11 +367,24 @@ class TerminalControllerImpl extends TerminalController
       cols: _gridCols,
       rows: _gridRows,
     );
-    StructuredMatch? match;
+    // #998 A: resolve per TIER — a cell covered by both a span match and its
+    // containing block match answers with the SPAN (innermost) match, so an
+    // inline tap on a URL inside a command never routes to the command block.
+    // [tier] scopes the query (the block match stays resolvable). Within a
+    // tier the last detected containing match wins, as before.
+    StructuredMatch? span;
+    StructuredMatch? block;
     for (final m in _detectionMatches) {
-      if (m.contains(absRow, snappedCol)) match = m;
+      if (!m.contains(absRow, snappedCol)) continue;
+      if (m.tier == TextTier.block) {
+        block = m;
+      } else {
+        span = m;
+      }
     }
-    return match;
+    if (tier == TextTier.span) return span;
+    if (tier == TextTier.block) return block;
+    return span ?? block;
   }
 
   @override

--- a/native/third_party/flterm/test/foundation/structured_text_tier_test.dart
+++ b/native/third_party/flterm/test/foundation/structured_text_tier_test.dart
@@ -1,0 +1,284 @@
+// #998 slice A — pattern TIERING: block-tier (command-line) anchors coexist
+// with span-tier (url/path/OSC-8) anchors.
+//
+// Today's suppression rules, kept: the ONLY cross-pattern de-dup is OSC-8-wins
+// — a SPAN-tier regex match touching a hyperlinked cell is dropped so a
+// hyperlinked URL yields ONE exact anchor. New in this slice: that de-dup is
+// SCOPED to the span tier, so a BLOCK-tier match (a command line) may CONTAIN
+// an OSC-8 link (or any span match) without being suppressed — the foundation
+// for slice B's command detection. `rangeGroup` lets a block pattern anchor
+// only its capture group's span (the prompt stays un-anchored ink).
+//
+// No pattern registration changes anywhere: every existing pattern defaults to
+// the span tier and behaves byte-identically.
+
+import 'dart:ui';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A pure, headless [CellReader] built from per-row text + soft-wrap flags
+/// (same seam as structured_text_test.dart).
+class _FakeCellReader implements CellReader {
+  _FakeCellReader(
+    List<String> rowTexts, {
+    required this.cols,
+    List<bool>? wraps,
+    List<List<String?>>? hyperlinks,
+    // ignore: prefer_initializing_formals
+  }) : _hyperlinks = hyperlinks,
+       _rows = [
+         for (final t in rowTexts)
+           List<String>.generate(
+             cols,
+             (c) => c < t.length ? t[c] : ' ',
+           ),
+       ],
+       _wraps = wraps ?? List<bool>.filled(rowTexts.length, false);
+
+  final List<List<String>> _rows;
+  final List<bool> _wraps;
+  final List<List<String?>>? _hyperlinks;
+
+  @override
+  final int cols;
+
+  @override
+  final int baseAbsRow = 0;
+
+  @override
+  int get rows => _rows.length;
+
+  @override
+  String cellContent(int row, int col) {
+    final ch = _rows[row][col];
+    return ch == ' ' ? '' : ch;
+  }
+
+  @override
+  bool rowWrap(int row) => row >= 0 && row < _wraps.length && _wraps[row];
+
+  @override
+  String? hyperlinkAt(int row, int col) {
+    final links = _hyperlinks;
+    if (links == null) return null;
+    if (row < 0 || row >= links.length) return null;
+    final rowLinks = links[row];
+    if (col < 0 || col >= rowLinks.length) return null;
+    return rowLinks[col];
+  }
+}
+
+/// Per-cell hyperlink map: cells covering [linkText]'s columns on [row] carry
+/// [uri]; everything else is null.
+List<List<String?>> _linkAt({
+  required int rows,
+  required int cols,
+  required int row,
+  required int startCol,
+  required int length,
+  required String uri,
+}) {
+  return [
+    for (var r = 0; r < rows; r++)
+      List<String?>.generate(
+        cols,
+        (c) =>
+            r == row && c >= startCol && c < startCol + length ? uri : null,
+      ),
+  ];
+}
+
+void main() {
+  const scanner = StructuredTextScanner();
+  final urlPattern = TextPattern.url(
+    style: const HighlightStyle(background: Color(0x335B9BD5)),
+  );
+
+  /// A synthetic BLOCK-tier "command line" pattern: a `$ ` prompt followed by
+  /// the command. [rangeGroup] 1 anchors only the command (prompt excluded).
+  /// This is the shape slice B's TextPattern.command will take — slice A ships
+  /// NO real command detection, only the tiering machinery it needs.
+  final blockPattern = TextPattern(
+    id: 'cmd',
+    regex: RegExp(r'^\$ (.+)$'),
+    tier: TextTier.block,
+    rangeGroup: 1,
+  );
+
+  group('TextTier defaults — zero registration changes (#998 A)', () {
+    test('every built-in pattern is span-tier with no rangeGroup', () {
+      expect(TextPattern.url().tier, TextTier.span);
+      expect(TextPattern.url().rangeGroup, isNull);
+      expect(TextPattern.path().tier, TextTier.span);
+      expect(TextPattern.path().rangeGroup, isNull);
+      expect(TextPattern.osc8().tier, TextTier.span);
+      expect(TextPattern.osc8().rangeGroup, isNull);
+    });
+
+    test('a raw TextPattern defaults to span tier', () {
+      final p = TextPattern(id: 'x', regex: RegExp('x'));
+      expect(p.tier, TextTier.span);
+      expect(p.rangeGroup, isNull);
+    });
+
+    test('a StructuredMatch defaults to span tier', () {
+      const m = StructuredMatch(
+        patternId: 'x',
+        ranges: [],
+        payload: 'x',
+      );
+      expect(m.tier, TextTier.span);
+    });
+  });
+
+  group('cross-tier containment — both anchors exist (#998 A)', () {
+    test('a block match CONTAINING a span URL suppresses neither', () {
+      final reader = _FakeCellReader(
+        [r'$ curl https://example.com/x now'],
+        cols: 40,
+      );
+      final matches = scanner.scan(reader, [urlPattern, blockPattern]);
+
+      expect(matches, hasLength(2));
+      final url = matches.singleWhere((m) => m.patternId == 'url');
+      final cmd = matches.singleWhere((m) => m.patternId == 'cmd');
+      expect(url.tier, TextTier.span);
+      expect(url.payload, 'https://example.com/x');
+      expect(cmd.tier, TextTier.block);
+    });
+
+    test('a block match CONTAINING an OSC-8 link survives the de-dup', () {
+      // `$ curl https://e.com/x now` where the URL's visible cells carry an
+      // OSC-8 hyperlink. Today's de-dup drops ANY regex match touching a
+      // hyperlinked cell — correct for the span-tier url regex (one exact
+      // OSC-8 anchor, no partial bubble beside it) but it must NOT kill the
+      // containing block match.
+      const text = r'$ curl https://e.com/x now';
+      const uri = 'https://e.com/x';
+      final urlStart = text.indexOf('https');
+      final reader = _FakeCellReader(
+        [text],
+        cols: 40,
+        hyperlinks: _linkAt(
+          rows: 1,
+          cols: 40,
+          row: 0,
+          startCol: urlStart,
+          length: uri.length,
+          uri: uri,
+        ),
+      );
+      final matches = scanner.scan(
+        reader,
+        [TextPattern.osc8(), urlPattern, blockPattern],
+      );
+
+      // OSC-8 anchor present; span-tier url regex suppressed (today's rule);
+      // block-tier command match present (the #998 A change).
+      expect(matches.where((m) => m.patternId == 'osc8'), hasLength(1));
+      expect(matches.where((m) => m.patternId == 'url'), isEmpty,
+          reason: 'span-tier OSC-8-wins de-dup is unchanged');
+      expect(matches.where((m) => m.patternId == 'cmd'), hasLength(1),
+          reason: 'a block-tier match may CONTAIN an OSC-8 link');
+    });
+
+    test('span-tier OSC-8-wins de-dup still fires without a block pattern',
+        () {
+      const text = 'see https://e.com/x here';
+      const uri = 'https://e.com/x';
+      final reader = _FakeCellReader(
+        [text],
+        cols: 40,
+        hyperlinks: _linkAt(
+          rows: 1,
+          cols: 40,
+          row: 0,
+          startCol: text.indexOf('https'),
+          length: uri.length,
+          uri: uri,
+        ),
+      );
+      final matches =
+          scanner.scan(reader, [TextPattern.osc8(), urlPattern]);
+      expect(matches, hasLength(1));
+      expect(matches.single.patternId, 'osc8');
+    });
+  });
+
+  group('rangeGroup — the prompt stays un-anchored ink (#998 A)', () {
+    test('a block anchor with rangeGroup excludes the prompt prefix', () {
+      final reader = _FakeCellReader(
+        [r'$ echo hi'],
+        cols: 20,
+      );
+      final matches = scanner.scan(reader, [blockPattern]);
+
+      expect(matches, hasLength(1));
+      final cmd = matches.single;
+      expect(cmd.ranges, hasLength(1));
+      final r = cmd.ranges.single;
+      // Ranges cover 'echo hi' only — cols 2..9; the `$ ` prompt (cols 0-1)
+      // is NOT part of the anchor.
+      expect(r.startRow, 0);
+      expect(r.startCol, 2);
+      expect(r.endCol, 9);
+      expect(cmd.contains(0, 0), isFalse,
+          reason: 'the prompt cell must not hit-test into the block anchor');
+      expect(cmd.contains(0, 2), isTrue);
+    });
+
+    test('payload still comes from the FULL raw match via normalize', () {
+      // rangeGroup narrows GEOMETRY only; normalize sees the full raw match
+      // (slice B's scorer needs the prompt) and produces the payload.
+      final stripping = TextPattern(
+        id: 'cmd',
+        regex: RegExp(r'^\$ (.+)$'),
+        tier: TextTier.block,
+        rangeGroup: 1,
+        normalize: (raw) => raw.substring(2),
+      );
+      final reader = _FakeCellReader([r'$ echo hi'], cols: 20);
+      final matches = scanner.scan(reader, [stripping]);
+      expect(matches, hasLength(1));
+      expect(matches.single.payload, 'echo hi');
+    });
+
+    test('rangeGroup spans wrapped rows, still excluding the prompt', () {
+      // 20-col grid; the command soft-wraps (authoritative rowWrap flag).
+      // Row 0: '$ curl https://exam' (19 visible chars, wraps)
+      // Row 1: 'ple.com/xy now'
+      final reader = _FakeCellReader(
+        [r'$ curl https://exam', 'ple.com/xy now'],
+        cols: 20,
+        wraps: [true, false],
+      );
+      final matches = scanner.scan(reader, [urlPattern, blockPattern]);
+
+      final cmd = matches.singleWhere((m) => m.patternId == 'cmd');
+      expect(cmd.ranges, hasLength(2));
+      expect(cmd.ranges.first.startRow, 0);
+      expect(cmd.ranges.first.startCol, 2, reason: 'prompt excluded');
+      expect(cmd.ranges.first.endCol, 19);
+      expect(cmd.ranges.last.startRow, 1);
+      expect(cmd.ranges.last.startCol, 0);
+      expect(cmd.ranges.last.endCol, 'ple.com/xy now'.length);
+      // The inner URL anchor coexists across the same wrap.
+      final url = matches.singleWhere((m) => m.patternId == 'url');
+      expect(url.payload, 'https://example.com/xy');
+    });
+
+    test('an empty rangeGroup capture emits no anchor', () {
+      final emptyGroup = TextPattern(
+        id: 'cmd',
+        regex: RegExp(r'^\$ ?(.*)$'),
+        tier: TextTier.block,
+        rangeGroup: 1,
+      );
+      final reader = _FakeCellReader([r'$ '], cols: 10);
+      final matches = scanner.scan(reader, [emptyGroup]);
+      expect(matches, isEmpty,
+          reason: 'a block anchor needs a non-empty anchored span');
+    });
+  });
+}

--- a/native/third_party/flterm/test/widgets/terminal_controller_tier_test.dart
+++ b/native/third_party/flterm/test/widgets/terminal_controller_tier_test.dart
@@ -1,0 +1,95 @@
+// #998 slice A — matchAt tier preference: a tap on a cell covered by BOTH a
+// span-tier match (url/path) and a block-tier match (command line) resolves
+// the SPAN match — inline taps never route to the containing command block —
+// while the block match stays resolvable via `matchAt(tier: TextTier.block)`.
+//
+// Before this slice matchAt returned the LAST containing match (registration-
+// order accident), so a block pattern registered after the url pattern would
+// steal every inline tap.
+
+@Tags(['ffi'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/widgets/terminal_controller_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('matchAt tier preference (#998 slice A)', () {
+    late TerminalControllerImpl controller;
+
+    setUp(() {
+      controller = TerminalControllerImpl();
+      // url FIRST, block SECOND — under the old last-wins rule the block match
+      // would shadow the url at every covered cell.
+      controller.registerTextPattern(TextPattern.url());
+      controller.registerTextPattern(
+        TextPattern(
+          id: 'cmd',
+          regex: RegExp(r'^\$ (.+)$'),
+          tier: TextTier.block,
+          rangeGroup: 1,
+        ),
+      );
+    });
+    tearDown(() => controller.dispose());
+
+    /// Pump the terminal with [text] and flush the detection debounce.
+    Future<void> writeAndScan(String text) async {
+      controller.write(Uint8List.fromList(text.codeUnits));
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+    }
+
+    test('a cell covered by both tiers resolves the SPAN match', () async {
+      await writeAndScan('\$ curl https://foo.io now\r\n');
+
+      // '$ curl ' == 7 chars; the URL covers cols 7..20. Col 8 sits inside
+      // BOTH the url span and the command block.
+      final match = controller.matchAt(row: 0, col: 8);
+      expect(match, isNotNull);
+      expect(match!.patternId, 'url',
+          reason: 'inline taps never route to the containing command block');
+      expect(match.payload, 'https://foo.io');
+    });
+
+    test('the block match stays resolvable at the same cell', () async {
+      await writeAndScan('\$ curl https://foo.io now\r\n');
+
+      final block = controller.matchAt(row: 0, col: 8, tier: TextTier.block);
+      expect(block, isNotNull);
+      expect(block!.patternId, 'cmd');
+      expect(block.tier, TextTier.block);
+
+      final span = controller.matchAt(row: 0, col: 8, tier: TextTier.span);
+      expect(span, isNotNull);
+      expect(span!.patternId, 'url');
+    });
+
+    test('a block-only cell resolves the block match by default', () async {
+      await writeAndScan('\$ curl https://foo.io now\r\n');
+
+      // Col 3 ('u' of curl) is inside the command but outside the URL.
+      final match = controller.matchAt(row: 0, col: 3);
+      expect(match, isNotNull);
+      expect(match!.patternId, 'cmd');
+      // But scoped to span, there is nothing there.
+      expect(controller.matchAt(row: 0, col: 3, tier: TextTier.span), isNull);
+    });
+
+    test('the prompt cell is un-anchored ink (rangeGroup)', () async {
+      await writeAndScan('\$ curl https://foo.io now\r\n');
+
+      // Col 0 is the '$' prompt — excluded from the block anchor by
+      // rangeGroup, and no span covers it either.
+      expect(controller.matchAt(row: 0, col: 0), isNull);
+      expect(
+        controller.matchAt(row: 0, col: 0, tier: TextTier.block),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Slice A of #998 — pattern TIERING in the flterm fork, per the design comment on the issue (https://github.com/flavordrake/mobissh/issues/998#issuecomment — "Spike: wrapped command-line block anchors", section 2 "Nested anchors: tier field, scoped de-dup, span-wins hit-test" and section 5 slice A). Fork-only; NO app changes, NO new pattern registrations, NO command detection (that's slice B).

## What this adds

- `TextTier { span, block }`; `TextPattern.tier` defaults to `span` — every existing pattern (url/path/osc8) keeps today's behavior with zero registration changes (asserted by the new defaults tests + the untouched 795-test fork suite).
- **Scoped de-dup**: the OSC-8-wins suppression now applies only to SPAN-tier regex matches. A block-tier anchor may CONTAIN span anchors and OSC-8 links — both coexist; same-tier overlap keeps today's suppression exactly.
- **Hit-test span preference**: `matchAt` resolves a cell covered by both tiers to the SPAN (innermost) match — inline taps never route to the containing block. New optional `matchAt(tier:)` scopes the query so the block match stays resolvable at the same cell. Within a tier, last-detected still wins (today's rule).
- **`TextPattern.rangeGroup`**: emitted ranges cover the capture group's span instead of the full match — a command anchor's ranges exclude the leading prompt ("rangeGroup keeps the prompt out of the anchor"). Geometry only: `normalize` still receives the full raw match (slice B's scorer needs the prompt) and produces the payload as today. Note: Dart's `Match` exposes no per-group offsets, so the group span is located as its last occurrence within the match — exact for the suffix-group prompt-strip shape this exists for (documented on the field).
- `StructuredMatch.tier`, stamped by the scanner.

## What slices B–D build on this

- **B (fork)**: `TextPattern.command(lexicon: …)` registers as `tier: block, rangeGroup: <command group>`; its normalize does prompt-strip + scoring on the full raw. Real-trace fixtures red→green.
- **C (app)**: registers the command pattern + a `GutterPatternPresentation` (Icons.terminal, Copy command); tap routing needs no work — `matchAt` already routes inline taps to the inner URL and the gutter queries `tier: TextTier.block`.
- **D (app)**: "Not a command" exception entry once #995 lands.

## Tests

- `test/foundation/structured_text_tier_test.dart` — defaults (zero registration changes), block-contains-span coexistence, block-contains-OSC-8 survives the de-dup while the span url regex is still suppressed, rangeGroup prompt exclusion (single-row + wrapped rows + empty-group suppression), payload-from-full-raw via normalize.
- `test/widgets/terminal_controller_tier_test.dart` — matchAt span-wins tie-break, `tier:`-scoped block query, block-only cell default, prompt cell un-anchored.
- Red baseline confirmed (compile-level: new API), then green.
- Full fork suite: 795 passed. `scripts/native-fast-gate.sh`: analyze clean + 1772 tests passed.

Closes nothing on its own (#998 stays open for slices B–D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa