### PR TITLE
feat(native): "Not a URL"/"Not a file" detection exceptions (#995)

### DIFF
--- a/native/integration_test/detection_exception_995_test.dart
+++ b/native/integration_test/detection_exception_995_test.dart
@@ -1,0 +1,258 @@
+// On-emulator "Not a URL" detection-exception flow (#995).
+//
+// Validates the device-class behaviour end-to-end against test-sshd:
+//   1. a printed URL is detected → its right-edge gutter chip renders
+//   2. tapping the chip opens the URL action menu; tapping the LAST item
+//      ("Not a URL") persists a detection exception and the chip disappears
+//      IMMEDIATELY — while the scanner's anchor is untouched (the suppression
+//      is the app-layer visibility gate, composing with #990, not a scanner
+//      change)
+//   3. close + reconnect → the SAME text is detected by the scanner again but
+//      shows NO affordance (the exception persisted across sessions)
+//   4. removing the exception in Settings restores detection: a third session
+//      printing the same URL gets its chip back
+//
+// The viewport is `clear`ed before each echo so the ONLY detectable content on
+// screen is the printed URL (login MOTD noise scrolls away; the gutter marks
+// viewport rows only) — chip presence ⇔ the URL's affordance.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/detection_exception_995_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/detection_exceptions_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+const _url = 'https://example.com/mobissh/995/exception';
+
+Finder _gutterChips() => find.byWidgetPredicate(
+  (w) => w.key != null && w.key.toString().contains('gutter-mark-'),
+);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'Not a URL persists an exception, suppresses across reconnect, and '
+    'Settings remove restores detection (#995)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      Future<SessionEntry> connect() async {
+        await adhocPasswordConnect(
+          tester,
+          host: '127.0.0.1',
+          port: '2222',
+          user: 'testuser',
+          pass: 'testpass',
+        );
+        var connected = false;
+        for (var i = 0; i < 60; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+          final accept = find.text('Trust + connect');
+          if (accept.evaluate().isNotEmpty) {
+            await tester.tap(accept.first);
+            await tester.pump(const Duration(milliseconds: 300));
+          }
+          if (find
+              .byKey(const Key('session-menu-button'))
+              .evaluate()
+              .isNotEmpty) {
+            connected = true;
+            break;
+          }
+        }
+        expect(connected, isTrue, reason: 'never reached the terminal screen');
+        final entry = container.read(sessionsProvider).active;
+        expect(entry, isNotNull, reason: 'no active session after connect');
+        // Wait for the live shell prompt (bytes flowing).
+        final out = <int>[];
+        final sub = entry!.proxy.output.listen(out.addAll);
+        for (var i = 0; i < 40 && out.isEmpty; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+        }
+        await sub.cancel();
+        expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+        return entry;
+      }
+
+      TerminalController controllerFor(SessionEntry entry) {
+        TerminalController? c;
+        c = GhosttyTerminalView.debugControllers[entry.id];
+        expect(c, isNotNull, reason: 'no ghostty controller for session');
+        return c!;
+      }
+
+      /// Clear the viewport, print the URL, and wait for the scanner's anchor.
+      Future<void> printAndDetect(SessionEntry entry) async {
+        final controller = controllerFor(entry);
+        entry.proxy.sendInput(Uint8List.fromList(utf8.encode('clear\n')));
+        await tester.pump(const Duration(milliseconds: 800));
+        entry.proxy.sendInput(
+          Uint8List.fromList(utf8.encode('echo M995 $_url\n')),
+        );
+        bool anchored() => controller.anchors.any((a) => a.payload == _url);
+        for (var i = 0; i < 40 && !anchored(); i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+        }
+        expect(
+          anchored(),
+          isTrue,
+          reason: 'the printed URL was never detected (no anchor)',
+        );
+      }
+
+      Future<bool> chipsAppear() async {
+        for (var i = 0; i < 20; i++) {
+          await tester.pump(const Duration(milliseconds: 300));
+          if (_gutterChips().evaluate().isNotEmpty) return true;
+        }
+        return false;
+      }
+
+      Future<bool> chipsGone() async {
+        for (var i = 0; i < 20; i++) {
+          await tester.pump(const Duration(milliseconds: 300));
+          if (_gutterChips().evaluate().isEmpty) return true;
+        }
+        return false;
+      }
+
+      // 1) First session: detect → chip present.
+      final first = await connect();
+      await printAndDetect(first);
+      expect(
+        await chipsAppear(),
+        isTrue,
+        reason: 'no gutter chip for the detected URL',
+      );
+
+      // 2) Chip tap → URL action menu → LAST item "Not a URL".
+      await tester.pump(const Duration(milliseconds: 600)); // settle scroll
+      await tester.tap(_gutterChips().first);
+      var menuShown = false;
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+        if (find.byKey(const Key('url-action-menu')).evaluate().isNotEmpty) {
+          menuShown = true;
+          break;
+        }
+      }
+      expect(menuShown, isTrue, reason: 'chip tap never opened the URL menu');
+      expect(
+        find.byKey(const Key('url-action-not-url')),
+        findsOneWidget,
+        reason: 'the URL menu is missing the Not a URL item',
+      );
+      // Screenshot window: hold the open menu (stays under its 6s
+      // auto-dismiss) so the orchestrator can `scripts/emu-shot.sh` it.
+      debugPrint('SHOT995 menu-open hold');
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      await tester.tap(find.byKey(const Key('url-action-not-url')));
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // Persisted + immediately suppressed: record exists, chips vanish, and
+      // the SCANNER anchor is untouched (app-layer gate, not a scanner change).
+      final exceptions = container.read(detectionExceptionsProvider);
+      expect(exceptions, hasLength(1));
+      expect(exceptions.single.matchedText, _url);
+      expect(
+        await chipsGone(),
+        isTrue,
+        reason: 'gutter chip survived the Not a URL report',
+      );
+      expect(
+        controllerFor(first).anchors.any((a) => a.payload == _url),
+        isTrue,
+        reason:
+            'the scanner anchor disappeared — suppression must be the '
+            'app-layer visibility gate, not a scanner change',
+      );
+
+      // 3) Reconnect: the same text is re-detected but shows NO affordance.
+      container.read(sessionsProvider.notifier).close(first.id);
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        if (find.byKey(const Key('new-connection')).evaluate().isNotEmpty) {
+          break;
+        }
+      }
+      final second = await connect();
+      await printAndDetect(second);
+      // Give the gutter every chance to (wrongly) render, then assert absence.
+      await tester.pump(const Duration(seconds: 2));
+      expect(
+        _gutterChips(),
+        findsNothing,
+        reason: 'the persisted exception did not suppress after reconnect',
+      );
+
+      // 4) Remove in Settings → detection returns in a fresh session.
+      container.read(sessionsProvider.notifier).close(second.id);
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        if (find.byKey(const Key('home-nav-settings')).evaluate().isNotEmpty) {
+          break;
+        }
+      }
+      await tester.tap(find.byKey(const Key('home-nav-settings')));
+      await tester.pump(const Duration(milliseconds: 800));
+      final removeButton = find.byKey(
+        const ValueKey('detection-exception-remove-0'),
+      );
+      await tester.ensureVisible(removeButton);
+      await tester.pump(const Duration(milliseconds: 300));
+      // Screenshot window: hold the rendered exceptions list.
+      debugPrint('SHOT995 settings-list hold');
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      await tester.tap(removeButton);
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        if (container.read(detectionExceptionsProvider).isEmpty) break;
+      }
+      expect(
+        container.read(detectionExceptionsProvider),
+        isEmpty,
+        reason: 'Settings remove did not clear the exception',
+      );
+      await tester.tap(find.byKey(const Key('home-nav-profiles')));
+      await tester.pump(const Duration(milliseconds: 800));
+
+      final third = await connect();
+      await printAndDetect(third);
+      expect(
+        await chipsAppear(),
+        isTrue,
+        reason: 'detection did not return after removing the exception',
+      );
+    },
+  );
+}

--- a/native/lib/diagnostics/feedback_bundle.dart
+++ b/native/lib/diagnostics/feedback_bundle.dart
@@ -68,12 +68,17 @@ String scrubSecrets(String input) {
 /// secrets before it enters the bundle.
 ///
 /// Returns a pretty-printed JSON string. Never throws.
+/// Cap on how many recent detection-exception entries ride in the bundle
+/// (#995). The COUNT always reports the full corpus size.
+const int maxDetectionExceptionsInBundle = 20;
+
 String assembleFeedbackBundle({
   required CrashEnvironmentInfo info,
   required List<String> connectLog,
   List<String> gestureLog = const <String>[],
   List<String> lifecycleLog = const <String>[],
   List<String> controlModeTrace = const <String>[],
+  List<String> detectionExceptions = const <String>[],
   String? crashJson,
 }) {
   final scrubbedLog = connectLog.map(scrubSecrets).toList(growable: false);
@@ -94,6 +99,20 @@ String assembleFeedbackBundle({
   // it carries only ids/indices/commands, never terminal content. Empty when
   // control mode is OFF.
   final scrubbedControlModeTrace = controlModeTrace
+      .map(scrubSecrets)
+      .toList(growable: false);
+  // #995: the saved "Not a URL" / "Not a file" reports (oldest first, so the
+  // RECENT entries are the tail). Count carries the full corpus size; the
+  // entry list is capped so a large corpus can't bloat the bundle. These are
+  // the raw material for turning recurring false-positive CLASSES into
+  // upstream detector fixes. Scrubbed like every other free-text ring.
+  final recentExceptions = detectionExceptions.length >
+          maxDetectionExceptionsInBundle
+      ? detectionExceptions.sublist(
+          detectionExceptions.length - maxDetectionExceptionsInBundle,
+        )
+      : detectionExceptions;
+  final scrubbedExceptions = recentExceptions
       .map(scrubSecrets)
       .toList(growable: false);
 
@@ -122,6 +141,8 @@ String assembleFeedbackBundle({
     'gestureLog': scrubbedGestureLog,
     'lifecycleLog': scrubbedLifecycleLog,
     'controlModeTrace': scrubbedControlModeTrace,
+    'detectionExceptionCount': detectionExceptions.length,
+    'detectionExceptions': scrubbedExceptions,
     'lastCrash': lastCrash,
     // Null-aware element: the entry is omitted entirely when there is no raw
     // (non-JSON) crash blob to preserve.

--- a/native/lib/state/detection_exceptions_providers.dart
+++ b/native/lib/state/detection_exceptions_providers.dart
@@ -1,0 +1,98 @@
+// Detection exceptions provider (#995) — the session-facing side of the
+// "Not a URL" / "Not a file" reports.
+//
+// Holds the hydrated exception list and answers the HOT question — "is this
+// payload suppressed?" — with a per-family hash-set lookup, rebuilt only when
+// the list changes. The lookup runs inside the #990 visibility gate
+// (`_isPayloadVisible` in ghostty_terminal_view.dart), which is consulted on
+// every gutter/bubble regroup and every tap hit-test, so it must be O(1).
+//
+// State is the exception LIST (Settings renders it; the terminal view watches
+// it so an add/remove immediately regroups the affordance layers). Suppression
+// is GLOBAL (v1); records carry host for later per-profile scoping.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../storage/detection_exceptions_store.dart';
+
+class DetectionExceptionsNotifier
+    extends StateNotifier<List<DetectionException>> {
+  DetectionExceptionsNotifier({DetectionExceptionsStore? store})
+    : _store = store ?? DetectionExceptionsStore(),
+      super(const <DetectionException>[]) {
+    ready = _hydrate();
+  }
+
+  final DetectionExceptionsStore _store;
+
+  /// Completes when the persisted corpus has hydrated (tests await this; the
+  /// UI just watches state — the empty default is correct pre-hydrate).
+  late final Future<void> ready;
+
+  /// family → set of suppressed matched texts. Rebuilt on every state change
+  /// so [isSuppressed] stays a pure hash lookup.
+  Map<String, Set<String>> _index = const <String, Set<String>>{};
+
+  void _setState(List<DetectionException> entries) {
+    state = List<DetectionException>.unmodifiable(entries);
+    final index = <String, Set<String>>{};
+    for (final e in entries) {
+      (index[e.family] ??= <String>{}).add(e.matchedText);
+    }
+    _index = index;
+  }
+
+  Future<void> _hydrate() async {
+    try {
+      _setState(await _store.load());
+    } catch (_) {
+      // best-effort; keep the empty default if prefs are unavailable (tests).
+    }
+  }
+
+  /// True when [payload]'s exact text was reported as a false positive for
+  /// [patternId]'s family. O(1) hash-set lookup — safe on the per-anchor
+  /// visibility path.
+  bool isSuppressed(String patternId, String payload) =>
+      _index[detectionExceptionFamily(patternId)]?.contains(payload) ?? false;
+
+  /// Persist a new false-positive report and suppress it immediately.
+  /// [tsMs] defaults to now.
+  Future<void> report({
+    required String patternId,
+    required String matchedText,
+    String contextLine = '',
+    String host = '',
+    int? tsMs,
+  }) async {
+    final entries = await _store.add(
+      DetectionException(
+        matchedText: matchedText,
+        patternId: patternId,
+        contextLine: contextLine,
+        host: host,
+        tsMs: tsMs ?? DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+    _setState(entries);
+  }
+
+  /// Remove [exception] — detection of its text returns immediately.
+  Future<void> removeException(DetectionException exception) async {
+    final entries = await _store.remove(
+      patternId: exception.patternId,
+      matchedText: exception.matchedText,
+    );
+    _setState(entries);
+  }
+}
+
+/// Global detection-exceptions provider (#995). The terminal view watches the
+/// list (an add/remove regroups the affordance layers) and reads the notifier
+/// for the hot [DetectionExceptionsNotifier.isSuppressed] lookup; Settings
+/// renders + removes entries.
+final detectionExceptionsProvider =
+    StateNotifierProvider<
+      DetectionExceptionsNotifier,
+      List<DetectionException>
+    >((ref) => DetectionExceptionsNotifier());

--- a/native/lib/storage/detection_exceptions_store.dart
+++ b/native/lib/storage/detection_exceptions_store.dart
@@ -1,0 +1,211 @@
+// Detection exceptions — "Not a URL" / "Not a file" reports (#995).
+//
+// When the owner marks a detected anchor as a false positive, the EXACT matched
+// text is persisted here and suppresses future detection affordances of that
+// text (exact-match suppression is the safe v1; generalizing a report into a
+// pattern fix is an upstream detector change informed by this corpus — the
+// records ride in the feedback bundle for exactly that purpose).
+//
+// Storage follows the favorites_store.dart precedent: a single JSON blob in
+// shared_preferences under [detectionExceptionsPrefsKey], schema version INSIDE
+// the value (never a key bump), corrupt / unknown-version data falls back to an
+// empty list (validate → fallback, never crash).
+//
+// Scope is GLOBAL by default (a false-positive string is usually falsely
+// matched everywhere); each record carries [DetectionException.host] and
+// [DetectionException.scope] so per-profile scoping can come later without a
+// schema break.
+
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// shared_preferences key. `v1` in the NAME is the storage namespace only; the
+/// migratable schema version lives inside the value (see [_schemaVersion]).
+const String detectionExceptionsPrefsKey = 'mobissh.detection.exceptions.v1';
+
+/// Current in-value schema version. Bump + migrate in [DetectionExceptionsStore.load]
+/// on a shape change.
+const int _schemaVersion = 1;
+
+/// Maps a concrete pattern id to its suppression FAMILY. The `url` regex
+/// pattern and the `osc8` hyperlink source are ONE user-facing type (a link),
+/// so a report against either suppresses the text for both. Any other pattern
+/// (path, a future custom regex) is its own family.
+String detectionExceptionFamily(String patternId) =>
+    patternId == 'osc8' ? 'url' : patternId;
+
+/// One persisted false-positive report. Equality/dedupe is by
+/// (family([patternId]), [matchedText]) — the same text reported via `url` and
+/// `osc8` is one exception.
+class DetectionException {
+  const DetectionException({
+    required this.matchedText,
+    required this.patternId,
+    this.contextLine = '',
+    this.tsMs = 0,
+    this.host = '',
+    this.scope = 'global',
+  });
+
+  /// The EXACT matched text the detector produced (the anchor payload) — the
+  /// suppression key. For a file:// anchor this is the file:// URI as matched,
+  /// not the derived bare path.
+  final String matchedText;
+
+  /// The concrete pattern id that produced the match (`url`/`osc8`/`path`).
+  /// Diagnostic — suppression uses [family].
+  final String patternId;
+
+  /// A small snippet of the line the match appeared on (may be empty when the
+  /// line was not resolvable at report time). Corpus context for turning
+  /// recurring false-positive CLASSES into upstream regex fixes.
+  final String contextLine;
+
+  /// Report time, epoch milliseconds (0 = unknown).
+  final int tsMs;
+
+  /// Host the session was connected to when reported (diagnostic; scope is
+  /// global in v1).
+  final String host;
+
+  /// Suppression scope. v1 always writes `global`; carried in the record so a
+  /// later per-profile scoping needs no schema break.
+  final String scope;
+
+  /// The suppression family this record belongs to.
+  String get family => detectionExceptionFamily(patternId);
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'text': matchedText,
+    'pattern': patternId,
+    if (contextLine.isNotEmpty) 'line': contextLine,
+    if (tsMs > 0) 'ts': tsMs,
+    if (host.isNotEmpty) 'host': host,
+    'scope': scope,
+  };
+
+  /// Parse one stored record. Returns null for anything that isn't a Map with
+  /// usable `text` + `pattern` strings (a bad entry is dropped, not fatal).
+  static DetectionException? fromJson(Object? raw) {
+    if (raw is! Map) return null;
+    final text = raw['text'];
+    final pattern = raw['pattern'];
+    if (text is! String || text.trim().isEmpty) return null;
+    if (pattern is! String || pattern.isEmpty) return null;
+    final line = raw['line'];
+    final ts = raw['ts'];
+    final host = raw['host'];
+    final scope = raw['scope'];
+    return DetectionException(
+      matchedText: text,
+      patternId: pattern,
+      contextLine: line is String ? line : '',
+      tsMs: ts is int ? ts : 0,
+      host: host is String ? host : '',
+      scope: (scope is String && scope.isNotEmpty) ? scope : 'global',
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DetectionException &&
+          other.family == family &&
+          other.matchedText == matchedText);
+
+  @override
+  int get hashCode => Object.hash(family, matchedText);
+
+  @override
+  String toString() => 'DetectionException($patternId, $matchedText)';
+}
+
+/// Persistence layer for detection exceptions (#995). UI consumers go through
+/// `detectionExceptionsProvider` (state/detection_exceptions_providers.dart).
+/// Tests inject a [SharedPreferences] via [SharedPreferences.setMockInitialValues]
+/// and construct directly (mirrors [FavoritesStore]).
+class DetectionExceptionsStore {
+  DetectionExceptionsStore({SharedPreferences? prefs}) : _prefs = prefs;
+
+  // ignore_for_file: prefer_initializing_formals
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> _ensure() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// Read all stored exceptions, oldest first. Returns an empty list when
+  /// nothing is stored, the JSON is malformed, the shape is wrong, or the
+  /// schema version is unknown (corrupt-resilience per .claude/rules —
+  /// validate → fallback to empty, never crash).
+  Future<List<DetectionException>> load() async {
+    final prefs = await _ensure();
+    final raw = prefs.getString(detectionExceptionsPrefsKey);
+    if (raw == null || raw.isEmpty) return <DetectionException>[];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return <DetectionException>[];
+      final version = decoded['v'];
+      // Unknown / future version: don't risk misreading a shape we don't know.
+      if (version is! int || version != _schemaVersion) {
+        return <DetectionException>[];
+      }
+      final entries = decoded['entries'];
+      if (entries is! List) return <DetectionException>[];
+      final out = <DetectionException>[];
+      final seen = <DetectionException>{};
+      for (final entry in entries) {
+        final e = DetectionException.fromJson(entry);
+        if (e == null) continue;
+        if (seen.add(e)) out.add(e);
+      }
+      return out;
+    } on FormatException {
+      return <DetectionException>[];
+    }
+  }
+
+  Future<void> _saveAll(List<DetectionException> entries) async {
+    final prefs = await _ensure();
+    final encoded = jsonEncode(<String, dynamic>{
+      'v': _schemaVersion,
+      'entries': entries.map((e) => e.toJson()).toList(),
+    });
+    await prefs.setString(detectionExceptionsPrefsKey, encoded);
+  }
+
+  /// Add [exception] (no-op when the same family+text is already stored, or
+  /// when the matched text is blank). Returns the updated list.
+  Future<List<DetectionException>> add(DetectionException exception) async {
+    if (exception.matchedText.trim().isEmpty) return load();
+    final entries = await load();
+    if (entries.contains(exception)) return entries;
+    entries.add(exception);
+    await _saveAll(entries);
+    return entries;
+  }
+
+  /// Remove the exception for ([patternId]'s family, [matchedText]).
+  /// Returns the updated list.
+  Future<List<DetectionException>> remove({
+    required String patternId,
+    required String matchedText,
+  }) async {
+    final target = DetectionException(
+      matchedText: matchedText,
+      patternId: patternId,
+    );
+    final entries = await load();
+    final before = entries.length;
+    entries.removeWhere((e) => e == target);
+    if (entries.length != before) await _saveAll(entries);
+    return entries;
+  }
+
+  /// Clear all exceptions.
+  Future<void> clear() async {
+    final prefs = await _ensure();
+    await prefs.remove(detectionExceptionsPrefsKey);
+  }
+}

--- a/native/lib/ui/diagnostics_section.dart
+++ b/native/lib/ui/diagnostics_section.dart
@@ -13,6 +13,7 @@ import '../diagnostics/connect_trace.dart';
 import '../diagnostics/crash_reporter.dart';
 import '../diagnostics/feedback_bundle.dart';
 import '../diagnostics/gesture_trace.dart';
+import '../storage/detection_exceptions_store.dart';
 import 'connection_audit.dart';
 import 'settings_subheader.dart';
 import 'top_toast.dart';
@@ -85,12 +86,29 @@ class _DiagnosticsSectionState extends State<DiagnosticsSection> {
     try {
       final info = await CrashReporter.environmentSnapshot();
       final crashJson = await CrashReporter.latestCrashContent();
+      // #995: the saved "Not a URL"/"Not a file" reports ride along (count +
+      // recent) so recurring false-positive classes can become detector fixes.
+      // Best-effort: a storage hiccup must not block the share path.
+      List<String> exceptionLines = const <String>[];
+      try {
+        final exceptions = await DetectionExceptionsStore().load();
+        exceptionLines = [
+          for (final e in exceptions)
+            '${e.matchedText} [${e.patternId}]'
+                '${e.host.isNotEmpty ? ' host=${e.host}' : ''}'
+                '${e.tsMs > 0 ? ' ts=${DateTime.fromMillisecondsSinceEpoch(e.tsMs, isUtc: true).toIso8601String()}' : ''}'
+                '${e.contextLine.isNotEmpty ? ' line=${e.contextLine}' : ''}',
+        ];
+      } catch (_) {
+        // Bundle ships without the corpus rather than not at all.
+      }
       final bundle = assembleFeedbackBundle(
         info: info,
         connectLog: connectLogSnapshot(),
         gestureLog: gestureLogSnapshot(),
         lifecycleLog: lifecycleLogSnapshot(),
         controlModeTrace: controlModeLogSnapshot(),
+        detectionExceptions: exceptionLines,
         crashJson: crashJson,
       );
 

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -189,9 +189,17 @@ class GutterPatternRegistry {
   /// action). A url/osc8 anchor whose payload is a well-formed file:// URI is
   /// a REMOTE PATH: it gets the PATH action set (Open in the explorer, Copy
   /// bare path, Copy sftp URL) instead of the browser URL actions.
+  ///
+  /// [onReportException] (#995): persists a "Not a URL" / "Not a file" false-
+  /// positive report for (patternId, payload). When non-null every action set
+  /// gains a LAST 'not' item, and the single-match action overlays offer the
+  /// same. The payload handed back is ALWAYS the ORIGINAL matched text (a
+  /// file:// anchor reports its file:// URI, not the derived bare path) —
+  /// suppression matches the anchor payload exactly.
   factory GutterPatternRegistry.standard({
     required Future<bool> Function(String path) openPath,
     String? Function(String path)? sftpUrlOf,
+    void Function(String patternId, String payload)? onReportException,
   }) {
     GutterItemAction copyAction(String payload) => GutterItemAction(
       keyLabel: 'copy',
@@ -212,6 +220,27 @@ class GutterPatternRegistry {
         }
       },
     );
+
+    // #995: the LAST 'not' list action — reports (patternId, ORIGINAL payload)
+    // as a false positive. Null callback → no item (purely additive).
+    GutterItemAction? notAction(
+      String patternId,
+      String payload,
+      String label,
+    ) {
+      final report = onReportException;
+      if (report == null) return null;
+      return GutterItemAction(
+        keyLabel: 'not',
+        // A file:// URL anchor reads as "Not a file" with the folder glyph
+        // even though its patternId is url/osc8.
+        icon: label == 'Not a file'
+            ? Icons.folder_off_outlined
+            : Icons.link_off,
+        label: label,
+        onInvoke: (context) async => report(patternId, payload),
+      );
+    }
 
     // #994: the path-class actions for a file:// url/osc8 anchor — Open the
     // explorer at the BARE path, copy the BARE path (command-line use), copy
@@ -239,6 +268,11 @@ class GutterPatternRegistry {
       typeLabel: 'Link',
       showActions: (context, anchor, markGlobal) {
         final payload = '${anchor.payload}';
+        // #995: report with the anchor's OWN patternId (url vs osc8) and its
+        // ORIGINAL payload text, whatever menu shape it gets below.
+        final markNot = onReportException == null
+            ? null
+            : () => onReportException(anchor.patternId, payload);
         // #994: a file:// anchor is a REMOTE path → the PATH menu.
         final barePath = fileUrlToRemotePath(payload);
         if (barePath != null) {
@@ -249,6 +283,7 @@ class GutterPatternRegistry {
             anchor: markGlobal,
             onOpen: openPath,
             sftpUrl: sftpUrlOf?.call(barePath),
+            onMarkNotDetection: markNot,
           );
           return;
         }
@@ -257,11 +292,21 @@ class GutterPatternRegistry {
           payload,
           highlightRects: const [],
           anchor: markGlobal,
+          onMarkNotDetection: markNot,
         );
       },
       itemActions: (payload) {
         final barePath = fileUrlToRemotePath(payload);
-        if (barePath != null) return fileUrlActions(barePath);
+        // #995: the 'not' action reports the ORIGINAL payload (the file://
+        // URI for a file:// anchor) — suppression keys on the matched text.
+        final not = notAction(
+          kGhosttyUrlPatternId,
+          payload,
+          barePath != null ? 'Not a file' : 'Not a URL',
+        );
+        if (barePath != null) {
+          return [...fileUrlActions(barePath), ?not];
+        }
         return [
           copyAction(payload),
           GutterItemAction(
@@ -276,6 +321,7 @@ class GutterPatternRegistry {
               }
             },
           ),
+          ?not,
         ];
       },
     );
@@ -290,10 +336,14 @@ class GutterPatternRegistry {
         highlightRects: const [],
         anchor: markGlobal,
         onOpen: openPath,
+        onMarkNotDetection: onReportException == null
+            ? null
+            : () => onReportException(anchor.patternId, '${anchor.payload}'),
       ),
       itemActions: (payload) => [
         openPathAction(payload),
         copyAction(payload),
+        ?notAction(kGhosttyPathPatternId, payload, 'Not a file'),
       ],
     );
 

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -183,6 +183,7 @@ import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../terminal/tmux_control_mode_flag.dart';
 import '../state/ctrl_modifier_provider.dart';
+import '../state/detection_exceptions_providers.dart';
 import '../state/detection_providers.dart';
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
@@ -2367,6 +2368,8 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         openPath: _openPath,
         // #994: lets the registry offer "Copy sftp URL" for file:// anchors.
         sftpUrlOf: _sftpUrlFor,
+        // #995: "Not a URL" / "Not a file" — persist a detection exception.
+        onReportException: _reportDetectionException,
       );
 
   /// #705: the long-press selection ANCHOR — the 1-based VIEWPORT cell of the
@@ -2759,6 +2762,14 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// exists on this host. `pending` and `missing` are both suppressed.
   /// Multi-segment paths (and every non-path pattern) are always visible.
   bool _isPayloadVisible(String patternId, String payload) {
+    // #995: a user-reported false positive ("Not a URL" / "Not a file")
+    // suppresses this exact matched text — checked FIRST so it composes with
+    // (never forks) the #990 verification gate below. O(1) hash-set lookup.
+    if (ref
+        .read(detectionExceptionsProvider.notifier)
+        .isSuppressed(patternId, payload)) {
+      return false;
+    }
     if (patternId != kGhosttyPathPatternId) return true;
     if (!ghosttyPathRequiresVerification(payload)) return true;
     return _pathVerifier?.status(payload) == PathVerification.verified;
@@ -3711,6 +3722,10 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // #778: a `path` long-press shows the PATH menu (Open → explorer, Copy path)
     // — the file-path analogue of the URL menu. A url/osc8 match keeps the URL
     // Copy/Open menu. The router suppresses selection for both.
+    // #995: every menu shape offers a LAST "Not a URL"/"Not a file" item that
+    // persists a detection exception for the ORIGINAL matched payload text.
+    void markNot() =>
+        _reportDetectionException(match.patternId, '${match.payload}');
     if (match.patternId == _kPathPatternId) {
       showPathActions(
         context,
@@ -3718,6 +3733,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         highlightRects: rects,
         anchor: globalAnchor,
         onOpen: _openPath,
+        onMarkNotDetection: markNot,
       );
       return;
     }
@@ -3732,6 +3748,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         anchor: globalAnchor,
         onOpen: _openPath,
         sftpUrl: _sftpUrlFor(filePath),
+        onMarkNotDetection: markNot,
       );
       return;
     }
@@ -3740,6 +3757,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       '${match.payload}',
       highlightRects: rects,
       anchor: globalAnchor,
+      onMarkNotDetection: markNot,
     );
   }
 
@@ -3758,6 +3776,61 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       }
     }
     return null;
+  }
+
+  /// #995: this view's session host (for the exception record) — from the live
+  /// session entry, falling back to the id's host segment when the entry is
+  /// gone.
+  String _sessionHost() {
+    for (final e in ref.read(sessionsProvider).entries) {
+      if (e.id == widget.sessionId) return e.host;
+    }
+    return widget.sessionId.split(':').first;
+  }
+
+  /// #995: persist a "Not a URL" / "Not a file" report for ([patternId],
+  /// [payload]) and suppress its affordances immediately (the provider watch in
+  /// [build] regroups the bubble + gutter layers on the state change).
+  ///
+  /// The LIVE anchor matching [payload] (when still on screen) supplies the
+  /// authoritative patternId (a shared url/osc8 menu passes the family
+  /// representative) and the context line via `textForRows` — defensively: a
+  /// scrolled-away anchor or an FFI hiccup just records an empty snippet.
+  void _reportDetectionException(String patternId, String payload) {
+    final controller = _controller;
+    var concretePatternId = patternId;
+    var contextLine = '';
+    if (controller != null) {
+      try {
+        for (final anchor in controller.anchors) {
+          if ('${anchor.payload}' != payload) continue;
+          concretePatternId = anchor.patternId;
+          if (anchor.ranges.isNotEmpty) {
+            final top = anchor.ranges.first.topRow;
+            contextLine = controller.textForRows(top, top);
+          }
+          break;
+        }
+      } catch (_) {
+        // Context is best-effort — the record is still useful without it.
+      }
+    }
+    if (contextLine.length > 200) {
+      contextLine = contextLine.substring(0, 200);
+    }
+    unawaited(
+      ref
+          .read(detectionExceptionsProvider.notifier)
+          .report(
+            patternId: concretePatternId,
+            matchedText: payload,
+            contextLine: contextLine,
+            host: _sessionHost(),
+          ),
+    );
+    if (mounted) {
+      showTopToast(context, "Won't detect again — undo in Settings");
+    }
   }
 
   /// The GLOBAL on-screen rects for [match]'s cell range (#734/#767). One per
@@ -3941,6 +4014,12 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         if (mounted) _forceTerminalRepaint();
       });
     });
+    // #995: watch the detection-exceptions list so a "Not a URL"/"Not a file"
+    // report (or a Settings remove) rebuilds this view — the bubble + gutter
+    // layers regroup through the [_isPayloadVisible] gate and the affordances
+    // disappear/return immediately. The hot per-anchor lookup itself reads the
+    // notifier's hash-set index, not this state.
+    ref.watch(detectionExceptionsProvider);
     final controller = _controller;
     if (controller == null) {
       return Container(

--- a/native/lib/ui/path_action_overlay.dart
+++ b/native/lib/ui/path_action_overlay.dart
@@ -61,6 +61,10 @@ void debugDismissPathActions() => _dismiss();
 /// offered (a file:// anchor's share/canonical form); the bare-path Copy stays
 /// the primary copy for command-line pasting.
 ///
+/// [onMarkNotDetection] (#995): when non-null a LAST "Not a file" item is
+/// offered (destructive-adjacent placement) — tapping dismisses the menu and
+/// fires the callback (the caller persists the detection exception).
+///
 /// Safe to call from any context under an [Overlay]. No-op if no overlay.
 void showPathActions(
   BuildContext context,
@@ -69,6 +73,7 @@ void showPathActions(
   required Offset anchor,
   Future<bool> Function(String path)? onOpen,
   String? sftpUrl,
+  VoidCallback? onMarkNotDetection,
   Duration timeout = const Duration(seconds: 6),
 }) {
   final overlay = Overlay.maybeOf(context, rootOverlay: true);
@@ -114,6 +119,14 @@ void showPathActions(
       onDismiss: () {
         if (identical(_activeEntry, entry)) _dismiss();
       },
+      // #995: dismiss first, then report — the exception write regroups the
+      // affordance layers, so the menu must not outlive its anchor.
+      onMarkNotDetection: onMarkNotDetection == null
+          ? null
+          : () {
+              if (identical(_activeEntry, entry)) _dismiss();
+              onMarkNotDetection();
+            },
     ),
   );
   _activeEntry = entry;
@@ -134,6 +147,7 @@ class _PathActionLayer extends StatelessWidget {
     required this.onOpen,
     required this.onDismiss,
     this.onCopySftp,
+    this.onMarkNotDetection,
   });
 
   final String path;
@@ -145,6 +159,9 @@ class _PathActionLayer extends StatelessWidget {
 
   /// #994: copies the canonical sftp:// URL; null hides the action.
   final VoidCallback? onCopySftp;
+
+  /// #995: persists a "Not a file" detection exception; null hides the item.
+  final VoidCallback? onMarkNotDetection;
 
   @override
   Widget build(BuildContext context) {
@@ -230,6 +247,14 @@ class _PathActionLayer extends StatelessWidget {
                         icon: Icons.link,
                         label: 'Copy sftp URL',
                         onTap: onCopySftp!,
+                      ),
+                    // #995: LAST (destructive-adjacent) — report false positive.
+                    if (onMarkNotDetection != null)
+                      _ActionButton(
+                        key: const Key('path-action-not-file'),
+                        icon: Icons.folder_off_outlined,
+                        label: 'Not a file',
+                        onTap: onMarkNotDetection!,
                       ),
                   ],
                 ),

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -17,12 +17,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/battery_optimization.dart';
 import '../services/clipboard.dart';
+import '../state/detection_exceptions_providers.dart';
 import '../state/detection_providers.dart';
 import '../state/keepalive_providers.dart';
 import '../state/sessions.dart';
 import '../state/terminal_backend.dart';
 import '../state/tmux_control_mode_setting.dart';
 import '../state/ui_prefs_providers.dart';
+import '../storage/detection_exceptions_store.dart';
+import '../util/relative_time.dart';
 import 'feedback_overlay.dart' show VersionResolver, resolveBuildVersion;
 import 'settings_subheader.dart';
 import 'top_toast.dart';
@@ -42,6 +45,9 @@ class SettingsPanel extends ConsumerWidget {
     final fontSize = ref.watch(fontSizeProvider);
     final controlMode = ref.watch(tmuxControlModeProvider);
     final detection = ref.watch(detectionSettingsProvider);
+    // #995: persisted "Not a URL" / "Not a file" reports — listed for review,
+    // each removable (removal restores detection of that text).
+    final exceptions = ref.watch(detectionExceptionsProvider);
     // Flat layout (#897): a Column of top-level controls grouped by light,
     // non-collapsing subheaders. The 'settings-section' key is retained on the
     // root so existing tests / screenshots can still address the block, but it
@@ -213,6 +219,45 @@ class SettingsPanel extends ConsumerWidget {
               ? (v) => ref.read(detectionSettingsProvider.notifier).setPath(v)
               : null,
         ),
+        // #995: reviewable detection exceptions — the saved "Not a URL" /
+        // "Not a file" reports. Each entry shows the suppressed text + when/
+        // where it was reported, with a per-entry remove that restores
+        // detection. NOT cleared by Reset settings (user data, like favorites).
+        const SettingsSubheader('Detection exceptions'),
+        if (exceptions.isEmpty)
+          const ListTile(
+            key: ValueKey('detection-exceptions-empty'),
+            leading: Icon(Icons.playlist_remove_outlined),
+            title: Text('No exceptions'),
+            subtitle: Text(
+              'Use "Not a URL" / "Not a file" on a detected link or path to '
+              'stop detecting that exact text. Saved reports appear here.',
+            ),
+          )
+        else
+          for (var i = 0; i < exceptions.length; i++)
+            ListTile(
+              key: ValueKey('detection-exception-$i'),
+              leading: Icon(
+                exceptions[i].family == 'path'
+                    ? Icons.folder_off_outlined
+                    : Icons.link_off,
+              ),
+              title: Text(
+                exceptions[i].matchedText,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              subtitle: Text(_exceptionSubtitle(exceptions[i])),
+              trailing: IconButton(
+                key: ValueKey('detection-exception-remove-$i'),
+                icon: const Icon(Icons.delete_outline),
+                tooltip: 'Remove exception (detect again)',
+                onPressed: () => ref
+                    .read(detectionExceptionsProvider.notifier)
+                    .removeException(exceptions[i]),
+              ),
+            ),
         const SizedBox(height: 16),
         // #897: destructive reset. Confirms, then restores every persisted user
         // pref to its documented default by calling each provider's setter (NOT
@@ -233,6 +278,16 @@ class SettingsPanel extends ConsumerWidget {
         const SizedBox(height: 8),
       ],
     );
+  }
+
+  /// Subtitle for one detection-exception row (#995): "when · host", dropping
+  /// whichever segment is unknown (a record may carry neither).
+  String _exceptionSubtitle(DetectionException e) {
+    final when = formatRelative(e.tsMs > 0 ? e.tsMs ~/ 1000 : null);
+    return [
+      if (when.isNotEmpty) when,
+      if (e.host.isNotEmpty) e.host,
+    ].join(' · ');
   }
 
   Future<void> _copyVersion(BuildContext context, String version) async {

--- a/native/lib/ui/url_action_overlay.dart
+++ b/native/lib/ui/url_action_overlay.dart
@@ -68,12 +68,17 @@ void debugDismissUrlActions() => _dismiss();
 /// coordinates (one per rendered row the URL spans). [anchor] is the global
 /// point the menu is positioned near (typically the long-press location).
 ///
+/// [onMarkNotDetection] (#995): when non-null a LAST "Not a URL" item is
+/// offered (destructive-adjacent placement) — tapping dismisses the menu and
+/// fires the callback (the caller persists the detection exception).
+///
 /// Safe to call from any context under an [Overlay]. No-op if no overlay.
 void showUrlActions(
   BuildContext context,
   String url, {
   required List<Rect> highlightRects,
   required Offset anchor,
+  VoidCallback? onMarkNotDetection,
   Duration timeout = const Duration(seconds: 6),
 }) {
   final overlay = Overlay.maybeOf(context, rootOverlay: true);
@@ -109,6 +114,14 @@ void showUrlActions(
       onDismiss: () {
         if (identical(_activeEntry, entry)) _dismiss();
       },
+      // #995: dismiss first, then report — the exception write regroups the
+      // affordance layers, so the menu must not outlive its anchor.
+      onMarkNotDetection: onMarkNotDetection == null
+          ? null
+          : () {
+              if (identical(_activeEntry, entry)) _dismiss();
+              onMarkNotDetection();
+            },
     ),
   );
   _activeEntry = entry;
@@ -128,6 +141,7 @@ class _UrlActionLayer extends StatelessWidget {
     required this.onCopy,
     required this.onOpen,
     required this.onDismiss,
+    this.onMarkNotDetection,
   });
 
   final String url;
@@ -136,6 +150,9 @@ class _UrlActionLayer extends StatelessWidget {
   final VoidCallback onCopy;
   final Future<void> Function() onOpen;
   final VoidCallback onDismiss;
+
+  /// #995: persists a "Not a URL" detection exception; null hides the item.
+  final VoidCallback? onMarkNotDetection;
 
   @override
   Widget build(BuildContext context) {
@@ -206,8 +223,12 @@ class _UrlActionLayer extends StatelessWidget {
               ),
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
+                // Wrap, not Row (#995): with the third "Not a URL" item the
+                // buttons can exceed the max width — they flow to a second
+                // line instead of overflowing (mirrors the path overlay).
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
                   children: [
                     _ActionButton(
                       key: const Key('url-action-copy'),
@@ -215,7 +236,6 @@ class _UrlActionLayer extends StatelessWidget {
                       label: 'Copy',
                       onTap: onCopy,
                     ),
-                    const SizedBox(width: 8),
                     _ActionButton(
                       key: const Key('url-action-open'),
                       icon: Icons.open_in_new,
@@ -224,6 +244,14 @@ class _UrlActionLayer extends StatelessWidget {
                         onOpen();
                       },
                     ),
+                    // #995: LAST (destructive-adjacent) — report false positive.
+                    if (onMarkNotDetection != null)
+                      _ActionButton(
+                        key: const Key('url-action-not-url'),
+                        icon: Icons.link_off,
+                        label: 'Not a URL',
+                        onTap: onMarkNotDetection!,
+                      ),
                   ],
                 ),
               ),

--- a/native/test/diagnostics/feedback_bundle_test.dart
+++ b/native/test/diagnostics/feedback_bundle_test.dart
@@ -212,6 +212,65 @@ void main() {
       expect(decoded['lastCrash'], isNull);
     });
 
+    test('includes the detection-exceptions corpus when supplied (#995)', () {
+      final blob = assembleFeedbackBundle(
+        info: info,
+        connectLog: const [],
+        detectionExceptions: const [
+          'https://false.positive/x [url] host=test-sshd',
+          '/config [path] host=test-sshd',
+        ],
+        crashJson: null,
+      );
+      final decoded = jsonDecode(blob) as Map<String, Object?>;
+      expect(decoded['detectionExceptionCount'], 2);
+      expect(decoded['detectionExceptions'], isA<List<Object?>>());
+      expect(
+        (decoded['detectionExceptions'] as List).first,
+        contains('https://false.positive/x'),
+        reason:
+            'the saved false-positive reports are the corpus for improving '
+            'the detector (#995)',
+      );
+    });
+
+    test('detection exceptions default empty + recent list is capped (#995)', () {
+      final none = assembleFeedbackBundle(
+        info: info,
+        connectLog: const [],
+        crashJson: null,
+      );
+      final decodedNone = jsonDecode(none) as Map<String, Object?>;
+      expect(decodedNone['detectionExceptionCount'], 0);
+      expect(decodedNone['detectionExceptions'], isEmpty);
+
+      final many = assembleFeedbackBundle(
+        info: info,
+        connectLog: const [],
+        detectionExceptions: [
+          for (var i = 0; i < 50; i++) 'https://fp.example/$i [url]',
+        ],
+        crashJson: null,
+      );
+      final decodedMany = jsonDecode(many) as Map<String, Object?>;
+      expect(decodedMany['detectionExceptionCount'], 50);
+      final recent = decodedMany['detectionExceptions'] as List;
+      expect(recent.length, lessThanOrEqualTo(20));
+      // The RECENT entries ride along (newest are at the end of the input).
+      expect(recent.last, contains('/49 '));
+    });
+
+    test('detection exceptions are scrubbed like the other rings (#995)', () {
+      const planted = 'hunter2-SUPER-SECRET-pw';
+      final blob = assembleFeedbackBundle(
+        info: info,
+        connectLog: const [],
+        detectionExceptions: const ['token=$planted [url]'],
+        crashJson: null,
+      );
+      expect(blob.contains(planted), isFalse);
+    });
+
     test('contains NO credential material (planted password is scrubbed)', () {
       const plantedPassword = 'hunter2-SUPER-SECRET-pw';
       const plantedKey = 'BEGIN OPENSSH PRIVATE KEY';

--- a/native/test/state/detection_exceptions_providers_test.dart
+++ b/native/test/state/detection_exceptions_providers_test.dart
@@ -1,0 +1,97 @@
+// Detection exceptions provider (#995) — session-facing suppression lookup.
+//
+// Contract under test:
+//   - hydrates persisted exceptions once (ready future)
+//   - report() persists + immediately suppresses the exact matched text
+//   - suppression is per pattern FAMILY: a url report suppresses the same text
+//     seen via osc8 (and vice versa), but NOT the same text as a path
+//   - a DIFFERENT text in the same family stays visible (exact-match v1)
+//   - removeException() restores detection and persists the removal
+//   - isSuppressed is cheap (hash-set) — smoke: many lookups after one load
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/detection_exceptions_providers.dart';
+import 'package:mobissh/storage/detection_exceptions_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  Future<DetectionExceptionsNotifier> notifier() async {
+    final prefs = await SharedPreferences.getInstance();
+    final n = DetectionExceptionsNotifier(
+      store: DetectionExceptionsStore(prefs: prefs),
+    );
+    await n.ready;
+    return n;
+  }
+
+  test('report persists + suppresses the exact matched text', () async {
+    final n = await notifier();
+    expect(n.isSuppressed('url', 'https://a.b/c'), isFalse);
+
+    await n.report(
+      patternId: 'url',
+      matchedText: 'https://a.b/c',
+      contextLine: 'log line',
+      host: 'test-sshd',
+    );
+
+    expect(n.isSuppressed('url', 'https://a.b/c'), isTrue);
+    // Exact-match v1: a different text in the same family stays visible.
+    expect(n.isSuppressed('url', 'https://a.b/other'), isFalse);
+    // Record fields captured.
+    expect(n.state, hasLength(1));
+    expect(n.state.single.host, 'test-sshd');
+    expect(n.state.single.contextLine, 'log line');
+    expect(n.state.single.tsMs, greaterThan(0));
+
+    // Persisted: a FRESH notifier over the same prefs hydrates it.
+    final n2 = await notifier();
+    expect(n2.isSuppressed('url', 'https://a.b/c'), isTrue);
+  });
+
+  test('url and osc8 share one suppression family; path does not', () async {
+    final n = await notifier();
+    await n.report(patternId: 'url', matchedText: 'https://a.b/c');
+
+    expect(n.isSuppressed('osc8', 'https://a.b/c'), isTrue);
+    expect(n.isSuppressed('path', 'https://a.b/c'), isFalse);
+  });
+
+  test('removeException restores detection and persists', () async {
+    final n = await notifier();
+    await n.report(patternId: 'path', matchedText: '/etc/hosts');
+    expect(n.isSuppressed('path', '/etc/hosts'), isTrue);
+
+    await n.removeException(n.state.single);
+    expect(n.isSuppressed('path', '/etc/hosts'), isFalse);
+    expect(n.state, isEmpty);
+
+    final n2 = await notifier();
+    expect(n2.isSuppressed('path', '/etc/hosts'), isFalse);
+  });
+
+  test('duplicate report is a no-op (one record)', () async {
+    final n = await notifier();
+    await n.report(patternId: 'url', matchedText: 'https://a.b/c');
+    await n.report(patternId: 'osc8', matchedText: 'https://a.b/c');
+    expect(n.state, hasLength(1));
+  });
+
+  test('hydrates a stored corpus on construction', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final seed = DetectionExceptionsStore(prefs: prefs);
+    await seed.add(
+      const DetectionException(matchedText: '/config', patternId: 'path'),
+    );
+
+    final n = await notifier();
+    expect(n.isSuppressed('path', '/config'), isTrue);
+  });
+}

--- a/native/test/storage/detection_exceptions_store_test.dart
+++ b/native/test/storage/detection_exceptions_store_test.dart
@@ -1,0 +1,149 @@
+// Detection exceptions store (#995) — "Not a URL" / "Not a file" reports
+// persisted as exact-match suppression records.
+//
+// Contract under test (favorites_store.dart precedent):
+//   - round-trip: add → load returns the record with all fields
+//   - dedupe: same (family, matchedText) added twice stores once
+//   - url and osc8 share ONE family ('url'); path is its own
+//   - remove restores (record gone from load)
+//   - corrupt JSON / wrong shape / unknown schema version → empty (never throws)
+//   - schema version lives INSIDE the value (no key bumping)
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/storage/detection_exceptions_store.dart';
+
+Future<DetectionExceptionsStore> _store() async {
+  final prefs = await SharedPreferences.getInstance();
+  return DetectionExceptionsStore(prefs: prefs);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('family mapping: url and osc8 share one family, path is its own', () {
+    expect(detectionExceptionFamily('url'), 'url');
+    expect(detectionExceptionFamily('osc8'), 'url');
+    expect(detectionExceptionFamily('path'), 'path');
+    // A future custom pattern id maps to itself.
+    expect(detectionExceptionFamily('custom-regex-1'), 'custom-regex-1');
+  });
+
+  test('round-trip: add then load returns the full record', () async {
+    final store = await _store();
+    await store.add(
+      const DetectionException(
+        matchedText: 'https://example.com/x',
+        patternId: 'url',
+        contextLine: 'curl https://example.com/x failed',
+        tsMs: 1720000000000,
+        host: 'test-sshd',
+      ),
+    );
+
+    final loaded = await store.load();
+    expect(loaded, hasLength(1));
+    final e = loaded.single;
+    expect(e.matchedText, 'https://example.com/x');
+    expect(e.patternId, 'url');
+    expect(e.contextLine, 'curl https://example.com/x failed');
+    expect(e.tsMs, 1720000000000);
+    expect(e.host, 'test-sshd');
+    expect(e.scope, 'global');
+  });
+
+  test('dedupe: same family + matchedText stores once (osc8 == url)', () async {
+    final store = await _store();
+    await store.add(
+      const DetectionException(matchedText: 'https://a.b/c', patternId: 'url'),
+    );
+    // Same text reported via the OSC-8 pattern — same family, deduped.
+    await store.add(
+      const DetectionException(matchedText: 'https://a.b/c', patternId: 'osc8'),
+    );
+    expect(await store.load(), hasLength(1));
+
+    // Same text as a PATH is a different family — kept separately.
+    await store.add(
+      const DetectionException(matchedText: 'https://a.b/c', patternId: 'path'),
+    );
+    expect(await store.load(), hasLength(2));
+  });
+
+  test('remove by pattern family + text restores detection', () async {
+    final store = await _store();
+    await store.add(
+      const DetectionException(matchedText: '/etc/hosts', patternId: 'path'),
+    );
+    await store.add(
+      const DetectionException(matchedText: 'https://a.b', patternId: 'url'),
+    );
+
+    await store.remove(patternId: 'path', matchedText: '/etc/hosts');
+    final loaded = await store.load();
+    expect(loaded, hasLength(1));
+    expect(loaded.single.matchedText, 'https://a.b');
+  });
+
+  test('corrupt JSON falls back to empty (never throws)', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      detectionExceptionsPrefsKey: '{not json',
+    });
+    final store = await _store();
+    expect(await store.load(), isEmpty);
+  });
+
+  test('wrong shape falls back to empty', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      detectionExceptionsPrefsKey: jsonEncode(['not', 'a', 'map']),
+    });
+    final store = await _store();
+    expect(await store.load(), isEmpty);
+  });
+
+  test('unknown schema version falls back to empty (version-in-value)', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      detectionExceptionsPrefsKey: jsonEncode({
+        'v': 999,
+        'entries': [
+          {'text': 'https://a.b', 'pattern': 'url'},
+        ],
+      }),
+    });
+    final store = await _store();
+    expect(await store.load(), isEmpty);
+  });
+
+  test('bad entries are dropped, good entries survive', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      detectionExceptionsPrefsKey: jsonEncode({
+        'v': 1,
+        'entries': [
+          {'text': 'https://good.example', 'pattern': 'url'},
+          {'pattern': 'url'}, // no text → dropped
+          'garbage', // not a map → dropped
+          {'text': '', 'pattern': 'url'}, // empty text → dropped
+        ],
+      }),
+    });
+    final store = await _store();
+    final loaded = await store.load();
+    expect(loaded, hasLength(1));
+    expect(loaded.single.matchedText, 'https://good.example');
+  });
+
+  test('blank matched text is rejected (no-op add)', () async {
+    final store = await _store();
+    await store.add(
+      const DetectionException(matchedText: '   ', patternId: 'url'),
+    );
+    expect(await store.load(), isEmpty);
+  });
+}

--- a/native/test/widget/detection_exceptions_widget_test.dart
+++ b/native/test/widget/detection_exceptions_widget_test.dart
@@ -1,0 +1,321 @@
+// Widget contract for #995 "Not a URL" / "Not a file" detection exceptions.
+//
+// Asserts:
+//   - the URL action overlay offers a 'Not a URL' item (LAST) when the caller
+//     provides onMarkNotDetection; tapping fires the callback and dismisses
+//   - the PATH action overlay offers 'Not a file' the same way
+//   - neither overlay shows the item when no callback is provided (additive)
+//   - the gutter registry's per-match list actions gain a LAST 'not' action per
+//     anchor class ('Not a URL' for url payloads, 'Not a file' for path and
+//     file:// payloads — the file:// report carries the ORIGINAL matched text)
+//   - the Settings page lists persisted exceptions (text + host) with a
+//     per-entry remove that restores detection
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/detection_exceptions_providers.dart';
+import 'package:mobissh/storage/detection_exceptions_store.dart';
+import 'package:mobissh/ui/ghostty_gutter_layer.dart';
+import 'package:mobissh/ui/path_action_overlay.dart';
+import 'package:mobissh/ui/settings_screen.dart';
+import 'package:mobissh/ui/url_action_overlay.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 10}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  Future<void> settleUrl(WidgetTester tester) async {
+    debugDismissUrlActions();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  Future<void> settlePath(WidgetTester tester) async {
+    debugDismissPathActions();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  Future<void> pumpFire(WidgetTester tester, void Function(BuildContext) fire) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => fire(context),
+                child: const Text('fire'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('fire'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+
+  group('URL action overlay', () {
+    testWidgets('offers Not a URL last; tap fires callback + dismisses', (
+      tester,
+    ) async {
+      var reported = 0;
+      await pumpFire(
+        tester,
+        (context) => showUrlActions(
+          context,
+          'https://example.com/x',
+          highlightRects: const [Rect.fromLTWH(40, 40, 120, 18)],
+          anchor: const Offset(100, 50),
+          onMarkNotDetection: () => reported++,
+        ),
+      );
+
+      final notItem = find.byKey(const Key('url-action-not-url'));
+      expect(notItem, findsOneWidget);
+      expect(find.text('Not a URL'), findsOneWidget);
+      // Destructive-adjacent placement: LAST — after Copy and Open in reading
+      // order (the Wrap may flow it to a second line).
+      final notPos = tester.getTopLeft(notItem);
+      final openPos = tester.getTopLeft(
+        find.byKey(const Key('url-action-open')),
+      );
+      expect(
+        notPos.dy > openPos.dy ||
+            (notPos.dy == openPos.dy && notPos.dx > openPos.dx),
+        isTrue,
+        reason: 'Not a URL must be the last item in the menu',
+      );
+
+      await tester.tap(notItem);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(reported, 1);
+      expect(find.byKey(const Key('url-action-menu')), findsNothing);
+      await settleUrl(tester);
+    });
+
+    testWidgets('absent without a callback (additive)', (tester) async {
+      await pumpFire(
+        tester,
+        (context) => showUrlActions(
+          context,
+          'https://example.com/x',
+          highlightRects: const [],
+          anchor: const Offset(100, 50),
+        ),
+      );
+      expect(find.byKey(const Key('url-action-not-url')), findsNothing);
+      await settleUrl(tester);
+    });
+  });
+
+  group('Path action overlay', () {
+    testWidgets('offers Not a file last; tap fires callback + dismisses', (
+      tester,
+    ) async {
+      var reported = 0;
+      await pumpFire(
+        tester,
+        (context) => showPathActions(
+          context,
+          '/etc/hosts',
+          highlightRects: const [Rect.fromLTWH(40, 40, 120, 18)],
+          anchor: const Offset(100, 50),
+          onMarkNotDetection: () => reported++,
+        ),
+      );
+
+      final notItem = find.byKey(const Key('path-action-not-file'));
+      expect(notItem, findsOneWidget);
+      expect(find.text('Not a file'), findsOneWidget);
+
+      await tester.tap(notItem);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(reported, 1);
+      expect(find.byKey(const Key('path-action-menu')), findsNothing);
+      await settlePath(tester);
+    });
+
+    testWidgets('absent without a callback (additive)', (tester) async {
+      await pumpFire(
+        tester,
+        (context) => showPathActions(
+          context,
+          '/etc/hosts',
+          highlightRects: const [],
+          anchor: const Offset(100, 50),
+        ),
+      );
+      expect(find.byKey(const Key('path-action-not-file')), findsNothing);
+      await settlePath(tester);
+    });
+  });
+
+  group('Gutter registry list actions', () {
+    ({String pattern, String payload})? reported;
+    GutterPatternRegistry registry() {
+      reported = null;
+      return GutterPatternRegistry.standard(
+        openPath: (_) async => true,
+        onReportException: (patternId, payload) =>
+            reported = (pattern: patternId, payload: payload),
+      );
+    }
+
+    Future<BuildContext> pumpContext(WidgetTester tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              ctx = context;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+      return ctx;
+    }
+
+    testWidgets('url payload gets a LAST Not a URL action', (tester) async {
+      final reg = registry();
+      final actions = reg.forPattern('url')!.itemActions('https://a.b/c');
+      expect(actions.last.keyLabel, 'not');
+      expect(actions.last.label, 'Not a URL');
+
+      final ctx = await pumpContext(tester);
+      await actions.last.onInvoke(ctx);
+      expect(reported, isNotNull);
+      expect(reported!.payload, 'https://a.b/c');
+    });
+
+    testWidgets('path payload gets a LAST Not a file action', (tester) async {
+      final reg = registry();
+      final actions = reg.forPattern('path')!.itemActions('/etc/hosts');
+      expect(actions.last.keyLabel, 'not');
+      expect(actions.last.label, 'Not a file');
+
+      final ctx = await pumpContext(tester);
+      await actions.last.onInvoke(ctx);
+      expect(reported, isNotNull);
+      expect(reported!.pattern, 'path');
+      expect(reported!.payload, '/etc/hosts');
+    });
+
+    testWidgets('file:// payload reports the ORIGINAL matched text', (
+      tester,
+    ) async {
+      final reg = registry();
+      const fileUrl = 'file:///home/dev/notes.md';
+      final actions = reg.forPattern('url')!.itemActions(fileUrl);
+      expect(actions.last.keyLabel, 'not');
+      expect(actions.last.label, 'Not a file');
+
+      final ctx = await pumpContext(tester);
+      await actions.last.onInvoke(ctx);
+      expect(reported, isNotNull);
+      expect(
+        reported!.payload,
+        fileUrl,
+        reason: 'suppression matches the anchor payload, not the bare path',
+      );
+    });
+
+    testWidgets('no report callback → no not action (additive)', (
+      tester,
+    ) async {
+      final reg = GutterPatternRegistry.standard(openPath: (_) async => true);
+      final actions = reg.forPattern('url')!.itemActions('https://a.b/c');
+      expect(actions.where((a) => a.keyLabel == 'not'), isEmpty);
+    });
+  });
+
+  group('Settings: Detection exceptions', () {
+    Future<ProviderContainer> pumpSettings(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1000, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: Scaffold(body: SettingsScreen())),
+        ),
+      );
+      await _pumpFrames(tester);
+      return container;
+    }
+
+    testWidgets('lists persisted exceptions with text + host', (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final store = DetectionExceptionsStore(prefs: prefs);
+      await store.add(
+        DetectionException(
+          matchedText: 'https://false.positive/x',
+          patternId: 'url',
+          host: 'test-sshd',
+          tsMs: DateTime.now().millisecondsSinceEpoch,
+        ),
+      );
+
+      final container = await pumpSettings(tester);
+      expect(container.read(detectionExceptionsProvider), hasLength(1));
+
+      expect(find.text('Detection exceptions'), findsOneWidget);
+      expect(find.byKey(const ValueKey('detection-exception-0')), findsOneWidget);
+      expect(find.text('https://false.positive/x'), findsOneWidget);
+      expect(find.textContaining('test-sshd'), findsOneWidget);
+    });
+
+    testWidgets('empty state renders a hint, no entries', (tester) async {
+      await pumpSettings(tester);
+      expect(
+        find.byKey(const ValueKey('detection-exceptions-empty')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const ValueKey('detection-exception-0')), findsNothing);
+    });
+
+    testWidgets('per-entry remove restores detection', (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final store = DetectionExceptionsStore(prefs: prefs);
+      await store.add(
+        const DetectionException(matchedText: '/etc/hosts', patternId: 'path'),
+      );
+
+      final container = await pumpSettings(tester);
+      final notifier = container.read(detectionExceptionsProvider.notifier);
+      expect(notifier.isSuppressed('path', '/etc/hosts'), isTrue);
+
+      await tester.tap(
+        find.byKey(const ValueKey('detection-exception-remove-0')),
+      );
+      await _pumpFrames(tester);
+
+      expect(find.byKey(const ValueKey('detection-exception-0')), findsNothing);
+      expect(notifier.isSuppressed('path', '/etc/hosts'), isFalse);
+      // Persisted: the store no longer has it either.
+      expect(await store.load(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Implements #995: a "Not a URL" / "Not a file" feedback item on detected anchors, persisted as detection exceptions that suppress future detection of the exact matched text.

## What
- **Menus** (`url_action_overlay.dart`, `path_action_overlay.dart`, `ghostty_gutter_layer.dart`): every anchor menu shape — long-press overlay, gutter single-tap overlay, gutter multi-match list — gains one LAST item (destructive-adjacent, monochrome glyph): "Not a URL" for url/osc8 anchors, "Not a file" for path anchors AND file:// payloads. A file:// anchor records its ORIGINAL file:// matched text (suppression keys on the anchor payload). Purely additive: no callback → no item (the xterm fallback path is unchanged).
- **Store** (`storage/detection_exceptions_store.dart`, new): schema-in-value shared_prefs blob (`mobissh.detection.exceptions.v1`, version INSIDE the value, corrupt/unknown-version → empty, no key bumping — favorites_store precedent). Record: `{text, pattern, line, ts, host, scope:'global'}`. Dedupe on (family, text); url+osc8 are one family.
- **Suppression** (`state/detection_exceptions_providers.dart` new + `ghostty_terminal_view.dart`): loaded once, O(1) per-family hash-set lookup checked FIRST inside the existing #990 visibility seam (`_isPayloadVisible`) — bubble, gutter chip, and tap hit-test all gate through the one seam; the view `ref.watch`es the list so a report/remove regroups the layers immediately. **No flterm change** (scanner anchors stay intact — asserted on-emulator).
- **Settings** (`settings_panel.dart`): "Detection exceptions" section — entries show text + when + host, per-entry remove restores detection live. Deliberately NOT cleared by Reset settings (user data, like favorites).
- **Feedback bundle** (`feedback_bundle.dart`, `diagnostics_section.dart`): additive `detectionExceptionCount` + `detectionExceptions` (recent 20, scrubbed) so recurring false-positive classes can become upstream detector fixes.

## Red → green
- New unit/widget/diagnostics tests written first; confirmed failing (compile-red: modules/params absent, `No named parameter 'detectionExceptions'`, etc.), then green: 40/40 in the four touched test files.
- `scripts/native-fast-gate.sh`: PASSED (analyze clean, 1800 tests green).
- Emulator (`integration_test/detection_exception_995_test.dart` via `scripts/native-connect-test.sh` against test-sshd): PASSED — detect URL → chip renders → chip tap → "Not a URL" → exception persisted + chip gone while the scanner anchor is UNTOUCHED → close/reconnect → same text re-detected but NO affordance → Settings remove → third session shows the chip again.

## Screenshots (emulator, captured during the integration run)
- Menu with the new item: `test-results/emulator-shots/*995-not-a-url-menu*.png`
- Settings exceptions list: `test-results/emulator-shots/*995-settings-exceptions*.png`

## Notes / caveats
- Exact-match suppression (v1 per the issue); records carry host + scope for later per-profile scoping.
- The gutter multi-match list's file:// "Not a file" records patternId `url` unless the live anchor is still on screen (the view's report helper prefers the live anchor's concrete patternId, e.g. `osc8`). Family-level suppression is identical either way.
- Reset settings does not clear exceptions (treated as user data); flagged in Settings section comment — say the word if it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa