### PR TITLE
feat(native): command-line gutter chip + "Not a command" (#998 slices C+D)

### DIFF
--- a/native/.gitignore
+++ b/native/.gitignore
@@ -44,6 +44,11 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
+# Kotlin tooling session artifacts (gradle drops these during builds).
+# Untracked build noise here is dangerous: ship-native.sh stages `native/`
+# wholesale, so anything not ignored would ship in a release commit.
+/android/.kotlin/
+
 # Signing material — keystore + key.properties MUST stay out of git.
 # Canonical location is /home/dev/.mobissh-android/ (per #501); these
 # patterns are defensive in case someone accidentally drops them in-tree.

--- a/native/integration_test/command_chip_998_test.dart
+++ b/native/integration_test/command_chip_998_test.dart
@@ -1,0 +1,288 @@
+// On-emulator COMMAND-LINE detection + gutter chip (#998 slices C+D).
+//
+// Drives the real chain (SSH → shell echo → flterm scanner → gutter layer)
+// against test-sshd:
+//   1. ensure a STRONG-tier prompt (`user@host:~$ ` — the design's bash
+//      userhost shape; exported explicitly so the test doesn't depend on the
+//      fixture shell's default PS1), `clear`, then TYPE a real command at the
+//      real prompt: `curl -fsSL <url> | tail -1`. The typed line at the prompt
+//      IS the detection target (lexicon hit + flag + pipe = score 4 behind a
+//      strong prompt); whether curl exists on the fixture is irrelevant.
+//   2. assert the scanner anchors BOTH the whole command (block tier, payload
+//      EXACTLY the typed command — paste-exact) AND the inner URL (span).
+//   3. tap the command chip → clipboard = the FULL command. When the inner URL
+//      shares the chip's viewport row the chip is the multi-match count badge
+//      and the copy goes through the list sheet's "Copy command" action —
+//      which is also where "Not a command" (#998 D) lives; both branches are
+//      handled because the wrap point depends on the emulator grid width.
+//   4. copy the URL through ITS affordance (own chip → URL menu → Copy, or the
+//      shared sheet's URL "Copy") → clipboard = JUST the URL.
+//
+// SHOT998 debugPrints mark screenshot hold windows (scripts/emu-shot.sh).
+//
+// Run: scripts/native-connect-test.sh integration_test/command_chip_998_test.dart
+
+import 'dart:convert';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/clipboard.dart' show clipboardChannel;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+const _url = 'https://example.com/mobissh/998/x';
+const _command = 'curl -fsSL $_url | tail -1';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'command chip copies the whole typed command; the inner URL keeps its own '
+    'copy (#998 C+D)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      String? copied;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        clipboardChannel,
+        (call) async {
+          if (call.method == 'setText') {
+            copied = (call.arguments as Map)['text'] as String?;
+            return true;
+          }
+          return null;
+        },
+      );
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied = (call.arguments as Map)['text'] as String?;
+          }
+          if (call.method == 'Clipboard.getData') {
+            return <String, dynamic>{'text': copied ?? ''};
+          }
+          return null;
+        },
+      );
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          clipboardChannel,
+          null,
+        );
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        );
+      });
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+      final sessionId = entry.id;
+      TerminalController? ctrlOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && ctrlOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = ctrlOf()!;
+
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'dead PTY — no shell prompt');
+
+      void send(String line) {
+        entry.proxy.sendInput(Uint8List.fromList(utf8.encode('$line\n')));
+      }
+
+      // A STRONG-tier prompt (the design's `user@host:path$ ` shape), set
+      // explicitly so the test controls the tier instead of trusting the
+      // fixture shell's default. Then clear away login noise + the export
+      // line itself, so the typed command is the only detectable content.
+      send(r"export PS1='testuser@test-sshd:~$ '");
+      await tester.pump(const Duration(milliseconds: 800));
+      send('clear');
+      await tester.pump(const Duration(milliseconds: 800));
+
+      // The REAL command, typed at the REAL prompt (echoed by the PTY). Score:
+      // curl (lexicon +2) + -fsSL (flag +1) + | (operator +1) behind a strong
+      // prompt → detected; payload must be the prompt-stripped typed line.
+      send(_command);
+
+      // Select by payload too: the `export PS1=…` line typed at an
+      // already-strong fixture prompt may ALSO be anchored (export is in the
+      // lexicon) but lives in cleared-away scrollback — anchors persist.
+      StructuredAnchor? commandAnchor() {
+        for (final a in controller.anchors) {
+          if (a.patternId == kGhosttyCommandPatternId &&
+              '${a.payload}'.startsWith('curl')) {
+            return a;
+          }
+        }
+        return null;
+      }
+
+      StructuredAnchor? urlAnchor() {
+        for (final a in controller.anchors) {
+          if (a.patternId == kGhosttyUrlPatternId && '${a.payload}' == _url) {
+            return a;
+          }
+        }
+        return null;
+      }
+
+      for (var i = 0;
+          i < 60 && (commandAnchor() == null || urlAnchor() == null);
+          i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      final cmd = commandAnchor();
+      final url = urlAnchor();
+      expect(cmd, isNotNull, reason: 'the typed command was never anchored');
+      expect(url, isNotNull, reason: 'the inner URL was never anchored');
+      expect(
+        '${cmd!.payload}',
+        _command,
+        reason: 'the command payload must be the prompt-stripped typed line, '
+            'paste-exact',
+      );
+
+      int? rowOf(StructuredAnchor a) {
+        for (final r in a.ranges) {
+          final row = controller.anchorGutterRow(r);
+          if (row != null) return row;
+        }
+        return null;
+      }
+
+      final cmdRow = rowOf(cmd);
+      final urlRow = rowOf(url!);
+      expect(cmdRow, isNotNull, reason: 'command anchor has no on-screen row');
+      expect(urlRow, isNotNull, reason: 'URL anchor has no on-screen row');
+      debugPrint('CHIP998 rows: command=$cmdRow url=$urlRow');
+      final sharedRow = cmdRow == urlRow;
+
+      // Screenshot window: both affordances on screen (chips visible).
+      debugPrint('SHOT998 chips hold');
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+
+      // 1) COPY THE COMMAND via its chip.
+      copied = null;
+      await tester.tap(find.byKey(Key('gutter-mark-$cmdRow')));
+      await tester.pump(const Duration(milliseconds: 400));
+      if (sharedRow) {
+        // Count-badge chip → the list sheet; "Copy command" + "Not a command".
+        await tester.pumpAndSettle();
+        expect(
+          find.byKey(const Key('gutter-pattern-list')),
+          findsOneWidget,
+          reason: 'shared-row chip did not open the multi-match sheet',
+        );
+        expect(
+          find.byTooltip('Not a command'),
+          findsOneWidget,
+          reason: 'the command sheet item is missing "Not a command" (#998 D)',
+        );
+        // Screenshot window: the sheet with Copy command / Not a command.
+        debugPrint('SHOT998 sheet hold');
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+        }
+        await tester.tap(find.byTooltip('Copy command'));
+        await tester.pumpAndSettle();
+      }
+      for (var i = 0; i < 10 && copied == null; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(
+        copied,
+        _command,
+        reason: 'the command chip must copy the FULL command paste-exact',
+      );
+
+      // 2) COPY THE URL via its own affordance.
+      copied = null;
+      if (sharedRow) {
+        await tester.tap(find.byKey(Key('gutter-mark-$cmdRow')));
+        await tester.pumpAndSettle();
+        // The URL row in the sheet: its plain "Copy" action.
+        await tester.tap(find.byTooltip('Copy'));
+        await tester.pumpAndSettle();
+      } else {
+        await tester.tap(find.byKey(Key('gutter-mark-$urlRow')));
+        var menuShown = false;
+        for (var i = 0; i < 20; i++) {
+          await tester.pump(const Duration(milliseconds: 300));
+          if (find.byKey(const Key('url-action-menu')).evaluate().isNotEmpty) {
+            menuShown = true;
+            break;
+          }
+        }
+        expect(menuShown, isTrue, reason: 'URL chip never opened the URL menu');
+        // Screenshot window: the URL menu open beside the command chip.
+        debugPrint('SHOT998 url-menu hold');
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+        }
+        await tester.tap(find.byKey(const Key('url-action-copy')));
+        await tester.pump(const Duration(milliseconds: 400));
+      }
+      for (var i = 0; i < 10 && copied == null; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(
+        copied,
+        _url,
+        reason: 'the URL affordance must copy JUST the URL, not the command',
+      );
+    },
+  );
+}

--- a/native/lib/state/detection_providers.dart
+++ b/native/lib/state/detection_providers.dart
@@ -2,7 +2,8 @@
 //
 // Controls whether (and what kind of) structured-text detection runs over the
 // terminal's own cells. Detection is a GHOSTTY-backend affordance: the flterm
-// controller registers `TextPattern`s (osc8 + url + path) and maintains anchors
+// controller registers `TextPattern`s (osc8 + url + path + command, #998) and
+// maintains anchors
 // across scroll / wrap / eviction (#767, #778). When a type is OFF, that pattern
 // is simply NOT registered — the scan/decoration machinery already no-ops on an
 // empty pattern set, so OFF means zero scan + zero decoration.
@@ -65,6 +66,7 @@ class DetectionSettings {
     this.enabled = true,
     this.url = true,
     this.path = true,
+    this.command = true,
   });
 
   /// The schema version this instance was built from (defaults to current).
@@ -79,6 +81,11 @@ class DetectionSettings {
   /// Detect absolute file paths.
   final bool path;
 
+  /// Detect prompt-anchored COMMAND LINES (#998 slice C). Default TRUE like the
+  /// others (purely additive; a pre-#998 stored value hydrates it back on via
+  /// the field-by-field fallback below).
+  final bool command;
+
   /// Whether the URL patterns should be registered (master AND url), UNLESS the
   /// #971 kill switch has force-disabled detection (see [kDetectionDisabled971]).
   bool get detectUrls => !kDetectionDisabled971 && enabled && url;
@@ -87,21 +94,38 @@ class DetectionSettings {
   /// #971 kill switch has force-disabled detection.
   bool get detectPaths => !kDetectionDisabled971 && enabled && path;
 
-  DetectionSettings copyWith({bool? enabled, bool? url, bool? path}) {
+  /// Whether the command-line pattern should be registered (master AND command),
+  /// under the same #971 kill switch (#998 slice C).
+  bool get detectCommands => !kDetectionDisabled971 && enabled && command;
+
+  /// Whether ANY pattern is registered — the single truth the terminal view's
+  /// repaint gating reads (#921), instead of re-deriving boolean combinations
+  /// per call site (#998 C added a third type; state-management rule).
+  bool get detectionActive => detectUrls || detectPaths || detectCommands;
+
+  DetectionSettings copyWith({
+    bool? enabled,
+    bool? url,
+    bool? path,
+    bool? command,
+  }) {
     return DetectionSettings(
       schemaVersion: detectionSettingsSchemaVersion,
       enabled: enabled ?? this.enabled,
       url: url ?? this.url,
       path: path ?? this.path,
+      command: command ?? this.command,
     );
   }
 
-  /// Serialize to the persisted JSON shape: `{"v":1,"enabled":..,"url":..,"path":..}`.
+  /// Serialize to the persisted JSON shape:
+  /// `{"v":1,"enabled":..,"url":..,"path":..,"command":..}`.
   String toJsonString() => jsonEncode(<String, dynamic>{
     'v': detectionSettingsSchemaVersion,
     'enabled': enabled,
     'url': url,
     'path': path,
+    'command': command,
   });
 
   /// Parse a stored JSON string, FIELD-BY-FIELD with a per-field default
@@ -128,6 +152,8 @@ class DetectionSettings {
         enabled: field('enabled', def.enabled),
         url: field('url', def.url),
         path: field('path', def.path),
+        // Absent in pre-#998 stored values → defaults TRUE (additive).
+        command: field('command', def.command),
       );
     } catch (_) {
       // Corrupt / non-JSON value → safe all-true default (no silent disable).
@@ -141,14 +167,16 @@ class DetectionSettings {
       other.schemaVersion == schemaVersion &&
       other.enabled == enabled &&
       other.url == url &&
-      other.path == path;
+      other.path == path &&
+      other.command == command;
 
   @override
-  int get hashCode => Object.hash(schemaVersion, enabled, url, path);
+  int get hashCode => Object.hash(schemaVersion, enabled, url, path, command);
 
   @override
   String toString() =>
-      'DetectionSettings(v:$schemaVersion, enabled:$enabled, url:$url, path:$path)';
+      'DetectionSettings(v:$schemaVersion, enabled:$enabled, url:$url, '
+      'path:$path, command:$command)';
 }
 
 /// Persisted GLOBAL detection settings (#888 Part A). Synchronous default
@@ -200,6 +228,12 @@ class DetectionSettingsNotifier extends StateNotifier<DetectionSettings> {
   /// Toggle file-path detection.
   Future<void> setPath(bool value) async {
     state = state.copyWith(path: value);
+    await _persist();
+  }
+
+  /// Toggle command-line detection (#998 slice C).
+  Future<void> setCommand(bool value) async {
+    state = state.copyWith(command: value);
     await _persist();
   }
 }

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -31,6 +31,8 @@
 // Per memory feedback_monochrome_icons_no_emoji the mark is a Material glyph in
 // the theme highlight colour (currentColor), never an emoji.
 
+import 'dart:async' show unawaited;
+
 import 'package:flterm/flterm.dart' hide Key;
 import 'package:flutter/material.dart';
 
@@ -233,10 +235,13 @@ class GutterPatternRegistry {
       return GutterItemAction(
         keyLabel: 'not',
         // A file:// URL anchor reads as "Not a file" with the folder glyph
-        // even though its patternId is url/osc8.
-        icon: label == 'Not a file'
-            ? Icons.folder_off_outlined
-            : Icons.link_off,
+        // even though its patternId is url/osc8. Material has no terminal_off,
+        // so "Not a command" (#998 D) gets the generic block glyph.
+        icon: switch (label) {
+          'Not a file' => Icons.folder_off_outlined,
+          'Not a command' => Icons.block,
+          _ => Icons.link_off,
+        },
         label: label,
         onInvoke: (context) async => report(patternId, payload),
       );
@@ -347,6 +352,33 @@ class GutterPatternRegistry {
       ],
     );
 
+    // #998 slice C: the COMMAND-LINE block anchor. GUTTER-ONLY affordance —
+    // no bubble, no glass tap. A single-match chip tap COPIES the whole
+    // command payload paste-exact (the copy IS the primary use; no action
+    // overlay in between); a multi-match row's list sheet labels the copy
+    // "Copy command" and carries the LAST "Not a command" (#998 D → #995
+    // exception store, family 'command'). NOTE: a SOLO command chip therefore
+    // has no "Not a command" path of its own — the sheet appears when an
+    // inner url/path shares the chip's row (the common case for a detected
+    // command).
+    final command = GutterPatternPresentation(
+      patternId: kGhosttyCommandPatternId,
+      icon: Icons.terminal,
+      typeLabel: 'Command',
+      showActions: (context, anchor, markGlobal) {
+        unawaited(_copyWithToast(context, '${anchor.payload}'));
+      },
+      itemActions: (payload) => [
+        GutterItemAction(
+          keyLabel: 'copy',
+          icon: Icons.content_copy,
+          label: 'Copy command',
+          onInvoke: (context) => _copyWithToast(context, payload),
+        ),
+        ?notAction(kGhosttyCommandPatternId, payload, 'Not a command'),
+      ],
+    );
+
     return GutterPatternRegistry([
       url,
       // OSC-8 hyperlinks render the SAME affordance as a regex URL.
@@ -358,6 +390,7 @@ class GutterPatternRegistry {
         itemActions: url.itemActions,
       ),
       path,
+      command,
     ]);
   }
 

--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -37,6 +37,14 @@ const String kGhosttyOsc8PatternId = 'osc8';
 /// the path mark (a distinct glyph + action set from the URL).
 const String kGhosttyPathPatternId = 'path';
 
+/// The id of the COMMAND-LINE pattern (#998 slice C) — the fork's BLOCK-tier
+/// `TextPattern.command` over a whole prompt-anchored command line, for
+/// copy-to-paste. Matches the factory's default id. Deliberately ABSENT from
+/// [GhosttyBubbleLayer._bubblePatternIds]: the command block's affordance is
+/// GUTTER-ONLY (an Icons.terminal chip); its inner url/path/osc8 span anchors
+/// keep their own bubbles and taps inside it.
+const String kGhosttyCommandPatternId = 'command';
+
 /// #864: the URL/OSC-8 pattern highlight style — DELIBERATELY EMPTY (no
 /// background fill, no underline). The bubble is a WIDGET-layer decorator
 /// ([GhosttyBubbleLayer], #767 Slice B / #988) — never a per-glyph fill; the

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -1362,6 +1362,38 @@ Future<String?> ghosttyTapMatchAction(
   return ghosttyTapCopyMatch(match, copy: copy);
 }
 
+/// The structured-text patterns to register on the controller for [detection]
+/// (#888 Part A gating, #998 slice C). PURE — the registration list is the
+/// whole per-type gating contract, so a unit test can assert exactly which
+/// patterns each toggle adds/removes without an FFI terminal.
+///
+/// URLs (#767 Slice B): the OSC-8 hyperlink source is the PRIMARY, exact URL
+/// source ALONGSIDE the regex `url` pattern. The scanner runs both and an
+/// OSC-8 match WINS over an overlapping regex one, so a hyperlinked URL yields
+/// ONE exact anchor spanning all its wrapped rows; a plain-text URL still
+/// falls to the regex pattern. The URL toggle gates BOTH sources (one
+/// user-facing "URLs" type). #864: both carry the EMPTY highlight style (no
+/// fill, no underline) so the bubble decorator is the SINGLE affordance.
+///
+/// Paths (#778 Slice 1): absolute file paths get their own decorator and route
+/// a tap to the SFTP explorer; `://` contexts are rejected so a URL stays a URL.
+///
+/// Commands (#998 C): the fork's BLOCK-tier prompt-anchored command-line
+/// pattern (default [kDefaultCommandLexicon]). Its affordance is GUTTER-ONLY
+/// (no bubble — [kGhosttyCommandPatternId] is not a bubble pattern id) and its
+/// inner url/path/osc8 SPAN anchors coexist inside it (slice A tiering).
+List<TextPattern> ghosttyDetectionPatterns(DetectionSettings detection) => [
+  if (detection.detectUrls) ...[
+    TextPattern.osc8(
+      id: kGhosttyOsc8PatternId,
+      style: kGhosttyUrlHighlightStyle,
+    ),
+    TextPattern.url(id: kGhosttyUrlPatternId, style: kGhosttyUrlHighlightStyle),
+  ],
+  if (detection.detectPaths) TextPattern.path(id: kGhosttyPathPatternId),
+  if (detection.detectCommands) TextPattern.command(id: kGhosttyCommandPatternId),
+];
+
 /// Map a vertical swipe DELTA (logical px the finger moved this update) to a
 /// scrollback pixel delta to apply to the [TerminalScrollController] (#690).
 ///
@@ -2420,20 +2452,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// scroll leaves this false, so the selection is retained and tracks.
   bool _remoteOutputPending = false;
 
-  /// #767: the URL pattern id registered on the controller, so a theme-recolour
-  /// (clear + re-register) and the initial registration share one identity.
-  static const String _kUrlPatternId = kGhosttyUrlPatternId;
-
-  /// #767 Slice B: the OSC-8 hyperlink source id — the PRIMARY, exact URL
-  /// source registered ALONGSIDE the regex `url` pattern. The terminal reads the
-  /// OSC-8 URI off its own cells, so a wrapped link spans all rows and copy/open
-  /// get the exact full URI; an OSC-8 match wins over an overlapping regex one.
-  static const String _kOsc8PatternId = kGhosttyOsc8PatternId;
-
-  /// #778 paths Slice 1: the absolute file-path pattern id, registered alongside
-  /// the URL patterns so the terminal also detects/anchors paths over its own
-  /// cells. A `path` match routes a tap to the SFTP explorer (not clipboard).
-  static const String _kPathPatternId = kGhosttyPathPatternId;
+  // #767/#778/#998: the pattern ids registered on the controller live in
+  // ghostty_terminal_decorators.dart (kGhostty*PatternId); the registration
+  // list itself is the pure [ghosttyDetectionPatterns].
 
   /// #971: short per-session tag for repaint telemetry so multi-session captures
   /// are ATTRIBUTABLE (which view is stuck vs busy). `host#tail` from the session
@@ -2812,30 +2833,8 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // type (the controller no-ops on an empty pattern set). Master OFF →
     // register nothing.
     final detection = ref.read(detectionSettingsProvider);
-    if (detection.detectUrls) {
-      // #767 Slice B: register the OSC-8 hyperlink source as the PRIMARY, exact
-      // URL source ALONGSIDE the regex `url` pattern. The scanner runs both and
-      // an OSC-8 match WINS over an overlapping regex one (the partial first-row
-      // `https://…` over a hyperlink's visible text is suppressed), so a
-      // hyperlinked URL yields ONE exact anchor spanning all its wrapped rows. A
-      // plain-text URL (no OSC-8) still falls to the regex pattern unchanged.
-      // The URL toggle gates BOTH sources (one user-facing "URLs" type).
-      // #864: register both URL sources with the EMPTY highlight style (no fill,
-      // no underline) so the bubble decorator is the SINGLE affordance — the app
-      // never co-renders an underline that reads redundant with the chip.
-      controller.registerTextPattern(
-        TextPattern.osc8(id: _kOsc8PatternId, style: kGhosttyUrlHighlightStyle),
-      );
-      controller.registerTextPattern(
-        TextPattern.url(id: _kUrlPatternId, style: kGhosttyUrlHighlightStyle),
-      );
-    }
-    if (detection.detectPaths) {
-      // #778 paths Slice 1: also detect absolute file paths. A `path` anchor
-      // gets its own decorator (folder glyph + dotted underline) and routes a
-      // tap to the SFTP explorer; `://` contexts are rejected so a URL stays a
-      // URL.
-      controller.registerTextPattern(TextPattern.path(id: _kPathPatternId));
+    for (final pattern in ghosttyDetectionPatterns(detection)) {
+      controller.registerTextPattern(pattern);
     }
     // #921: tell the render box whether detection is now active. Active means the
     // controller's detection RenderState handle competes to consume the shared
@@ -2843,7 +2842,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // change to keep repainting. Deferred to a post-frame callback so the keyed
     // render box exists (this runs from initState-time registration before first
     // layout, where the box lookup would no-op).
-    final detectionActive = detection.detectUrls || detection.detectPaths;
+    final detectionActive = detection.detectionActive;
     // Detection-saga telemetry (#966-era "URLs not detected" report): record what
     // this registration + the SYNCHRONOUS rescan produced so the next bug report
     // is one-shot diagnosable instead of a blind build loop. Cheap; runs on init
@@ -2864,6 +2863,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     ctrace(
       'detect',
       'register url=${detection.detectUrls} path=${detection.detectPaths} '
+      'command=${detection.detectCommands} '
       'screen=${controller.activeScreen} mouse=${controller.mouseTracking} '
       'anchors=${anchors.length} gutterResolved=$gutterResolved',
     );
@@ -3193,7 +3193,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final detection = ref.read(detectionSettingsProvider);
-      _applyDetectionActive(detection.detectUrls || detection.detectPaths);
+      _applyDetectionActive(detection.detectionActive);
     });
     // 4. FORCE REPAINT WHEN FOCUS WAS RETAINED (#720): the #718 re-focus above
     //    only repaints when focus was LOST while backgrounded — the focus CHANGE
@@ -3415,7 +3415,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         final detection = ref.read(detectionSettingsProvider);
-        _applyDetectionActive(detection.detectUrls || detection.detectPaths);
+        _applyDetectionActive(detection.detectionActive);
       });
     }
     if (ghosttyShouldCaptureKeyboardOnSessionSwitch(
@@ -3726,7 +3726,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // persists a detection exception for the ORIGINAL matched payload text.
     void markNot() =>
         _reportDetectionException(match.patternId, '${match.payload}');
-    if (match.patternId == _kPathPatternId) {
+    if (match.patternId == kGhosttyPathPatternId) {
       showPathActions(
         context,
         '${match.payload}',
@@ -4343,7 +4343,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             // SUPPRESSED match (unverified single-segment path) shows NO
             // affordance — including tap actions — so it doesn't hit-test.
             urlAtCell: (col, row) {
-              final match = controller.matchAt(row: row, col: col);
+              // #998 C: glass taps hit-test SPAN-tier matches only. The
+              // BLOCK-tier command anchor's affordance is the gutter chip —
+              // a tap on command text that is not an inner URL/path must keep
+              // its pre-#998 behavior (selection etc.), never block tap-copy.
+              final match = controller.matchAt(
+                row: row,
+                col: col,
+                tier: TextTier.span,
+              );
               if (match == null) return null;
               if (!_isPayloadVisible(match.patternId, '${match.payload}')) {
                 return null;

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -190,8 +190,8 @@ class SettingsPanel extends ConsumerWidget {
             kDetectionDisabled971
                 ? 'Temporarily turned off while we fix a repaint issue (#971). '
                   'Your setting is remembered and comes back when it\'s fixed.'
-                : 'Find URLs and file paths in terminal output and make them '
-                  'tappable.',
+                : 'Find URLs, file paths and command lines in terminal '
+                  'output and make them tappable.',
           ),
           value: detection.enabled,
           onChanged: (v) =>
@@ -219,6 +219,23 @@ class SettingsPanel extends ConsumerWidget {
               ? (v) => ref.read(detectionSettingsProvider.notifier).setPath(v)
               : null,
         ),
+        // #998 slice C: command-line detection — a gutter chip that copies the
+        // whole prompt-anchored command line paste-exact.
+        SwitchListTile(
+          key: const ValueKey('detection-command-toggle'),
+          secondary: const Icon(Icons.terminal),
+          contentPadding: const EdgeInsets.only(left: 32, right: 16),
+          title: const Text('Command lines'),
+          subtitle: const Text(
+            'Detect command lines at a shell prompt; the gutter chip copies '
+            'the whole command.',
+          ),
+          value: detection.command,
+          onChanged: detection.enabled
+              ? (v) =>
+                  ref.read(detectionSettingsProvider.notifier).setCommand(v)
+              : null,
+        ),
         // #995: reviewable detection exceptions — the saved "Not a URL" /
         // "Not a file" reports. Each entry shows the suppressed text + when/
         // where it was reported, with a per-entry remove that restores
@@ -230,19 +247,21 @@ class SettingsPanel extends ConsumerWidget {
             leading: Icon(Icons.playlist_remove_outlined),
             title: Text('No exceptions'),
             subtitle: Text(
-              'Use "Not a URL" / "Not a file" on a detected link or path to '
-              'stop detecting that exact text. Saved reports appear here.',
+              'Use "Not a URL" / "Not a file" / "Not a command" on a '
+              'detected item to stop detecting that exact text. Saved '
+              'reports appear here.',
             ),
           )
         else
           for (var i = 0; i < exceptions.length; i++)
             ListTile(
               key: ValueKey('detection-exception-$i'),
-              leading: Icon(
-                exceptions[i].family == 'path'
-                    ? Icons.folder_off_outlined
-                    : Icons.link_off,
-              ),
+              leading: Icon(switch (exceptions[i].family) {
+                'path' => Icons.folder_off_outlined,
+                // #998 D: "Not a command" reports (family 'command').
+                'command' => Icons.terminal,
+                _ => Icons.link_off,
+              }),
               title: Text(
                 exceptions[i].matchedText,
                 maxLines: 2,
@@ -369,6 +388,7 @@ class SettingsPanel extends ConsumerWidget {
     await detectionNotifier.setEnabled(true);
     await detectionNotifier.setUrl(true);
     await detectionNotifier.setPath(true);
+    await detectionNotifier.setCommand(true);
 
     if (context.mounted) {
       showTopToast(context, 'Settings reset to defaults');

--- a/native/test/state/detection_exceptions_providers_test.dart
+++ b/native/test/state/detection_exceptions_providers_test.dart
@@ -64,6 +64,24 @@ void main() {
     expect(n.isSuppressed('path', 'https://a.b/c'), isFalse);
   });
 
+  test('"Not a command" (#998 D): family "command" suppresses + persists, '
+      'isolated from url/path', () async {
+    const cmd = 'curl -fsSL https://a.b/c | tail -1';
+    final n = await notifier();
+    await n.report(patternId: 'command', matchedText: cmd);
+
+    expect(n.isSuppressed('command', cmd), isTrue);
+    // Its own family: the same text as a URL/path stays visible…
+    expect(n.isSuppressed('url', cmd), isFalse);
+    expect(n.isSuppressed('path', cmd), isFalse);
+    // …and exact-match v1 within the family.
+    expect(n.isSuppressed('command', 'curl -fsSL https://a.b/c'), isFalse);
+
+    // Persisted across a fresh notifier (survives reconnect/app restart).
+    final n2 = await notifier();
+    expect(n2.isSuppressed('command', cmd), isTrue);
+  });
+
   test('removeException restores detection and persists', () async {
     final n = await notifier();
     await n.report(patternId: 'path', matchedText: '/etc/hosts');

--- a/native/test/state/detection_providers_test.dart
+++ b/native/test/state/detection_providers_test.dart
@@ -29,11 +29,13 @@ void main() {
       expect(s.enabled, isTrue);
       expect(s.url, isTrue);
       expect(s.path, isTrue);
+      expect(s.command, isTrue);
       expect(s.schemaVersion, detectionSettingsSchemaVersion);
       // The stored prefs still default all-true; the effective getters follow
       // the #971 kill switch (force-disabled while it's set).
       expect(s.detectUrls, !kDetectionDisabled971);
       expect(s.detectPaths, !kDetectionDisabled971);
+      expect(s.detectCommands, !kDetectionDisabled971);
     });
 
     test('#971 kill switch force-disables the getters regardless of prefs', () {
@@ -47,10 +49,17 @@ void main() {
       expect(on.path, isTrue);
     });
 
-    test('master off gates both url and path registration', () {
-      const s = DetectionSettings(enabled: false, url: true, path: true);
+    test('master off gates url, path AND command registration', () {
+      const s = DetectionSettings(
+        enabled: false,
+        url: true,
+        path: true,
+        command: true,
+      );
       expect(s.detectUrls, isFalse);
       expect(s.detectPaths, isFalse);
+      expect(s.detectCommands, isFalse);
+      expect(s.detectionActive, isFalse);
     });
 
     test('per-type off gates only that type', () {
@@ -60,21 +69,55 @@ void main() {
       const noPath = DetectionSettings(path: false);
       expect(noPath.detectUrls, !kDetectionDisabled971);
       expect(noPath.detectPaths, isFalse);
+      // #998 slice C: the command-line toggle is a third per-type gate.
+      const noCommand = DetectionSettings(command: false);
+      expect(noCommand.detectCommands, isFalse);
+      expect(noCommand.detectUrls, !kDetectionDisabled971);
+      expect(noCommand.detectPaths, !kDetectionDisabled971);
+    });
+
+    test('detectionActive is true while ANY type is registered (#998 C)', () {
+      const onlyCommand = DetectionSettings(url: false, path: false);
+      expect(onlyCommand.detectCommands, !kDetectionDisabled971);
+      expect(onlyCommand.detectionActive, !kDetectionDisabled971);
+      const allOff = DetectionSettings(url: false, path: false, command: false);
+      expect(allOff.detectionActive, isFalse);
     });
 
     test('toJsonString emits the versioned shape', () {
-      const s = DetectionSettings(enabled: true, url: false, path: true);
+      const s = DetectionSettings(
+        enabled: true,
+        url: false,
+        path: true,
+        command: false,
+      );
       final decoded = jsonDecode(s.toJsonString()) as Map<String, dynamic>;
       expect(decoded['v'], detectionSettingsSchemaVersion);
       expect(decoded['enabled'], true);
       expect(decoded['url'], false);
       expect(decoded['path'], true);
+      expect(decoded['command'], false);
     });
 
     test('fromJsonString round-trips a serialized value', () {
-      const s = DetectionSettings(enabled: false, url: false, path: true);
+      const s = DetectionSettings(
+        enabled: false,
+        url: false,
+        path: true,
+        command: false,
+      );
       final back = DetectionSettings.fromJsonString(s.toJsonString());
       expect(back, s);
+    });
+
+    test('a stored pre-#998 value (no command field) defaults command TRUE', () {
+      // The v1 shape persisted before the command toggle existed must hydrate
+      // with command detection ON (purely-additive setting, no regression).
+      final s = DetectionSettings.fromJsonString(
+        '{"v":1,"enabled":true,"url":false,"path":true}',
+      );
+      expect(s.command, isTrue);
+      expect(s.url, isFalse);
     });
 
     group('fromJsonString fallback', () {
@@ -169,13 +212,16 @@ void main() {
       expect(decoded['enabled'], false);
     });
 
-    test('setUrl / setPath persist independently (round-trip)', () async {
+    test('setUrl / setPath / setCommand persist independently (round-trip)',
+        () async {
       final n = DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
       await _settle();
       await n.setUrl(false);
       await n.setPath(false);
+      await n.setCommand(false);
       expect(n.state.url, isFalse);
       expect(n.state.path, isFalse);
+      expect(n.state.command, isFalse);
       expect(n.state.enabled, isTrue);
 
       // A fresh notifier reading the persisted value sees the same state.
@@ -184,6 +230,7 @@ void main() {
       await _settle();
       expect(n2.state.url, isFalse);
       expect(n2.state.path, isFalse);
+      expect(n2.state.command, isFalse);
       expect(n2.state.enabled, isTrue);
     });
   });

--- a/native/test/ui/ghostty_gutter_command_test.dart
+++ b/native/test/ui/ghostty_gutter_command_test.dart
@@ -1,0 +1,369 @@
+// #998 slices C+D — the COMMAND-LINE gutter chip.
+//
+// A command anchor (the fork's block-tier TextPattern.command, slices A/B) gets
+// a GUTTER-ONLY affordance: an Icons.terminal chip on the anchor's FIRST
+// visible row (the gutter's existing anchorGutterRow semantics — never one chip
+// per wrapped row). Single tap = COPY the whole command payload paste-exact
+// (the existing copy toast); a multi-match row's list sheet labels the action
+// "Copy command" and carries the LAST item "Not a command" (#995 exception
+// store, family 'command'). Inner URL/path anchors keep their own affordances
+// alongside — the block never fights the spans.
+//
+// Also locks the registration gating: `ghosttyDetectionPatterns` registers the
+// command pattern only while the "Detect command lines" setting (AND the
+// master switch) is on.
+//
+// No FFI: the fake controller supplies scripted anchors (the same harness as
+// ghostty_gutter_layer_test.dart). Real-prompt detection + wrap-join payload
+// exactness are the fork's slice-B tests + the emulator integration test.
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:mobissh/ui/ghostty_gutter_layer.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+/// The paste-exact payload contract: internal quoting AND double spacing must
+/// survive verbatim (the design's `bash  -s` case).
+const _command =
+    'curl -fsSL https://example.com/setup.sh | bash  -s "reset" >log 2>&1';
+const _innerUrl = 'https://example.com/setup.sh';
+
+StructuredAnchor _commandAnchor({List<int> rows = const [3]}) =>
+    StructuredAnchor(
+      patternId: kGhosttyCommandPatternId,
+      payload: _command,
+      ranges: [
+        for (final r in rows)
+          HighlightRange(
+            startRow: r,
+            startCol: 0,
+            endRow: r,
+            endCol: 20,
+            payload: _command,
+          ),
+      ],
+    );
+
+StructuredAnchor _urlAnchor({int row = 3}) => StructuredAnchor(
+  patternId: kGhosttyUrlPatternId,
+  payload: _innerUrl,
+  ranges: [
+    HighlightRange(
+      startRow: row,
+      startCol: 6,
+      endRow: row,
+      endCol: 6 + _innerUrl.length,
+      payload: _innerUrl,
+    ),
+  ],
+);
+
+/// Fake controller exposing scripted [anchors] + [anchorGutterRow] — the only
+/// surface [GhosttyGutterLayer] reads (mirrors ghostty_gutter_layer_test.dart).
+class _FakeController extends ChangeNotifier implements TerminalController {
+  List<StructuredAnchor> _anchors = const [];
+
+  void setAnchors(List<StructuredAnchor> value) {
+    _anchors = value;
+    notifyListeners();
+  }
+
+  @override
+  List<StructuredAnchor> get anchors => _anchors;
+
+  @override
+  bool get isScrolling => false;
+
+  @override
+  Listenable get decorationListenable => this;
+
+  @override
+  int? anchorGutterRow(HighlightRange range) {
+    final row = range.topRow;
+    if (row < 0 || row >= 24) return null;
+    return row;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Capture clipboard writes: the copy path routes through the hardened
+  // `mobissh/clipboard` channel (#845) with a platform-channel fallback.
+  String? lastClipboard;
+
+  setUp(() {
+    lastClipboard = null;
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('mobissh/clipboard'),
+      (call) async {
+        if (call.method == 'setText') {
+          lastClipboard = (call.arguments as Map)['text'] as String?;
+          return true;
+        }
+        return null;
+      },
+    );
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        lastClipboard = (call.arguments as Map)['text'] as String?;
+      }
+      if (call.method == 'Clipboard.getData') {
+        return <String, dynamic>{'text': lastClipboard};
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('mobissh/clipboard'),
+      null,
+    );
+    messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  /// Drain the top-toast auto-dismiss timer before the test body ends.
+  Future<void> drainToast(WidgetTester tester) async {
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  group('registration gating (ghosttyDetectionPatterns, #998 C)', () {
+    test('all-on registers osc8+url+path+command', () {
+      final ids = ghosttyDetectionPatterns(const DetectionSettings())
+          .map((p) => p.id)
+          .toList();
+      expect(ids, containsAll(<String>['osc8', 'url', 'path', 'command']));
+    });
+
+    test('the command pattern id matches the fork factory default', () {
+      expect(kGhosttyCommandPatternId, TextPattern.command().id);
+    });
+
+    test('command toggle OFF removes ONLY the command registration', () {
+      final ids = ghosttyDetectionPatterns(
+        const DetectionSettings(command: false),
+      ).map((p) => p.id).toList();
+      expect(ids, isNot(contains('command')));
+      expect(ids, containsAll(<String>['osc8', 'url', 'path']));
+    });
+
+    test('master OFF registers nothing', () {
+      expect(
+        ghosttyDetectionPatterns(const DetectionSettings(enabled: false)),
+        isEmpty,
+      );
+    });
+
+    test('the registered command pattern is BLOCK tier (gutter-only)', () {
+      final command = ghosttyDetectionPatterns(const DetectionSettings())
+          .firstWhere((p) => p.id == kGhosttyCommandPatternId);
+      expect(command.tier, TextTier.block);
+    });
+  });
+
+  group('command gutter chip (#998 C)', () {
+    Future<_FakeController> pumpLayer(
+      WidgetTester tester, {
+      void Function(String patternId, String payload)? onReportException,
+      bool Function(StructuredAnchor anchor)? isVisible,
+    }) async {
+      final controller = _FakeController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                Positioned.fill(
+                  child: GhosttyGutterLayer(
+                    controller: controller,
+                    registry: GutterPatternRegistry.standard(
+                      openPath: (_) async => true,
+                      onReportException: onReportException,
+                    ),
+                    color: const Color(0xFF5B9BD5),
+                    cellHeight: 20,
+                    isVisible: isVisible,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return controller;
+    }
+
+    testWidgets('a command anchor row shows the terminal chip', (tester) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([_commandAnchor(rows: const [5])]);
+      await tester.pump();
+      expect(find.byKey(const Key('gutter-mark-5')), findsOneWidget);
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(const Key('gutter-mark-5')),
+          matching: find.byType(Icon),
+        ),
+      );
+      expect(icon.icon, Icons.terminal);
+    });
+
+    testWidgets('a MULTI-ROW command anchor chips only its FIRST row',
+        (tester) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([
+        _commandAnchor(rows: const [4, 5, 6]),
+      ]);
+      await tester.pump();
+      expect(find.byKey(const Key('gutter-mark-4')), findsOneWidget);
+      expect(find.byKey(const Key('gutter-mark-5')), findsNothing);
+      expect(find.byKey(const Key('gutter-mark-6')), findsNothing);
+    });
+
+    testWidgets('tap the command chip → copies the EXACT payload + toast',
+        (tester) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([_commandAnchor(rows: const [5])]);
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('gutter-mark-5')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        lastClipboard,
+        _command,
+        reason: 'the copy must be paste-exact (quotes, redirects, double '
+            'space preserved verbatim)',
+      );
+      // The existing copy toast — and NO url/path action overlay.
+      expect(find.textContaining('Copied'), findsOneWidget);
+      expect(find.byKey(const Key('url-action-menu')), findsNothing);
+      expect(find.byKey(const Key('path-action-menu')), findsNothing);
+      await drainToast(tester);
+    });
+
+    testWidgets(
+        'command + inner URL on one row → list sheet: "Copy command" copies '
+        'the whole command; the URL item copies just the URL', (tester) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([
+        _commandAnchor(rows: const [3]),
+        _urlAnchor(row: 3),
+      ]);
+      await tester.pump();
+
+      // Both anchors share the row → the count badge, not two chips.
+      expect(find.byKey(const Key('gutter-mark-3')), findsOneWidget);
+      expect(find.text('2'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('gutter-mark-3')));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('gutter-pattern-list')), findsOneWidget);
+      // Item 0 is the command (anchor order): labeled clearly.
+      expect(find.text('Command'), findsOneWidget);
+      final copyCommand = find.byKey(const Key('gutter-item-0-copy'));
+      expect(
+        tester.widget<IconButton>(copyCommand).tooltip,
+        'Copy command',
+        reason: 'the sheet must label the whole-command copy clearly',
+      );
+      await tester.tap(copyCommand);
+      await tester.pumpAndSettle();
+      expect(lastClipboard, _command);
+
+      // Re-open: the URL item's copy still copies JUST the URL.
+      await tester.tap(find.byKey(const Key('gutter-mark-3')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('gutter-item-1-copy')));
+      await tester.pumpAndSettle();
+      expect(lastClipboard, _innerUrl);
+      await drainToast(tester);
+    });
+
+    testWidgets(
+        'the inner URL keeps its OWN chip on its own row beside a wrapped '
+        'command block', (tester) async {
+      final controller = await pumpLayer(tester);
+      controller.setAnchors([
+        _commandAnchor(rows: const [3, 4]),
+        _urlAnchor(row: 4),
+      ]);
+      await tester.pump();
+      // Command chips row 3; the URL (starting on the wrap row) chips row 4.
+      final commandIcon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(const Key('gutter-mark-3')),
+          matching: find.byType(Icon),
+        ),
+      );
+      final urlIcon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(const Key('gutter-mark-4')),
+          matching: find.byType(Icon),
+        ),
+      );
+      expect(commandIcon.icon, Icons.terminal);
+      expect(urlIcon.icon, Icons.link);
+    });
+
+    testWidgets('"Not a command" is the LAST sheet action and reports the '
+        'command patternId + exact payload (#998 D)', (tester) async {
+      final reports = <(String, String)>[];
+      final controller = await pumpLayer(
+        tester,
+        onReportException: (patternId, payload) =>
+            reports.add((patternId, payload)),
+      );
+      controller.setAnchors([
+        _commandAnchor(rows: const [3]),
+        _urlAnchor(row: 3),
+      ]);
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('gutter-mark-3')));
+      await tester.pumpAndSettle();
+
+      final notCommand = find.byKey(const Key('gutter-item-0-not'));
+      expect(tester.widget<IconButton>(notCommand).tooltip, 'Not a command');
+      // LAST action on the command item: no other action follows it in the row.
+      final commandActions = tester
+          .widgetList<IconButton>(
+            find.descendant(
+              of: find.byKey(const Key('gutter-item-0')),
+              matching: find.byType(IconButton),
+            ),
+          )
+          .toList();
+      expect(commandActions.last.tooltip, 'Not a command');
+
+      await tester.tap(notCommand);
+      await tester.pumpAndSettle();
+      expect(reports, [(kGhosttyCommandPatternId, _command)]);
+      await drainToast(tester);
+    });
+
+    testWidgets('a suppressed command anchor renders NO chip (the #995/#990 '
+        'visibility seam)', (tester) async {
+      final controller = await pumpLayer(
+        tester,
+        isVisible: (a) => '${a.payload}' != _command,
+      );
+      controller.setAnchors([_commandAnchor(rows: const [5])]);
+      await tester.pump();
+      expect(find.byKey(const Key('gutter-mark-5')), findsNothing);
+    });
+  });
+}

--- a/native/test/widget/settings_page_combined_test.dart
+++ b/native/test/widget/settings_page_combined_test.dart
@@ -65,6 +65,7 @@ void main() {
       'detection-master-toggle',
       'detection-url-toggle',
       'detection-path-toggle',
+      'detection-command-toggle',
       'settings-reset-button',
     ]) {
       expect(


### PR DESCRIPTION
Implements slices C and D of #998 per the design comment (https://github.com/flavordrake/mobissh/issues/998#issuecomment — "Spike: wrapped command-line block anchors"): app-side registration of the fork's `TextPattern.command` (slices A/B already on main) plus the gutter command chip and the "Not a command" exception.

## Slice C — registration + gutter chip
- `detection_providers.dart`: new `command` field (default ON, additive — a pre-#998 stored value hydrates it ON), `detectCommands` under the same master/#971 kill switch, `setCommand`, and a `detectionActive` getter replacing the `detectUrls || detectPaths` boolean combos at the view's three call sites.
- `ghostty_terminal_view.dart`: registration factored into pure `ghosttyDetectionPatterns(DetectionSettings)` (unit-testable gating); registers `TextPattern.command(id: kGhosttyCommandPatternId)` when the toggle is on. Glass hit-test (`urlAtCell`) now queries `matchAt(tier: TextTier.span)` — taps on text NEVER route to the block anchor (spec: no block tap handling on the glass; inner URL/path taps unchanged).
- `ghostty_terminal_decorators.dart`: `kGhosttyCommandPatternId = 'command'`; deliberately NOT a bubble pattern — the affordance is gutter-only.
- `ghostty_gutter_layer.dart`: command `GutterPatternPresentation` — monochrome `Icons.terminal` chip, typeLabel `Command`; single-tap COPIES the whole payload paste-exact (existing copy toast); multi-match list sheet action is labeled "Copy command". Multi-row anchors chip only the first visible row (existing `anchorGutterRow` grouping).
- `settings_panel.dart`: "Command lines" toggle (`detection-command-toggle`) beside URLs/File paths, disabled when master off; Reset settings restores it; master subtitle mentions command lines.

## Slice D — "Not a command"
- The command sheet item carries a LAST "Not a command" action through the existing #995 `notAction` seam → `_reportDetectionException('command', payload)` → exceptions store (family `command` is generic) → suppression via the same composed `_isPayloadVisible` / gutter `isVisible` gate. No new suppression machinery.
- Settings "Detection exceptions" renders command entries with a terminal leading icon; empty-state hint mentions "Not a command".

## Tests
- `test/state/detection_providers_test.dart`: command field defaults/gating/JSON round-trip/pre-#998 hydration/persist; `detectionActive`.
- `test/state/detection_exceptions_providers_test.dart`: family `command` suppresses + persists, isolated from url/path.
- `test/ui/ghostty_gutter_command_test.dart` (new): registration gating per toggle, terminal chip on first row only, tap-copy paste-exact (double space/quotes/redirects preserved), sheet "Copy command" + URL "Copy" coexistence, "Not a command" is LAST and reports (patternId, exact payload), visibility-seam suppression.
- `test/widget/settings_page_combined_test.dart`: command toggle is a top-level control.
- `integration_test/command_chip_998_test.dart` (new, emulator): real test-sshd session, strong `user@host:~$` prompt, real `curl -fsSL <url> | tail -1` typed at the prompt → command anchor payload EXACTLY the typed line; chip tap → clipboard = full command; inner URL affordance coexists and copies just the URL. PASSED twice on the emulator (rows shared → the count-2 badge + list-sheet path, exercising "Copy command" and asserting "Not a command" presence; copies verified 54-char command then 33-char URL). Screenshots: `test-results/emulator-shots/20260708T181835+0000-998-chips_.png` (wrapped command at the real prompt, inner-URL wash, count-2 chip) and `...-998-sheet_.png` (sheet with Link + Command items, Copy command + Not a command).

## Caveats
- A SOLO command chip's tap copies immediately (per design: single-tap = copy), so "Not a command" is only reachable when the chip is a multi-match badge (an inner URL/path sharing the row — the common case for detected commands). Noted in code.
- The unrelated `reconnect_shell_revive_test` flaked once in a full gate run (green in isolation and in the final gate) — the known emulator/CPU-load flake class.

Closes #998.