### PR TITLE
fix(native): reset stale mouse-reporting DEC modes at the reconnect revive boundary (#1014)

### DIFF
--- a/native/integration_test/reconnect_mouse_mode_1014_test.dart
+++ b/native/integration_test/reconnect_mouse_mode_1014_test.dart
@@ -1,0 +1,274 @@
+// On-emulator #1014: stale mouse-reporting mode after reconnect.
+//
+// Owner telemetry (2026-07-08T18-13-09): a network blip dropped 5 sessions;
+// ALL reconnected in ~5s, but the app kept synthesizing SGR mouse reports
+// (`mouseMode` still on from the pre-drop tmux) into the revived remote —
+// into a plain shell they land as literal `[<65;...M` text at the prompt.
+//
+// FIX under test: at the revive boundary (`proxy.shellReady`, re-fires on every
+// reconnect) the ghostty view writes `ghosttyInputModeResetSequence` (DECRST
+// for every synthesized-input-gating DEC private mode) LOCALLY into the
+// terminal parser. The remote re-enables the modes through the byte stream if
+// its TUI is still alive (tmux attach re-emits DECSET).
+//
+// Shape mirrors the owner's MULTI-SESSION incident: session B (plain shell,
+// port 2223 — requires BRIDGE_PORT2=2223 on native-connect-test.sh) holds the
+// foreground service while session A (tmux, mouse on) takes a REAL transport
+// drop. A single-session soft drop instead trips a pre-existing keepalive race
+// (softDisconnected does not hold the FGS; the 1→0 count stops the service
+// mid-reconnect) — that race is a SEPARATE issue, deliberately not exercised.
+//
+// Device-class transitions validated end-to-end (real tmux on test-sshd, real
+// transport drop, real held-params reconnect through the task gateway):
+//   1. tmux (mouse on) → controller.mouseTracking engages; a firm TAP forwards
+//      an SGR click (existing #693 behavior — the sent-SGR recorder grows).
+//   2. kill session A's `sshd: testuser@pts/N` (via a throwaway dartssh2 EXEC
+//      connection; exec = @notty so the killer never matches itself) → A goes
+//      softDisconnected like the owner's blip → reconnect revives a PLAIN
+//      prompt (tmux stays detached) → mouseTracking resets to NONE; a tap
+//      forwards NO SGR; no literal `[<` garbage renders; B stays connected.
+//   3. `tmux attach` (the TUI was alive all along) → its re-emitted DECSET
+//      re-engages mouse tracking with no user action.
+//
+// Bridge: BRIDGE_PORT2=2223 scripts/native-connect-test.sh \
+//     integration_test/reconnect_mouse_mode_1014_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'reconnect resets stale mouse mode: no SGR into the revived plain shell; '
+    'a live TUI re-enables via bytes (#1014)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      /// Pump in 500ms slices until [test] passes or [maxSlices] elapse,
+      /// accepting any host-key trust prompt along the way.
+      Future<bool> pumpUntil(bool Function() test, {int maxSlices = 60}) async {
+        for (var i = 0; i < maxSlices; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+          final trust = find.text('Trust + connect');
+          if (trust.evaluate().isNotEmpty) {
+            await tester.tap(trust.first);
+            await tester.pump(const Duration(milliseconds: 300));
+          }
+          if (test()) return true;
+        }
+        return false;
+      }
+
+      Future<void> settle([int ticks = 8]) async {
+        for (var i = 0; i < ticks; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+        }
+      }
+
+      // Session B FIRST (plain shell on the 2223 bridge): holds the foreground
+      // service through A's drop, mirroring the owner's multi-session incident.
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2223',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      final reachedB = await pumpUntil(
+        () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+      );
+      expect(reachedB, isTrue, reason: 'session B never reached the terminal');
+      final entryB = container.read(sessionsProvider).active!;
+      final connectedB = await pumpUntil(
+        () => entryB.proxy.data.state == SshSessionState.connected,
+      );
+      expect(connectedB, isTrue, reason: 'session B never connected');
+
+      // Session A (the victim, on 2222) via the New-session flow. Connected
+      // LAST so it is the ACTIVE, VISIBLE view for the whole gesture phase.
+      await tester.tap(find.byKey(const Key('session-menu-button')));
+      await settle(4);
+      expect(find.byKey(const Key('session-menu-new')), findsOneWidget,
+          reason: 'no New-session affordance in the session menu');
+      await tester.tap(find.byKey(const Key('session-menu-new')));
+      await settle(6);
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      final connectedA = await pumpUntil(() {
+        final entries = container.read(sessionsProvider).entries;
+        return entries.length == 2 &&
+            entries.every(
+              (e) => e.proxy.data.state == SshSessionState.connected,
+            );
+      });
+      expect(connectedA, isTrue, reason: 'session A never connected');
+      final entry = container.read(sessionsProvider).active!;
+      expect(entry.id, isNot(entryB.id),
+          reason: 'active session after the 2nd connect must be A');
+      final sessionId = entry.id;
+
+      TerminalController? ctrlOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      final gotController = await pumpUntil(() => ctrlOf() != null);
+      expect(gotController, isTrue, reason: 'no ghostty controller for A');
+      final controller = ctrlOf()!;
+
+      void send(String cmd) =>
+          entry.proxy.sendInput(Uint8List.fromList(utf8.encode(cmd)));
+
+      String rendered() {
+        final v = controller.scrollbar.visible;
+        final rows = v > 0 ? v : 24;
+        return controller.visibleRowsText(0, rows - 1);
+      }
+
+      // A firm tap at the terminal center — under mouse mode the #693 overlay
+      // forwards it as an SGR click (press+release), recorded by the sent-SGR
+      // recorder; with mouse mode off it only focuses (NO SGR by design).
+      Future<void> tapTerminalCenter() async {
+        final center = tester.getCenter(
+          find.byKey(Key('ghostty-terminal-$sessionId')),
+        );
+        await tester.tapAt(center);
+        await settle(4);
+      }
+
+      final recorder = GhosttyTerminalView.debugByteRecorders[sessionId];
+      expect(recorder, isNotNull, reason: 'no byte recorder for session A');
+      int sgrCount() => recorder!.snapshotSentSgrTrace().length;
+
+      // Phase 1 — pre-drop: a mouse-reporting TUI (tmux, mouse on) on A.
+      send('tmux kill-server 2>/dev/null; tmux set -g mouse on \\; '
+          'new -s m1014\n');
+      var engaged = await pumpUntil(
+        () => controller.mouseTracking != MouseTracking.none,
+        maxSlices: 30,
+      );
+      if (!engaged) {
+        send('tmux set -g mouse on\n');
+        engaged = await pumpUntil(
+          () => controller.mouseTracking != MouseTracking.none,
+          maxSlices: 20,
+        );
+      }
+      expect(engaged, isTrue, reason: 'setup: tmux mouse mode never engaged');
+
+      final sgrBeforeTap = sgrCount();
+      await tapTerminalCenter();
+      expect(sgrCount(), greaterThan(sgrBeforeTap),
+          reason: 'precondition (existing #693 behavior): a tap under mouse '
+              'mode must forward an SGR click');
+
+      // Phase 2 — REAL transport drop of A ONLY: kill the sshd process behind
+      // the tmux-attached client tty (that is A; B is not attached to tmux).
+      // Run over a throwaway dartssh2 EXEC connection: exec allocates no pty
+      // (`@notty`), so the pattern can never match the killer itself.
+      final killer = SSHClient(
+        await SSHSocket.connect('127.0.0.1', 2222),
+        username: 'testuser',
+        onPasswordRequest: () => 'testpass',
+      );
+      final killOut = utf8.decode(
+        await killer.run(
+          r'T=$(tmux display -p -t m1014 "#{client_tty}"); '
+          r'pkill -9 -f "sshd: testuser@${T#/dev/}"; '
+          r'echo "KILLED_TTY=$T"',
+        ),
+      );
+      debugPrint('#1014 transport kill: $killOut');
+      killer.close();
+
+      final dropped = await pumpUntil(
+        () => entry.proxy.data.state != SshSessionState.connected,
+      );
+      expect(dropped, isTrue,
+          reason: 'transport kill never dropped session A ($killOut)');
+
+      // Held-params revive (force-now skips the reconnect backoff — the same
+      // task-side `reconnectNow()` path the auto-reconnect takes).
+      entry.proxy.reconnect();
+      final revived = await pumpUntil(
+        () => entry.proxy.data.state == SshSessionState.connected,
+        maxSlices: 80,
+      );
+      expect(revived, isTrue, reason: 'held-params reconnect never revived A');
+
+      // THE #1014 ASSERT: the revive boundary must reset the stale mouse mode.
+      final resetLanded = await pumpUntil(
+        () => controller.mouseTracking == MouseTracking.none,
+        maxSlices: 24,
+      );
+      expect(
+        resetLanded,
+        isTrue,
+        reason: 'STALE MODE (#1014): mouse tracking survived the reconnect '
+            '(still ${controller.mouseTracking}) — the app would keep '
+            'synthesizing SGR into the revived plain shell',
+      );
+
+      // Prove the gesture path is disarmed: a tap forwards NOTHING and no
+      // mouse-report garbage renders at the revived prompt.
+      await settle(12);
+      final sgrBeforeRevivedTap = sgrCount();
+      await tapTerminalCenter();
+      expect(
+        sgrCount(),
+        sgrBeforeRevivedTap,
+        reason: '#1014: a tap AFTER the plain-shell revive still forwarded an '
+            'SGR mouse report — stale mode state kept the synth path armed',
+      );
+      expect(
+        rendered().contains('[<'),
+        isFalse,
+        reason: '#1014 owner symptom: literal SGR mouse-report text ([<...M) '
+            'rendered at the revived prompt',
+      );
+
+      // Isolation: B (never in mouse mode, never dropped) must be untouched.
+      expect(entryB.proxy.data.state, SshSessionState.connected,
+          reason: 'session B must survive A\'s drop/revive');
+
+      // Phase 3 — the TUI was alive all along: re-attach re-emits DECSET
+      // through the byte stream and mouse tracking re-engages, no user action.
+      send('tmux attach\n');
+      final reEngaged = await pumpUntil(
+        () => controller.mouseTracking != MouseTracking.none,
+        maxSlices: 30,
+      );
+      expect(reEngaged, isTrue,
+          reason: 'a re-attached tmux (mouse on) must re-enable tracking via '
+              'its own DECSET bytes — the parser path, no manual re-arm');
+    },
+  );
+}

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -1094,6 +1094,40 @@ bool ghosttyHasCopyableSelection({
   required String snapshot,
 }) => liveSelection || snapshot.isNotEmpty;
 
+/// #1014: DECRST sequence resetting every synthesized-input-gating DEC private
+/// mode to its default, written LOCALLY into the terminal parser
+/// (`controller.write`) at the REVIVE boundary (`proxy.shellReady`, which
+/// re-fires on every reconnect — the same seam as the #702 resize-resync and
+/// the #717 focus latch).
+///
+/// Why: the flterm controller (and the libghostty VT terminal under it)
+/// SURVIVES a reconnect — only the task-side shell reopens. A pre-drop
+/// mouse-reporting TUI (tmux, mouse on) leaves `mouseTracking` ON, so the
+/// gesture overlay kept synthesizing SGR reports into the revived remote; a
+/// plain shell renders them as literal `[<65;...M` text at the prompt (owner
+/// telemetry 2026-07-08T18-13-09: sentSgrTrace bursts right after a SUCCESSFUL
+/// 5-session reconnect). Resetting the parser at shellReady re-syncs the local
+/// mode state to a fresh shell's reality; if the remote's TUI is still alive
+/// (tmux auto-attach) its redraw re-emits DECSET through the byte stream and
+/// the parser re-enables the modes naturally — no user action, no heuristics.
+///
+/// Ordering is safe: shellReady and PTY output arrive on the SAME gateway IPC
+/// stream (ssh_session_proxy `_handleEvent`), so this reset always lands
+/// BEFORE the revived shell's first output bytes.
+///
+/// Covered modes (all remote-toggled, all gate synthesized input):
+///   9/1000/1002/1003  mouse tracking (drive `controller.mouseTracking`);
+///   1005/1006/1015    mouse report encodings (UTF-8 / SGR / urxvt);
+///   1007              alternate scroll (wheel → arrow keys on alt screen);
+///   2004              bracketed paste.
+/// Deliberately NOT reset: the alternate SCREEN (would blank the restored
+/// grid) and DECCKM (keyboard arrows work in both encodings at a shell).
+/// LOCAL-only: DECRST produces no reply, so nothing is sent to the remote.
+const String ghosttyInputModeResetSequence =
+    '\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l'
+    '\x1b[?1005l\x1b[?1006l\x1b[?1015l'
+    '\x1b[?1007l\x1b[?2004l';
+
 /// SGR-1006 button1-PRESS report at the 1-based ([col], [row]) cell (#692).
 ///
 /// `CSI < 0 ; col ; row M` — button 0 (left), uppercase `M` = press.
@@ -2692,6 +2726,21 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // not the pre-shellReady default that gets dropped. Re-fires on reconnect.
       _shellReadySub = proxy.shellReady.listen((_) {
         if (!mounted) return;
+        // #1014: a shellReady tick is the REVIVE boundary — the terminal
+        // instance survived the reconnect, so re-sync its synthesized-input-
+        // gating DEC modes (stale tmux mouse mode kept the SGR path firing
+        // into the revived plain shell as literal [<65;...M text). Runs FIRST:
+        // shellReady precedes the new shell's output on the shared IPC stream,
+        // so a still-alive TUI's re-emitted DECSET re-enables the modes right
+        // after. See [ghosttyInputModeResetSequence].
+        final staleTracking = controller.mouseTracking;
+        controller.write(
+          Uint8List.fromList(ghosttyInputModeResetSequence.codeUnits),
+        );
+        ctrace(
+          'ui.modes1014',
+          'shellReady: input-mode reset (mouse was ${staleTracking.name})',
+        );
         // #717: a shellReady tick is a fresh connect (re-fires on reconnect), so
         // reset the per-connect focus latch and re-focus this connect. flterm is
         // autofocus:false, so without this the terminal stays unfocused and its

--- a/native/test/ui/ghostty_reconnect_mode_reset_1014_test.dart
+++ b/native/test/ui/ghostty_reconnect_mode_reset_1014_test.dart
@@ -1,0 +1,187 @@
+@Tags(['ffi'])
+library;
+
+// #1014 — stale mouse-reporting mode after reconnect: the app kept synthesizing
+// SGR mouse reports into a REVIVED session whose remote no longer had mouse
+// mode enabled, landing as literal `[<65;...M` text at the prompt.
+//
+// ROOT CAUSE: the flterm controller (and the libghostty VT terminal under it)
+// SURVIVES a reconnect — only the task-side shell reopens. The terminal's DEC
+// private modes (9/1000/1002/1003 → `mouseTracking`, plus 1005/1006/1015
+// encodings, 1007 alternate scroll, 2004 bracketed paste) are set by the
+// PRE-DROP remote's byte stream and nothing resets them at the revive boundary,
+// so `_mouseTracking` stays on and the gesture overlay keeps forwarding SGR.
+//
+// FIX: at the revive seam (`proxy.shellReady`, which re-fires on every
+// reconnect — the same seam the #702 resize-resync and #717 focus latch use)
+// the view writes [ghosttyInputModeResetSequence] (DECRST for every
+// synthesized-input-gating DEC private mode) LOCALLY into the terminal parser.
+// The remote re-enables the modes through the byte stream if its TUI is still
+// alive (tmux re-attach re-emits DECSET on redraw) — the parser picks that up
+// naturally. Ordering is safe: shellReady and output events share one IPC
+// stream, so the reset always lands before the revived shell's first output.
+//
+// These are STATE-TRANSITION tests (rules/state-management.md) against the REAL
+// libghostty parser (ffi tag, runs in gate 2): connected(TUI, mouse on) → drop →
+// reconnect(plain shell) → the reset drives tracking to none (gestures stop
+// forwarding SGR) → the remote re-enables via bytes → gestures forward again.
+// The shellReady wiring itself is covered on-emulator by
+// integration_test/reconnect_mouse_mode_1014_test.dart.
+
+// ignore_for_file: depend_on_referenced_packages, implementation_imports
+// ignore_for_file: invalid_use_of_internal_member
+// (The controller impl import mirrors flterm's own tests and exposes
+// `.terminal` for direct mode assertions; production callers use the public
+// interface.)
+
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flterm/src/widgets/terminal_controller_impl.dart'
+    show TerminalControllerImpl;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+Uint8List bytes(String s) => Uint8List.fromList(s.codeUnits);
+
+/// tmux-style mouse-mode enable: button tracking + SGR encoding (what
+/// `set -g mouse on` emits on attach).
+const String kTmuxMouseOn = '\x1b[?1002h\x1b[?1006h';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('#1014 revive-boundary input-mode reset (state transitions)', () {
+    test(
+        'connected(TUI, mouse ON) → revive reset → tracking none and the '
+        'swipe gate stops forwarding SGR', () {
+      final controller = TerminalControllerImpl(
+        config: const TerminalConfig(cols: 80, rows: 24),
+      );
+      addTearDown(controller.dispose);
+
+      // Pre-drop remote: a mouse-reporting TUI (tmux, mouse on).
+      controller.write(bytes(kTmuxMouseOn));
+      expect(controller.mouseTracking, MouseTracking.button,
+          reason: 'precondition: DECSET 1002 must enable button tracking');
+      expect(
+        ghosttySwipeShouldScrollLocally(
+          mouseTracking: controller.mouseTracking,
+        ),
+        isTrue,
+        reason: 'precondition: mouse mode on → overlay intercepts + '
+            'synthesizes SGR (existing behavior)',
+      );
+
+      // Drop → reconnect: the revived remote is a PLAIN shell. The view writes
+      // the reset sequence at shellReady; the parser must drive tracking to
+      // none so no further SGR is synthesized.
+      controller.write(bytes(ghosttyInputModeResetSequence));
+      expect(
+        controller.mouseTracking,
+        MouseTracking.none,
+        reason: 'STALE MODE (#1014): the revive reset did not clear mouse '
+            'tracking — gestures would keep sending SGR into the plain shell '
+            'as literal [<65;...M text',
+      );
+      expect(
+        ghosttySwipeShouldScrollLocally(
+          mouseTracking: controller.mouseTracking,
+        ),
+        isFalse,
+        reason: 'after the reset a swipe must scroll locally, never forward',
+      );
+    });
+
+    test('remote re-enables via the byte stream → gestures forward again', () {
+      final controller = TerminalControllerImpl(
+        config: const TerminalConfig(cols: 80, rows: 24),
+      );
+      addTearDown(controller.dispose);
+
+      controller.write(bytes(kTmuxMouseOn));
+      controller.write(bytes(ghosttyInputModeResetSequence));
+      expect(controller.mouseTracking, MouseTracking.none);
+
+      // The revived remote's TUI is still alive (e.g. tmux auto-attach): its
+      // redraw re-emits DECSET AFTER the reset — the parser must pick it up
+      // with no user action.
+      controller.write(bytes(kTmuxMouseOn));
+      expect(controller.mouseTracking, MouseTracking.button,
+          reason: 'a re-attached TUI re-enabling mouse mode must re-arm the '
+              'SGR path without user action');
+      expect(
+        ghosttySwipeShouldScrollLocally(
+          mouseTracking: controller.mouseTracking,
+        ),
+        isTrue,
+      );
+    });
+
+    test('reset clears EVERY synthesized-input-gating DEC private mode', () {
+      final controller = TerminalControllerImpl(
+        config: const TerminalConfig(cols: 80, rows: 24),
+      );
+      addTearDown(controller.dispose);
+
+      // Enable every mode the reset claims to cover: all four tracking
+      // variants would overwrite each other's report semantics, so set the
+      // strongest (any-motion) + the encodings + scroll/paste modes.
+      controller.write(
+        bytes('\x1b[?1003h\x1b[?1005h\x1b[?1006h\x1b[?1015h'
+            '\x1b[?1007h\x1b[?2004h'),
+      );
+      expect(controller.mouseTracking, MouseTracking.any);
+      expect(
+        controller.terminal.modeGet(const TerminalMode.alternateScroll()),
+        isTrue,
+      );
+      expect(
+        controller.terminal.modeGet(const TerminalMode.bracketedPaste()),
+        isTrue,
+      );
+
+      controller.write(bytes(ghosttyInputModeResetSequence));
+
+      expect(controller.mouseTracking, MouseTracking.none);
+      for (final (mode, name) in <(TerminalMode, String)>[
+        (const TerminalMode.x10Mouse(), 'x10Mouse (9)'),
+        (const TerminalMode.normalMouse(), 'normalMouse (1000)'),
+        (const TerminalMode.buttonMouse(), 'buttonMouse (1002)'),
+        (const TerminalMode.anyMouse(), 'anyMouse (1003)'),
+        (const TerminalMode.utf8Mouse(), 'utf8Mouse (1005)'),
+        (const TerminalMode.sgrMouse(), 'sgrMouse (1006)'),
+        (const TerminalMode.urxvtMouse(), 'urxvtMouse (1015)'),
+        (const TerminalMode.alternateScroll(), 'alternateScroll (1007)'),
+        (const TerminalMode.bracketedPaste(), 'bracketedPaste (2004)'),
+      ]) {
+        expect(
+          controller.terminal.modeGet(mode),
+          isFalse,
+          reason: '$name must be reset at the revive boundary',
+        );
+      }
+    });
+
+    test('reset is LOCAL-only: nothing is emitted toward the remote, and it '
+        'is a no-op on a default-mode (first-connect) terminal', () {
+      final controller = TerminalControllerImpl(
+        config: const TerminalConfig(cols: 80, rows: 24),
+      );
+      addTearDown(controller.dispose);
+      final emitted = <int>[];
+      controller.onOutput = emitted.addAll;
+
+      // First connect: modes are already default — the unconditional reset at
+      // shellReady must be harmless.
+      controller.write(bytes(ghosttyInputModeResetSequence));
+      expect(controller.mouseTracking, MouseTracking.none);
+      expect(
+        emitted,
+        isEmpty,
+        reason: 'the revive reset must never SEND bytes to the remote — it '
+            'only re-syncs the LOCAL parser state',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #1014.

## Root cause (telemetry-backed)
The owner's 2026-07-08T18-13-09 report showed the reconnect SUCCEEDED (all 5 sessions softDisconnected → connected in ~5s, heartbeats + snapshots flowing) while sentSgrTrace kept bursting — the app was still synthesizing SGR mouse reports into the revived remote. The flterm controller and the libghostty VT terminal under it SURVIVE a reconnect (only the task-side shell reopens), so the DEC private modes the PRE-DROP tmux set (9/1000/1002/1003 → `mouseTracking`, plus SGR/UTF-8/urxvt encodings, alternate scroll, bracketed paste) stayed latched. `_mouseTracking` kept gating the gesture overlay ON, and every tap/swipe forwarded SGR into whatever the revived shell now was — a plain prompt renders them as literal `[<65;...M` garbage.

## Fix — mode reset at the revive seam (per-session, no fork API)
`proxy.shellReady` re-fires on every reconnect and is already the revive seam (the #702 resize-resync and #717 focus latch live there). The view now writes a DECRST sequence (`ghosttyInputModeResetSequence`: modes 9/1000/1002/1003, 1005/1006/1015, 1007, 2004) LOCALLY into `controller.write(...)` FIRST in that listener — the existing parser path, no new flterm API.

- Ordering is safe by construction: shellReady and PTY output share ONE gateway IPC stream (`ssh_session_proxy._handleEvent`), so the reset always lands before the revived shell's first output. A still-alive TUI (tmux re-attach) then re-emits DECSET through the byte stream and the parser re-enables the modes naturally — no user action, no heuristics.
- Deliberately NOT reset: the alternate SCREEN (would blank the restored grid) and DECCKM (harmless at a shell). Local-only: DECRST produces no reply, so nothing is sent to the remote.
- `ui.modes1014` ctrace records each reset with the stale tracking value, so a future device report shows the seam fired.

## Tests (state transitions, rules/state-management.md)
RED first: `test/ui/ghostty_reconnect_mode_reset_1014_test.dart` failed to compile (`Undefined name 'ghosttyInputModeResetSequence'`) — nothing reset the modes. GREEN after: 4/4 pass against the REAL libghostty parser (ffi tag, runs in gate 2 on every commit):
- connected(TUI, mouse ON) → revive reset → tracking none, swipe gate stops forwarding SGR
- remote re-enables via the byte stream → gestures forward again (no user action)
- EVERY gated mode (9/1000/1002/1003/1005/1006/1015/1007/2004) cleared
- reset is LOCAL-only (no bytes emitted to the remote) and a no-op on a default-mode first connect

Emulator, PASSED (`BRIDGE_PORT2=2223 scripts/native-connect-test.sh integration_test/reconnect_mouse_mode_1014_test.dart`), mirroring the owner's MULTI-session incident: session B (plain, port 2223) holds the FGS; session A runs real tmux with mouse on; a tap forwards an SGR click (existing #693 behavior, recorder-asserted); then a REAL transport drop — a throwaway dartssh2 EXEC connection pkills A's `sshd: testuser@pts/N` (resolved via tmux `#{client_tty}`; exec = `@notty`, never matches itself) → A softDisconnects exactly like the owner's blip → held-params revive → device log shows `[ui.modes1014] shellReady: input-mode reset (mouse was button)` → tracking none, a tap forwards NO SGR, no literal `[<` renders, B untouched → `tmux attach` re-emits DECSET and tracking re-engages with no user action.

`scripts/native-fast-gate.sh` PASSED (analyze clean, 1828 tests incl. the reconnect_shell_revive suite).

## Found along the way — filed separately
#1018: a SINGLE-session soft drop kills the keepalive FGS mid-reconnect (`_holdsService` excludes softDisconnected → transient 1→0 count → unawaited `_stopIfRunning()` wins the race; every reconnect then buffers against a not-ready gateway). Hit twice while building this repro; the two-session test shape sidesteps it deliberately. Plausibly the "reconnect didn't succeed" component of single-session incidents.

## Scope / caveats
- Ghostty backend only (the default). The legacy xterm backend has the same class of staleness — out of scope here.
- The issue's secondary question (session-menu dot colors during the incident) is untouched — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa