### PR TITLE
fix(native): keepalive FGS holds through every reconnect-bound state (#1018)

### DIFF
--- a/native/integration_test/single_session_soft_drop_fgs_1018_test.dart
+++ b/native/integration_test/single_session_soft_drop_fgs_1018_test.dart
@@ -1,0 +1,148 @@
+// On-emulator #1018: a SINGLE-session soft drop must not kill the keepalive
+// foreground service mid-reconnect.
+//
+// Pre-fix race (found while building the #1014 repro, which deliberately used
+// TWO sessions to sidestep it): `_holdsService()` counted only
+// connected|reconnecting, so the lone session's `connected → softDisconnected`
+// dipped the holder count 1→0 and scheduled an unawaited stop; the
+// `reconnecting` transition 1ms later saw the service still running and
+// skipped its start, then the scheduled stop landed — task isolate gone, UI
+// gateway not-ready, every reconnect command buffered forever.
+//
+// Shape (single session, REAL transport drop, same kill mechanism as #1014):
+//   1. connect ONE session (127.0.0.1:2222 bridge to test-sshd)
+//   2. kill its `sshd: testuser@pts/N` via a throwaway dartssh2 EXEC
+//      connection (exec = @notty, so the killer can never match itself)
+//   3. assert the session leaves `connected` (the soft drop happened),
+//      the FGS keeps running through the drop, and the held-params
+//      reconnect revives a `connected` session — with the FGS still up.
+//
+// Pre-fix, step 3 fails: the FGS dies within the drop→reconnecting window and
+// the revive never happens (reconnect buffers into a dead task isolate).
+//
+// Bridge: scripts/native-connect-test.sh \
+//     integration_test/single_session_soft_drop_fgs_1018_test.dart
+
+import 'dart:convert';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'single-session transport drop: FGS survives softDisconnected and the '
+    'session revives (#1018)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      /// Pump in 500ms slices until [test] passes or [maxSlices] elapse,
+      /// accepting any host-key trust prompt along the way.
+      Future<bool> pumpUntil(bool Function() test, {int maxSlices = 60}) async {
+        for (var i = 0; i < maxSlices; i++) {
+          await tester.pump(const Duration(milliseconds: 500));
+          final trust = find.text('Trust + connect');
+          if (trust.evaluate().isNotEmpty) {
+            await tester.tap(trust.first);
+            await tester.pump(const Duration(milliseconds: 300));
+          }
+          if (test()) return true;
+        }
+        return false;
+      }
+
+      // The ONE session — no second holder to mask the 1→0 dip.
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      final reached = await pumpUntil(
+        () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+      );
+      expect(reached, isTrue, reason: 'session never reached the terminal');
+      final entry = container.read(sessionsProvider).active!;
+      final connected = await pumpUntil(
+        () => entry.proxy.data.state == SshSessionState.connected,
+      );
+      expect(connected, isTrue, reason: 'session never connected');
+      expect(await FlutterForegroundTask.isRunningService, isTrue,
+          reason: 'precondition: FGS must be up while connected');
+
+      // REAL transport drop: kill the pty-backed sshd process (only our
+      // session has a pty; the killer runs over exec = @notty).
+      final killer = SSHClient(
+        await SSHSocket.connect('127.0.0.1', 2222),
+        username: 'testuser',
+        onPasswordRequest: () => 'testpass',
+      );
+      final killOut = utf8.decode(
+        await killer.run(
+          r'pkill -9 -f "sshd: testuser@pts/"; echo KILLED',
+        ),
+      );
+      debugPrint('#1018 transport kill: $killOut');
+      killer.close();
+
+      final dropped = await pumpUntil(
+        () => entry.proxy.data.state != SshSessionState.connected,
+        maxSlices: 40,
+      );
+      expect(dropped, isTrue,
+          reason: 'transport kill never dropped the session ($killOut)');
+
+      // THE #1018 ASSERT (part 1): the drop schedules NO service stop — the
+      // FGS must still be running while the lone session is reconnect-bound.
+      // Poll a few slices so a pre-fix unawaited stop has time to land.
+      var fgsSurvived = true;
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        if (!await FlutterForegroundTask.isRunningService) {
+          fgsSurvived = false;
+          break;
+        }
+      }
+      expect(fgsSurvived, isTrue,
+          reason: '#1018: the single-session soft drop killed the keepalive '
+              'FGS mid-reconnect (transient 1→0 holder count)');
+
+      // Held-params revive (force-now skips the reconnect backoff). Pre-fix
+      // this buffers into a dead task isolate and never lands.
+      entry.proxy.reconnect();
+      final revived = await pumpUntil(
+        () => entry.proxy.data.state == SshSessionState.connected,
+        maxSlices: 80,
+      );
+      expect(revived, isTrue,
+          reason: '#1018: held-params reconnect never revived the session — '
+              'the reconnect command buffered into a dead task isolate');
+
+      // THE #1018 ASSERT (part 2): still exactly one FGS, still running.
+      expect(await FlutterForegroundTask.isRunningService, isTrue,
+          reason: 'FGS must still be running after the revive');
+    },
+  );
+}

--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -445,18 +445,27 @@ class KeepaliveController {
   int get connectedCount => _connectedCount;
 
   /// Returns true while the given state should hold the foreground service
-  /// open. `reconnecting` (#517) is treated as "still connected" so Android
-  /// doesn't freeze the Dart isolate mid-reconnect.
+  /// open: every non-idle, non-terminal lifecycle state (#1018). The service
+  /// releases only on `idle`/`failed`/`disconnected` — a user disconnect ends
+  /// in `disconnected`, so user intent (#986) still tears it down.
   ///
-  /// This predicate drives the connected-COUNT (start on 0→1, stop on 1→0).
-  /// The in-flight handshake states (`connecting`, `authenticating`,
-  /// `awaitingHostKey`) deliberately do NOT increment the count — the service
-  /// for those is started explicitly by [ensureStarted] on connect-initiation
-  /// (#539). Because they never increment the count, they also never trigger
-  /// the 1→0 stop, so a session mid-handshake cannot tear the service down.
+  /// This predicate drives the connected-COUNT (start on 0→1, stop on 1→0),
+  /// so it must never dip to 0 mid-lifecycle: any transient 1→0 schedules an
+  /// unawaited stop that lands AFTER the next holding state already saw the
+  /// service running and skipped its start (#1018 — single-session
+  /// `connected → softDisconnected → reconnecting` killed the FGS
+  /// mid-reconnect). The reconnect attempt re-runs connect(), which re-emits
+  /// `connecting`/`authenticating` on the observed stream, so an enumerated
+  /// connected+reconnecting allow-list dips at `reconnecting → connecting`
+  /// too — hence hold-unless-terminal rather than a state allow-list.
+  ///
+  /// Consequence for fresh connects: `connecting` now increments the count,
+  /// so the count path may start the service itself. In production it is
+  /// already up — [ensureStarted] starts it on connect-initiation (#539) and
+  /// `_startIfStopped` is idempotent. A connect that never reaches
+  /// `connected` still releases via the terminal `failed`/`disconnected`.
   static bool _holdsService(SshSessionState state) {
-    return state == SshSessionState.connected ||
-        state == SshSessionState.reconnecting;
+    return state != SshSessionState.idle && !_isTerminal(state);
   }
 
   /// Start the foreground service immediately, independent of how many

--- a/native/test/services/keepalive_task_test.dart
+++ b/native/test/services/keepalive_task_test.dart
@@ -111,15 +111,19 @@ void main() {
 
       session.emit(SshSessionState.connecting);
       await _drain();
-      expect(gateway.calls, isEmpty,
-          reason: 'no service start while still connecting');
+      // #1018: `connecting` now holds the service (hold-unless-terminal), so
+      // the count path starts it here already. Pre-#1018 the start waited for
+      // `connected` (production relied on ensureStarted #539 instead); the
+      // dip-free count is what keeps a mid-reconnect stop from firing.
+      expect(gateway.calls.first, 'init');
+      expect(gateway.calls.any((c) => c.startsWith('start:')), isTrue);
+      expect(controller.connectedCount, 1);
 
       session.emit(SshSessionState.connected);
       await _drain();
-      expect(gateway.calls.first, 'init');
-      expect(gateway.calls.any((c) => c.startsWith('start:')), isTrue);
       expect(await gateway.isRunningService, isTrue);
-      expect(controller.connectedCount, 1);
+      expect(controller.connectedCount, 1,
+          reason: 'no double-count when connecting reaches connected');
 
       await controller.dispose();
       await session.dispose();
@@ -287,6 +291,98 @@ void main() {
 
       await controller.dispose();
       await session.dispose();
+    });
+
+    // #1018: a single-session soft drop must not transiently release the
+    // service. The real reconnect path re-emits connecting/authenticating via
+    // connect(), so the hold must survive the FULL cycle — any 1→0 dip
+    // schedules an unawaited stop that races (and beats) the revive.
+    test(
+        'single-session soft drop → full reconnect cycle never stops the '
+        'service (#1018)', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+
+      // connected → softDisconnected → reconnecting → (idle is set silently,
+      // not emitted) → connecting → authenticating → connected, exactly as
+      // SshSessionController emits during an auto-reconnect.
+      session.emit(SshSessionState.softDisconnected);
+      session.emit(SshSessionState.reconnecting);
+      await _drain();
+      session.emit(SshSessionState.connecting);
+      session.emit(SshSessionState.authenticating);
+      await _drain();
+      session.emit(SshSessionState.connected);
+      await _drain();
+
+      expect(gateway.calls.where((c) => c == 'stop'), isEmpty,
+          reason: 'no stop may be scheduled at ANY point mid-reconnect — an '
+              'unawaited stop lands after the revive and kills the task '
+              'isolate\n${gateway.calls}');
+      expect(await gateway.isRunningService, isTrue);
+      expect(controller.connectedCount, 1,
+          reason: 'count must not dip or double across the cycle');
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('user disconnect after a soft drop still stops the service (#1018)',
+        () async {
+      // #986 adjacency: user intent ends in the terminal `disconnected`
+      // state — softDisconnected holding must not keep the FGS alive past it.
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final session = StubSession();
+      controller.attach(session);
+
+      session.emit(SshSessionState.connected);
+      await _drain();
+      session.emit(SshSessionState.softDisconnected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue,
+          reason: 'softDisconnected is reconnect-bound — it holds');
+
+      session.emit(SshSessionState.disconnected);
+      await _drain();
+      expect(await gateway.isRunningService, isFalse);
+      expect(controller.connectedCount, 0);
+
+      await controller.dispose();
+      await session.dispose();
+    });
+
+    test('multi-session: one soft-dropping session never stops the service '
+        '(#1018)', () async {
+      final gateway = FakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final a = StubSession();
+      final b = StubSession();
+      controller.attach(a);
+      controller.attach(b);
+
+      a.emit(SshSessionState.connected);
+      b.emit(SshSessionState.connected);
+      await _drain();
+      expect(controller.connectedCount, 2);
+
+      a.emit(SshSessionState.softDisconnected);
+      a.emit(SshSessionState.reconnecting);
+      await _drain();
+
+      expect(gateway.calls.where((c) => c == 'stop'), isEmpty);
+      expect(await gateway.isRunningService, isTrue);
+      expect(controller.connectedCount, 2);
+
+      await controller.dispose();
+      await a.dispose();
+      await b.dispose();
     });
   });
 


### PR DESCRIPTION
Fixes #1018.

## Root cause
`KeepaliveController._holdsService()` counted only `connected|reconnecting`. A lone session's `connected → softDisconnected` dipped the holder count 1→0, scheduling an unawaited `_stopIfRunning()`; the `reconnecting` transition 1ms later saw the service still running and skipped its start, then the scheduled stop landed — task isolate gone, UI gateway not-ready, every reconnect buffered forever.

## Fix (state-set, per rules/state-management.md)
The hold predicate is now derived from the lifecycle enum in one place: **hold in every non-idle, non-terminal state** (`state != idle && !_isTerminal(state)`, i.e. releases only on `failed`/`disconnected`).

Why not just add `softDisconnected` to the allow-list: the reconnect attempt re-runs `connect()`, which re-emits `connecting`/`authenticating` on the observed stream — the red baseline showed **two** stops scheduled per soft drop (`connected→softDisconnected` AND `reconnecting→connecting`). Any enumerated allow-list keeps a dip somewhere; hold-unless-terminal removes the class.

#986 adjacency preserved: user disconnect ends in the terminal `disconnected` state, so user intent still tears the service down (covered by a dedicated test).

Behavior delta: `connecting` now increments the count, so the count path may start the service itself. In production it is already up (`ensureStarted`, #539) and `_startIfStopped` is idempotent; a connect that never reaches `connected` still releases via `failed`/`disconnected`. One existing test assertion ("no service start while still connecting") encoded the old detail and was updated with rationale.

## Red → green
Red (pre-fix), `test/services/keepalive_task_test.dart`:
- `single-session soft drop → full reconnect cycle never stops the service (#1018)` — FAILED: `Actual: ['stop', 'stop']`
- `user disconnect after a soft drop still stops the service (#1018)` — FAILED: service already dead at softDisconnected
- multi-session variant passed pre-fix (interleave masks the dip — matches the issue analysis of why the owner never hit it)

Green (post-fix): all 25 keepalive tests pass; full `scripts/native-fast-gate.sh` green (analyze + 1831 tests).

## Emulator integration test
New `integration_test/single_session_soft_drop_fgs_1018_test.dart`: ONE session, real transport kill (throwaway dartssh2 exec, same mechanism as the #1014 test), asserts the FGS survives the drop window and the held-params reconnect revives `connected` with the FGS still running. Run: `scripts/native-connect-test.sh integration_test/single_session_soft_drop_fgs_1018_test.dart`.

## Known residual (out of scope, pre-existing)
`_stopIfRunning()` still never re-checks the holder count after its awaits, so a cross-session race remains possible (session A goes terminal — stop scheduled — while session B concurrently connects). Different trigger than #1018; can be filed separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa