### PR TITLE
fix(native): keepalive stale stop re-checks holder count before killing the FGS (#1021)

### DIFF
--- a/native/lib/services/keepalive_task.dart
+++ b/native/lib/services/keepalive_task.dart
@@ -673,6 +673,24 @@ class KeepaliveController {
   Future<void> _stopIfRunning({bool notifyGateway = true}) async {
     if (!_gateway.isInitialized) return;
     if (!await _gateway.isRunningService) return;
+    // #1021: re-check the holder count after the await, immediately before the
+    // actual stop. This stop may be STALE: it was scheduled when the count hit
+    // 0 (session A terminal), but a concurrent connect (session B) can bump
+    // the count back up while `isRunningService` resolves — landing the stop
+    // then kills the FGS (and its task isolate) under B's live session.
+    // Complementary to the #1018 hold predicate: that keeps one session's
+    // lifecycle from dipping the count; this guards the stop path against a
+    // genuine 0→1 from ANOTHER session in the await gap. The `_enabled` term
+    // exempts the user toggle-off stop, which is unconditional by design
+    // ("drop the service even if sessions are still up"). No await sits
+    // between this check and `stopService`, so it cannot go stale itself.
+    if (_enabled && _connectedCount > 0) {
+      ctrace(
+        'ui.keepalive',
+        '_stopIfRunning: stale — count=$_connectedCount re-held, abort (#1021)',
+      );
+      return;
+    }
     await _gateway.stopService();
     // The task isolate is gone — tell the UI↔task gateway to re-buffer until a
     // fresh isolate re-handshakes, so a later reconnect isn't sent into the

--- a/native/test/services/keepalive_task_test.dart
+++ b/native/test/services/keepalive_task_test.dart
@@ -62,6 +62,28 @@ class FakeKeepaliveGateway implements KeepaliveGateway {
   }
 }
 
+/// Gateway whose `isRunningService` reads can be suspended on a [Completer]
+/// (#1021). Lets a test hold `_stopIfRunning()` mid-await while another
+/// session's transition interleaves, reproducing the stale-stop race
+/// deterministically instead of relying on microtask ordering.
+class GatedFakeKeepaliveGateway extends FakeKeepaliveGateway {
+  /// When non-null, every `isRunningService` read suspends until completed.
+  Completer<void>? holdIsRunning;
+
+  @override
+  Future<bool> get isRunningService async {
+    final gate = holdIsRunning;
+    if (gate != null) await gate.future;
+    return _running;
+  }
+
+  void releaseGate() {
+    final gate = holdIsRunning;
+    holdIsRunning = null;
+    gate?.complete();
+  }
+}
+
 /// Test double for SshSessionController. We avoid spinning up a real
 /// dartssh2 client by emitting [SshSessionData] directly through the
 /// public broadcast stream.
@@ -383,6 +405,149 @@ void main() {
       await controller.dispose();
       await a.dispose();
       await b.dispose();
+    });
+  });
+
+  // #1021: `_stopIfRunning()` must re-check the holder count after its awaits
+  // and immediately before the actual `stopService` call. A stop scheduled by
+  // A going terminal (count → 0) is STALE if B's connect bumps the count back
+  // up before the stop's awaits resolve — landing it anyway kills the FGS
+  // (and its task isolate) under B's live session. Complementary to the #1018
+  // predicate fix: that keeps the count from dipping mid-lifecycle; this
+  // guards the stop PATH itself against a genuine 0→1 in the await gap.
+  group('KeepaliveController stale-stop recheck (#1021)', () {
+    test('stale stop aborts when a concurrent connect re-holds the service',
+        () async {
+      final gateway = GatedFakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final a = StubSession();
+      final b = StubSession();
+      controller.attach(a);
+      controller.attach(b);
+
+      a.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+      expect(controller.connectedCount, 1);
+
+      // Suspend all isRunningService reads so the scheduled stop parks
+      // mid-await, exactly like a slow platform-channel round trip.
+      gateway.holdIsRunning = Completer<void>();
+      a.emit(SshSessionState.disconnected); // count 1→0, stop scheduled
+      await _drain();
+
+      // B's connect interleaves BEFORE the stop's awaits resolve.
+      b.emit(SshSessionState.connecting); // count 0→1
+      await _drain();
+      expect(controller.connectedCount, 1);
+
+      gateway.releaseGate();
+      await _drain();
+
+      expect(gateway.calls.where((c) => c == 'stop'), isEmpty,
+          reason: 'the stale stop must abort — landing it kills the FGS under '
+              'B\'s live connection\n${gateway.calls}');
+      expect(await gateway.isRunningService, isTrue);
+      expect(controller.connectedCount, 1);
+
+      await controller.dispose();
+      await a.dispose();
+      await b.dispose();
+    });
+
+    test('A terminal alone still stops through the same delayed path',
+        () async {
+      final gateway = GatedFakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final a = StubSession();
+      controller.attach(a);
+
+      a.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+
+      gateway.holdIsRunning = Completer<void>();
+      a.emit(SshSessionState.disconnected);
+      await _drain();
+      gateway.releaseGate();
+      await _drain();
+
+      expect(gateway.calls.where((c) => c == 'stop'), hasLength(1),
+          reason: 'recheck must not block a legitimate stop\n${gateway.calls}');
+      expect(await gateway.isRunningService, isFalse);
+      expect(controller.connectedCount, 0);
+
+      await controller.dispose();
+      await a.dispose();
+    });
+
+    test('double-scheduled stale stops both abort under a concurrent connect',
+        () async {
+      // The #1020 red baseline showed double-scheduling shapes: a second
+      // terminal emit while count==0 re-schedules the stop via the #539
+      // leak-guard branch. Both parked stops must abort once B re-holds.
+      final gateway = GatedFakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final a = StubSession();
+      final b = StubSession();
+      controller.attach(a);
+      controller.attach(b);
+
+      a.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+
+      gateway.holdIsRunning = Completer<void>();
+      a.emit(SshSessionState.disconnected); // count 1→0, stop #1 scheduled
+      await _drain();
+      a.emit(SshSessionState.disconnected); // count==0 + terminal → stop #2
+      await _drain();
+
+      b.emit(SshSessionState.connecting); // count 0→1
+      await _drain();
+
+      gateway.releaseGate();
+      await _drain();
+
+      expect(gateway.calls.where((c) => c == 'stop'), isEmpty,
+          reason: 'BOTH parked stops are stale once B holds the service\n'
+              '${gateway.calls}');
+      expect(await gateway.isRunningService, isTrue);
+      expect(controller.connectedCount, 1);
+
+      await controller.dispose();
+      await a.dispose();
+      await b.dispose();
+    });
+
+    test('user toggle-off stop is unconditional even while sessions hold',
+        () async {
+      // The recheck exempts the disabled path: `enabled = false` means "drop
+      // the service even if sessions are still up" — a count recheck must not
+      // veto user intent. (Fast-path variant exists as "toggle off stops a
+      // running service"; this one parks the stop mid-await first.)
+      final gateway = GatedFakeKeepaliveGateway();
+      final controller = KeepaliveController(gateway: gateway);
+      final a = StubSession();
+      controller.attach(a);
+
+      a.emit(SshSessionState.connected);
+      await _drain();
+      expect(await gateway.isRunningService, isTrue);
+
+      gateway.holdIsRunning = Completer<void>();
+      controller.enabled = false; // stop scheduled with count still 1
+      await _drain();
+      gateway.releaseGate();
+      await _drain();
+
+      expect(gateway.calls.where((c) => c == 'stop'), hasLength(1),
+          reason: 'user disable stops regardless of holder count\n'
+              '${gateway.calls}');
+      expect(await gateway.isRunningService, isFalse);
+
+      await controller.dispose();
+      await a.dispose();
     });
   });
 


### PR DESCRIPTION
Fixes #1021 — the stop-PATH complement to the #1018 hold-predicate fix (PR #1020).

## Bug
`_stopIfRunning()` in `native/lib/services/keepalive_task.dart` never re-checked the holder count after its awaits. Session A goes terminal (count → 0, stop scheduled unawaited) while session B concurrently connects (count → 1); the parked stop's `isRunningService` await resolves and it stops the service anyway — killing the FGS and its task isolate under B's live connection.

## Fix (minimal recheck)
Re-read `_connectedCount` after the `isRunningService` await, immediately before `stopService()`, and abort the stop if the service is re-held. No await sits between the recheck and the stop, so the recheck itself cannot go stale. The recheck exempts the user toggle-off path (`_enabled == false`) — that stop is unconditional by design ("drop the service even if sessions are still up").

#1020 predicate semantics untouched — all 25 pre-existing keepalive tests (incl. the #1018 group) pass unmodified.

## Red → green evidence
New `GatedFakeKeepaliveGateway` parks `isRunningService` reads on a `Completer`, making the interleave deterministic (no microtask-ordering luck).

Red baseline (before the fix), both race tests failed showing the exact bug — the stale stop landed, then the parked start restarted the FGS cold onto "Connecting…":

```
Expected: empty
  Actual: WhereIterable<String>:['stop']
the stale stop must abort — landing it kills the FGS under B's live connection
[init, start:Connected — session, update:Connected — session, stop, start:Connecting…, ...]
```

Green after the fix (log shows the guard firing):

```
[ui.keepalive] _stopIfRunning: stale — count=1 re-held, abort (#1021)
00:00 +29: All tests passed!
```

New tests:
- stale stop aborts when a concurrent connect re-holds the service (was RED)
- A terminal alone still stops through the same delayed path (guard doesn't block legit stops)
- double-scheduled stale stops both abort (the #539 leak-guard re-schedule shape seen in the #1020 red baseline) (was RED)
- user toggle-off stop is unconditional even while sessions hold (guard exemption)

## Gate
`scripts/native-fast-gate.sh` PASSED in the worktree: flutter analyze clean, 1835 tests, all passed (`reconnect_shell_revive_test` included and green in this run).

Caveat: unit-level only — the gate notes the emulator integration suite is required before merging session-state/connect/reconnect changes; this touches the FGS stop path, so a `scripts/native-connect-test.sh` run at integration time is prudent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa