### PR TITLE
fix(native): user-intent disconnect bit — emit disconnected before teardown; abort raced connect (#986)

### DIFF
--- a/native/lib/ssh/ssh_session.dart
+++ b/native/lib/ssh/ssh_session.dart
@@ -228,7 +228,9 @@ class SshSessionController {
   int _reconnectAttempts = 0;
 
   /// The single authoritative "user intent suppresses auto-reconnect" bit
-  /// (#813). Set by [disconnect], reset by [connect]. This is the one bit the
+  /// (#813). Set by [disconnect]; cleared at the single transition seam in
+  /// [_emit] when a new connect actually starts (`connecting`/`reconnecting`,
+  /// #986). This is the one bit the
   /// issue permits ("keep at most ONE explicit user-intent bit"): the
   /// `disconnected` state alone is AMBIGUOUS — both a user ✕ (suppress) and an
   /// involuntary clean close while not-connected (don't suppress) land there —
@@ -316,11 +318,9 @@ class SshSessionController {
       return;
     }
 
-    // Fresh user-initiated connect — clear the user-intent bit so we'll
-    // reconnect again if the socket later flakes (#517). The `connecting` emit
-    // below moves state off `disconnected`, keeping the bit and the state-
-    // derived suppress predicate in lockstep (#813).
-    _userDisconnected = false;
+    // Fresh user-initiated connect — the `connecting` emit below clears the
+    // user-intent bit at the single transition seam in [_emit] (#986), so
+    // we'll reconnect again if the socket later flakes (#517/#813).
     _lastParams = params;
 
     ctrace(
@@ -343,6 +343,11 @@ class SshSessionController {
     // first connect pays it; subsequent connects find it already hydrated.
     if (!_hostKeyStore.isHydrated) {
       await _hostKeyStore.ready;
+      // #986: a user ✕/Disconnect raced in while we were parked at this await.
+      // The user's intent wins — abort instead of resurrecting a session the
+      // user closed (disconnect() already drove `disconnected`). Same guard
+      // after every await below.
+      if (_userDisconnected) return;
     }
 
     // Fail fast on an unusable private key BEFORE touching the network. A
@@ -395,9 +400,18 @@ class SshSessionController {
         params.port,
         timeout: handshakeTimeout,
       );
+      // #986: user disconnected while the socket was opening — tear the fresh
+      // socket down and bail before any SSH bytes flow.
+      if (_userDisconnected) {
+        ctrace('task.ssh', 'connect: aborted (user disconnected mid-open)');
+        socket.destroy();
+        return;
+      }
       _socket = socket;
       ctrace('task.ssh', 'connect: socket open OK → SSHClient handshake');
     } catch (e) {
+      // #986: don't overwrite a raced user `disconnected` with `failed`.
+      if (_userDisconnected) return;
       ctrace('task.ssh', 'connect: TCP connect FAILED — $e');
       _emit(
         _data.copyWith(
@@ -440,6 +454,9 @@ class SshSessionController {
       // transition to `authenticating` from `onVerifyHostKey`'s resolution.
       await client.authenticated;
     } catch (e) {
+      // #986: a raced user disconnect closed the client under us — that's the
+      // user's terminal `disconnected`, not an auth failure. Keep it.
+      if (_userDisconnected) return;
       // If we already transitioned to `failed` (e.g. user rejected the host
       // key) preserve the more-specific error message rather than overwriting
       // it with a generic "auth aborted" reason.
@@ -457,6 +474,19 @@ class SshSessionController {
       } catch (_) {
         /* ignore */
       }
+      return;
+    }
+
+    // #986: user disconnected during userauth but the auth still completed
+    // (close/auth race) — the session stays closed.
+    if (_userDisconnected) {
+      ctrace('task.ssh', 'connect: aborted (user disconnected mid-auth)');
+      try {
+        client.close();
+      } catch (_) {
+        /* ignore */
+      }
+      if (identical(_client, client)) _client = null;
       return;
     }
 
@@ -654,10 +684,10 @@ class SshSessionController {
         state == SshSessionState.reconnecting;
     if (!canReconnect) return;
     if (_lastParams == null) return;
-    // Explicit revive: overrides a prior user disconnect. Keep the bit and the
-    // state-derived suppress predicate consistent — the `reconnecting` emit in
-    // [_scheduleReconnect] moves state off `disconnected`/`failed` (#813).
-    _userDisconnected = false;
+    // Explicit revive: overrides a prior user disconnect. The `reconnecting`
+    // emit in [_scheduleReconnect] clears the user-intent bit at the single
+    // transition seam in [_emit] (#986), keeping the bit and the state-derived
+    // suppress predicate in lockstep (#813).
     // Force-now: drop any pending backoff timer and restart with a full budget.
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
@@ -924,6 +954,15 @@ class SshSessionController {
     _socket = null;
     final client = _client;
     _client = null;
+    // #986: drive the terminal state BEFORE the async client teardown. Closing
+    // the client resolves its `done` future, whose handler (wired in [connect]
+    // to [handleTransportClosed]) registered earlier on that future and so ran
+    // FIRST — inside the old `await client.done` window it observed the bit
+    // set while state was still `connected`: the #838 invariant fired on every
+    // user disconnect of a live session, and the clean-close path re-armed a
+    // spurious softDisconnected → reconnecting hop. Emitting first makes the
+    // handler see `disconnected` and ignore the stale close.
+    _emit(_data.copyWith(state: SshSessionState.disconnected));
     if (client != null) {
       try {
         client.close();
@@ -932,7 +971,6 @@ class SshSessionController {
         /* ignore */
       }
     }
-    _emit(_data.copyWith(state: SshSessionState.disconnected));
   }
 
   /// Release controller resources. Safe to call multiple times.
@@ -958,6 +996,16 @@ class SshSessionController {
         username: params.username,
       ),
     );
+  }
+
+  /// Attach a live [SSHClient] for tests (#986). Production reaches a non-null
+  /// [_client] only via [connect]; tests need one to exercise the [disconnect]
+  /// teardown ordering against the client's `done` future (whose handler,
+  /// wired in [connect], must observe `disconnected` — not the pre-#986
+  /// bit-set-but-still-connected window) without a real handshake.
+  @visibleForTesting
+  void debugAttachClientForTest(SSHClient client) {
+    _client = client;
   }
 
   /// Drive the host-key verification path directly, bypassing the real SSH
@@ -1017,6 +1065,17 @@ class SshSessionController {
       _terminalSinceMs ??= DateTime.now().millisecondsSinceEpoch;
     } else {
       _terminalSinceMs = null;
+    }
+    // #986: the SINGLE transition seam that clears the user-intent bit
+    // (rules/state-management.md: one transition function decides). Entering
+    // `connecting` (a fresh [connect]) or `reconnecting` ([reconnectNow] /
+    // [_scheduleReconnect]) means a NEW connect is actually starting, so a
+    // prior user ✕/Disconnect no longer suppresses anything. No other
+    // transition clears it — a user-closed session that stays closed keeps the
+    // bit (and per #1020 never resurrects a keepalive hold).
+    if (next.state == SshSessionState.connecting ||
+        next.state == SshSessionState.reconnecting) {
+      _userDisconnected = false;
     }
     _data = next;
     if (!_stateCtrl.isClosed) {

--- a/native/test/ssh/user_disconnect_reconnect_bit_test.dart
+++ b/native/test/ssh/user_disconnect_reconnect_bit_test.dart
@@ -1,0 +1,277 @@
+// #986 — user-intent disconnect bit lifecycle across disconnect/reconnect.
+//
+// The #838 debug invariant (`_assertSuppressConsistent`) fired on every user
+// disconnect of a LIVE session: `disconnect()` set the bit, closed the client,
+// and only emitted `disconnected` AFTER `await client.done` — but the client's
+// done-handler (wired in `connect()`, registered earlier on the same future)
+// ran FIRST, observing bit=true while state was still `connected`. Besides the
+// assert spam, the clean-close path re-armed a spurious softDisconnected →
+// reconnecting hop, and the disconnect-cause classifier mislabeled.
+//
+// Second hole: a user disconnect racing an in-flight `connect()` (parked at
+// the socket-open await) let the zombie connect keep going and resurrect a
+// session the user had closed (#1020: user-closed stays closed).
+//
+// These tests pin: (A) live-client disconnect never violates the invariant or
+// re-arms reconnect, (B) a mid-connect user disconnect aborts the connect,
+// (C) disconnect → reconnectNow clears the bit and reconnects cleanly,
+// (D) an involuntary drop keeps the bit false throughout auto-reconnect,
+// (E) a user disconnect without any reconnect keeps the bit set.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+
+const _params = SshConnectParams(
+  host: 'example',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// A fake transport socket: never emits, records what was written, and
+/// completes `done` on destroy. Mirrors `_SilentSocket` in
+/// handshake_timeout_test.dart plus a written-bytes recorder.
+class _FakeSocket implements SSHSocket {
+  _FakeSocket() {
+    _sinkCtrl.stream.listen(sank.add);
+  }
+
+  final _streamCtrl = StreamController<Uint8List>();
+  final _sinkCtrl = StreamController<List<int>>();
+  final _doneCompleter = Completer<void>();
+
+  /// Everything the client wrote to the wire.
+  final sank = <List<int>>[];
+  bool destroyed = false;
+
+  @override
+  Stream<Uint8List> get stream => _streamCtrl.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _sinkCtrl.sink;
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    return done;
+  }
+
+  @override
+  void destroy() {
+    destroyed = true;
+    if (!_streamCtrl.isClosed) _streamCtrl.close();
+    if (!_sinkCtrl.isClosed) _sinkCtrl.close();
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+}
+
+Future<void> _pump([int turns = 8]) async {
+  for (var i = 0; i < turns; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  group('#986 user disconnect of a LIVE session (stale done-handler)', () {
+    test(
+      'disconnect drives `disconnected` before the client teardown — the '
+      'done-handler never sees bit=true+connected (no assert, no re-arm)',
+      () async {
+        final controller = SshSessionController(reconnectDelay: Duration.zero);
+        controller.debugSetConnectedForTest(_params);
+
+        final socket = _FakeSocket();
+        final client = SSHClient(
+          socket,
+          username: 'u',
+          onPasswordRequest: () => 'p',
+        );
+        controller.debugAttachClientForTest(client);
+        // Mirror connect()'s production done wiring: this handler registers on
+        // client.done BEFORE disconnect()'s own await, so it runs first when
+        // the future resolves — exactly the window the bug lived in.
+        unawaited(
+          client.done
+              .then((_) => controller.handleTransportClosed(null))
+              .catchError((Object e) {
+            controller.handleTransportClosed(e);
+          }),
+        );
+
+        final states = <SshSessionState>[];
+        final sub = controller.stream.listen((d) => states.add(d.state));
+
+        await controller.disconnect();
+        await _pump();
+
+        expect(controller.data.state, SshSessionState.disconnected);
+        expect(controller.userInitiatedDisconnect, isTrue);
+        expect(
+          states,
+          isNot(contains(SshSessionState.softDisconnected)),
+          reason: 'the stale clean-close must not re-arm a user disconnect',
+        );
+        expect(states, isNot(contains(SshSessionState.reconnecting)));
+
+        await sub.cancel();
+        await controller.dispose();
+      },
+    );
+  });
+
+  group('#986 user disconnect racing an in-flight connect()', () {
+    test(
+      'disconnect while connect() is parked at socket-open aborts the '
+      'connect — the user-closed session is never resurrected',
+      () async {
+        final gate = Completer<SSHSocket>();
+        final controller = SshSessionController(
+          socketOpener: (host, port, {timeout}) => gate.future,
+        );
+
+        final connectFuture = controller.connect(_params);
+        await _pump(2);
+        expect(controller.data.state, SshSessionState.connecting);
+
+        await controller.disconnect();
+        expect(controller.data.state, SshSessionState.disconnected);
+        expect(controller.userInitiatedDisconnect, isTrue);
+
+        // The socket opens AFTER the user disconnected. Without the abort the
+        // zombie connect builds an SSHClient over it and starts the handshake.
+        final socket = _FakeSocket();
+        gate.complete(socket);
+        await connectFuture.timeout(
+          const Duration(seconds: 2),
+          onTimeout: () {},
+        );
+        await _pump();
+
+        expect(controller.data.state, SshSessionState.disconnected);
+        expect(controller.userInitiatedDisconnect, isTrue);
+        expect(
+          socket.sank,
+          isEmpty,
+          reason: 'no SSH bytes may flow on a session the user closed',
+        );
+        expect(socket.destroyed, isTrue);
+
+        await controller.dispose();
+      },
+    );
+
+    test(
+      'disconnect while connect() is parked at socket-open, opener then '
+      'FAILS — the user\'s `disconnected` is not overwritten with `failed`',
+      () async {
+        final gate = Completer<SSHSocket>();
+        final controller = SshSessionController(
+          socketOpener: (host, port, {timeout}) => gate.future,
+        );
+
+        final connectFuture = controller.connect(_params);
+        await _pump(2);
+        expect(controller.data.state, SshSessionState.connecting);
+
+        await controller.disconnect();
+
+        gate.completeError(const SocketException('refused'));
+        await connectFuture.timeout(
+          const Duration(seconds: 2),
+          onTimeout: () {},
+        );
+        await _pump();
+
+        expect(controller.data.state, SshSessionState.disconnected);
+        expect(controller.userInitiatedDisconnect, isTrue);
+
+        await controller.dispose();
+      },
+    );
+  });
+
+  group('#986 bit lifecycle across reconnect', () {
+    test(
+      'user disconnect → reconnectNow: bit clears, session reaches connected, '
+      'invariant holds at every call site',
+      () async {
+        final controller = SshSessionController(
+          reconnectDelay: Duration.zero,
+          reconnectAttemptOverride: (_) async => true,
+        );
+        controller.debugSetConnectedForTest(_params);
+
+        await controller.disconnect();
+        expect(controller.userInitiatedDisconnect, isTrue);
+        expect(controller.data.state, SshSessionState.disconnected);
+
+        controller.reconnectNow();
+        for (var i = 0; i < 20; i++) {
+          await Future<void>.delayed(Duration.zero);
+          if (controller.data.state == SshSessionState.connected) break;
+        }
+
+        expect(controller.data.state, SshSessionState.connected);
+        expect(
+          controller.userInitiatedDisconnect,
+          isFalse,
+          reason: 'a new connect clears the user-intent bit',
+        );
+
+        // Exercise an invariant call site while connected — must not throw.
+        await controller.resumeReconnectIfStale(staleThreshold: Duration.zero);
+        expect(controller.data.state, SshSessionState.connected);
+
+        await controller.dispose();
+      },
+    );
+
+    test('involuntary drop → auto-reconnect keeps the bit false throughout',
+        () async {
+      final controller = SshSessionController(
+        reconnectDelay: Duration.zero,
+        reconnectAttemptOverride: (_) async => true,
+      );
+      controller.debugSetConnectedForTest(_params);
+
+      controller.handleTransportClosed(
+        SSHSocketError(
+          const SocketException('reset', osError: OSError('reset', 104)),
+        ),
+      );
+      expect(controller.userInitiatedDisconnect, isFalse);
+
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(Duration.zero);
+        if (controller.data.state == SshSessionState.connected) break;
+      }
+
+      expect(controller.data.state, SshSessionState.connected);
+      expect(controller.userInitiatedDisconnect, isFalse);
+
+      await controller.dispose();
+    });
+
+    test('user disconnect WITHOUT reconnect keeps the bit set', () async {
+      final controller = SshSessionController(reconnectDelay: Duration.zero);
+      controller.debugSetConnectedForTest(_params);
+
+      await controller.disconnect();
+      await _pump();
+
+      expect(controller.data.state, SshSessionState.disconnected);
+      expect(controller.userInitiatedDisconnect, isTrue);
+
+      await controller.dispose();
+    });
+  });
+}


### PR DESCRIPTION
Fixes #986 — the ssh_session.dart:264 assert spam (`user-intent bit set but state=connected`) and the disconnect-cause mislabel.

## Root cause (differs from the issue's framing)
`connect()` and `reconnectNow()` already cleared the bit — the reconnect path was not the hole. Two real ones:

1. **Deterministic, every user disconnect of a LIVE session**: `disconnect()` set `_userDisconnected`, closed the client, then `await client.done` BEFORE emitting `disconnected`. The done-handler wired in `connect()` registered earlier on that same future, so it ran FIRST — inside the await window it saw bit=true + state=connected → the exact logged assert, and the clean-close path re-armed a spurious `softDisconnected → reconnecting` hop.
2. **Raced connect**: a user disconnect landing while `connect()` was parked at `hostKeyStore.ready` / `_openSocket` / `client.authenticated` let the zombie connect resurrect the user-closed session (`connected`, or `failed` overwriting the user's `disconnected`) with the bit still set.

## Fix (native/lib/ssh/ssh_session.dart)
- `disconnect()` emits `disconnected` before the async client teardown — the stale done-handler now sees the terminal state and returns.
- `connect()` aborts after every await when a user disconnect raced in (fresh socket destroyed, no SSH bytes flow, no state overwrite). Per the #1020 adjacency, the bit clears ONLY when a new connect actually starts — a user-closed session never resurrects a keepalive hold.
- `_emit` is now the SINGLE transition seam clearing the bit (entry to `connecting`/`reconnecting`); the scattered clears in `connect()`/`reconnectNow()` are removed (rules/state-management.md). `_assertSuppressConsistent` stays untouched — it is the guard proving the fix.
- New `@visibleForTesting debugAttachClientForTest` so the done-future ordering is unit-testable.

## Red → green
New `native/test/ssh/user_disconnect_reconnect_bit_test.dart`:
- RED: reproduced the exact `:264` assert verbatim (`Failed assertion: line 264 … state=connected`) via a fake `SSHSocket` + real `SSHClient` done wiring.
- RED: zombie connect wrote SSH handshake bytes to a socket opened after the user closed the session (`socket.sank` non-empty).
- RED: opener failure after user disconnect overwrote `disconnected` with `failed`.
- GREEN pins: disconnect → `reconnectNow()` → connected with bit cleared and no assert; involuntary drop keeps bit false throughout auto-reconnect; user disconnect without reconnect keeps bit true.

All 6 green after the fix. Adjacent suites green: `state_fold_userdisconnect`, `reconnect_now`, `reconnect_on_transient` (disconnect-cause classifier inputs), `resume_liveness_probe`, `handshake_timeout`.

`scripts/native-fast-gate.sh`: analyze clean, 1837 tests passed (~5 standing skips).

## Caveats for /integrate
- Session state machine touched → per `.claude/rules/testing.md` (#589) the emulator integration suite is required before merge; not run here (fast gate only, as specified in the issue).
- Behavioral delta: `disconnected` is now emitted before (not after) client teardown; a mid-connect user disconnect aborts the connect instead of resurrecting the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa