### PR TITLE
fix(flterm): bare ~ (no slash) no longer anchors a path (#1024)

### DIFF
--- a/native/third_party/flterm/lib/src/foundation/structured_text.dart
+++ b/native/third_party/flterm/lib/src/foundation/structured_text.dart
@@ -164,7 +164,8 @@ final class TextPattern {
   /// pwd-relative resolution to a later slice:
   ///   * absolute — a leading `/` followed by one or more `/`-separated segments
   ///     of path chars (`[\w.\-~@+]`), e.g. `/etc/ssh/sshd_config`;
-  ///   * home — `~/…` (a `~` followed by `/` and segments) or a BARE `~`;
+  ///   * home — `~/…` (a `~` followed by `/` and segments); a BARE `~` never
+  ///     anchors (#1024 — it's usually prose: `cd ~`, `about ~5 seconds`);
   ///   * explicit-relative — `./x`, `../x`, or a `../` chain, e.g. `../../lib`.
   /// BARE relative tokens (`src/foo`) are DEFERRED to Slice 3 — including them
   /// would over-match ordinary prose like `and/or`.
@@ -316,9 +317,9 @@ const String _kPathLookbehindMeta = r'''${}*?\[\]()`|<>&;=\\''';
 /// The ABSOLUTE FILE PATH regex (#778, paths Slice 1; precision #826). Matches
 /// three shapes that resolve WITHOUT a working directory:
 ///   * absolute — `/` + one-or-more `/`-separated segments of path chars;
-///   * home — `~/…` or a BARE `~` (word-bounded so it isn't a stray tilde in
-///     prose like `approx ~3s` — a bare `~` matches only when not followed by a
-///     path char other than `/`);
+///   * home — `~/…` only (a BARE `~` never anchors, #1024: prose tildes like
+///     `cd ~` / `about ~5 seconds` are far more common than a tap-worthy lone
+///     home reference, and the #990 stat gate would happily VERIFY `~`);
 ///   * explicit-relative — `./…`, `../…`, or a `../` chain.
 /// A path char is `[\w.\-~@+]` (mirrors the issue's class). A NEGATIVE LOOKBEHIND
 /// keeps the match from starting MID-token — critically it rejects the `//` after
@@ -341,8 +342,7 @@ final RegExp _kPathPattern = RegExp(
   '(?<![\\w.\\-~@+:/$_kPathLookbehindMeta])'
   r'(?:'
   r'/(?:[\w.\-~@+]+/?)+' // absolute: /a/b/c
-  r'|~/(?:[\w.\-~@+]+/?)*' // home: ~/a/b
-  r'|~(?![\w.\-@+])' // bare ~ (not ~word)
+  r'|~/(?:[\w.\-~@+]+/?)*' // home: ~/a/b (a BARE ~ never anchors, #1024)
   r'|\.\.?/(?:[\w.\-~@+]+/?|\.\.?/)*' // ./x ../x ../../ chains
   r')'
   // #826: swallow any adjacent REJECT-class (glob/var/command-sub) suffix so

--- a/native/third_party/flterm/test/foundation/structured_text_test.dart
+++ b/native/third_party/flterm/test/foundation/structured_text_test.dart
@@ -1004,4 +1004,41 @@ void main() {
       },
     );
   });
+
+  group('TextPattern.path() — bare tilde must NOT anchor (#1024)', () {
+    final pathPattern = TextPattern.path();
+
+    List<String> pathPayloads(String row, {int? cols}) {
+      final reader = _FakeCellReader([row], cols: cols ?? (row.length + 2));
+      return scanner
+          .scan(reader, [pathPattern])
+          .where((m) => m.patternId == 'path')
+          .map((m) => '${m.payload}')
+          .toList();
+    }
+
+    test('a lone `~` is not a path', () {
+      expect(pathPayloads('~'), isEmpty);
+    });
+
+    test('`cd ~` — trailing bare tilde is not a path', () {
+      expect(pathPayloads('cd ~'), isEmpty);
+    });
+
+    test('`~ 5 seconds` — prose tilde before a space is not a path', () {
+      expect(pathPayloads('~ 5 seconds'), isEmpty);
+    });
+
+    test('`about ~50%` — approx-tilde glued to a number is not a path', () {
+      expect(pathPayloads('about ~50% done'), isEmpty);
+    });
+
+    test('`~/x/y.txt` STILL anchors with the tilde in the payload', () {
+      expect(pathPayloads('open ~/x/y.txt now'), contains('~/x/y.txt'));
+    });
+
+    test('`~/x` STILL anchors with the tilde in the payload', () {
+      expect(pathPayloads('cat ~/x'), contains('~/x'));
+    });
+  });
 }


### PR DESCRIPTION
Fixes #1024.

## What
A bare `~` (tilde with no following slash) was detected as a path anchor — owner device report on +129: "let's exclude raw ~ without a /". Only `~/...` should anchor a home path.

## Fix
Removed the bare-tilde alternative (`~(?![\w.\-@+])`) from `_kPathPattern` in `native/third_party/flterm/lib/src/foundation/structured_text.dart`. The `~/` alternative is untouched, so `~/x`, `~/x/y.txt` still anchor with the tilde in the payload. `~user/...` was never supported by this regex, so nothing to preserve there. Doc comments updated.

Why the regex is the only gate: the #990 SFTP-stat verification would VERIFY a bare `~` (home exists), so it cannot save us here.

## Tests (red → green)
New scanner-level group in `test/foundation/structured_text_test.dart` — `TextPattern.path() — bare tilde must NOT anchor (#1024)`:
- red before the fix (3 failures): `~` alone, `cd ~`, `~ 5 seconds` — each anchored as payload `~`
- guard (already passing): `about ~50%` — the old lookahead already rejected `~word`
- still-anchors: `~/x/y.txt`, `~/x` — payload includes the tilde

After the fix: file suite 72/72, full flterm fork suite 829/829, `scripts/native-fast-gate.sh` PASSED (analyze + 1841 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa