### PR TITLE
feat(desktop): Linux desktop target proven end-to-end (#1012 Phase 0)

### DIFF
--- a/native/DESKTOP.md
+++ b/native/DESKTOP.md
@@ -72,3 +72,28 @@ flutter build linux          # → build/linux/x64/release/bundle/mobissh
 `libsecret-1-dev` is required because `flutter_secure_storage_linux` stores the
 vault via libsecret (the Linux Secret Service). macOS uses the Keychain instead
 and needs no extra system package.
+
+## Headless E2E smoke (#1012 Phase 0)
+
+`scripts/desktop-smoke.sh` runs the whole loop on this box: toolchain check
+(→ `scripts/setup-linux-desktop-toolchain.sh` if incomplete), test-sshd up,
+Xvfb, `flutter test integration_test/desktop_smoke_test.dart -d linux`, and an
+x11grab screenshot into `test-results/emulator-shots/`. The desktop process
+reaches `test-sshd:22` directly over the docker network — no socat/adb bridge.
+
+Proven end-to-end 2026-07-09 (Phase 0): release build (54 MB bundle;
+`lib/libghostty.so` 6.7 MB downloaded by libghostty 0.0.9's native-assets
+hook — the same mechanism that will fetch the macOS dylib), connect via the
+in-process SessionHost, shell bytes + echo round-trip, Ghostty rendering.
+
+Runtime caveats found on headless Linux (not desktop-session Linux / macOS):
+
+- **Vault**: libsecret throws `Failed to unlock the keyring` without a Secret
+  Service (gnome-keyring). The smoke overrides `secretsStoreProvider` with the
+  in-memory backend; a real desktop session provides a keyring, macOS uses the
+  Keychain. Graceful app handling of a missing Secret Service is follow-up UX.
+- **path_provider**: `getApplicationDocumentsDirectory` throws
+  `MissingPlatformDirectoryException` (no XDG user dirs headless) — the crash
+  reporter catches + logs it; non-fatal.
+- **UX deltas** (noted, not Phase 0 scope): the mobile keybar + hidden-IME
+  strip render on desktop; physical-keyboard-first input is a later phase.

--- a/native/integration_test/desktop_smoke_test.dart
+++ b/native/integration_test/desktop_smoke_test.dart
@@ -1,0 +1,144 @@
+// Desktop (Linux) E2E smoke — Phase 0 of the desktop-targets arc (#1012).
+//
+// Runs ON THE HOST, no emulator/adb: scripts/desktop-smoke.sh drives
+// `flutter test integration_test/desktop_smoke_test.dart -d linux` under Xvfb.
+// The host process reaches test-sshd DIRECTLY over the docker network
+// (test-sshd:22) — no socat bridge, no adb reverse. Host/port are injectable
+// via --dart-define (SMOKE_HOST / SMOKE_PORT) for other environments; the
+// Android smokes hardcode 127.0.0.1:2222 because they run inside the emulator.
+//
+// What this proves (the #577 desktop path, end-to-end):
+//   - taskSshGatewayProvider resolves the IN-PROCESS SessionHost (no
+//     flutter_foreground_task, no task isolate — kIsDesktop gates FFT off).
+//   - dartssh2 connects directly over dart:io.
+//   - libghostty's prebuilt linux .so loads and the terminal renders — the
+//     same download+FFI path macOS will use with its dylib.
+//
+// Mirrors shell_bytes_smoke_test.dart: prompt bytes must arrive, and a typed
+// command must echo back through the proxy round-trip.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+
+import 'support/connect_helpers.dart';
+
+const _host = String.fromEnvironment('SMOKE_HOST', defaultValue: 'test-sshd');
+const _port = String.fromEnvironment('SMOKE_PORT', defaultValue: '22');
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('desktop in-process host connects and streams shell bytes', (
+    tester,
+  ) async {
+    // NO FlutterForegroundTask.initCommunicationPort() here — that's the
+    // Android smoke's bootstrap. On desktop the plugin isn't registered and
+    // the SessionHost is hosted in-process (#577).
+    //
+    // PHASE 0 FINDING (#1012): the real vault (flutter_secure_storage_linux →
+    // libsecret) throws "Failed to unlock the keyring" in a headless container
+    // — there is no Secret Service / gnome-keyring on this box. A real Linux
+    // desktop session provides one; macOS uses the Keychain (no daemon
+    // dependency). The smoke overrides the secrets store with the in-memory
+    // backend so it exercises SSH + rendering, not keyring availability.
+    // Graceful app-level handling of a missing Secret Service is follow-up UX.
+    final container = ProviderContainer(
+      overrides: [
+        secretsStoreProvider.overrideWithValue(
+          SecretsStore(backend: InMemorySecretsBackend()),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    // Ad-hoc connect via "New connection" → editor → "Save & connect" (#583).
+    await adhocPasswordConnect(
+      tester,
+      host: _host,
+      port: _port,
+      user: 'testuser',
+      pass: 'testpass',
+    );
+
+    // Reach the terminal screen, accepting the host-key prompt if shown.
+    var connected = false;
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      final accept = find.text('Trust + connect');
+      if (accept.evaluate().isNotEmpty) {
+        await tester.tap(accept.first);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+        connected = true;
+        break;
+      }
+    }
+    expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+    // Capture everything the in-process host streams to the UI terminal.
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after connect');
+    final out = <int>[];
+    final sub = entry!.proxy.output.listen(out.addAll);
+    addTearDown(sub.cancel);
+
+    // 1) The shell must produce SOME output (a prompt) — proves the PTY opened
+    //    and bytes flow through the in-process gateway pair.
+    var gotPrompt = false;
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      if (out.isNotEmpty) {
+        gotPrompt = true;
+        break;
+      }
+    }
+    expect(
+      gotPrompt,
+      isTrue,
+      reason: 'terminal received ZERO bytes after connect on desktop',
+    );
+
+    // 2) A typed command must echo back through the proxy round-trip.
+    const marker = 'MOBISSH_DESKTOP_OK_1012';
+    entry.proxy.sendInput(Uint8List.fromList(utf8.encode('echo $marker\n')));
+    var sawMarker = false;
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+      if (utf8.decode(out, allowMalformed: true).contains(marker)) {
+        sawMarker = true;
+        break;
+      }
+    }
+    expect(
+      sawMarker,
+      isTrue,
+      reason: 'typed command never echoed back — input not routed to the PTY',
+    );
+
+    // Hold the final frame so the runner's display-capture watcher
+    // (scripts/desktop-smoke.sh) grabs the rendered terminal with the echoed
+    // marker visible — the screenshot IS the visual half of this smoke.
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+  });
+}

--- a/scripts/desktop-smoke.sh
+++ b/scripts/desktop-smoke.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# scripts/desktop-smoke.sh — Linux DESKTOP E2E smoke (#1012 Phase 0).
+#
+# Runs the desktop integration smoke on THIS box (no emulator, no adb):
+#   1. toolchain check → scripts/setup-linux-desktop-toolchain.sh if missing
+#   2. test-sshd up (Docker DNS test-sshd:22 — the host process reaches it
+#      directly on the mobissh network; no socat/adb-reverse bridge)
+#   3. Xvfb virtual display
+#   4. `flutter test integration_test/desktop_smoke_test.dart -d linux`
+#      (this builds the Linux debug bundle — the desktop build proof; run
+#       `scripts/flutter-cmd.sh --in native build linux --release` for the
+#       release-bundle proof)
+#   5. screenshot of the live window via ffmpeg x11grab, captured every 2s
+#      while the test runs; the LAST frame (the test holds the rendered
+#      terminal for ~5s before exiting) lands in test-results/emulator-shots/
+#      with the emu-shot.sh naming style. The path is the last stdout line.
+#
+# Usage: scripts/desktop-smoke.sh [integration_test/other_test.dart]
+# Env: SMOKE_HOST (default test-sshd), SMOKE_PORT (default 22),
+#      SMOKE_DISPLAY (default 97), MOBISSH_SHOTDIR (default
+#      <repo>/test-results/emulator-shots).
+#
+# Exit 0 = smoke green (screenshot path printed). Exit 1 = test failed.
+# Exit 2 = setup error.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MOBISSH_TMPDIR="${MOBISSH_TMPDIR:-/tmp/mobissh}"
+MOBISSH_LOGDIR="${MOBISSH_LOGDIR:-/tmp/mobissh/logs}"
+mkdir -p "$MOBISSH_TMPDIR" "$MOBISSH_LOGDIR"
+LOGFILE="${MOBISSH_LOGDIR}/desktop-smoke.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+TEST_FILE="${1:-integration_test/desktop_smoke_test.dart}"
+NATIVE_DIR="${REPO_ROOT}/native"
+SMOKE_HOST="${SMOKE_HOST:-test-sshd}"
+SMOKE_PORT="${SMOKE_PORT:-22}"
+DISPLAY_NUM=":${SMOKE_DISPLAY:-97}"
+SCREEN_GEOM="1280x800"
+SHOTDIR="${MOBISSH_SHOTDIR:-${REPO_ROOT}/test-results/emulator-shots}"
+FRAMES_DIR="${MOBISSH_TMPDIR}/desktop-smoke-frames"
+mkdir -p "$SHOTDIR"
+rm -rf "$FRAMES_DIR"
+mkdir -p "$FRAMES_DIR"
+
+log() { echo "> $*"; }
+err() { echo "! $*" >&2; }
+
+XVFB_PID=""
+WATCHER_PID=""
+cleanup() {
+  if [[ -n "$WATCHER_PID" ]] && kill -0 "$WATCHER_PID" 2>/dev/null; then
+    kill "$WATCHER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$XVFB_PID" ]] && kill -0 "$XVFB_PID" 2>/dev/null; then
+    kill "$XVFB_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# 1. Toolchain check — run the setup script only if something is missing.
+missing=0
+for t in clang cmake ninja pkg-config Xvfb ffmpeg; do
+  command -v "$t" >/dev/null 2>&1 || missing=1
+done
+pkg-config --exists gtk+-3.0 2>/dev/null || missing=1
+if [[ "$missing" == "1" ]]; then
+  log "toolchain incomplete — running setup-linux-desktop-toolchain.sh"
+  if ! "${REPO_ROOT}/scripts/setup-linux-desktop-toolchain.sh"; then
+    err "toolchain setup failed"
+    exit 2
+  fi
+else
+  log "toolchain present"
+fi
+
+# 2. test-sshd reachable (bring it up + join the mobissh network if needed).
+if ! getent hosts "$SMOKE_HOST" >/dev/null 2>&1; then
+  log "$SMOKE_HOST not resolvable — running test-sshd-up.sh"
+  if ! "${REPO_ROOT}/scripts/test-sshd-up.sh"; then
+    err "test-sshd-up failed — cannot reach $SMOKE_HOST"
+    exit 2
+  fi
+fi
+log "$SMOKE_HOST resolves OK"
+
+# 3. Virtual display. A stale Xvfb on this display (crashed prior run) leaves
+# a lock file; remove it only if no live server owns it.
+LOCKFILE="/tmp/.X${DISPLAY_NUM#:}-lock"
+if [[ -e "$LOCKFILE" ]] && ! pgrep -f "Xvfb ${DISPLAY_NUM}" >/dev/null 2>&1; then
+  rm -f "$LOCKFILE"
+fi
+if ! pgrep -f "Xvfb ${DISPLAY_NUM}" >/dev/null 2>&1; then
+  log "starting Xvfb ${DISPLAY_NUM} (${SCREEN_GEOM}x24)"
+  Xvfb "$DISPLAY_NUM" -screen 0 "${SCREEN_GEOM}x24" -nolisten tcp &
+  XVFB_PID=$!
+  sleep 1
+else
+  log "Xvfb ${DISPLAY_NUM} already running (reusing)"
+fi
+
+# 4. Frame watcher: grab the display every 2s while the test runs. The last
+# frame captured is the held final terminal state (the test pumps ~5s after
+# its assertions pass exactly so this watcher can catch it).
+(
+  n=0
+  while true; do
+    n=$((n + 1))
+    ffmpeg -loglevel error -f x11grab -video_size "$SCREEN_GEOM" \
+      -i "$DISPLAY_NUM" -frames:v 1 -y \
+      "$(printf '%s/frame-%04d.png' "$FRAMES_DIR" "$n")" 2>/dev/null || true
+    sleep 2
+  done
+) &
+WATCHER_PID=$!
+
+# 5. Run the integration test on the linux device. Builds the Linux debug
+# bundle (incl. the libghostty prebuilt .so via the native-assets hook) —
+# the same FFI path macOS uses with its dylib.
+log "running $TEST_FILE on -d linux (host=$SMOKE_HOST:$SMOKE_PORT, display=$DISPLAY_NUM)"
+STATUS=0
+if ! DISPLAY="$DISPLAY_NUM" "${REPO_ROOT}/scripts/flutter-cmd.sh" --in "$NATIVE_DIR" \
+    test "$TEST_FILE" -d linux \
+    --dart-define="SMOKE_HOST=${SMOKE_HOST}" \
+    --dart-define="SMOKE_PORT=${SMOKE_PORT}"; then
+  STATUS=1
+fi
+
+# 6. Keep the last captured frame as the smoke screenshot (emu-shot naming).
+kill "$WATCHER_PID" 2>/dev/null || true
+WATCHER_PID=""
+LAST_FRAME="$(ls -1 "$FRAMES_DIR"/frame-*.png 2>/dev/null | sort | tail -n 1 || true)"
+if [[ -n "$LAST_FRAME" ]]; then
+  STAMP="$(date +%Y%m%dT%H%M%S%z)"
+  OUT="${SHOTDIR}/${STAMP}-desktop-smoke.png"
+  cp "$LAST_FRAME" "$OUT"
+  if [[ "$STATUS" == "0" ]]; then
+    echo "+ SMOKE PASSED — $TEST_FILE"
+  else
+    echo "! SMOKE FAILED — $TEST_FILE (screenshot may show why)"
+  fi
+  echo "$OUT"
+else
+  err "no display frame captured (test may have failed before first paint)"
+fi
+exit "$STATUS"

--- a/scripts/setup-linux-desktop-toolchain.sh
+++ b/scripts/setup-linux-desktop-toolchain.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scripts/setup-linux-desktop-toolchain.sh — install the GTK/clang toolchain
+# Flutter needs to build the LINUX DESKTOP target in this container (#1012
+# Phase 0). Used to validate the desktop flavor of the native app (direct
+# dart:io SSH + in-process SessionHost, no Android foreground service) without
+# a Mac — macOS desktop shares ~all of this code; only the final .app
+# packaging needs a Mac.
+#
+# Also installs what the headless E2E loop needs (scripts/desktop-smoke.sh):
+# xvfb for a virtual display and ffmpeg for x11grab screenshots.
+#
+# Idempotent. Requires passwordless sudo (confirmed in fd-dev).
+
+set -euo pipefail
+
+MOBISSH_LOGDIR="${MOBISSH_LOGDIR:-/tmp/mobissh/logs}"
+mkdir -p "$MOBISSH_LOGDIR"
+LOGFILE="${MOBISSH_LOGDIR}/setup-linux-desktop-toolchain.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "> apt-get update"
+sudo apt-get update -y
+
+echo "> installing flutter linux-desktop toolchain + headless E2E deps"
+# libsecret-1-dev: flutter_secure_storage_linux (credential vault) builds
+# against libsecret. NOTE: at RUNTIME the vault also needs a Secret Service
+# (gnome-keyring) — absent in a headless container; see desktop_smoke_test.dart.
+# xvfb + ffmpeg: virtual display + x11grab screenshot for desktop-smoke.sh.
+sudo apt-get install -y \
+  clang \
+  cmake \
+  ninja-build \
+  pkg-config \
+  libgtk-3-dev \
+  liblzma-dev \
+  libsecret-1-dev \
+  xvfb \
+  ffmpeg
+
+echo "> flutter config --enable-linux-desktop (idempotent)"
+"${REPO_ROOT}/scripts/flutter-cmd.sh" config --enable-linux-desktop
+
+echo "+ toolchain installed:"
+for t in clang cmake ninja pkg-config Xvfb ffmpeg; do
+  printf '  %s: ' "$t"
+  command -v "$t" >/dev/null && echo ok || echo MISSING
+done
+printf '  gtk+-3.0: '
+pkg-config --exists gtk+-3.0 && echo ok || echo MISSING
+printf '  libsecret-1: '
+pkg-config --exists libsecret-1 && echo ok || echo MISSING


### PR DESCRIPTION
Phase 0 of the desktop-targets arc (#1012): enable and prove the LINUX desktop target end-to-end on the dev box, as the cheap de-risk for macOS/iOS.

## What was proven

1. **Toolchain**: GTK/clang/ninja toolchain works in fd-dev. `scripts/setup-linux-desktop-toolchain.sh` (adopted from the untracked draft, finished) installs everything idempotently — adds `libsecret-1-dev` (vault), `xvfb` + `ffmpeg` (headless E2E) to the original list, and runs `flutter config --enable-linux-desktop`. `native/linux/` runner was already committed (#577) — no `flutter create` needed.
2. **Build proof**: `flutter build linux --release` succeeds. Bundle: **54 MB** at `native/build/linux/x64/release/bundle/`, containing `lib/libghostty.so` (**6.7 MB**) — libghostty 0.0.9's native-assets build hook downloaded the prebuilt linux-gnu binary and linked it with zero configuration. **This is the exact mechanism macOS will use for its dylib.**
3. **E2E smoke on this box**: `integration_test/desktop_smoke_test.dart` under Xvfb, `-d linux`, connects to `test-sshd:22` DIRECTLY over the docker network (host process — no socat, no adb reverse; `SMOKE_HOST`/`SMOKE_PORT` dart-defines parameterize it). Asserts: terminal screen reached → prompt bytes arrive through the in-process SessionHost (#577 path, no FFT/task isolate) → typed `echo MOBISSH_DESKTOP_OK_1012` round-trips. Green in ~9s.
4. **Runner**: `scripts/desktop-smoke.sh` — setup-if-needed → test-sshd up → Xvfb → test → ffmpeg x11grab screenshot to `test-results/emulator-shots/<stamp>-desktop-smoke.png` (emu-shot naming; path is the last stdout line).

Smoke screenshot (terminal rendering the prompt + echoed marker + session bar `testuser@test-sshd`): `test-results/emulator-shots/20260709T202028+0000-desktop-smoke.png` (copied to the main checkout's shots dir; gitignored artifact).

## Honest findings

- **Vault needs a Secret Service at runtime**: `flutter_secure_storage_linux` threw `PlatformException(Libsecret error, Failed to unlock the keyring)` on profile save in the headless container — no gnome-keyring/DBus Secret Service. The smoke overrides `secretsStoreProvider` with `InMemorySecretsBackend`. Linux-specific: a real desktop session has a keyring; **macOS Keychain has no daemon dependency**. Follow-up UX: graceful app-level handling when the Secret Service is absent (per security rules: block persistence, don't fall back to plaintext).
- **path_provider**: `getApplicationDocumentsDirectory` throws `MissingPlatformDirectoryException` headless (no XDG user dirs); CrashReporter catches + logs, non-fatal. macOS provides the documents dir natively — won't transfer.
- **HostKeyStore is desktop-safe**: shared_preferences backend worked on Linux; trust persisted across runs.
- **UX deltas (noted, not fixed — Phase 1+)**: mobile keybar + session bar render on desktop (fine but touch-first); there's a blank strip below the session bar (mobile inset/IME reservation); keyboard-inset logic did NOT misbehave under a fixed-size window. Physical-keyboard-first input is the macOS-phase work.
- **What transfers to macOS**: the entire in-process SessionHost/dartssh2/Ghostty path (proven here), the libghostty prebuilt-binary hook, `kIsDesktop` gating of flutter_foreground_task (no `MissingPluginException` at boot). What does NOT transfer: apt toolchain, Xvfb/x11grab harness, libsecret caveat.

Gate: `scripts/native-fast-gate.sh` green (analyze + 1841 unit tests). Android path untouched (additive-only: 4 new/doc files).

Part of #1012 (do not auto-close — this is Phase 0 of the spike, the macOS phases remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa