### PR TITLE
feat(native): iOS routes to the in-process SessionHost (kUsesInProcessHost, #1026 gating slice)

### DIFF
--- a/native/DESKTOP.md
+++ b/native/DESKTOP.md
@@ -14,8 +14,10 @@ directly.
 | Keep-alive service | `flutter_foreground_task` | **no-op** (`NoopKeepaliveGateway`) |
 | Credential vault | flutter_secure_storage (Android Keystore) | flutter_secure_storage (macOS Keychain / libsecret on Linux) |
 
-The platform split is driven by `isDesktopProvider` (see
-`lib/platform/desktop.dart`). On desktop, `taskSshGatewayProvider`
+The hosting split is driven by `usesInProcessHostProvider` (see
+`lib/platform/desktop.dart`) — true on desktop AND iOS (#1026: no FGS
+equivalent, sessions revive on foreground); `isDesktopProvider` remains the
+desktop-UX predicate. On desktop, `taskSshGatewayProvider`
 (`lib/state/session_host_providers.dart`) builds an `InMemoryGatewayPair` and
 hosts a live `SessionHost` on its task side in the same isolate, returning the
 UI side. This reuses the exact in-process path the unit tests exercise — SSH

--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -35,10 +35,10 @@ void main() {
     // Fire-and-forget — don't block first paint on bridge reachability.
     unawaited(CrashReporter.uploadPending());
     // Open the isolate port so the foreground task isolate can send data
-    // back to the UI (#512). Android-only: `flutter_foreground_task` is not
-    // available on desktop (macOS / Linux / Windows, #577) where there is no
-    // task isolate — calling it would throw `MissingPluginException` at boot.
-    if (!kIsDesktop) {
+    // back to the UI (#512). Android-only: platforms hosting the SessionHost
+    // in-process (desktop #577, iOS #1026) have no task isolate — calling
+    // this there would throw `MissingPluginException` at boot.
+    if (!kUsesInProcessHost) {
       FlutterForegroundTask.initCommunicationPort();
     }
     runApp(const ProviderScope(child: MobisshApp()));

--- a/native/lib/platform/desktop.dart
+++ b/native/lib/platform/desktop.dart
@@ -1,26 +1,58 @@
-// Desktop-platform detection (#577).
+// Platform detection: desktop (#577) + hosting model (#1026).
 //
-// The native app targets Android (foreground-service + task-isolate machinery)
-// AND desktop (macOS / Linux / Windows). On desktop the OS does not kill the
-// process, so the SSH `SessionHost` runs in-process and the
-// `flutter_foreground_task` keep-alive service is skipped entirely.
+// The native app targets Android (foreground-service + task-isolate
+// machinery), desktop (macOS / Linux / Windows), and iOS. Two DISTINCT
+// predicates live here — pick by meaning, not by platform list:
 //
-// Detection is INJECTABLE for tests: the real `Platform` is read only inside
-// [kIsDesktop]; providers resolve through [isDesktopProvider] which a test can
-// override to force desktop vs android without binding to a real platform.
+//   - [kIsDesktop]: "this is a desktop OS" (windowed UX, hardware keyboard,
+//     the OS never kills the process).
+//   - [kUsesInProcessHost]: "the SSH `SessionHost` runs in-process — there is
+//     no Android foreground service and no task isolate". True on desktop AND
+//     on iOS: iOS has no FGS equivalent, so backgrounded sessions drop and
+//     revive on foreground via the resume machinery (#1026).
+//
+// Detection is INJECTABLE for tests: the real `Platform` is read only through
+// [debugOperatingSystemOverride]; providers resolve through
+// [isDesktopProvider] / [usesInProcessHostProvider] which a test can override
+// to force a platform path without binding to a real platform.
 
 import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+/// Test seam: force the operating-system name ('android', 'ios', 'macos',
+/// 'linux', 'windows') the predicates below resolve against. Production leaves
+/// this null → the real `Platform.operatingSystem` is read.
+@visibleForTesting
+String? debugOperatingSystemOverride;
+
+String get _os => debugOperatingSystemOverride ?? Platform.operatingSystem;
+
 /// True on a desktop platform (macOS / Linux / Windows). Reads the real
-/// `Platform`; tests should NOT call this directly — override
-/// [isDesktopProvider] instead.
+/// `Platform` (via the test seam); tests should NOT call this directly —
+/// override [isDesktopProvider] instead.
 bool get kIsDesktop =>
-    !kIsWeb && (Platform.isMacOS || Platform.isLinux || Platform.isWindows);
+    !kIsWeb && (_os == 'macos' || _os == 'linux' || _os == 'windows');
+
+/// True where the SSH `SessionHost` runs IN-PROCESS: no Android foreground
+/// service, no task isolate (#1026). Desktop qualifies because the OS never
+/// kills the process; iOS qualifies because it has NO foreground-service
+/// equivalent — the app suspends on background, sessions drop, and the
+/// existing resume/reconnect machinery revives them on foreground. Only
+/// Android uses the `flutter_foreground_task` task-isolate host.
+bool get kUsesInProcessHost => kIsDesktop || (!kIsWeb && _os == 'ios');
 
 /// Injectable desktop flag. Production resolves to [kIsDesktop]; tests override
 /// this provider to force the desktop or android code path deterministically
 /// (no real `Platform` read in the test isolate).
 final isDesktopProvider = Provider<bool>((ref) => kIsDesktop);
+
+/// Injectable hosting-model flag (#1026). Derived from [isDesktopProvider]
+/// (so existing desktop-flag overrides keep steering the hosting path) OR the
+/// iOS check. Tests can also override this provider directly, or set
+/// [debugOperatingSystemOverride] = 'ios' to exercise the full production
+/// resolution chain.
+final usesInProcessHostProvider = Provider<bool>(
+  (ref) => ref.watch(isDesktopProvider) || (!kIsWeb && _os == 'ios'),
+);

--- a/native/lib/state/attention_providers.dart
+++ b/native/lib/state/attention_providers.dart
@@ -200,10 +200,12 @@ Future<String?> _reconnectHostFromProfile(Ref ref, String host) async {
 ///      provider's future first).
 ///
 /// Telemetry flows through `clifecycle` (#766): its durable 80-line ring ships
-/// in the feedback upload and survives connect-ring churn. Desktop (#577) has
-/// no FLN/FGS machinery → no-op.
+/// in the feedback upload and survives connect-ring churn. Platforms without
+/// the FGS-task attention pipeline (desktop #577, iOS #1026 — the pending
+/// store is FFT-backed and notifications are posted from the task isolate)
+/// → no-op.
 final attentionUiFlnInitProvider = FutureProvider<void>((ref) async {
-  if (ref.watch(isDesktopProvider)) return;
+  if (ref.watch(usesInProcessHostProvider)) return;
   final binding = AttentionUiTapBinding(
     // clifecycle-bound bridge: the pending WRITE line lands in the uploaded
     // lifecycle ring (the task/background-isolate writes only reach logcat).

--- a/native/lib/state/keepalive_providers.dart
+++ b/native/lib/state/keepalive_providers.dart
@@ -18,12 +18,13 @@ import '../ssh/ssh_session.dart';
 import 'session_host_providers.dart';
 import 'sessions.dart';
 
-/// Selects the keep-alive gateway for the current platform (#577). Desktop has
-/// no foreground service (the process persists), so it uses a no-op gateway;
-/// Android uses the real `flutter_foreground_task`-backed gateway. Reading this
-/// keeps the FFT statics out of the desktop code path entirely.
+/// Selects the keep-alive gateway for the current platform (#577, #1026).
+/// Platforms without an Android-style foreground service (desktop: the
+/// process persists; iOS: no FGS equivalent exists) use a no-op gateway;
+/// Android uses the real `flutter_foreground_task`-backed gateway. Reading
+/// this keeps the FFT statics out of the non-Android code paths entirely.
 KeepaliveGateway _keepaliveGatewayFor(Ref ref) {
-  return ref.watch(isDesktopProvider)
+  return ref.watch(usesInProcessHostProvider)
       ? const NoopKeepaliveGateway()
       : FlutterForegroundTaskGateway();
 }
@@ -107,10 +108,11 @@ final batteryOptimizationProvider = Provider<BatteryOptimizationController>((
 /// machine (#737) — it only OBSERVES the sessions list via `ref.listen`, never
 /// mutates session state. The controller itself guards against re-nagging
 /// (prompts at most once, persists the asked flag), so this listener can fire
-/// freely on every connect without annoying the user. No-op on desktop (no
-/// Doze). Read this provider once at app start to arm the listener.
+/// freely on every connect without annoying the user. No-op off Android
+/// (Doze + the FFT battery-opt statics are Android-only — desktop #577,
+/// iOS #1026). Read this provider once at app start to arm the listener.
 final batteryOptimizationFirstConnectTriggerProvider = Provider<void>((ref) {
-  if (ref.read(isDesktopProvider)) return;
+  if (ref.read(usesInProcessHostProvider)) return;
   final controller = ref.read(batteryOptimizationProvider);
   var prompted = false;
   bool anyConnected(SessionsState s) =>

--- a/native/lib/state/session_host_providers.dart
+++ b/native/lib/state/session_host_providers.dart
@@ -32,25 +32,27 @@ final gatewayPairProvider = Provider<InMemoryGatewayPair>((ref) {
 
 /// UI-side gateway the proxy + UI consumers talk to.
 ///
-/// Two production flavors, selected by [isDesktopProvider]:
+/// Two production flavors, selected by [usesInProcessHostProvider]:
 ///
 ///   - **Android**: [FlutterForegroundSshGateway] bound to FFT statics. The
 ///     `SessionHost` (and its `SSHClient`s) lives in the foreground-task
 ///     isolate so the socket survives the UI isolate being killed (#531).
 ///
-///   - **Desktop** (macOS / Linux / Windows, #577): an IN-PROCESS setup. The
-///     OS doesn't kill desktop processes, so there's no foreground service and
-///     no task isolate — we build an [InMemoryGatewayPair] and host a live
+///   - **Desktop** (macOS / Linux / Windows, #577) **and iOS** (#1026): an
+///     IN-PROCESS setup. Desktop processes aren't killed by the OS; iOS has
+///     no foreground-service equivalent (suspended sessions drop and revive
+///     on foreground via the resume machinery). Either way there's no task
+///     isolate — we build an [InMemoryGatewayPair] and host a live
 ///     [SessionHost] on its task side in the same isolate, returning the UI
 ///     side. This reuses the exact in-process path the unit tests exercise.
 ///     dartssh2 connects directly over dart:io (no WS bridge).
 ///
 /// Tests override this provider with a [TaskSshGateway] backed by
-/// `InMemoryGatewayPair.uiSide`, OR override [isDesktopProvider] to force a
-/// platform path deterministically.
+/// `InMemoryGatewayPair.uiSide`, OR override [isDesktopProvider] /
+/// [usesInProcessHostProvider] to force a platform path deterministically.
 final taskSshGatewayProvider = Provider<TaskSshGateway>((ref) {
-  if (ref.watch(isDesktopProvider)) {
-    // Desktop: host the SessionHost in-process. No FFT, no task isolate.
+  if (ref.watch(usesInProcessHostProvider)) {
+    // Desktop/iOS: host the SessionHost in-process. No FFT, no task isolate.
     final pair = InMemoryGatewayPair();
     final host = SessionHost(gateway: pair.taskSide);
     ref.onDispose(() async {

--- a/native/test/platform/desktop_predicate_test.dart
+++ b/native/test/platform/desktop_predicate_test.dart
@@ -1,0 +1,48 @@
+// Platform-predicate truth table (#1026 iOS gating slice).
+//
+// `kIsDesktop` means "desktop UX / desktop OS" (macOS / Linux / Windows).
+// `kUsesInProcessHost` means "the SSH SessionHost runs IN-PROCESS — no Android
+// foreground service, no task isolate". Those are NOT the same set: iOS has no
+// FGS equivalent, so it must use the in-process host (sessions drop on
+// background and revive on foreground via the existing resume machinery) while
+// remaining non-desktop for UX purposes.
+//
+// The real `Platform` is unreadable-per-OS from a test host, so the predicates
+// resolve the OS through the injectable `debugOperatingSystemOverride` seam.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/platform/desktop.dart';
+
+void main() {
+  tearDown(() {
+    debugOperatingSystemOverride = null;
+  });
+
+  group('kIsDesktop truth table', () {
+    for (final os in ['macos', 'linux', 'windows']) {
+      test('$os → desktop', () {
+        debugOperatingSystemOverride = os;
+        expect(kIsDesktop, isTrue);
+      });
+    }
+    for (final os in ['android', 'ios']) {
+      test('$os → NOT desktop', () {
+        debugOperatingSystemOverride = os;
+        expect(kIsDesktop, isFalse);
+      });
+    }
+  });
+
+  group('kUsesInProcessHost truth table (#1026)', () {
+    for (final os in ['macos', 'linux', 'windows', 'ios']) {
+      test('$os → in-process host (no FGS)', () {
+        debugOperatingSystemOverride = os;
+        expect(kUsesInProcessHost, isTrue);
+      });
+    }
+    test('android → FGT task-isolate host', () {
+      debugOperatingSystemOverride = 'android';
+      expect(kUsesInProcessHost, isFalse);
+    });
+  });
+}

--- a/native/test/state/ios_gateway_test.dart
+++ b/native/test/state/ios_gateway_test.dart
@@ -1,0 +1,101 @@
+// iOS gateway routing (#1026 gating slice).
+//
+// iOS has NO foreground-service equivalent, so it must take the desktop-style
+// IN-PROCESS SessionHost path — never the Android flutter_foreground_task
+// path. These tests force the OS to 'ios' through the
+// `debugOperatingSystemOverride` seam (no provider overrides), so the FULL
+// production resolution chain is exercised: kIsDesktop stays false (iOS is not
+// desktop UX) while `usesInProcessHostProvider` routes hosting in-process.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/platform/desktop.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/state/keepalive_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+
+void main() {
+  tearDown(() {
+    debugOperatingSystemOverride = null;
+  });
+
+  group('iOS platform routing (#1026)', () {
+    test('ios → in-process gateway backed by a live SessionHost', () async {
+      debugOperatingSystemOverride = 'ios';
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // iOS is NOT desktop (UX predicate stays false)…
+      expect(container.read(isDesktopProvider), isFalse);
+      // …but it DOES use the in-process host (no FGS on iOS).
+      expect(container.read(usesInProcessHostProvider), isTrue);
+
+      final gateway = container.read(taskSshGatewayProvider);
+      expect(gateway, isNot(isA<FlutterForegroundSshGateway>()));
+
+      // Prove a live SessionHost is wired: drive a connect through a proxy on
+      // the UI side and observe the host emit `connecting` back (same probe as
+      // desktop_gateway_test.dart).
+      final proxy = SshSessionProxy(sessionId: 'ios-sid', gateway: gateway);
+      addTearDown(proxy.dispose);
+
+      final states = <SshSessionState>[];
+      final sub = proxy.stream.listen((d) => states.add(d.state));
+
+      proxy.connect(
+        const SshConnectParams(
+          host: 'unreachable.invalid',
+          port: 22,
+          username: 'u',
+          auth: SshAuth.password('p'),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        states,
+        contains(SshSessionState.connecting),
+        reason: 'iOS must host the SessionHost in-process',
+      );
+
+      await sub.cancel();
+    });
+
+    test('ios → NoopKeepaliveGateway, never touches FFT statics', () async {
+      debugOperatingSystemOverride = 'ios';
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // Must resolve + run without a MissingPluginException: the FFT-backed
+      // keepalive gateway would hit platform channels on ensureStarted().
+      final starter = container.read(keepaliveServiceStarterProvider);
+      await starter();
+    });
+
+    test('android still → FlutterForegroundSshGateway (FFT-backed)', () {
+      debugOperatingSystemOverride = 'android';
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(usesInProcessHostProvider), isFalse);
+      final gateway = container.read(taskSshGatewayProvider);
+      expect(gateway, isA<FlutterForegroundSshGateway>());
+    });
+
+    test(
+      'usesInProcessHostProvider follows an isDesktopProvider override '
+      '(existing desktop test seam keeps working)',
+      () {
+        final container = ProviderContainer(
+          overrides: [isDesktopProvider.overrideWithValue(true)],
+        );
+        addTearDown(container.dispose);
+
+        expect(container.read(usesInProcessHostProvider), isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
iOS platform-gating slice from the #1026 design (Part 1 §3 gap / slice 4). `kIsDesktop` excludes iOS, so an iOS build would wrongly take the Android `flutter_foreground_task` path. iOS has no FGS equivalent — it must route to the desktop-style IN-PROCESS `SessionHost`; backgrounded sessions drop and revive on foreground via the existing resume machinery (#1014/#1018/#986).

## What changed
`native/lib/platform/desktop.dart` now carries TWO meaning-named predicates:
- `kIsDesktop` — desktop OS / desktop UX (unchanged semantics).
- `kUsesInProcessHost` (= `kIsDesktop || iOS`) + injectable `usesInProcessHostProvider`, derived from `isDesktopProvider` so every existing test override keeps steering the hosting path.
- New `@visibleForTesting debugOperatingSystemOverride` seam: the raw predicates are truth-table testable per OS, and an `'ios'` override exercises the FULL production resolution chain (no provider overrides).

## Call-site audit (site → predicate → why)
| Site | Predicate | Why |
|---|---|---|
| `main.dart:41` `initCommunicationPort` | `!kUsesInProcessHost` | FFT task-isolate comm port is Android-only; throws `MissingPluginException` at boot elsewhere |
| `session_host_providers.dart:55` `taskSshGatewayProvider` | `usesInProcessHostProvider` | THE hosting-model split: in-process `SessionHost` (desktop + iOS) vs FFT gateway (Android) |
| `keepalive_providers.dart:30` `_keepaliveGatewayFor` | `usesInProcessHostProvider` | keep-alive FGS doesn't exist off Android → `NoopKeepaliveGateway`, keeps FFT statics out of the path |
| `keepalive_providers.dart:117` `batteryOptimizationFirstConnectTrigger` | `usesInProcessHostProvider` | Doze + the FFT battery-opt statics are Android-only; must no-op at startup on iOS |
| `attention_providers.dart:208` `attentionUiFlnInit` | `usesInProcessHostProvider` | the attention pipeline is FGS-shaped (FFT-backed pending store, task-isolate posting) — gated off for iOS startup safety; iOS notifications = future slice |
| (no site kept `kIsDesktop`) | — | `isDesktopProvider` remains for genuine desktop-UX meaning + as the existing test seam |

Startup-safety audit of adjacent Android touchpoints: `crash_environment.dart:83` already gates on `Platform.isAndroid`; POST_NOTIFICATIONS request lives inside the FFT gateway path (unreachable on iOS with the Noop gateway); Settings' battery-opt `requestNow` is user-initiated and try/caught → `unavailable`; `consumePending()`/`FftKeyValueStore` runs unconditionally today and desktop already survives it — untouched.

## Tests (TDD, red first — confirmed compile-red before implementation)
- `test/platform/desktop_predicate_test.dart` — truth tables: macos/linux/windows → desktop + in-process; ios → NOT desktop but in-process; android → neither.
- `test/state/ios_gateway_test.dart` — via the OS seam: ios → in-process gateway backed by a LIVE `SessionHost` (connect probe emits `connecting`), ios → Noop keepalive (no FFT statics), android → `FlutterForegroundSshGateway` unchanged; plus `usesInProcessHostProvider` follows an `isDesktopProvider` override.
- Existing desktop tests (`desktop_gateway_test.dart` etc.) untouched and green.

`scripts/native-fast-gate.sh` green (analyze + 1855 tests).

## Caveats
- No iOS build possible on this box (no Xcode) — analyze + tests are the bar, per the slice scope. First real verification lands with the #1026 simulator slices.
- No UI work, no keepalive redesign, no `native/ios/` scaffold (separate slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa