### PR TITLE
#1031 slice 1 — style store + resolver

### DIFF
--- a/native/lib/state/detection_style_providers.dart
+++ b/native/lib/state/detection_style_providers.dart
@@ -1,0 +1,124 @@
+// Riverpod surface for the detection style overrides (#1031 slice 1).
+//
+// [detectionStylesProvider] holds the hydrated [DetectionStyles] value; the
+// terminal view watches it and rebuilds its [DetectionStyleResolver] only when
+// the stored overrides change — the detectionSettingsProvider caching idiom
+// (resolve on change, never a prefs read per frame). Synchronous EMPTY default
+// while prefs hydrate: empty = shipped visuals, so the first frame is always
+// correct and a stored override re-applies on hydrate.
+//
+// [detectionPatternStyleProvider] is the cheap per-pattern family the lab UI
+// (later slice) watches: one pattern's row rebuilds only when ITS override
+// changes, not on siblings.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../storage/detection_styles_store.dart';
+
+/// Persisted per-pattern style overrides. Mutations go through the notifier;
+/// painters consume the value via the terminal view's resolver.
+final detectionStylesProvider =
+    StateNotifierProvider<DetectionStylesNotifier, DetectionStyles>((ref) {
+      return DetectionStylesNotifier();
+    });
+
+/// One pattern's override (null = untouched). Watch THIS from per-pattern UI
+/// so sibling changes don't rebuild it.
+final detectionPatternStyleProvider =
+    Provider.family<DetectionPatternStyle?, String>(
+      (ref, patternId) => ref.watch(detectionStylesProvider).of(patternId),
+    );
+
+/// Notifier over [DetectionStylesStore]. Best-effort hydrate/persist that
+/// never throws when prefs are unavailable (widget tests without bindings) —
+/// the DetectionSettingsNotifier idiom.
+class DetectionStylesNotifier extends StateNotifier<DetectionStyles> {
+  DetectionStylesNotifier({DetectionStylesStore? store})
+    : _store = store ?? DetectionStylesStore(),
+      super(DetectionStyles.empty) {
+    _hydrate();
+  }
+
+  final DetectionStylesStore _store;
+
+  Future<void> _hydrate() async {
+    try {
+      final stored = await _store.load();
+      if (!mounted) return;
+      if (stored != state) state = stored;
+    } catch (_) {
+      // best-effort; keep the empty (shipped-defaults) state.
+    }
+  }
+
+  /// Merge [change] into [patternId]'s current override and persist. An
+  /// override whose every field ends up null is REMOVED (absent = default).
+  Future<void> _update(
+    String patternId,
+    DetectionPatternStyle Function(DetectionPatternStyle current) change,
+  ) async {
+    final next = change(state.of(patternId) ?? const DetectionPatternStyle());
+    try {
+      final updated = await _store.setPatternStyle(patternId, next);
+      if (mounted) state = updated;
+    } catch (_) {
+      // best-effort persistence: still reflect the change in memory.
+      if (!mounted) return;
+      final map = Map<String, DetectionPatternStyle>.from(state.byPattern);
+      if (next.isEmpty) {
+        map.remove(patternId);
+      } else {
+        map[patternId] = next;
+      }
+      state = DetectionStyles(map);
+    }
+  }
+
+  /// Set (or clear, with null) the `#RRGGBB` hue override for [patternId].
+  Future<void> setColorHex(String patternId, String? colorHex) => _update(
+    patternId,
+    (c) => DetectionPatternStyle(
+      colorHex: colorHex,
+      inactiveIntensity: c.inactiveIntensity,
+      activeIntensity: c.activeIntensity,
+    ),
+  );
+
+  /// Set (or clear, with null) the DETECTED-state intensity multiplier.
+  Future<void> setInactiveIntensity(String patternId, double? value) =>
+      _update(
+        patternId,
+        (c) => DetectionPatternStyle(
+          colorHex: c.colorHex,
+          inactiveIntensity: value,
+          activeIntensity: c.activeIntensity,
+        ),
+      );
+
+  /// Set (or clear, with null) the ACTIVE-state intensity multiplier. Only
+  /// meaningful where an active state exists (`detectionPatternHasActiveState`
+  /// — verified paths today, #990); the lab UI gates its controls on that.
+  Future<void> setActiveIntensity(String patternId, double? value) => _update(
+    patternId,
+    (c) => DetectionPatternStyle(
+      colorHex: c.colorHex,
+      inactiveIntensity: c.inactiveIntensity,
+      activeIntensity: value,
+    ),
+  );
+
+  /// Reset ONE pattern to shipped defaults (#1031 IA "Reset this pattern").
+  Future<void> resetPattern(String patternId) =>
+      _update(patternId, (_) => const DetectionPatternStyle());
+
+  /// Clear EVERY tuned override (#1031 IA "Reset lab customizations"; the
+  /// seam the extended Settings reset calls in the lab slice).
+  Future<void> clearAllTuned() async {
+    try {
+      await _store.clearAllTuned();
+    } catch (_) {
+      // best-effort persistence
+    }
+    if (mounted) state = DetectionStyles.empty;
+  }
+}

--- a/native/lib/storage/detection_styles_store.dart
+++ b/native/lib/storage/detection_styles_store.dart
@@ -1,0 +1,241 @@
+// Detection style overrides — per-pattern color/intensity tuning (#1031
+// slice 1: the store + resolver the Detection Lab and the runtime affordances
+// BOTH read; the lab UI comes in a later slice).
+//
+// One override record per pattern id: {colorHex?, inactiveIntensity?,
+// activeIntensity?}. Every field is OPTIONAL and defaults to ABSENT — an empty
+// store means the runtime keeps today's derived values exactly (the session
+// accent + the #1000 luminance-tuned wash alphas). Composition into effective
+// colors lives in `ui/detection_style_resolver.dart`, the single source of
+// truth both the painters and the future lab preview consult.
+//
+// Keys are PLAIN STRINGS: nothing here assumes the built-in id set, so a
+// later slice's `custom.<slug>` patterns store styles with zero schema change.
+//
+// Storage follows the favorites_store / detection_exceptions_store precedent:
+// a single JSON blob in shared_preferences under [detectionStylesPrefsKey],
+// schema version INSIDE the value (never a key bump), corrupt / unknown-
+// version data falls back to empty (validate → fallback, never crash).
+//
+// Reset seams (#1031 IA review): [DetectionStylesStore.resetPattern] (the
+// per-pattern "Reset this pattern") and [DetectionStylesStore.clearAllTuned]
+// (the lab-wide reset the extended Settings "Reset settings" will call —
+// implemented now, WIRED in the lab slice). Styles are TUNED data, not
+// authored data, so they reset; authored data (custom pattern definitions,
+// exception reports) lives elsewhere and survives.
+
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// shared_preferences key. `v1` in the NAME is the storage namespace only; the
+/// migratable schema version lives inside the value (see [_schemaVersion]).
+const String detectionStylesPrefsKey = 'mobissh.detection.styles.v1';
+
+/// Current in-value schema version. Bump + migrate in
+/// [DetectionStylesStore.load] on a shape change.
+const int _schemaVersion = 1;
+
+/// One pattern's stored style override. Absent field = shipped default.
+///
+/// [colorHex] is a `#RRGGBB` hue replacing the session accent for BOTH the
+/// bubble wash and the gutter chip (alpha is never stored — the wash alpha is
+/// derived, the chip is forced opaque). [inactiveIntensity]/[activeIntensity]
+/// are per-STATE multipliers on the #1000 luminance-tuned base wash alphas
+/// (1.0 = shipped value); the resolver clamps them to the legibility band.
+/// activeIntensity is only MEANINGFUL for patterns with a real active state
+/// (verified paths, #990 — see `detectionPatternHasActiveState`); it is
+/// stored uniformly so the schema needn't change when pressed-state ships.
+class DetectionPatternStyle {
+  const DetectionPatternStyle({
+    this.colorHex,
+    this.inactiveIntensity,
+    this.activeIntensity,
+  });
+
+  /// `#RRGGBB` hue override, or null to follow the session accent.
+  final String? colorHex;
+
+  /// Multiplier on the DETECTED (inactive) wash alpha, or null for 1.0.
+  final double? inactiveIntensity;
+
+  /// Multiplier on the ACTIVE (verified) wash alpha, or null for 1.0.
+  final double? activeIntensity;
+
+  /// True when every field is absent — no override at all (such a style is
+  /// never persisted; setting it removes the entry).
+  bool get isEmpty =>
+      colorHex == null && inactiveIntensity == null && activeIntensity == null;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    if (colorHex != null) 'color': colorHex,
+    if (inactiveIntensity != null) 'inactive': inactiveIntensity,
+    if (activeIntensity != null) 'active': activeIntensity,
+  };
+
+  /// Parse one stored record, field-by-field: a wrong-typed field is dropped
+  /// (falls back to absent), a non-map or all-invalid record returns null so
+  /// the caller drops the entry entirely. Never throws.
+  static DetectionPatternStyle? fromJson(Object? raw) {
+    if (raw is! Map) return null;
+    final color = raw['color'];
+    final inactive = raw['inactive'];
+    final active = raw['active'];
+    final style = DetectionPatternStyle(
+      colorHex: color is String && color.isNotEmpty ? color : null,
+      inactiveIntensity: inactive is num ? inactive.toDouble() : null,
+      activeIntensity: active is num ? active.toDouble() : null,
+    );
+    return style.isEmpty ? null : style;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is DetectionPatternStyle &&
+      other.colorHex == colorHex &&
+      other.inactiveIntensity == inactiveIntensity &&
+      other.activeIntensity == activeIntensity;
+
+  @override
+  int get hashCode => Object.hash(colorHex, inactiveIntensity, activeIntensity);
+
+  @override
+  String toString() =>
+      'DetectionPatternStyle(color:$colorHex, inactive:$inactiveIntensity, '
+      'active:$activeIntensity)';
+}
+
+/// The immutable set of stored overrides, keyed by pattern id. This is the
+/// provider state the resolver composes over; [empty] (no overrides) MUST
+/// reproduce today's shipped visuals exactly.
+class DetectionStyles {
+  const DetectionStyles(this.byPattern);
+
+  /// No overrides — the runtime renders exactly today's derived values.
+  static const DetectionStyles empty = DetectionStyles(
+    <String, DetectionPatternStyle>{},
+  );
+
+  final Map<String, DetectionPatternStyle> byPattern;
+
+  /// The override for [patternId], or null when the pattern is untouched.
+  DetectionPatternStyle? of(String patternId) => byPattern[patternId];
+
+  bool get isEmpty => byPattern.isEmpty;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! DetectionStyles) return false;
+    if (other.byPattern.length != byPattern.length) return false;
+    for (final entry in byPattern.entries) {
+      if (other.byPattern[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAllUnordered([
+    for (final e in byPattern.entries) Object.hash(e.key, e.value),
+  ]);
+
+  @override
+  String toString() => 'DetectionStyles($byPattern)';
+}
+
+/// Persistence layer for detection style overrides (#1031). UI consumers go
+/// through `detectionStylesProvider` (state/detection_style_providers.dart).
+/// Tests inject a [SharedPreferences] via
+/// [SharedPreferences.setMockInitialValues] and construct directly (mirrors
+/// [DetectionExceptionsStore]).
+class DetectionStylesStore {
+  DetectionStylesStore({SharedPreferences? prefs}) : _prefs = prefs;
+
+  // ignore_for_file: prefer_initializing_formals
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> _ensure() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// Read all stored overrides. Returns [DetectionStyles.empty] when nothing
+  /// is stored, the JSON is malformed, the shape is wrong, or the schema
+  /// version is unknown (corrupt-resilience per .claude/rules — validate →
+  /// fallback to empty, never crash). Malformed per-pattern entries are
+  /// dropped individually; good ones survive.
+  Future<DetectionStyles> load() async {
+    final prefs = await _ensure();
+    final raw = prefs.getString(detectionStylesPrefsKey);
+    if (raw == null || raw.isEmpty) return DetectionStyles.empty;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return DetectionStyles.empty;
+      final version = decoded['v'];
+      // Unknown / future version: don't risk misreading a shape we don't know.
+      if (version is! int || version != _schemaVersion) {
+        return DetectionStyles.empty;
+      }
+      final styles = decoded['styles'];
+      if (styles is! Map) return DetectionStyles.empty;
+      final out = <String, DetectionPatternStyle>{};
+      for (final entry in styles.entries) {
+        final key = entry.key;
+        if (key is! String || key.isEmpty) continue;
+        final style = DetectionPatternStyle.fromJson(entry.value);
+        if (style == null) continue;
+        out[key] = style;
+      }
+      return out.isEmpty ? DetectionStyles.empty : DetectionStyles(out);
+    } on FormatException {
+      return DetectionStyles.empty;
+    }
+  }
+
+  Future<void> _saveAll(DetectionStyles styles) async {
+    final prefs = await _ensure();
+    if (styles.isEmpty) {
+      // No overrides at all → remove the key (absent = default everywhere).
+      await prefs.remove(detectionStylesPrefsKey);
+      return;
+    }
+    final encoded = jsonEncode(<String, dynamic>{
+      'v': _schemaVersion,
+      'styles': {
+        for (final e in styles.byPattern.entries) e.key: e.value.toJson(),
+      },
+    });
+    await prefs.setString(detectionStylesPrefsKey, encoded);
+  }
+
+  /// Store [style] for [patternId]. An EMPTY style removes the entry (absent
+  /// = shipped default). Returns the updated set.
+  Future<DetectionStyles> setPatternStyle(
+    String patternId,
+    DetectionPatternStyle style,
+  ) async {
+    final current = await load();
+    final next = Map<String, DetectionPatternStyle>.from(current.byPattern);
+    if (style.isEmpty) {
+      next.remove(patternId);
+    } else {
+      next[patternId] = style;
+    }
+    final updated = DetectionStyles(next);
+    await _saveAll(updated);
+    return updated;
+  }
+
+  /// Per-pattern reset (#1031 IA: "Reset this pattern") — drops [patternId]'s
+  /// override, leaving every other pattern untouched. Returns the updated set.
+  Future<DetectionStyles> resetPattern(String patternId) =>
+      setPatternStyle(patternId, const DetectionPatternStyle());
+
+  /// Lab-wide reset (#1031 IA: "Reset lab customizations", and the seam the
+  /// extended Settings "Reset settings" calls in the lab slice): clears every
+  /// TUNED override. Authored data (custom pattern definitions, exception
+  /// reports) is stored elsewhere and deliberately untouched.
+  Future<void> clearAllTuned() async {
+    final prefs = await _ensure();
+    await prefs.remove(detectionStylesPrefsKey);
+  }
+}

--- a/native/lib/ui/detection_style_resolver.dart
+++ b/native/lib/ui/detection_style_resolver.dart
@@ -1,0 +1,138 @@
+// Detection style RESOLVER (#1031 slice 1) — the single composition point
+// both the runtime affordances (bubble wash, gutter chip) and the future
+// Detection Lab preview read. Zero styling logic exists twice: the lab
+// previews call the SAME resolver over the SAME stored overrides.
+//
+// Composition, per (patternId, state):
+//   hue   = stored colorHex override, else the per-session accent
+//           (`palette.theme.selection` — overrides are GLOBAL, the accent
+//           stays per-session, per the #1031 IA review)
+//   alpha = the #1000 luminance-tuned base wash alpha for the state
+//           × the stored per-state intensity multiplier, clamped to the
+//           legibility band ([kDetectionIntensityMin]..[kDetectionIntensityMax],
+//           IA review change 6: every stored value stays visible)
+//
+// The gutter CHIP takes only the hue: `GutterMarkStyle.chipColor` forces it
+// opaque (contrast rule), so intensity governs the wash alone.
+//
+// An EMPTY store reproduces today's shipped visuals EXACTLY (the golden
+// equality asserted in detection_style_resolver_test.dart) — shipping this
+// slice changes nothing on screen.
+
+import 'package:flutter/widgets.dart';
+
+import '../storage/detection_styles_store.dart';
+import 'ghostty_terminal_decorators.dart';
+
+/// Floor of the intensity band. A stored multiplier below this clamps up so a
+/// tuned wash can never silently vanish (#1031 IA review change 6: no
+/// invisible no-op zone for a low-vision user relying on the preview).
+const double kDetectionIntensityMin = 0.25;
+
+/// Ceiling of the intensity band — keeps glyphs legible inside the wash.
+const double kDetectionIntensityMax = 1.75;
+
+/// Whether [patternId] has a REAL active state at runtime today. Per #990 the
+/// verified (active) rendering is wired for PATHS only; url/command gain a
+/// pressed state in a later slice. The lab UI reads this so it never offers a
+/// control that tunes a state with no runtime effect (#1031 IA review change
+/// 1: no dead controls). Unknown / custom ids have no active state.
+bool detectionPatternHasActiveState(String patternId) =>
+    patternId == kGhosttyPathPatternId;
+
+/// Parse a `#RRGGBB` (or bare `RRGGBB`) hex string to an opaque [Color].
+/// Anything else — wrong length, non-hex digits, empty — returns null so a
+/// corrupt stored hue falls back to the session accent instead of crashing
+/// or painting garbage.
+Color? detectionColorFromHex(String? hex) {
+  if (hex == null) return null;
+  var h = hex.trim();
+  if (h.startsWith('#')) h = h.substring(1);
+  if (h.length != 6) return null;
+  final rgb = int.tryParse(h, radix: 16);
+  if (rgb == null) return null;
+  return Color(0xFF000000 | rgb);
+}
+
+/// The effective style for one (pattern, state): what the painters fill with.
+@immutable
+class ResolvedDetectionStyle {
+  const ResolvedDetectionStyle({
+    required this.washColor,
+    required this.chipAccent,
+  });
+
+  /// The bubble wash fill — hue at the composed translucent alpha.
+  final Color washColor;
+
+  /// The gutter chip's accent HUE. The chip stays opaque by design
+  /// ([GutterMarkStyle.chipColor] forces alpha 1.0) and intensity never
+  /// touches it — only a colorHex override changes it.
+  final Color chipAccent;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ResolvedDetectionStyle &&
+      other.washColor == washColor &&
+      other.chipAccent == chipAccent;
+
+  @override
+  int get hashCode => Object.hash(washColor, chipAccent);
+}
+
+/// Composes stored overrides with the shipped defaults. Built per terminal
+/// build from (provider styles, session accent, background brightness) — the
+/// inputs only change on a settings/theme change, so the painters resolve on
+/// change, never per frame.
+@immutable
+class DetectionStyleResolver {
+  const DetectionStyleResolver({
+    this.styles = DetectionStyles.empty,
+    required this.accent,
+    required this.backgroundBrightness,
+  });
+
+  /// The stored per-pattern overrides (empty = shipped defaults everywhere).
+  final DetectionStyles styles;
+
+  /// The per-session accent (`palette.theme.selection`) used when a pattern
+  /// has no colorHex override.
+  final Color accent;
+
+  /// The TERMINAL background's luminance — the base wash alphas are tuned per
+  /// theme brightness (#1000).
+  final Brightness backgroundBrightness;
+
+  /// The effective color + alpha for [patternId] in the given state.
+  /// [verified] selects the ACTIVE (verified, #990) state; the runtime only
+  /// passes true where that state actually exists (paths today — see
+  /// [detectionPatternHasActiveState] for the UI-facing truth).
+  ResolvedDetectionStyle resolveStyle(
+    String patternId, {
+    required bool verified,
+  }) {
+    final style = styles.of(patternId);
+    final hue = detectionColorFromHex(style?.colorHex) ?? accent;
+    final intensity = verified
+        ? style?.activeIntensity
+        : style?.inactiveIntensity;
+    // The default path is BIT-IDENTICAL to the shipped derivation: no
+    // multiply, no re-clamp — ghosttyBubbleWashColor as-is.
+    final base = ghosttyBubbleWashColor(
+      hue,
+      verified: verified,
+      backgroundBrightness: backgroundBrightness,
+    );
+    final washColor = intensity == null
+        ? base
+        : base.withValues(
+            alpha: (base.a *
+                    intensity.clamp(
+                      kDetectionIntensityMin,
+                      kDetectionIntensityMax,
+                    ))
+                .clamp(0.0, 1.0),
+          );
+    return ResolvedDetectionStyle(washColor: washColor, chipAccent: hue);
+  }
+}

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -472,6 +472,7 @@ class GhosttyGutterLayer extends StatelessWidget {
     this.isVisible,
     this.verifiedStyle = GutterMarkStyle.bold,
     this.verificationListenable,
+    this.chipAccentOf,
   });
 
   /// The SAME controller handed to the flterm `TerminalView`.
@@ -516,6 +517,26 @@ class GhosttyGutterLayer extends StatelessWidget {
   /// #990: fires when a verification result lands (no anchor change involved)
   /// so the marks repaint. Merged with the controller's decoration listenable.
   final Listenable? verificationListenable;
+
+  /// #1031: the detection style RESOLVER seam — maps a pattern id to its
+  /// effective chip accent HUE (stored colorHex override, else the session
+  /// accent; [GutterMarkStyle.chipColor] still forces it opaque). Null → every
+  /// mark keeps [color], the pre-#1031 behavior; the production view passes
+  /// the resolver-backed function, whose EMPTY-store output equals [color]
+  /// (zero visual change). A row whose anchors resolve to ONE accent uses it
+  /// (url+osc8 share a family color naturally); a mixed-accent multi-match row
+  /// keeps the neutral [color] — no single override applies to it.
+  final Color Function(String patternId)? chipAccentOf;
+
+  /// The chip accent for one row's [anchors] under the seam rule above.
+  Color _rowAccent(List<StructuredAnchor> anchors) {
+    final resolve = chipAccentOf;
+    if (resolve == null) return color;
+    final accents = <Color>{
+      for (final anchor in anchors) resolve(anchor.patternId),
+    };
+    return accents.length == 1 ? accents.first : color;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -581,7 +602,8 @@ class GhosttyGutterLayer extends StatelessWidget {
                   controller: controller,
                   anchors: entry.value,
                   registry: registry,
-                  color: color,
+                  // #1031: per-pattern chip accent via the resolver seam.
+                  color: _rowAccent(entry.value),
                   // #990: a row with ANY verified anchor renders the bold
                   // shade (a multi-match row's badge inherits it too).
                   style: (isVerified != null && entry.value.any(isVerified!))

--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -214,10 +214,19 @@ Color ghosttyBubbleWashColor(
 /// widget test can assert shade selection without reaching into paint calls.
 @immutable
 class GhosttyBubbleSpec {
-  const GhosttyBubbleSpec({required this.segments, required this.verified});
+  const GhosttyBubbleSpec({
+    required this.segments,
+    required this.verified,
+    this.washColor,
+  });
 
   final List<GhosttyBubbleSegment> segments;
   final bool verified;
+
+  /// #1031: the RESOLVED per-pattern wash fill (from the detection style
+  /// resolver seam). Null → the painter derives the shipped default from its
+  /// accent + brightness, exactly as before the seam existed.
+  final Color? washColor;
 }
 
 /// The restored inline bubble layer (#988) — a paint-only overlay drawing one
@@ -244,6 +253,7 @@ class GhosttyBubbleLayer extends StatelessWidget {
     this.isVerified,
     this.isVisible,
     this.verificationListenable,
+    this.washColorOf,
   });
 
   /// The SAME controller handed to the flterm `TerminalView`. Its `anchors` /
@@ -276,6 +286,15 @@ class GhosttyBubbleLayer extends StatelessWidget {
   /// listenable.
   final Listenable? verificationListenable;
 
+  /// #1031: the detection style RESOLVER seam — maps (patternId, state) to the
+  /// effective wash fill (stored override composed over the shipped #1000
+  /// derivation). Null → the pre-#1031 default derivation from [color] +
+  /// [backgroundBrightness]; the production view always passes the
+  /// resolver-backed function, whose EMPTY-store output is bit-identical to
+  /// that default (zero visual change).
+  final Color Function(String patternId, {required bool verified})?
+  washColorOf;
+
   /// The pattern ids that render a bubble. URL, OSC-8 and path share the ONE
   /// mechanism (#988); a per-pattern shade difference is a separate issue.
   static const Set<String> _bubblePatternIds = {
@@ -304,10 +323,18 @@ class GhosttyBubbleLayer extends StatelessWidget {
           }
           final segments = ghosttyBubbleSegments(rects);
           if (segments.isEmpty) continue; // fully off-screen
+          final verified = isVerified?.call(anchor) ?? false;
           specs.add(
             GhosttyBubbleSpec(
               segments: segments,
-              verified: isVerified?.call(anchor) ?? false,
+              verified: verified,
+              // #1031: resolve the per-pattern wash HERE (on decoration
+              // change), so the painter stays a dumb fill — no per-frame
+              // resolver reads.
+              washColor: washColorOf?.call(
+                anchor.patternId,
+                verified: verified,
+              ),
             ),
           );
         }
@@ -346,30 +373,29 @@ class GhosttyBubblePainter extends CustomPainter {
   final Color color;
   final Brightness backgroundBrightness;
 
+  /// The fill a spec paints in: its RESOLVED wash (#1031 seam) when present,
+  /// else the shipped derivation from the accent + brightness. Public so
+  /// tests assert the painted color without recording canvas calls.
+  Color effectiveWashColor(GhosttyBubbleSpec spec) =>
+      spec.washColor ??
+      ghosttyBubbleWashColor(
+        color,
+        verified: spec.verified,
+        backgroundBrightness: backgroundBrightness,
+      );
+
   @override
   void paint(Canvas canvas, Size size) {
-    final detectedWash = Paint()
-      ..style = PaintingStyle.fill
-      ..color = ghosttyBubbleWashColor(
-        color,
-        verified: false,
-        backgroundBrightness: backgroundBrightness,
-      )
-      ..isAntiAlias = true;
-    final verifiedWash = Paint()
-      ..style = PaintingStyle.fill
-      ..color = ghosttyBubbleWashColor(
-        color,
-        verified: true,
-        backgroundBrightness: backgroundBrightness,
-      )
-      ..isAntiAlias = true;
+    // One Paint per distinct wash color (typically 1–2: detected + verified).
+    final paints = <Color, Paint>{};
     for (final spec in specs) {
+      final wash = effectiveWashColor(spec);
+      final paint = paints[wash] ??= (Paint()
+        ..style = PaintingStyle.fill
+        ..color = wash
+        ..isAntiAlias = true);
       for (final segment in spec.segments) {
-        canvas.drawRRect(
-          segment.toRRect(),
-          spec.verified ? verifiedWash : detectedWash,
-        );
+        canvas.drawRRect(segment.toRRect(), paint);
       }
     }
   }
@@ -383,6 +409,7 @@ class GhosttyBubblePainter extends CustomPainter {
       final a = specs[i];
       final b = old.specs[i];
       if (a.verified != b.verified) return true;
+      if (a.washColor != b.washColor) return true;
       if (a.segments.length != b.segments.length) return true;
       for (var j = 0; j < a.segments.length; j++) {
         if (a.segments[j] != b.segments[j]) return true;

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -185,10 +185,12 @@ import '../terminal/tmux_control_mode_flag.dart';
 import '../state/ctrl_modifier_provider.dart';
 import '../state/detection_exceptions_providers.dart';
 import '../state/detection_providers.dart';
+import '../state/detection_style_providers.dart';
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import '../util/file_url.dart';
+import 'detection_style_resolver.dart';
 import 'file_browser_screen.dart';
 import 'ghostty_gutter_layer.dart';
 import 'ghostty_terminal_decorators.dart';
@@ -4134,6 +4136,17 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // the brightness from the live session palette alongside the accent.
     final backgroundBrightness =
         ThemeData.estimateBrightnessForColor(palette.theme.background);
+    // #1031: the detection style RESOLVER — the single source of truth the
+    // bubble wash + gutter chip consult (and the future Detection Lab preview
+    // reads). Watching the styles provider means we resolve on CHANGE only
+    // (settings/theme), never per frame; an empty store composes to exactly
+    // the shipped #1000 derivation, so this is invisible until the owner
+    // tunes something in the lab.
+    final styleResolver = DetectionStyleResolver(
+      styles: ref.watch(detectionStylesProvider),
+      accent: highlightColor,
+      backgroundBrightness: backgroundBrightness,
+    );
     // #922: wrap in a LayoutBuilder so we read the terminal box's ACTUAL
     // constraints — the height the Scaffold has ALREADY shrunk for the soft
     // keyboard (terminal_screen.dart keeps `resizeToAvoidBottomInset:true`, so
@@ -4153,6 +4166,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
           cellSize: cellSize,
           highlightColor: highlightColor,
           backgroundBrightness: backgroundBrightness,
+          styleResolver: styleResolver,
         );
       },
     );
@@ -4206,6 +4220,7 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     required Size cellSize,
     required Color highlightColor,
     required Brightness backgroundBrightness,
+    required DetectionStyleResolver styleResolver,
   }) {
     // #975 (test-only): publish the grid the router will map gestures with this
     // frame so the keyboard-race repro can see the SGR target vs the visible box.
@@ -4434,6 +4449,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             isVerified: _isAnchorVerified,
             isVisible: _isAnchorVisible,
             verificationListenable: _pathVerifier,
+            // #1031: per-pattern wash via the style resolver (empty store =
+            // bit-identical to the shipped derivation).
+            washColorOf: (patternId, {required bool verified}) => styleResolver
+                .resolveStyle(patternId, verified: verified)
+                .washColor,
           ),
         ),
         // #962: right-edge LINE-SELECT layer. Drag the gutter to select WHOLE
@@ -4478,6 +4498,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
             isVerified: _isAnchorVerified,
             isVisible: _isAnchorVisible,
             verificationListenable: _pathVerifier,
+            // #1031: per-pattern chip accent via the style resolver (the chip
+            // stays opaque; only a colorHex override changes its hue).
+            chipAccentOf: (patternId) => styleResolver
+                .resolveStyle(patternId, verified: false)
+                .chipAccent,
           ),
         ),
         // Selection affordances (bottom-right). #712: shown ONLY while a

--- a/native/test/state/detection_style_providers_test.dart
+++ b/native/test/state/detection_style_providers_test.dart
@@ -1,0 +1,129 @@
+// #1031 slice 1 — Riverpod surface for the detection style store: a notifier
+// holding the hydrated DetectionStyles value (resolve-on-change; painters
+// never read prefs per frame — the detectionSettingsProvider caching idiom)
+// plus a family provider for cheap per-pattern watches (the lab UI slice
+// watches ONE pattern's override without rebuilding on siblings).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/detection_style_providers.dart';
+import 'package:mobissh/storage/detection_styles_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<ProviderContainer> containerWith(Map<String, Object> initial) async {
+    SharedPreferences.setMockInitialValues(initial);
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        detectionStylesProvider.overrideWith(
+          (ref) =>
+              DetectionStylesNotifier(store: DetectionStylesStore(prefs: prefs)),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    // Providers are lazy: instantiate the notifier, then let hydrate land.
+    container.read(detectionStylesProvider);
+    await pumpEventQueue();
+    return container;
+  }
+
+  test('hydrates a stored override on startup', () async {
+    final container = await containerWith({
+      detectionStylesPrefsKey:
+          '{"v":1,"styles":{"path":{"color":"#33AA55","active":1.4}}}',
+    });
+    final styles = container.read(detectionStylesProvider);
+    expect(styles.of('path')!.colorHex, '#33AA55');
+    expect(styles.of('path')!.activeIntensity, 1.4);
+  });
+
+  test('defaults to EMPTY while nothing is stored', () async {
+    final container = await containerWith({});
+    expect(container.read(detectionStylesProvider).isEmpty, isTrue);
+  });
+
+  test('mutations update state AND persist', () async {
+    final container = await containerWith({});
+    final notifier = container.read(detectionStylesProvider.notifier);
+    await notifier.setColorHex('url', '#FF8800');
+    await notifier.setInactiveIntensity('url', 1.2);
+    await notifier.setActiveIntensity('path', 0.8);
+
+    final styles = container.read(detectionStylesProvider);
+    expect(styles.of('url')!.colorHex, '#FF8800');
+    expect(styles.of('url')!.inactiveIntensity, 1.2);
+    expect(styles.of('path')!.activeIntensity, 0.8);
+
+    // Persisted: a FRESH store over the same prefs sees the same value.
+    final prefs = await SharedPreferences.getInstance();
+    final reloaded = await DetectionStylesStore(prefs: prefs).load();
+    expect(reloaded.of('url')!.colorHex, '#FF8800');
+    expect(reloaded.of('path')!.activeIntensity, 0.8);
+  });
+
+  test('clearing a field back to null drops it (absent = default)', () async {
+    final container = await containerWith({});
+    final notifier = container.read(detectionStylesProvider.notifier);
+    await notifier.setColorHex('url', '#FF8800');
+    await notifier.setColorHex('url', null);
+    expect(
+      container.read(detectionStylesProvider).of('url'),
+      isNull,
+      reason: 'an all-null style is no override at all',
+    );
+  });
+
+  test('resetPattern clears one pattern; clearAllTuned clears everything',
+      () async {
+    final container = await containerWith({});
+    final notifier = container.read(detectionStylesProvider.notifier);
+    await notifier.setColorHex('url', '#FF8800');
+    await notifier.setColorHex('path', '#33AA55');
+
+    await notifier.resetPattern('url');
+    expect(container.read(detectionStylesProvider).of('url'), isNull);
+    expect(container.read(detectionStylesProvider).of('path'), isNotNull);
+
+    await notifier.clearAllTuned();
+    expect(container.read(detectionStylesProvider).isEmpty, isTrue);
+  });
+
+  group('detectionPatternStyleProvider (family)', () {
+    test('exposes ONE pattern\'s override', () async {
+      final container = await containerWith({
+        detectionStylesPrefsKey: '{"v":1,"styles":{"url":{"color":"#FF8800"}}}',
+      });
+      expect(
+        container.read(detectionPatternStyleProvider('url'))!.colorHex,
+        '#FF8800',
+      );
+      expect(container.read(detectionPatternStyleProvider('path')), isNull);
+    });
+
+    test('a sibling-pattern change does NOT rebuild an unrelated watcher '
+        '(cheap per-pattern watch)', () async {
+      final container = await containerWith({});
+      var urlRebuilds = 0;
+      container.listen(
+        detectionPatternStyleProvider('url'),
+        (_, _) => urlRebuilds++,
+        fireImmediately: false,
+      );
+      final notifier = container.read(detectionStylesProvider.notifier);
+      await notifier.setColorHex('path', '#33AA55');
+      await pumpEventQueue();
+      expect(
+        urlRebuilds,
+        0,
+        reason: 'the family provider must isolate per-pattern watches',
+      );
+      await notifier.setColorHex('url', '#FF8800');
+      await pumpEventQueue();
+      expect(urlRebuilds, 1);
+    });
+  });
+}

--- a/native/test/storage/detection_styles_store_test.dart
+++ b/native/test/storage/detection_styles_store_test.dart
@@ -1,0 +1,163 @@
+// #1031 slice 1 — the detection STYLE store: per-pattern style overrides
+// (colorHex / inactiveIntensity / activeIntensity) keyed by plain-string
+// pattern id. Follows the favorites_store / detection_exceptions_store
+// precedent: one JSON blob in shared_preferences, schema version INSIDE the
+// value, corrupt / unknown-version → empty (never crash, never a key bump).
+//
+// Defaults are ABSENT: an empty store means the runtime keeps today's derived
+// values exactly (the zero-visual-change invariant is asserted in
+// detection_style_resolver_test.dart).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/storage/detection_styles_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<DetectionStylesStore> storeWith(Map<String, Object> initial) async {
+    SharedPreferences.setMockInitialValues(initial);
+    final prefs = await SharedPreferences.getInstance();
+    return DetectionStylesStore(prefs: prefs);
+  }
+
+  group('round-trip', () {
+    test('an untouched store loads EMPTY (all defaults absent)', () async {
+      final store = await storeWith({});
+      final styles = await store.load();
+      expect(styles.isEmpty, isTrue);
+      expect(styles.of('url'), isNull);
+      expect(styles.of('path'), isNull);
+    });
+
+    test('a stored override round-trips field-for-field', () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'path',
+        const DetectionPatternStyle(
+          colorHex: '#33AA55',
+          inactiveIntensity: 0.8,
+          activeIntensity: 1.4,
+        ),
+      );
+      final styles = await store.load();
+      final path = styles.of('path');
+      expect(path, isNotNull);
+      expect(path!.colorHex, '#33AA55');
+      expect(path.inactiveIntensity, 0.8);
+      expect(path.activeIntensity, 1.4);
+      // Other patterns stay absent.
+      expect(styles.of('url'), isNull);
+    });
+
+    test('partial overrides round-trip with the other fields ABSENT', () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'url',
+        const DetectionPatternStyle(inactiveIntensity: 1.25),
+      );
+      final url = (await store.load()).of('url');
+      expect(url!.colorHex, isNull);
+      expect(url.inactiveIntensity, 1.25);
+      expect(url.activeIntensity, isNull);
+    });
+
+    test('setting an EMPTY style removes the entry (absent = default)',
+        () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'url',
+        const DetectionPatternStyle(colorHex: '#FF0000'),
+      );
+      await store.setPatternStyle('url', const DetectionPatternStyle());
+      expect((await store.load()).of('url'), isNull);
+    });
+
+    test('store keys are PLAIN STRINGS — a custom.* id round-trips', () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'custom.jira-tickets',
+        const DetectionPatternStyle(colorHex: '#AA00FF'),
+      );
+      final styles = await store.load();
+      expect(styles.of('custom.jira-tickets')!.colorHex, '#AA00FF');
+    });
+  });
+
+  group('corrupt-data resilience (validate → fallback, never crash)', () {
+    test('non-JSON garbage → empty', () async {
+      final store = await storeWith({detectionStylesPrefsKey: 'not json {'});
+      expect((await store.load()).isEmpty, isTrue);
+    });
+
+    test('a JSON list instead of an object → empty', () async {
+      final store = await storeWith({detectionStylesPrefsKey: '[1,2,3]'});
+      expect((await store.load()).isEmpty, isTrue);
+    });
+
+    test('unknown FUTURE schema version → empty (never misread)', () async {
+      final store = await storeWith({
+        detectionStylesPrefsKey: '{"v":99,"styles":{"url":{"color":"#FF0000"}}}',
+      });
+      expect((await store.load()).isEmpty, isTrue);
+    });
+
+    test('a malformed entry is DROPPED, good entries survive', () async {
+      final store = await storeWith({
+        detectionStylesPrefsKey:
+            '{"v":1,"styles":{"url":"nope","path":{"color":"#33AA55"},'
+            '"osc8":{"inactive":"loud"}}}',
+      });
+      final styles = await store.load();
+      expect(styles.of('url'), isNull, reason: 'non-map entry dropped');
+      expect(styles.of('path')!.colorHex, '#33AA55');
+      expect(
+        styles.of('osc8'),
+        isNull,
+        reason: 'entry with only invalid-typed fields is dropped',
+      );
+    });
+
+    test('a corrupt store recovers on the next write', () async {
+      final store = await storeWith({detectionStylesPrefsKey: '{{{{'});
+      await store.setPatternStyle(
+        'command',
+        const DetectionPatternStyle(inactiveIntensity: 0.5),
+      );
+      expect((await store.load()).of('command')!.inactiveIntensity, 0.5);
+    });
+  });
+
+  group('reset seams (#1031 IA review: per-pattern + lab-wide)', () {
+    test('resetPattern removes ONE pattern, leaves the rest', () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'url',
+        const DetectionPatternStyle(colorHex: '#FF0000'),
+      );
+      await store.setPatternStyle(
+        'path',
+        const DetectionPatternStyle(activeIntensity: 1.5),
+      );
+      await store.resetPattern('url');
+      final styles = await store.load();
+      expect(styles.of('url'), isNull);
+      expect(styles.of('path'), isNotNull);
+    });
+
+    test('clearAllTuned removes EVERY override (the settings-reset seam — '
+        'implemented now, wired in the lab slice)', () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'url',
+        const DetectionPatternStyle(colorHex: '#FF0000'),
+      );
+      await store.setPatternStyle(
+        'custom.x',
+        const DetectionPatternStyle(inactiveIntensity: 1.2),
+      );
+      await store.clearAllTuned();
+      expect((await store.load()).isEmpty, isTrue);
+    });
+  });
+}

--- a/native/test/ui/detection_style_resolver_test.dart
+++ b/native/test/ui/detection_style_resolver_test.dart
@@ -1,0 +1,250 @@
+// #1031 slice 1 — the detection style RESOLVER: the single composition point
+// both the runtime affordances (bubble wash + gutter chip) and the future lab
+// preview read. Composes: stored override → the #1000 luminance-tuned base
+// alphas × a clamped intensity multiplier → the per-session accent when no
+// colorHex override exists.
+//
+// THE INVARIANT (zero visual change): a resolver over an EMPTY store must
+// reproduce today's exact colors/alphas — ghosttyBubbleWashColor for the wash,
+// the raw session accent for the chip — for every built-in pattern, both
+// states, both theme luminances. That equality IS the golden test for this
+// slice.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/storage/detection_styles_store.dart';
+import 'package:mobissh/ui/detection_style_resolver.dart';
+import 'package:mobissh/ui/ghostty_gutter_layer.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+
+void main() {
+  // A typical translucent session selection accent (the runtime hands the
+  // resolver `palette.theme.selection` as-is).
+  const accent = Color(0x335B9BD5);
+  const builtinIds = [
+    kGhosttyUrlPatternId,
+    kGhosttyOsc8PatternId,
+    kGhosttyPathPatternId,
+    kGhosttyCommandPatternId,
+  ];
+
+  DetectionStyleResolver emptyResolver(Brightness brightness) =>
+      DetectionStyleResolver(
+        styles: DetectionStyles.empty,
+        accent: accent,
+        backgroundBrightness: brightness,
+      );
+
+  group('GOLDEN EQUALITY: empty store == today\'s constants', () {
+    test('the wash color matches ghosttyBubbleWashColor exactly for every '
+        'built-in pattern × state × luminance', () {
+      for (final brightness in Brightness.values) {
+        final resolver = emptyResolver(brightness);
+        for (final id in builtinIds) {
+          for (final verified in [false, true]) {
+            final resolved = resolver.resolveStyle(id, verified: verified);
+            expect(
+              resolved.washColor,
+              ghosttyBubbleWashColor(
+                accent,
+                verified: verified,
+                backgroundBrightness: brightness,
+              ),
+              reason: 'no-override wash must be bit-identical for $id '
+                  '(verified=$verified, $brightness)',
+            );
+          }
+        }
+      }
+    });
+
+    test('the chip accent is the raw session accent — GutterMarkStyle '
+        'derives the SAME opaque chip from it', () {
+      for (final brightness in Brightness.values) {
+        final resolver = emptyResolver(brightness);
+        for (final id in builtinIds) {
+          final resolved = resolver.resolveStyle(id, verified: false);
+          expect(resolved.chipAccent, accent);
+          expect(
+            GutterMarkStyle.normal.chipColor(resolved.chipAccent),
+            GutterMarkStyle.normal.chipColor(accent),
+          );
+          expect(
+            GutterMarkStyle.bold.chipColor(resolved.chipAccent),
+            GutterMarkStyle.bold.chipColor(accent),
+          );
+        }
+      }
+    });
+
+    test('an unknown / custom pattern id with no override also resolves to '
+        'the defaults (no assumption ids come from the built-in set)', () {
+      final resolved = emptyResolver(Brightness.dark)
+          .resolveStyle('custom.jira', verified: false);
+      expect(
+        resolved.washColor,
+        ghosttyBubbleWashColor(
+          accent,
+          verified: false,
+          backgroundBrightness: Brightness.dark,
+        ),
+      );
+      expect(resolved.chipAccent, accent);
+    });
+  });
+
+  group('colorHex override', () {
+    DetectionStyleResolver resolverWith(DetectionPatternStyle style) =>
+        DetectionStyleResolver(
+          styles: DetectionStyles({'url': style}),
+          accent: accent,
+          backgroundBrightness: Brightness.dark,
+        );
+
+    test('replaces the hue for BOTH wash and chip, keeping the tuned alpha',
+        () {
+      final resolver =
+          resolverWith(const DetectionPatternStyle(colorHex: '#33AA55'));
+      final resolved = resolver.resolveStyle('url', verified: false);
+      // Same alpha as the untouched default…
+      expect(
+        resolved.washColor.a,
+        closeTo(kGhosttyBubbleDetectedWashAlphaOnDark, 1e-9),
+      );
+      // …but the override hue.
+      expect(resolved.washColor.toARGB32() & 0x00FFFFFF, 0x0033AA55);
+      expect(resolved.chipAccent.toARGB32() & 0x00FFFFFF, 0x0033AA55);
+    });
+
+    test('only overrides ITS pattern — others keep the session accent', () {
+      final resolver =
+          resolverWith(const DetectionPatternStyle(colorHex: '#33AA55'));
+      expect(resolver.resolveStyle('path', verified: false).chipAccent, accent);
+    });
+
+    test('an INVALID colorHex is ignored (falls back to the accent)', () {
+      for (final bad in ['', '#12', 'zzzzzz', '#GGGGGG', '#12345']) {
+        final resolver =
+            resolverWith(DetectionPatternStyle(colorHex: bad));
+        final resolved = resolver.resolveStyle('url', verified: false);
+        expect(
+          resolved.washColor,
+          ghosttyBubbleWashColor(
+            accent,
+            verified: false,
+            backgroundBrightness: Brightness.dark,
+          ),
+          reason: '"$bad" must not change the wash',
+        );
+        expect(resolved.chipAccent, accent);
+      }
+    });
+  });
+
+  group('intensity multipliers', () {
+    DetectionStyleResolver resolverWith(
+      DetectionPatternStyle style, {
+      String id = 'path',
+      Brightness brightness = Brightness.dark,
+    }) =>
+        DetectionStyleResolver(
+          styles: DetectionStyles({id: style}),
+          accent: accent,
+          backgroundBrightness: brightness,
+        );
+
+    test('inactiveIntensity scales the DETECTED base alpha (per luminance)',
+        () {
+      for (final brightness in Brightness.values) {
+        final base = ghosttyBubbleWashColor(
+          accent,
+          verified: false,
+          backgroundBrightness: brightness,
+        ).a;
+        final resolved = resolverWith(
+          const DetectionPatternStyle(inactiveIntensity: 1.5),
+          brightness: brightness,
+        ).resolveStyle('path', verified: false);
+        expect(resolved.washColor.a, closeTo(base * 1.5, 0.01));
+      }
+    });
+
+    test('activeIntensity scales the VERIFIED base alpha and does NOT touch '
+        'the detected state', () {
+      final baseVerified = ghosttyBubbleWashColorVerifiedAlphaOnDark();
+      final resolver = resolverWith(
+        const DetectionPatternStyle(activeIntensity: 0.5),
+      );
+      expect(
+        resolver.resolveStyle('path', verified: true).washColor.a,
+        closeTo(baseVerified * 0.5, 0.01),
+      );
+      expect(
+        resolver.resolveStyle('path', verified: false).washColor.a,
+        closeTo(kGhosttyBubbleDetectedWashAlphaOnDark, 1e-9),
+        reason: 'activeIntensity is per-STATE — detected stays default',
+      );
+    });
+
+    test('intensity NEVER changes the chip accent (chips stay opaque by '
+        'design — the wash is what intensity governs)', () {
+      final resolver = resolverWith(
+        const DetectionPatternStyle(inactiveIntensity: 0.3),
+      );
+      expect(resolver.resolveStyle('path', verified: false).chipAccent, accent);
+    });
+
+    test('the multiplier is clamped to the band and the alpha to [0,1]', () {
+      final resolvedHigh = resolverWith(
+        const DetectionPatternStyle(activeIntensity: 100.0),
+        brightness: Brightness.light,
+      ).resolveStyle('path', verified: true);
+      expect(
+        resolvedHigh.washColor.a,
+        closeTo(
+          kGhosttyBubbleVerifiedWashAlphaOnLight * kDetectionIntensityMax,
+          0.01,
+        ),
+      );
+      expect(resolvedHigh.washColor.a, lessThanOrEqualTo(1.0));
+
+      final resolvedLow = resolverWith(
+        const DetectionPatternStyle(inactiveIntensity: 0.0),
+      ).resolveStyle('path', verified: false);
+      expect(
+        resolvedLow.washColor.a,
+        closeTo(
+          kGhosttyBubbleDetectedWashAlphaOnDark * kDetectionIntensityMin,
+          0.01,
+        ),
+        reason: 'a zero multiplier must not make the wash vanish — the band '
+            'floor keeps every stored value visible (IA review change 6)',
+      );
+    });
+  });
+
+  group('per-pattern REAL states (IA review change 1: no dead controls)', () {
+    test('only PATH has an active (verified) state today (#990)', () {
+      expect(detectionPatternHasActiveState(kGhosttyPathPatternId), isTrue);
+      expect(detectionPatternHasActiveState(kGhosttyUrlPatternId), isFalse);
+      expect(detectionPatternHasActiveState(kGhosttyOsc8PatternId), isFalse);
+      expect(
+        detectionPatternHasActiveState(kGhosttyCommandPatternId),
+        isFalse,
+      );
+    });
+
+    test('a custom pattern id has NO active state (until pressed-state ships)',
+        () {
+      expect(detectionPatternHasActiveState('custom.jira'), isFalse);
+    });
+  });
+}
+
+/// The verified-on-dark base alpha via the shipped derivation (keeps the test
+/// honest against the constant it multiplies).
+double ghosttyBubbleWashColorVerifiedAlphaOnDark() => ghosttyBubbleWashColor(
+      const Color(0x335B9BD5),
+      verified: true,
+      backgroundBrightness: Brightness.dark,
+    ).a;

--- a/native/test/ui/detection_style_seam_test.dart
+++ b/native/test/ui/detection_style_seam_test.dart
@@ -1,0 +1,337 @@
+// #1031 slice 1 — the painters CONSUME the style resolver: GhosttyBubbleLayer
+// takes a washColorOf seam (per-pattern effective wash) and GhosttyGutterLayer
+// a chipAccentOf seam (per-pattern chip hue). The zero-visual-change
+// invariant: a resolver over an EMPTY store paints EXACTLY what the layers
+// painted before the seam existed.
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/storage/detection_styles_store.dart';
+import 'package:mobissh/ui/detection_style_resolver.dart';
+import 'package:mobissh/ui/ghostty_gutter_layer.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+
+const _accent = Color(0x335B9BD5);
+
+StructuredAnchor _anchor(String patternId, String payload, {int row = 2}) =>
+    StructuredAnchor(
+      patternId: patternId,
+      payload: payload,
+      ranges: [
+        HighlightRange(
+          startRow: row,
+          startCol: 2,
+          endRow: row,
+          endCol: 2 + payload.length,
+          payload: payload,
+        ),
+      ],
+    );
+
+/// Fake controller for the BUBBLE layer: scripted anchors + real-geometry
+/// anchorRects (mirrors ghostty_bubble_layer_test.dart).
+class _FakeBubbleController extends ChangeNotifier
+    implements TerminalController {
+  static const CellMetrics metrics = CellMetrics(
+    cellWidth: 8,
+    cellHeight: 16,
+    baseline: 12,
+  );
+
+  List<StructuredAnchor> _anchors = const [];
+
+  void setAnchors(List<StructuredAnchor> value) {
+    _anchors = value;
+    notifyListeners();
+  }
+
+  @override
+  List<StructuredAnchor> get anchors => _anchors;
+
+  @override
+  bool get isScrolling => false;
+
+  @override
+  Listenable get decorationListenable => this;
+
+  @override
+  List<Rect> anchorRects(HighlightRange range) => AnchorGeometry.rectsFor(
+        range,
+        metrics: metrics,
+        viewportOffset: 0,
+        cols: 50,
+        viewportRows: 24,
+        origin: const Offset(4, 4),
+      );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Fake controller for the GUTTER layer: scripted anchors + anchorGutterRow
+/// (mirrors ghostty_gutter_layer_test.dart).
+class _FakeGutterController extends ChangeNotifier
+    implements TerminalController {
+  List<StructuredAnchor> _anchors = const [];
+
+  void setAnchors(List<StructuredAnchor> value) {
+    _anchors = value;
+    notifyListeners();
+  }
+
+  @override
+  List<StructuredAnchor> get anchors => _anchors;
+
+  @override
+  bool get isScrolling => false;
+
+  @override
+  Listenable get decorationListenable => this;
+
+  @override
+  int? anchorGutterRow(HighlightRange range) {
+    final row = range.topRow;
+    if (row < 0 || row >= 24) return null;
+    return row;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+GhosttyBubblePainter _painterOf(WidgetTester tester) {
+  final paint = tester.widget<CustomPaint>(
+    find.byKey(const Key('ghostty-bubble-paint')),
+  );
+  return paint.painter! as GhosttyBubblePainter;
+}
+
+/// The chip Container's fill inside a gutter mark.
+Color _chipFillOf(WidgetTester tester, int row) {
+  final containers = tester.widgetList<Container>(
+    find.descendant(
+      of: find.byKey(Key('gutter-mark-$row')),
+      matching: find.byType(Container),
+    ),
+  );
+  for (final c in containers) {
+    final decoration = c.decoration;
+    if (decoration is BoxDecoration && decoration.shape == BoxShape.circle) {
+      return decoration.color!;
+    }
+  }
+  fail('no circular chip Container under gutter-mark-$row');
+}
+
+void main() {
+  group('GhosttyBubbleLayer consumes the resolver (washColorOf seam)', () {
+    Future<_FakeBubbleController> pumpBubble(
+      WidgetTester tester, {
+      Color Function(String patternId, {required bool verified})? washColorOf,
+    }) async {
+      final controller = _FakeBubbleController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                Positioned.fill(
+                  child: GhosttyBubbleLayer(
+                    controller: controller,
+                    color: _accent,
+                    backgroundBrightness: Brightness.dark,
+                    washColorOf: washColorOf,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return controller;
+    }
+
+    testWidgets('an override wash from the seam is what the painter fills',
+        (tester) async {
+      const overrideWash = Color(0x4D33AA55);
+      final controller = await pumpBubble(
+        tester,
+        washColorOf: (id, {required bool verified}) =>
+            id == kGhosttyUrlPatternId
+                ? overrideWash
+                : ghosttyBubbleWashColor(
+                    _accent,
+                    verified: verified,
+                    backgroundBrightness: Brightness.dark,
+                  ),
+      );
+      controller.setAnchors([
+        _anchor(kGhosttyUrlPatternId, 'https://example.com', row: 2),
+        _anchor(kGhosttyPathPatternId, '/etc/hosts', row: 5),
+      ]);
+      await tester.pump();
+      final painter = _painterOf(tester);
+      expect(painter.specs, hasLength(2));
+      expect(painter.specs[0].washColor, overrideWash);
+      expect(
+        painter.specs[1].washColor,
+        ghosttyBubbleWashColor(
+          _accent,
+          verified: false,
+          backgroundBrightness: Brightness.dark,
+        ),
+        reason: 'only the overridden pattern changes',
+      );
+    });
+
+    testWidgets('ZERO CHANGE: an empty-store resolver paints the SAME wash as '
+        'no seam at all', (tester) async {
+      // Baseline: no seam.
+      final bare = await pumpBubble(tester);
+      bare.setAnchors([_anchor(kGhosttyUrlPatternId, 'https://example.com')]);
+      await tester.pump();
+      final baseline = _painterOf(tester).effectiveWashColor(
+        _painterOf(tester).specs.single,
+      );
+
+      // Resolver-backed seam over an EMPTY store.
+      const resolver = DetectionStyleResolver(
+        styles: DetectionStyles.empty,
+        accent: _accent,
+        backgroundBrightness: Brightness.dark,
+      );
+      final wired = await pumpBubble(
+        tester,
+        washColorOf: (id, {required bool verified}) =>
+            resolver.resolveStyle(id, verified: verified).washColor,
+      );
+      wired.setAnchors([_anchor(kGhosttyUrlPatternId, 'https://example.com')]);
+      await tester.pump();
+      final painter = _painterOf(tester);
+      expect(
+        painter.effectiveWashColor(painter.specs.single),
+        baseline,
+        reason: 'the resolver with no overrides must be invisible',
+      );
+    });
+  });
+
+  group('GhosttyGutterLayer consumes the resolver (chipAccentOf seam)', () {
+    Future<_FakeGutterController> pumpGutter(
+      WidgetTester tester, {
+      Color Function(String patternId)? chipAccentOf,
+    }) async {
+      final controller = _FakeGutterController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                Positioned.fill(
+                  child: GhosttyGutterLayer(
+                    controller: controller,
+                    registry: GutterPatternRegistry.standard(
+                      openPath: (_) async => true,
+                    ),
+                    color: _accent,
+                    cellHeight: 20,
+                    chipAccentOf: chipAccentOf,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return controller;
+    }
+
+    testWidgets('a single-pattern row chips in ITS resolved accent',
+        (tester) async {
+      const pathAccent = Color(0xFF33AA55);
+      final controller = await pumpGutter(
+        tester,
+        chipAccentOf: (id) =>
+            id == kGhosttyPathPatternId ? pathAccent : _accent,
+      );
+      controller.setAnchors([
+        _anchor(kGhosttyPathPatternId, '/etc/hosts', row: 4),
+        _anchor(kGhosttyUrlPatternId, 'https://example.com', row: 7),
+      ]);
+      await tester.pump();
+      expect(
+        _chipFillOf(tester, 4),
+        GutterMarkStyle.normal.chipColor(pathAccent),
+      );
+      expect(
+        _chipFillOf(tester, 7),
+        GutterMarkStyle.normal.chipColor(_accent),
+      );
+    });
+
+    testWidgets('a mixed-accent multi-match row keeps the NEUTRAL accent',
+        (tester) async {
+      const pathAccent = Color(0xFF33AA55);
+      final controller = await pumpGutter(
+        tester,
+        chipAccentOf: (id) =>
+            id == kGhosttyPathPatternId ? pathAccent : _accent,
+      );
+      controller.setAnchors([
+        _anchor(kGhosttyPathPatternId, '/etc/hosts', row: 4),
+        _anchor(kGhosttyUrlPatternId, 'https://example.com', row: 4),
+      ]);
+      await tester.pump();
+      expect(
+        _chipFillOf(tester, 4),
+        GutterMarkStyle.normal.chipColor(_accent),
+        reason: 'no single override applies to a mixed row',
+      );
+    });
+
+    testWidgets('url + osc8 on one row share the url family accent',
+        (tester) async {
+      const urlAccent = Color(0xFFFF8800);
+      final controller = await pumpGutter(
+        tester,
+        chipAccentOf: (id) =>
+            (id == kGhosttyUrlPatternId || id == kGhosttyOsc8PatternId)
+                ? urlAccent
+                : _accent,
+      );
+      controller.setAnchors([
+        _anchor(kGhosttyUrlPatternId, 'https://a.example', row: 4),
+        _anchor(kGhosttyOsc8PatternId, 'https://b.example', row: 4),
+      ]);
+      await tester.pump();
+      expect(
+        _chipFillOf(tester, 4),
+        GutterMarkStyle.normal.chipColor(urlAccent),
+        reason: 'both patterns resolve to ONE accent → the row uses it',
+      );
+    });
+
+    testWidgets('ZERO CHANGE: an empty-store resolver chips the SAME fill as '
+        'no seam at all', (tester) async {
+      final bare = await pumpGutter(tester);
+      bare.setAnchors([_anchor(kGhosttyUrlPatternId, 'https://x.example')]);
+      await tester.pump();
+      final baseline = _chipFillOf(tester, 2);
+
+      const resolver = DetectionStyleResolver(
+        styles: DetectionStyles.empty,
+        accent: _accent,
+        backgroundBrightness: Brightness.dark,
+      );
+      final wired = await pumpGutter(
+        tester,
+        chipAccentOf: (id) =>
+            resolver.resolveStyle(id, verified: false).chipAccent,
+      );
+      wired.setAnchors([_anchor(kGhosttyUrlPatternId, 'https://x.example')]);
+      await tester.pump();
+      expect(_chipFillOf(tester, 2), baseline);
+    });
+  });
+}


### PR DESCRIPTION
Slice 1 of #1031 (Detection Lab), per the issue's IA draft comment and its binding IA review comment (#1031, 2026-07-10): the PATTERN STYLE STORE + RESOLVER — the single source of truth the runtime affordances consult now and the lab preview reads later. NO lab UI in this slice; the invariant is ZERO visual change while the store is empty.

## What's here

**Store** (`native/lib/storage/detection_styles_store.dart`)
- Per-pattern overrides `{colorHex?, inactiveIntensity?, activeIntensity?}` keyed by plain-string pattern id (a later slice's `custom.*` ids need no schema change).
- Schema-in-value (v inside the JSON, never a key bump), corrupt/unknown-version → empty, malformed entries dropped individually — the favorites/exceptions-store precedent.
- Reset seams per the IA review: `resetPattern` (the detail page's "Reset this pattern") and `clearAllTuned` (the lab-wide reset the extended Settings "Reset settings" will call — implemented now, wired in the lab slice; authored data lives elsewhere and survives).

**Resolver** (`native/lib/ui/detection_style_resolver.dart`)
- `resolveStyle(patternId, {required bool verified})` → effective wash color (bubble) + chip accent hue (gutter), composing: stored colorHex → the #1000 luminance-tuned base alphas × a clamped intensity multiplier (band 0.25–1.75, review change 6: no invisible no-op zone) → the per-session accent when no override (overrides are global; the accent stays per-session, per the review).
- `detectionPatternHasActiveState` exposes which states are REAL — paths only today (#990) — so the lab UI can never offer the dead url/command Active controls (review change 1).
- The chip takes hue only; `GutterMarkStyle.chipColor` keeps forcing it opaque (intensity governs the wash alone).

**Providers** (`native/lib/state/detection_style_providers.dart`)
- Hydrating `DetectionStylesNotifier` (detectionSettingsProvider idiom: synchronous safe default, best-effort hydrate/persist) — the view resolves on CHANGE, never per frame.
- `detectionPatternStyleProvider` family for cheap per-pattern watches (tested: sibling changes don't rebuild).

**Runtime wiring**
- `GhosttyBubbleLayer.washColorOf`: the wash is resolved at spec-build time (decoration notify), the painter stays a dumb fill; `GhosttyBubbleSpec` carries the resolved color.
- `GhosttyGutterLayer.chipAccentOf`: a row whose anchors resolve to ONE accent uses it (url+osc8 share a family color naturally); a mixed-accent multi-match row keeps the neutral session accent.
- `ghostty_terminal_view.dart` builds the resolver from the watched styles + live accent/brightness and passes both seams.

## Zero-change proof
- Golden equality tests: an empty-store resolver is bit-identical to `ghosttyBubbleWashColor` / the raw accent for url/osc8/path/command × detected/verified × dark/light.
- Zero-change widget tests on both layers: resolver-backed seam over an empty store paints the same fill as no seam at all.
- The resolver's no-override path is structurally the shipped derivation (no multiply, no re-clamp) — the invariant can't drift.

## Tests
42 new: store round-trip/corrupt/version/reset seams; resolver truth table (override × state × luminance, clamp band, invalid hex, hasActiveState table, custom.* ids); provider hydrate/persist/reset/family isolation; painter/chip seam consumption. `scripts/native-fast-gate.sh`: 1892 pass.

Emulator: honestly NOT run for this slice — no visual change is the point, and the gate's existing detection suites cover the unchanged rendering. The lab UI slice (with real visual deltas) is where emulator verification belongs.

Closes nothing — #1031 stays open for slices 2–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa