### PR TITLE
feat(native): first-class shared color picker for the profile swatch (#1030)

### DIFF
--- a/native/integration_test/profile_color_picker_1030_test.dart
+++ b/native/integration_test/profile_color_picker_1030_test.dart
@@ -1,0 +1,197 @@
+// On-emulator smoke for the shared color picker (#1030).
+//
+// Flow: open the new-connection editor → open the shared picker from the
+// color section's custom swatch → interact with the HSV surface (real gesture
+// routing, not a widget-test synthetic) → type a custom hex → Apply →
+// Save & connect → assert the SESSION BAR swatch renders the picked color
+// (the "live preview of where the color lands" contract, end to end through
+// SavedProfile.color → connect seeding → sessionColorProvider).
+//
+// Screenshot window: while the picker sheet is open the test prints
+// PICKER1030_SHOT_WINDOW_OPEN and holds ~30s so the runner can take
+// `scripts/emu-shot.sh picker-1030` for thumb-target review.
+//
+// Network: scripts/native-connect-test.sh sets up
+//   emulator 127.0.0.1:2222 → (adb reverse → socat) → test-sshd:22
+// Credentials: testuser/testpass (see CLAUDE.md → Test SSH).
+
+@Tags(['integration'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+const _pickedHex = '#ff3366';
+const _pickedColor = Color(0xFFFF3366);
+
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'picker: HSV + hex → Apply → connect → session bar shows the color (#1030)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Editor with connection fields filled but NOT yet submitted.
+      await openNewConnectionEditor(tester);
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-host')),
+        '127.0.0.1',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-port')),
+        '2222',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-username')),
+        'testuser',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-password')),
+        'testpass',
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Open the shared picker from the color section's custom swatch.
+      final custom = find.byKey(const Key('profile-editor-color-custom'));
+      await tester.ensureVisible(custom);
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(custom, warnIfMissed: false);
+      final pickerOpened = await _pumpUntil(
+        tester,
+        () =>
+            find.byKey(const Key('color-picker-panel')).evaluate().isNotEmpty,
+        maxSlices: 20,
+      );
+      expect(pickerOpened, isTrue, reason: 'picker sheet never opened');
+
+      // Real-gesture HSV interaction: tap inside the SV square and the hue
+      // bar; the hex field must track (proves the CustomPaint surfaces receive
+      // touches through the sheet, which widget tests cannot fully vouch for).
+      final hexField = find.byKey(const Key('color-picker-hex'));
+      String hexText() =>
+          tester.widget<TextField>(hexField).controller?.text ?? '';
+      final beforeSv = hexText();
+      final svRect = tester.getRect(find.byKey(const Key('color-picker-sv')));
+      await tester.tapAt(svRect.center + const Offset(40, -30));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(
+        hexText(),
+        isNot(beforeSv),
+        reason: 'SV square tap did not change the color on device',
+      );
+      final beforeHue = hexText();
+      await tester.tapAt(
+        tester.getCenter(find.byKey(const Key('color-picker-hue'))),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(
+        hexText(),
+        isNot(beforeHue),
+        reason: 'hue slider tap did not change the color on device',
+      );
+
+      // Screenshot HOLD: picker open with a live selection for emu-shot.
+      debugPrint('PICKER1030_SHOT_WINDOW_OPEN');
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(_slice);
+      }
+      debugPrint('PICKER1030_SHOT_WINDOW_CLOSED');
+
+      // Deterministic final value via hex entry, then Apply. Focusing the hex
+      // field raises the REAL soft keyboard on-device, which occludes the
+      // action row (first run failed exactly here: the apply tap derived an
+      // offset that no longer hit-tested) — dismiss the keyboard and re-reveal
+      // Apply inside the sheet's scroll view before tapping.
+      await tester.enterText(hexField, _pickedHex);
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump(const Duration(milliseconds: 500));
+      final apply = find.byKey(const Key('color-picker-apply'));
+      await tester.ensureVisible(apply);
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(apply, warnIfMissed: false);
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // The editor's backing hex field carries the picked value.
+      final editorField = tester.widget<TextField>(
+        find.byKey(const Key('profile-editor-color')),
+      );
+      expect(editorField.controller?.text, _pickedHex);
+
+      // Save & connect.
+      final submit = find.byKey(const Key('connect-submit'));
+      await tester.ensureVisible(submit);
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(submit);
+      final reached = await _pumpUntil(
+        tester,
+        () => find
+            .byKey(const Key('session-menu-button'))
+            .evaluate()
+            .isNotEmpty,
+      );
+      expect(reached, isTrue, reason: 'never reached the terminal screen');
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+
+      // The session bar swatch — where the profile color lands — must render
+      // the picked color, not the theme-accent fallback.
+      final swatch = find.byKey(const Key('session-bar-swatch'));
+      expect(swatch, findsOneWidget, reason: 'session bar swatch missing');
+      final decoration =
+          tester.widget<Container>(swatch).decoration! as BoxDecoration;
+      expect(
+        decoration.color,
+        _pickedColor,
+        reason: 'session bar swatch does not show the picked profile color',
+      );
+
+      // Teardown: close the session so the suite leaves a clean slate.
+      final notifier = container.read(sessionsProvider.notifier);
+      notifier.close(entry!.id);
+      await _pumpUntil(
+        tester,
+        () => container.read(sessionsProvider).entries.isEmpty,
+        maxSlices: 20,
+      );
+    },
+  );
+}

--- a/native/lib/ui/color_picker_sheet.dart
+++ b/native/lib/ui/color_picker_sheet.dart
@@ -1,0 +1,524 @@
+// Shared first-class color picker (#1030).
+//
+// Used by the profile editor for the per-profile device swatch; the detection
+// lab (#1031) reuses it for per-pattern highlight colors. Two entry points:
+//   - [ColorPickerPanel]: the picker surface itself (testable directly).
+//   - [showColorPickerSheet]: modal bottom-sheet wrapper. Returns
+//     `null` = cancelled, [ColorPickerResult] with `color == null` = cleared
+//     ("no color" / "use theme color" — the #1031 override-clearing contract),
+//     otherwise the picked color.
+//
+// Hand-rolled HSV panel (SV square + hue slider via CustomPaint) instead of a
+// pub dependency: flex_color_picker is pure Dart but drags flex_seed_scheme +
+// a large unused API and risks lockfile drift against the pinned
+// compileSdk-36 toolchain (file_picker precedent); the minimal panel is ~150
+// lines and gives exact control over thumb-friendly target sizes (the owner
+// is visually impaired, phone-first).
+//
+// Monochrome-glyph rule applies to ICONS only — the swatch/preview colors ARE
+// the user content here.
+
+import 'package:flutter/material.dart';
+
+import '../state/ui_prefs_providers.dart' show colorFromHex;
+
+/// Shared preset quick-swatches. The profile editor renders these as one-tap
+/// chips and the picker repeats them as presets; #1031 reuses the same set for
+/// pattern colors. Chosen for mutual distinguishability and legibility on both
+/// dark and light surfaces.
+const List<Color> colorPickerPresets = <Color>[
+  Color(0xFFE53935), // red
+  Color(0xFFFB8C00), // orange
+  Color(0xFFFDD835), // yellow
+  Color(0xFF43A047), // green
+  Color(0xFF00ACC1), // cyan
+  Color(0xFF1E88E5), // blue
+  Color(0xFF8E24AA), // purple
+  Color(0xFFD81B60), // pink
+];
+
+/// Format an (opaque) color as the lowercase `#rrggbb` hex the profile store
+/// carries ([SavedProfile.color]); inverse of [colorFromHex] for 6-digit input.
+String hexFromColor(Color color) {
+  final rgb = color.toARGB32() & 0xFFFFFF;
+  return '#${rgb.toRadixString(16).padLeft(6, '0')}';
+}
+
+/// Sheet outcome wrapper so callers can tell "picked nothing" (sheet returns
+/// null) from "picked NO color" (`color == null` — clear the override).
+class ColorPickerResult {
+  const ColorPickerResult(this.color);
+
+  /// The picked color, or null when the user chose the clear action.
+  final Color? color;
+}
+
+/// Open the shared picker as a modal bottom sheet.
+///
+/// [clearLabel], when given, adds a clear action returning
+/// `ColorPickerResult(null)` — e.g. 'No color (theme accent)' in the profile
+/// editor or 'Use theme color' in the detection lab.
+Future<ColorPickerResult?> showColorPickerSheet(
+  BuildContext context, {
+  Color? initial,
+  String title = 'Pick a color',
+  String? clearLabel,
+  List<Color> presets = colorPickerPresets,
+  String? previewLabel,
+}) {
+  return showModalBottomSheet<ColorPickerResult>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (sheetContext) => Padding(
+      // Keep the hex field + actions above the soft keyboard.
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.viewInsetsOf(sheetContext).bottom,
+      ),
+      child: SingleChildScrollView(
+        child: ColorPickerPanel(
+          initial: initial,
+          title: title,
+          clearLabel: clearLabel,
+          presets: presets,
+          previewLabel: previewLabel,
+          onApply: (color) =>
+              Navigator.of(sheetContext).pop(ColorPickerResult(color)),
+          onClear: clearLabel == null
+              ? null
+              : () =>
+                    Navigator.of(sheetContext).pop(const ColorPickerResult(null)),
+          onCancel: () => Navigator.of(sheetContext).pop(),
+        ),
+      ),
+    ),
+  );
+}
+
+/// The picker surface: SV square + hue slider + hex entry + preset chips +
+/// live preview + actions. Pure widget (no storage) so both the profile
+/// editor and the detection lab can host it.
+class ColorPickerPanel extends StatefulWidget {
+  const ColorPickerPanel({
+    super.key,
+    this.initial,
+    this.title = 'Pick a color',
+    this.clearLabel,
+    this.presets = colorPickerPresets,
+    this.previewLabel,
+    required this.onApply,
+    this.onClear,
+    this.onCancel,
+  });
+
+  /// Seed color; null starts on the first preset.
+  final Color? initial;
+
+  final String title;
+
+  /// Label for the clear ("no color") action; null hides the action.
+  final String? clearLabel;
+
+  final List<Color> presets;
+
+  /// Text shown next to the preview dot (defaults to a session-row mock).
+  final String? previewLabel;
+
+  final ValueChanged<Color> onApply;
+  final VoidCallback? onClear;
+  final VoidCallback? onCancel;
+
+  @override
+  State<ColorPickerPanel> createState() => _ColorPickerPanelState();
+}
+
+class _ColorPickerPanelState extends State<ColorPickerPanel> {
+  late HSVColor _hsv;
+  late final TextEditingController _hexCtrl;
+
+  /// Set when the hex field holds unparseable text; the preview and Apply then
+  /// stick to the last valid color / disable respectively.
+  bool _hexInvalid = false;
+
+  Color get _color => _hsv.toColor();
+
+  @override
+  void initState() {
+    super.initState();
+    final seed = widget.initial ?? widget.presets.first;
+    _hsv = HSVColor.fromColor(seed);
+    _hexCtrl = TextEditingController(text: hexFromColor(seed));
+  }
+
+  @override
+  void dispose() {
+    _hexCtrl.dispose();
+    super.dispose();
+  }
+
+  /// Adopt a color picked interactively (SV square / hue / preset) — syncs the
+  /// hex field to the selection.
+  void _select(HSVColor hsv) {
+    setState(() {
+      _hsv = hsv;
+      _hexInvalid = false;
+      _hexCtrl.text = hexFromColor(hsv.toColor());
+    });
+  }
+
+  void _onHexChanged(String text) {
+    final parsed = colorFromHex(text);
+    setState(() {
+      if (parsed == null) {
+        _hexInvalid = text.trim().isNotEmpty;
+      } else {
+        _hexInvalid = false;
+        _hsv = HSVColor.fromColor(parsed);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hex = hexFromColor(_color);
+    return Padding(
+      key: const Key('color-picker-panel'),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(widget.title, style: theme.textTheme.titleMedium),
+          const SizedBox(height: 12),
+          _SvSquare(hsv: _hsv, onChanged: _select),
+          const SizedBox(height: 12),
+          _HueSlider(hsv: _hsv, onChanged: _select),
+          const SizedBox(height: 12),
+          // Live preview: where the color lands — the session-row dot next to
+          // a big swatch carrying the hex value.
+          Row(
+            children: [
+              Container(
+                key: const Key('color-picker-preview'),
+                width: 14,
+                height: 14,
+                decoration: BoxDecoration(
+                  color: _color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  widget.previewLabel ?? 'session row',
+                  style: theme.textTheme.bodyMedium,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Container(
+                width: 72,
+                height: 36,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: _color,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: theme.colorScheme.outlineVariant),
+                ),
+                child: Text(
+                  hex,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    // Contrast the swatch itself, not the app theme.
+                    color: _color.computeLuminance() > 0.5
+                        ? Colors.black
+                        : Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            key: const Key('color-picker-hex'),
+            controller: _hexCtrl,
+            decoration: InputDecoration(
+              labelText: 'Hex',
+              hintText: '#ff8800',
+              errorText: _hexInvalid ? 'Invalid hex color' : null,
+              border: const OutlineInputBorder(),
+            ),
+            autocorrect: false,
+            enableSuggestions: false,
+            onChanged: _onHexChanged,
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final preset in widget.presets)
+                _PresetChip(
+                  key: Key('color-picker-preset-${hexFromColor(preset)}'),
+                  color: preset,
+                  selected: hexFromColor(preset) == hex,
+                  onTap: () => _select(HSVColor.fromColor(preset)),
+                ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              if (widget.onClear != null)
+                Expanded(
+                  child: OutlinedButton(
+                    key: const Key('color-picker-clear'),
+                    onPressed: widget.onClear,
+                    child: Text(
+                      widget.clearLabel ?? 'No color',
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+              if (widget.onClear != null) const SizedBox(width: 8),
+              TextButton(
+                key: const Key('color-picker-cancel'),
+                onPressed: widget.onCancel,
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: FilledButton(
+                  key: const Key('color-picker-apply'),
+                  onPressed: _hexInvalid
+                      ? null
+                      : () => widget.onApply(_color),
+                  child: const Text('Apply'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Round preset swatch, thumb-sized (48dp), with a selection ring.
+class _PresetChip extends StatelessWidget {
+  const _PresetChip({
+    super.key,
+    required this.color,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final Color color;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkResponse(
+      onTap: onTap,
+      radius: 28,
+      child: Container(
+        width: 48,
+        height: 48,
+        decoration: BoxDecoration(
+          color: color,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: selected
+                ? theme.colorScheme.onSurface
+                : theme.colorScheme.outlineVariant,
+            width: selected ? 3 : 1,
+          ),
+        ),
+        child: selected
+            ? Icon(
+                Icons.check,
+                size: 24,
+                color: color.computeLuminance() > 0.5
+                    ? Colors.black
+                    : Colors.white,
+              )
+            : null,
+      ),
+    );
+  }
+}
+
+/// Saturation/value plane for the current hue. Tap or drag anywhere on the
+/// square; the thumb rides the selection.
+class _SvSquare extends StatelessWidget {
+  const _SvSquare({required this.hsv, required this.onChanged});
+
+  final HSVColor hsv;
+  final ValueChanged<HSVColor> onChanged;
+
+  void _handle(Offset local, Size size) {
+    final s = (local.dx / size.width).clamp(0.0, 1.0);
+    final v = 1.0 - (local.dy / size.height).clamp(0.0, 1.0);
+    onChanged(hsv.withSaturation(s).withValue(v));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = Size(constraints.maxWidth, 200);
+        return GestureDetector(
+          key: const Key('color-picker-sv'),
+          behavior: HitTestBehavior.opaque,
+          onTapDown: (d) => _handle(d.localPosition, size),
+          onPanStart: (d) => _handle(d.localPosition, size),
+          onPanUpdate: (d) => _handle(d.localPosition, size),
+          child: CustomPaint(
+            size: size,
+            painter: _SvPainter(hsv),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SvPainter extends CustomPainter {
+  _SvPainter(this.hsv);
+
+  final HSVColor hsv;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    final rrect = RRect.fromRectAndRadius(rect, const Radius.circular(8));
+    canvas.clipRRect(rrect);
+    // White → pure hue along X, then transparent → black along Y.
+    final hueColor = HSVColor.fromAHSV(1, hsv.hue, 1, 1).toColor();
+    canvas.drawRect(
+      rect,
+      Paint()
+        ..shader = LinearGradient(
+          colors: [Colors.white, hueColor],
+        ).createShader(rect),
+    );
+    canvas.drawRect(
+      rect,
+      Paint()
+        ..shader = const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [Colors.transparent, Colors.black],
+        ).createShader(rect),
+    );
+    // Thumb ring at the current S/V.
+    final thumb = Offset(
+      hsv.saturation * size.width,
+      (1 - hsv.value) * size.height,
+    );
+    canvas.drawCircle(
+      thumb,
+      12,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 3
+        ..color = Colors.white,
+    );
+    canvas.drawCircle(
+      thumb,
+      12,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1
+        ..color = Colors.black54,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_SvPainter oldDelegate) => oldDelegate.hsv != hsv;
+}
+
+/// Full-spectrum hue bar, 48dp tall for a comfortable drag target.
+class _HueSlider extends StatelessWidget {
+  const _HueSlider({required this.hsv, required this.onChanged});
+
+  final HSVColor hsv;
+  final ValueChanged<HSVColor> onChanged;
+
+  void _handle(Offset local, double width) {
+    final hue = (local.dx / width).clamp(0.0, 1.0) * 360.0;
+    onChanged(hsv.withHue(hue.clamp(0.0, 359.999)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = Size(constraints.maxWidth, 48);
+        return GestureDetector(
+          key: const Key('color-picker-hue'),
+          behavior: HitTestBehavior.opaque,
+          onTapDown: (d) => _handle(d.localPosition, size.width),
+          onPanStart: (d) => _handle(d.localPosition, size.width),
+          onPanUpdate: (d) => _handle(d.localPosition, size.width),
+          child: CustomPaint(
+            size: size,
+            painter: _HuePainter(hsv.hue),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _HuePainter extends CustomPainter {
+  _HuePainter(this.hue);
+
+  final double hue;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    final rrect = RRect.fromRectAndRadius(rect, const Radius.circular(8));
+    canvas.clipRRect(rrect);
+    canvas.drawRect(
+      rect,
+      Paint()
+        ..shader = LinearGradient(
+          colors: [
+            for (var h = 0; h <= 360; h += 60)
+              HSVColor.fromAHSV(1, h.toDouble().clamp(0, 359.999), 1, 1)
+                  .toColor(),
+          ],
+        ).createShader(rect),
+    );
+    // Thumb: vertical pill at the current hue.
+    final x = (hue / 360.0) * size.width;
+    final thumbRect = RRect.fromRectAndRadius(
+      Rect.fromCenter(
+        center: Offset(x.clamp(6, size.width - 6), size.height / 2),
+        width: 10,
+        height: size.height - 6,
+      ),
+      const Radius.circular(5),
+    );
+    canvas.drawRRect(
+      thumbRect,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 3
+        ..color = Colors.white,
+    );
+    canvas.drawRRect(
+      thumbRect,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1
+        ..color = Colors.black54,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_HuePainter oldDelegate) => oldDelegate.hue != hue;
+}

--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -25,6 +25,7 @@ import '../diagnostics/connect_trace.dart';
 import '../state/profiles_providers.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
+import 'color_picker_sheet.dart';
 import 'top_toast.dart';
 
 enum _AuthKind { password, key }
@@ -483,19 +484,168 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor> {
                 ),
               ),
               const SizedBox(height: 8),
-              TextField(
+              // #1030: first-class color section. One-tap preset chips + the
+              // shared picker sheet for custom colors. The hex field stays the
+              // backing value (same key + controller) so the save path and
+              // existing tests are unchanged — presets/picker just write it.
+              _ColorSection(controller: _colorCtrl),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Color section (#1030): swatch button (opens the shared picker), the hex
+/// TextField (backing value — `SavedProfile.color` persists exactly this
+/// text), and the shared preset chips for one-tap selection. Stateful only to
+/// repaint the swatch/selection ring as the controller text changes.
+class _ColorSection extends StatefulWidget {
+  const _ColorSection({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  State<_ColorSection> createState() => _ColorSectionState();
+}
+
+class _ColorSectionState extends State<_ColorSection> {
+  Color? get _current => colorFromHex(widget.controller.text);
+
+  void _setHex(String hex) {
+    setState(() => widget.controller.text = hex);
+  }
+
+  Future<void> _openPicker() async {
+    final result = await showColorPickerSheet(
+      context,
+      initial: _current,
+      title: 'Profile color',
+      // Short label: the sheet's action row is three-up on a 360dp phone and a
+      // longer label ellipsized on the emulator shot.
+      clearLabel: 'No color',
+      previewLabel: 'session row',
+    );
+    if (result == null) return; // cancelled — keep as-is
+    _setHex(result.color == null ? '' : hexFromColor(result.color!));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final current = _current;
+    final currentHex = current == null ? null : hexFromColor(current);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            // Custom-color affordance: current swatch (or a neutral palette
+            // glyph when colorless) opening the shared picker sheet.
+            InkResponse(
+              key: const Key('profile-editor-color-custom'),
+              onTap: _openPicker,
+              radius: 28,
+              child: Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: current,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: theme.colorScheme.outlineVariant),
+                ),
+                child: current == null
+                    ? Icon(
+                        Icons.palette_outlined,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      )
+                    : null,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: TextField(
                 key: const Key('profile-editor-color'),
-                controller: _colorCtrl,
+                controller: widget.controller,
                 decoration: const InputDecoration(
                   labelText: 'Color (optional)',
                   hintText: '#ff8800',
                 ),
                 autocorrect: false,
                 enableSuggestions: false,
+                // Repaint the swatch + selection ring on manual hex edits.
+                onChanged: (_) => setState(() {}),
               ),
-            ],
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        // One-tap quick swatches — the shared preset set the picker also
+        // offers, kept inline so the common case stays a single tap.
+        Wrap(
+          key: const Key('profile-editor-color-presets'),
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final preset in colorPickerPresets)
+              _PresetSwatch(
+                key: Key(
+                  'profile-editor-color-preset-${hexFromColor(preset)}',
+                ),
+                color: preset,
+                selected: hexFromColor(preset) == currentHex,
+                onTap: () => _setHex(hexFromColor(preset)),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// Round one-tap swatch chip (44dp) with a selection ring — the editor-side
+/// twin of the picker's preset chip.
+class _PresetSwatch extends StatelessWidget {
+  const _PresetSwatch({
+    super.key,
+    required this.color,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final Color color;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkResponse(
+      onTap: onTap,
+      radius: 26,
+      child: Container(
+        width: 44,
+        height: 44,
+        decoration: BoxDecoration(
+          color: color,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: selected
+                ? theme.colorScheme.onSurface
+                : theme.colorScheme.outlineVariant,
+            width: selected ? 3 : 1,
           ),
         ),
+        child: selected
+            ? Icon(
+                Icons.check,
+                size: 22,
+                color: color.computeLuminance() > 0.5
+                    ? Colors.black
+                    : Colors.white,
+              )
+            : null,
       ),
     );
   }

--- a/native/test/widget/color_picker_sheet_test.dart
+++ b/native/test/widget/color_picker_sheet_test.dart
@@ -1,0 +1,281 @@
+// Widget tests for the shared color picker (#1030).
+//
+// The picker is a SHARED widget: the profile editor uses it for the device
+// swatch and the detection lab (#1031) will reuse it for pattern colors, so
+// the tests pin the reuse contract:
+//   - hex round-trip: initial color → hex field text → edited hex → color
+//   - '#' is optional in hex entry
+//   - invalid hex shows an inline error and disables Apply
+//   - preset chip tap selects (updates hex + preview)
+//   - HSV interaction (SV square tap, hue slider tap) changes the value
+//   - Apply reports the picked color; Clear (when offered) reports null-color
+//     (the #1031 "Use theme color" path, distinct from cancel)
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobissh/ui/color_picker_sheet.dart';
+
+Color _previewColor(WidgetTester tester) {
+  final container = tester.widget<Container>(
+    find.byKey(const Key('color-picker-preview')),
+  );
+  return (container.decoration! as BoxDecoration).color!;
+}
+
+String _hexFieldText(WidgetTester tester) {
+  final field = tester.widget<TextField>(
+    find.byKey(const Key('color-picker-hex')),
+  );
+  return field.controller?.text ?? '';
+}
+
+Future<void> _pumpPanel(
+  WidgetTester tester, {
+  Color? initial,
+  String? clearLabel,
+  ValueChanged<Color>? onApply,
+  VoidCallback? onClear,
+}) async {
+  tester.view.physicalSize = const Size(500, 1200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: ColorPickerPanel(
+            initial: initial,
+            clearLabel: clearLabel,
+            onApply: onApply ?? (_) {},
+            onClear: onClear,
+            onCancel: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('hexFromColor', () {
+    test('formats an opaque color as lowercase #rrggbb', () {
+      expect(hexFromColor(const Color(0xFF336699)), '#336699');
+      expect(hexFromColor(const Color(0xFFFF8800)), '#ff8800');
+      expect(hexFromColor(const Color(0xFF000000)), '#000000');
+    });
+  });
+
+  group('ColorPickerPanel', () {
+    testWidgets('seeds the hex field and preview from the initial color', (
+      tester,
+    ) async {
+      await _pumpPanel(tester, initial: const Color(0xFF336699));
+      expect(_hexFieldText(tester), '#336699');
+      expect(_previewColor(tester), const Color(0xFF336699));
+    });
+
+    testWidgets('hex entry round-trips: typed hex drives preview and Apply', (
+      tester,
+    ) async {
+      Color? applied;
+      await _pumpPanel(
+        tester,
+        initial: const Color(0xFF336699),
+        onApply: (c) => applied = c,
+      );
+
+      await tester.enterText(
+        find.byKey(const Key('color-picker-hex')),
+        '#ff8800',
+      );
+      await tester.pumpAndSettle();
+      expect(_previewColor(tester), const Color(0xFFFF8800));
+
+      await tester.tap(find.byKey(const Key('color-picker-apply')));
+      await tester.pumpAndSettle();
+      expect(applied, const Color(0xFFFF8800));
+    });
+
+    testWidgets('leading # is optional in hex entry', (tester) async {
+      await _pumpPanel(tester, initial: const Color(0xFF336699));
+      await tester.enterText(
+        find.byKey(const Key('color-picker-hex')),
+        '43a047',
+      );
+      await tester.pumpAndSettle();
+      expect(_previewColor(tester), const Color(0xFF43A047));
+    });
+
+    testWidgets('invalid hex shows an inline error and disables Apply', (
+      tester,
+    ) async {
+      await _pumpPanel(tester, initial: const Color(0xFF336699));
+      await tester.enterText(
+        find.byKey(const Key('color-picker-hex')),
+        'not-a-color',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invalid hex color'), findsOneWidget);
+      final apply = tester.widget<FilledButton>(
+        find.byKey(const Key('color-picker-apply')),
+      );
+      expect(apply.onPressed, isNull, reason: 'Apply must gate on valid hex');
+      // Preview keeps the last valid color — never blank, never crashes.
+      expect(_previewColor(tester), const Color(0xFF336699));
+    });
+
+    testWidgets('preset chip tap selects that color', (tester) async {
+      await _pumpPanel(tester, initial: const Color(0xFF336699));
+
+      final preset = colorPickerPresets.first;
+      final hex = hexFromColor(preset);
+      await tester.tap(find.byKey(Key('color-picker-preset-$hex')));
+      await tester.pumpAndSettle();
+
+      expect(_previewColor(tester), preset);
+      expect(_hexFieldText(tester), hex);
+    });
+
+    testWidgets('every shared preset renders a chip', (tester) async {
+      await _pumpPanel(tester);
+      for (final preset in colorPickerPresets) {
+        expect(
+          find.byKey(Key('color-picker-preset-${hexFromColor(preset)}')),
+          findsOneWidget,
+        );
+      }
+    });
+
+    testWidgets('tapping the SV square changes the color', (tester) async {
+      await _pumpPanel(tester, initial: const Color(0xFF336699));
+      final before = _previewColor(tester);
+
+      final sv = find.byKey(const Key('color-picker-sv'));
+      final rect = tester.getRect(sv);
+      // Near top-right = high saturation + high value for the current hue.
+      await tester.tapAt(rect.topRight + const Offset(-4, 4));
+      await tester.pumpAndSettle();
+
+      final after = _previewColor(tester);
+      expect(after, isNot(before));
+      // Hex field tracks the interactive selection.
+      expect(_hexFieldText(tester), hexFromColor(after));
+    });
+
+    testWidgets('tapping the hue slider changes the hue', (tester) async {
+      // Pure red, full S/V: any mid-slider hue tap must move off red.
+      await _pumpPanel(tester, initial: const Color(0xFFFF0000));
+      final before = _previewColor(tester);
+
+      final hue = find.byKey(const Key('color-picker-hue'));
+      await tester.tapAt(tester.getCenter(hue));
+      await tester.pumpAndSettle();
+
+      expect(_previewColor(tester), isNot(before));
+    });
+
+    testWidgets('Clear action reports the null-color path when offered', (
+      tester,
+    ) async {
+      var cleared = false;
+      await _pumpPanel(
+        tester,
+        initial: const Color(0xFF336699),
+        clearLabel: 'No color (theme accent)',
+        onClear: () => cleared = true,
+      );
+
+      await tester.tap(find.byKey(const Key('color-picker-clear')));
+      await tester.pumpAndSettle();
+      expect(cleared, isTrue);
+    });
+
+    testWidgets('Clear action is absent when no clearLabel is given', (
+      tester,
+    ) async {
+      await _pumpPanel(tester, initial: const Color(0xFF336699));
+      expect(find.byKey(const Key('color-picker-clear')), findsNothing);
+    });
+
+    testWidgets('touch targets are thumb-sized (>=44dp)', (tester) async {
+      await _pumpPanel(tester, initial: const Color(0xFF336699));
+
+      final presetSize = tester.getSize(
+        find.byKey(
+          Key('color-picker-preset-${hexFromColor(colorPickerPresets.first)}'),
+        ),
+      );
+      expect(presetSize.width, greaterThanOrEqualTo(44));
+      expect(presetSize.height, greaterThanOrEqualTo(44));
+
+      final hueSize = tester.getSize(find.byKey(const Key('color-picker-hue')));
+      expect(hueSize.height, greaterThanOrEqualTo(44));
+    });
+  });
+
+  group('showColorPickerSheet', () {
+    testWidgets('Apply pops with the picked color; Cancel pops null', (
+      tester,
+    ) async {
+      ColorPickerResult? result;
+      var opened = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: FilledButton(
+                  key: const Key('open-picker'),
+                  onPressed: () async {
+                    opened += 1;
+                    result = await showColorPickerSheet(
+                      context,
+                      initial: const Color(0xFF336699),
+                      clearLabel: 'No color',
+                    );
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Apply path.
+      await tester.tap(find.byKey(const Key('open-picker')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('color-picker-hex')),
+        '#d81b60',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('color-picker-apply')));
+      await tester.pumpAndSettle();
+      expect(result, isNotNull);
+      expect(result!.color, const Color(0xFFD81B60));
+
+      // Clear path: a result with a null color (≠ cancel).
+      await tester.tap(find.byKey(const Key('open-picker')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('color-picker-clear')));
+      await tester.pumpAndSettle();
+      expect(result, isNotNull);
+      expect(result!.color, isNull);
+
+      // Cancel path: null result.
+      await tester.tap(find.byKey(const Key('open-picker')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('color-picker-cancel')));
+      await tester.pumpAndSettle();
+      expect(result, isNull);
+      expect(opened, 3);
+    });
+  });
+}

--- a/native/test/widget/profile_editor_color_picker_test.dart
+++ b/native/test/widget/profile_editor_color_picker_test.dart
@@ -1,0 +1,173 @@
+// Profile editor ↔ shared color picker wiring (#1030).
+//
+// The editor's color section replaces the bare hex TextField with:
+//   - one-tap preset chips (the shared quick swatches)
+//   - a custom-color affordance opening the shared picker sheet
+//   - the hex field retained (same 'profile-editor-color' key) as the
+//     backing value the save path already persists (SavedProfile.color)
+//
+// Asserts the full persistence loop: preset tap → save → store colorHex, and
+// picker Apply → save → store colorHex. No storage change — same _colorCtrl
+// path as before.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/color_picker_sheet.dart';
+import 'package:mobissh/ui/profile_editor.dart';
+
+Future<ProfilesStore> _pump(
+  WidgetTester tester, {
+  String? color,
+}) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final store = ProfilesStore();
+  await store.save(<SavedProfile>[
+    SavedProfile(
+      title: 'Box',
+      host: 'home.example',
+      port: 22,
+      username: 'me',
+      authType: 'password',
+      color: color,
+    ),
+  ]);
+  final secrets = SecretsStore(backend: InMemorySecretsBackend());
+
+  tester.view.physicalSize = const Size(1000, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        profilesStoreProvider.overrideWithValue(store),
+        secretsStoreProvider.overrideWithValue(secrets),
+      ],
+      child: MaterialApp(home: ProfileEditor(profile: (await store.load()).first)),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return store;
+}
+
+Future<void> _tapSave(WidgetTester tester) async {
+  final save = find.byKey(const Key('profile-editor-save'));
+  await tester.ensureVisible(save);
+  await tester.pumpAndSettle();
+  await tester.tap(save);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ProfileEditor color section (#1030)', () {
+    testWidgets('renders one-tap preset chips for the shared swatches', (
+      tester,
+    ) async {
+      await _pump(tester, color: '#ff8800');
+      expect(
+        find.byKey(const Key('profile-editor-color-presets')),
+        findsOneWidget,
+      );
+      for (final preset in colorPickerPresets) {
+        expect(
+          find.byKey(
+            Key('profile-editor-color-preset-${hexFromColor(preset)}'),
+          ),
+          findsOneWidget,
+        );
+      }
+    });
+
+    testWidgets('preset chip tap fills the hex field and Save persists it', (
+      tester,
+    ) async {
+      final store = await _pump(tester, color: '#ff8800');
+
+      final preset = colorPickerPresets.first;
+      final hex = hexFromColor(preset);
+      final chip = find.byKey(Key('profile-editor-color-preset-$hex'));
+      await tester.ensureVisible(chip);
+      await tester.pumpAndSettle();
+      await tester.tap(chip);
+      await tester.pumpAndSettle();
+
+      final field = tester.widget<TextField>(
+        find.byKey(const Key('profile-editor-color')),
+      );
+      expect(field.controller?.text, hex);
+
+      await _tapSave(tester);
+      expect((await store.load()).first.color, hex);
+    });
+
+    testWidgets('custom picker Apply fills the hex field and Save persists', (
+      tester,
+    ) async {
+      final store = await _pump(tester, color: '#ff8800');
+
+      final custom = find.byKey(const Key('profile-editor-color-custom'));
+      await tester.ensureVisible(custom);
+      await tester.pumpAndSettle();
+      await tester.tap(custom);
+      await tester.pumpAndSettle();
+
+      // Shared picker opens, seeded from the profile color.
+      expect(find.byKey(const Key('color-picker-panel')), findsOneWidget);
+      expect(
+        tester
+            .widget<TextField>(find.byKey(const Key('color-picker-hex')))
+            .controller
+            ?.text,
+        '#ff8800',
+      );
+
+      await tester.enterText(
+        find.byKey(const Key('color-picker-hex')),
+        '#123456',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('color-picker-apply')));
+      await tester.pumpAndSettle();
+
+      final field = tester.widget<TextField>(
+        find.byKey(const Key('profile-editor-color')),
+      );
+      expect(field.controller?.text, '#123456');
+
+      await _tapSave(tester);
+      expect((await store.load()).first.color, '#123456');
+    });
+
+    testWidgets('picker Clear empties the color (falls back to theme accent)', (
+      tester,
+    ) async {
+      final store = await _pump(tester, color: '#ff8800');
+
+      final custom = find.byKey(const Key('profile-editor-color-custom'));
+      await tester.ensureVisible(custom);
+      await tester.pumpAndSettle();
+      await tester.tap(custom);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('color-picker-clear')));
+      await tester.pumpAndSettle();
+
+      final field = tester.widget<TextField>(
+        find.byKey(const Key('profile-editor-color')),
+      );
+      expect(field.controller?.text, isEmpty);
+
+      await _tapSave(tester);
+      expect((await store.load()).first.color, isNull);
+    });
+  });
+}


### PR DESCRIPTION
First-class color picker for the per-profile device swatch, built as a SHARED widget so the #1031 Detection Lab reuses it for pattern colors.

## What

- **`native/lib/ui/color_picker_sheet.dart` (new, shared):**
  - `ColorPickerPanel` — full HSV selection: SV square + full-spectrum hue slider (hand-rolled CustomPaint), hex entry (`#` optional, inline `Invalid hex color` error, Apply gated on validity), the shared quick-swatch presets as 48dp chips, live preview of where the color lands (session-row dot + big hex swatch with contrast-aware text).
  - `showColorPickerSheet()` — modal bottom-sheet wrapper. Return contract for #1031: `null` = cancelled, `ColorPickerResult(color: null)` = cleared ("Use theme color" / "No color"), else the picked color.
  - `colorPickerPresets` + `hexFromColor()` exported for reuse (editor chips use the same set/format).
- **`native/lib/ui/profile_editor.dart`:** the bare color hex TextField becomes a color section — 48dp swatch button opening the shared picker, the hex field retained (same `profile-editor-color` key + controller, so the save path and all existing tests are untouched), and one-tap preset chips with a selection ring. Persistence is the existing `SavedProfile.color` path — no storage change.

## Dependency decision

**Hand-rolled HSV panel, no new dependency.** flex_color_picker is pure Dart (gradle-safe) but drags flex_seed_scheme plus a large unused API surface and adds lockfile-drift risk against the pinned compileSdk-36 toolchain (file_picker precedent); the minimal SV-square + hue-slider panel is ~150 lines and gives exact control over thumb-friendly target sizes (owner is visually impaired, phone-first). No pubspec change at all.

## Notes

- No preset swatch set existed in native before this (the editor was a bare hex field; the PWA uses `<input type=color>`) — `colorPickerPresets` (8 mutually-distinguishable colors legible on dark+light) becomes the canonical quick-swatch set for editor chips, picker presets, and #1031.
- Monochrome-glyph rule applies to icons only (check/palette glyphs are Material + currentColor); the swatch colors are user content.
- Does not touch `native/lib/state` pattern-style store or `ghostty_terminal_decorators.dart` (parallel #1031 agent surface).

## Tests

- TDD red→green. `native/test/widget/color_picker_sheet_test.dart` (13 tests): hex round-trip, `#` optional, invalid-hex inline error + disabled Apply, preset tap, SV-square tap, hue-slider tap, clear-vs-cancel sheet contract, ≥44dp touch targets.
- `native/test/widget/profile_editor_color_picker_test.dart` (4 tests): preset chip → Save persists colorHex; picker Apply → Save persists; picker Clear → color null.
- `native/integration_test/profile_color_picker_1030_test.dart` (emulator): editor → picker → real-gesture SV/hue taps → hex `#ff3366` → Apply → Save & connect → session-bar swatch renders the picked color end-to-end. Includes a screenshot hold window (`PICKER1030_SHOT_WINDOW_OPEN`).
- `scripts/native-fast-gate.sh` PASSED (analyze clean, 1872 tests).
- Emulator run PASSED (`scripts/native-connect-test.sh integration_test/profile_color_picker_1030_test.dart` — `All tests passed!`). Two cycles: run 1 caught a real device-only bug — the hex-field focus raises the soft keyboard, which occluded the Apply row (tap no longer hit-tested); the test now dismisses the keyboard + `ensureVisible` before tapping. Run 1's shot also showed the clear-action label ellipsizing on 360dp → shortened to "No color".
- Screenshot of the open picker, reviewed (all targets thumb-sized, one screen, label untruncated): `test-results/emulator-shots/20260710T141843+0000-picker-1030-final_.png`

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa