### PR TITLE
#1031 slice 2 — Detection Lab UI

### DIFF
--- a/native/integration_test/detection_lab_1031_test.dart
+++ b/native/integration_test/detection_lab_1031_test.dart
@@ -1,0 +1,236 @@
+// On-emulator PROOF for #1031 slice 2 — the Detection Lab tunes a LIVE
+// session's affordances.
+//
+// Flow: connect to test-sshd, print a URL line, wait for its anchor. Open the
+// session menu and LONG-PRESS the detection glyph (review change 7 shortcut)
+// → the lab root. Open the URL detail: assert the review's gating (no active
+// preview/slider for url). Pick the red preset via the shared #1030 picker +
+// drag the detected-intensity slider up, then pop back to the terminal and
+// assert the LIVE bubble painter now fills the red hue at a stronger-than-
+// shipped alpha (the slice-1 provider→resolver wiring, no reconnect).
+//
+// Screenshot windows (the orchestrator runs `scripts/emu-shot.sh <label>`
+// while each marker window is open — the PNGs are reviewed for phone-density
+// scanability):
+//   LAB1031_SHOT_ROOT_OPEN    — lab root (cards + mini previews)
+//   LAB1031_SHOT_DETAIL_OPEN  — url detail (pinned preview, recolored)
+//   LAB1031_SHOT_SESSION_OPEN — the live session with the recolored wash/chip
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/detection_lab_1031_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/detection_style_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+Future<void> _shotWindow(
+  WidgetTester tester,
+  String label, {
+  // Generous: the orchestrator's marker→emu-shot latency ran ~10-15s on the
+  // first pass, which pushed every shot one stage late.
+  int halfSeconds = 60,
+}) async {
+  debugPrint('LAB1031_SHOT_${label}_OPEN');
+  for (var i = 0; i < halfSeconds; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+  debugPrint('LAB1031_SHOT_${label}_CLOSED');
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'lab recolors a live session URL wash/chip immediately (#1031 slice 2)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller');
+
+      // Wait for a live shell, then print a URL line.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      const url = 'https://example.com/lab/recolor';
+      entry.proxy.sendInput(
+        Uint8List.fromList(utf8.encode('echo LAB1031 $url\n')),
+      );
+      bool urlDetected() => controller!.anchors.any(
+        (a) => a.patternId == 'url' && a.payload == url,
+      );
+      for (var i = 0; i < 40 && !urlDetected(); i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(urlDetected(), isTrue, reason: 'URL anchor never appeared');
+
+      // Review change 7: session menu → LONG-PRESS the detection glyph → lab.
+      await tester.tap(find.byKey(const Key('session-menu-button')));
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      await tester.longPress(
+        find.byKey(const Key('session-menu-detection-toggle')),
+      );
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(
+        find.byKey(const Key('lab-card-url')),
+        findsOneWidget,
+        reason: 'long-press must open the lab root',
+      );
+
+      await _shotWindow(tester, 'ROOT');
+
+      // URL detail page.
+      await tester.tap(find.byKey(const Key('lab-card-tile-url')));
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(
+        find.byKey(const Key('lab-detail-preview-detected')),
+        findsOneWidget,
+      );
+      // Review change 1: no dead active controls for url.
+      expect(find.byKey(const Key('lab-detail-preview-active')), findsNothing);
+      expect(find.byKey(const Key('lab-active-slider')), findsNothing);
+
+      // Recolor: shared #1030 picker, red preset, Apply.
+      await tester.tap(find.byKey(const Key('lab-color-row')));
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      await tester.tap(find.byKey(const Key('color-picker-preset-#e53935')));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(find.byKey(const Key('color-picker-apply')));
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      // Stronger detected intensity (drag right; the band is the slider).
+      await tester.drag(
+        find.byKey(const Key('lab-inactive-slider')),
+        const Offset(250, 0),
+      );
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      final urlStyle = container.read(detectionStylesProvider).of('url');
+      expect(urlStyle?.colorHex, '#e53935');
+      expect(urlStyle?.inactiveIntensity, isNotNull);
+      expect(urlStyle!.inactiveIntensity!, greaterThan(1.0));
+      // osc8 carries the same id-level style (one user-facing type).
+      expect(
+        container.read(detectionStylesProvider).of('osc8')?.colorHex,
+        '#e53935',
+      );
+
+      await _shotWindow(tester, 'DETAIL');
+
+      // Back to the live terminal (detail → root → terminal).
+      await tester.pageBack();
+      for (var i = 0; i < 6; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      await tester.pageBack();
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      // THE PROOF: the live bubble painter now fills the override — red hue,
+      // alpha ABOVE the shipped detected base (intensity > 1) — with no
+      // reconnect and no manual refresh (slice-1 provider→resolver wiring).
+      final paintFinder = find.byKey(const Key('ghostty-bubble-paint'));
+      for (var i = 0; i < 20 && paintFinder.evaluate().isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(paintFinder, findsOneWidget, reason: 'bubble layer not painting');
+      final painter =
+          tester.widget<CustomPaint>(paintFinder).painter!
+              as GhosttyBubblePainter;
+      expect(painter.specs, isNotEmpty);
+      final wash = painter.effectiveWashColor(painter.specs.first);
+      expect(
+        wash.r > wash.g && wash.r > wash.b,
+        isTrue,
+        reason: 'wash must carry the red override hue, got $wash',
+      );
+      final baseDetectedAlpha = ghosttyBubbleWashColor(
+        const Color(0xFFE53935),
+        verified: false,
+        backgroundBrightness: painter.backgroundBrightness,
+      ).a;
+      expect(
+        wash.a,
+        greaterThan(baseDetectedAlpha),
+        reason: 'intensity > 1 must scale the wash alpha up',
+      );
+
+      await _shotWindow(tester, 'SESSION');
+    },
+  );
+}

--- a/native/lib/state/detection_style_providers.dart
+++ b/native/lib/state/detection_style_providers.dart
@@ -81,6 +81,8 @@ class DetectionStylesNotifier extends StateNotifier<DetectionStyles> {
       colorHex: colorHex,
       inactiveIntensity: c.inactiveIntensity,
       activeIntensity: c.activeIntensity,
+      verifyShortPaths: c.verifyShortPaths,
+      lexicon: c.lexicon,
     ),
   );
 
@@ -92,6 +94,8 @@ class DetectionStylesNotifier extends StateNotifier<DetectionStyles> {
           colorHex: c.colorHex,
           inactiveIntensity: value,
           activeIntensity: c.activeIntensity,
+          verifyShortPaths: c.verifyShortPaths,
+          lexicon: c.lexicon,
         ),
       );
 
@@ -104,6 +108,34 @@ class DetectionStylesNotifier extends StateNotifier<DetectionStyles> {
       colorHex: c.colorHex,
       inactiveIntensity: c.inactiveIntensity,
       activeIntensity: value,
+      verifyShortPaths: c.verifyShortPaths,
+      lexicon: c.lexicon,
+    ),
+  );
+
+  /// Set (or clear, with null) the short-path verification gate (#1031 slice
+  /// 2 behavior knob, paths only — null = the shipped #990 default, true).
+  Future<void> setVerifyShortPaths(String patternId, bool? value) => _update(
+    patternId,
+    (c) => DetectionPatternStyle(
+      colorHex: c.colorHex,
+      inactiveIntensity: c.inactiveIntensity,
+      activeIntensity: c.activeIntensity,
+      verifyShortPaths: value,
+      lexicon: c.lexicon,
+    ),
+  );
+
+  /// Set (or clear, with null) the command lexicon override (#1031 slice 2
+  /// behavior knob, command pattern only — null = `kDefaultCommandLexicon`).
+  Future<void> setLexicon(String patternId, List<String>? value) => _update(
+    patternId,
+    (c) => DetectionPatternStyle(
+      colorHex: c.colorHex,
+      inactiveIntensity: c.inactiveIntensity,
+      activeIntensity: c.activeIntensity,
+      verifyShortPaths: c.verifyShortPaths,
+      lexicon: value == null ? null : List<String>.unmodifiable(value),
     ),
   );
 

--- a/native/lib/storage/detection_styles_store.dart
+++ b/native/lib/storage/detection_styles_store.dart
@@ -51,6 +51,8 @@ class DetectionPatternStyle {
     this.colorHex,
     this.inactiveIntensity,
     this.activeIntensity,
+    this.verifyShortPaths,
+    this.lexicon,
   });
 
   /// `#RRGGBB` hue override, or null to follow the session accent.
@@ -62,31 +64,68 @@ class DetectionPatternStyle {
   /// Multiplier on the ACTIVE (verified) wash alpha, or null for 1.0.
   final double? activeIntensity;
 
+  /// #1031 slice 2 BEHAVIOR knob (paths only): gate low-confidence
+  /// single-segment path matches behind SFTP verification (#990). Null =
+  /// shipped default (true). Stored per pattern id like every other TUNED
+  /// value — the IA's documented growth path (knobs inside the styles record,
+  /// so resets come free).
+  final bool? verifyShortPaths;
+
+  /// #1031 slice 2 BEHAVIOR knob (command pattern only): the app-supplied
+  /// command lexicon fed to `TextPattern.command(lexicon:)`. Null = shipped
+  /// default (`kDefaultCommandLexicon`).
+  final List<String>? lexicon;
+
   /// True when every field is absent — no override at all (such a style is
   /// never persisted; setting it removes the entry).
   bool get isEmpty =>
-      colorHex == null && inactiveIntensity == null && activeIntensity == null;
+      colorHex == null &&
+      inactiveIntensity == null &&
+      activeIntensity == null &&
+      verifyShortPaths == null &&
+      lexicon == null;
 
   Map<String, dynamic> toJson() => <String, dynamic>{
     if (colorHex != null) 'color': colorHex,
     if (inactiveIntensity != null) 'inactive': inactiveIntensity,
     if (activeIntensity != null) 'active': activeIntensity,
+    if (verifyShortPaths != null) 'verify': verifyShortPaths,
+    if (lexicon != null) 'lexicon': lexicon,
   };
 
   /// Parse one stored record, field-by-field: a wrong-typed field is dropped
   /// (falls back to absent), a non-map or all-invalid record returns null so
-  /// the caller drops the entry entirely. Never throws.
+  /// the caller drops the entry entirely. A lexicon with any non-string entry
+  /// is dropped whole (a partial lexicon would silently change detection).
+  /// Never throws.
   static DetectionPatternStyle? fromJson(Object? raw) {
     if (raw is! Map) return null;
     final color = raw['color'];
     final inactive = raw['inactive'];
     final active = raw['active'];
+    final verify = raw['verify'];
+    final lexiconRaw = raw['lexicon'];
+    List<String>? lexicon;
+    if (lexiconRaw is List && lexiconRaw.every((e) => e is String)) {
+      lexicon = List<String>.unmodifiable(lexiconRaw.cast<String>());
+    }
     final style = DetectionPatternStyle(
       colorHex: color is String && color.isNotEmpty ? color : null,
       inactiveIntensity: inactive is num ? inactive.toDouble() : null,
       activeIntensity: active is num ? active.toDouble() : null,
+      verifyShortPaths: verify is bool ? verify : null,
+      lexicon: lexicon,
     );
     return style.isEmpty ? null : style;
+  }
+
+  static bool _lexiconEquals(List<String>? a, List<String>? b) {
+    if (identical(a, b)) return true;
+    if (a == null || b == null || a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 
   @override
@@ -94,15 +133,23 @@ class DetectionPatternStyle {
       other is DetectionPatternStyle &&
       other.colorHex == colorHex &&
       other.inactiveIntensity == inactiveIntensity &&
-      other.activeIntensity == activeIntensity;
+      other.activeIntensity == activeIntensity &&
+      other.verifyShortPaths == verifyShortPaths &&
+      _lexiconEquals(other.lexicon, lexicon);
 
   @override
-  int get hashCode => Object.hash(colorHex, inactiveIntensity, activeIntensity);
+  int get hashCode => Object.hash(
+    colorHex,
+    inactiveIntensity,
+    activeIntensity,
+    verifyShortPaths,
+    lexicon == null ? null : Object.hashAll(lexicon!),
+  );
 
   @override
   String toString() =>
       'DetectionPatternStyle(color:$colorHex, inactive:$inactiveIntensity, '
-      'active:$activeIntensity)';
+      'active:$activeIntensity, verify:$verifyShortPaths, lexicon:$lexicon)';
 }
 
 /// The immutable set of stored overrides, keyed by pattern id. This is the

--- a/native/lib/ui/detection_lab_detail_screen.dart
+++ b/native/lib/ui/detection_lab_detail_screen.dart
@@ -1,0 +1,568 @@
+// Detection Lab per-pattern DETAIL page (#1031 slice 2).
+//
+// Anatomy per the reviewed IA:
+//   - enable switch in the app bar (always visible, biggest target — the same
+//     detectionSettingsProvider bit as Settings/root),
+//   - the preview block PINNED under the app bar (review change 3: it must
+//     never scroll away during a slider drag — it sits OUTSIDE the scrolling
+//     controls list), labeled with its theme source (review change 2) and a
+//     dark/light luminance override,
+//   - states rendered HONESTLY (review change 1): "Detected" always; "Active
+//     (verified)" ONLY where a real runtime active state exists (paths, #990),
+//   - STYLE: color row (shared #1030 picker; cleared = session theme) +
+//     intensity slider(s) whose min/max ARE the legibility band, the path pair
+//     push-clamped so Active never inverts under Detected (review change 6),
+//   - BEHAVIOR: only knobs that are REAL today (path verification gate,
+//     command lexicon editor) — no disabled "coming" rows (review change 1),
+//   - "Reset this pattern" at the BOTTOM behind a confirm (review change 4).
+//
+// The URL page writes id-level style to BOTH `url` and `osc8` (one
+// user-facing type; reads resolve against the primary `url` id).
+
+import 'package:flterm/flterm.dart' show kDefaultCommandLexicon;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/detection_providers.dart';
+import '../state/detection_style_providers.dart';
+import '../storage/detection_styles_store.dart';
+import 'color_picker_sheet.dart';
+import 'detection_lab_preview.dart';
+import 'detection_style_resolver.dart';
+import 'settings_subheader.dart';
+
+class DetectionLabDetailScreen extends ConsumerStatefulWidget {
+  const DetectionLabDetailScreen({super.key, required this.spec});
+
+  final DetectionLabPatternSpec spec;
+
+  @override
+  ConsumerState<DetectionLabDetailScreen> createState() =>
+      _DetectionLabDetailScreenState();
+}
+
+class _DetectionLabDetailScreenState
+    extends ConsumerState<DetectionLabDetailScreen> {
+  DetectionLabPatternSpec get spec => widget.spec;
+
+  /// Luminance override for the preview strip (null = follow the theme).
+  Brightness? _luminance;
+
+  /// In-flight slider values: the preview renders these live during a drag;
+  /// the store is written once on release (avoids racing per-tick persists).
+  double? _draftInactive;
+  double? _draftActive;
+
+  /// The stored styles with the in-flight drafts merged over this pattern's
+  /// ids — what the pinned preview resolves against mid-drag.
+  DetectionStyles _mergeDrafts(DetectionStyles base) {
+    if (_draftInactive == null && _draftActive == null) return base;
+    final map = Map<String, DetectionPatternStyle>.from(base.byPattern);
+    for (final id in spec.styleIds) {
+      final cur = base.of(id) ?? const DetectionPatternStyle();
+      map[id] = DetectionPatternStyle(
+        colorHex: cur.colorHex,
+        inactiveIntensity: _draftInactive ?? cur.inactiveIntensity,
+        activeIntensity: _draftActive ?? cur.activeIntensity,
+        verifyShortPaths: cur.verifyShortPaths,
+        lexicon: cur.lexicon,
+      );
+    }
+    return DetectionStyles(map);
+  }
+
+  double _clampBand(double v) =>
+      v.clamp(kDetectionIntensityMin, kDetectionIntensityMax);
+
+  void _onInactiveChanged(double v, DetectionPatternStyle? stored) {
+    if (spec.hasActiveState) {
+      final pair = detectionResolveIntensityPair(
+        inactive: v,
+        active: _draftActive ?? stored?.activeIntensity ?? 1.0,
+        activeDragged: false,
+      );
+      setState(() {
+        _draftInactive = pair.inactive;
+        _draftActive = pair.active;
+      });
+    } else {
+      setState(() => _draftInactive = _clampBand(v));
+    }
+  }
+
+  void _onActiveChanged(double v, DetectionPatternStyle? stored) {
+    final pair = detectionResolveIntensityPair(
+      inactive: _draftInactive ?? stored?.inactiveIntensity ?? 1.0,
+      active: v,
+      activeDragged: true,
+    );
+    setState(() {
+      _draftInactive = pair.inactive;
+      _draftActive = pair.active;
+    });
+  }
+
+  /// Write the drafts through the store on slider release — the runtime
+  /// affordances re-resolve immediately via the slice-1 provider watch.
+  Future<void> _commitIntensities() async {
+    final notifier = ref.read(detectionStylesProvider.notifier);
+    final inactive = _draftInactive;
+    final active = _draftActive;
+    for (final id in spec.styleIds) {
+      if (inactive != null) await notifier.setInactiveIntensity(id, inactive);
+      if (active != null && spec.hasActiveState) {
+        await notifier.setActiveIntensity(id, active);
+      }
+    }
+    if (mounted) {
+      setState(() {
+        _draftInactive = null;
+        _draftActive = null;
+      });
+    }
+  }
+
+  Future<void> _pickColor(Color effectiveAccent) async {
+    final notifier = ref.read(detectionStylesProvider.notifier);
+    final stored = ref.read(detectionStylesProvider).of(spec.primaryId);
+    final result = await showColorPickerSheet(
+      context,
+      initial: detectionColorFromHex(stored?.colorHex) ?? effectiveAccent,
+      title: '${spec.title}: highlight color',
+      clearLabel: 'Use theme color',
+      previewLabel: spec.sampleMatch,
+    );
+    if (result == null) return; // cancelled
+    final hex = result.color == null ? null : hexFromColor(result.color!);
+    for (final id in spec.styleIds) {
+      await notifier.setColorHex(id, hex);
+    }
+  }
+
+  Future<void> _confirmResetPattern() async {
+    final notifier = ref.read(detectionStylesProvider.notifier);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        key: const ValueKey('lab-reset-pattern-dialog'),
+        title: Text('Reset ${spec.title}?'),
+        content: const Text(
+          'Restore this pattern\'s color, intensity, and behavior to the '
+          'shipped defaults. The on/off switch and your saved detection '
+          'exceptions are not affected.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const ValueKey('lab-reset-pattern-confirm'),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Reset'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    for (final id in spec.styleIds) {
+      await notifier.resetPattern(id);
+    }
+  }
+
+  Future<void> _openLexiconEditor() {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => _LexiconEditorSheet(spec: spec),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final detection = ref.watch(detectionSettingsProvider);
+    final styles = ref.watch(detectionStylesProvider);
+    final stored = styles.of(spec.primaryId);
+    final preview = detectionLabPreviewTheme(ref, luminanceOverride: _luminance);
+    final resolver = DetectionStyleResolver(
+      styles: _mergeDrafts(styles),
+      accent: preview.accent,
+      backgroundBrightness: preview.brightness,
+    );
+    final enabled = detectionLabTypeEnabled(detection, spec.key);
+    final inactiveValue =
+        _clampBand(_draftInactive ?? stored?.inactiveIntensity ?? 1.0);
+    final activeValue =
+        _clampBand(_draftActive ?? stored?.activeIntensity ?? 1.0);
+    final effectiveLexicon = stored?.lexicon ?? kDefaultCommandLexicon;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(spec.title),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Switch(
+              key: const ValueKey('lab-detail-enable'),
+              value: enabled,
+              onChanged: detection.enabled
+                  ? (v) => detectionLabSetTypeEnabled(ref, spec.key, v)
+                  : null,
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // PINNED preview (review change 3): lives OUTSIDE the scrolling
+            // controls list so a slider drag / keyboard can never push it
+            // off-screen.
+            Material(
+              key: const ValueKey('lab-detail-preview'),
+              elevation: 1,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            preview.sourceLabel,
+                            key: const ValueKey('lab-preview-source'),
+                            style: theme.textTheme.bodySmall,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        SegmentedButton<Brightness>(
+                          key: const ValueKey('lab-preview-luminance'),
+                          showSelectedIcon: false,
+                          style: const ButtonStyle(
+                            visualDensity: VisualDensity.compact,
+                          ),
+                          segments: const [
+                            ButtonSegment(
+                              value: Brightness.dark,
+                              icon: Icon(Icons.dark_mode_outlined),
+                              tooltip: 'Preview on a dark terminal',
+                            ),
+                            ButtonSegment(
+                              value: Brightness.light,
+                              icon: Icon(Icons.light_mode_outlined),
+                              tooltip: 'Preview on a light terminal',
+                            ),
+                          ],
+                          selected: {preview.brightness},
+                          onSelectionChanged: (sel) =>
+                              setState(() => _luminance = sel.first),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          DetectionPreviewLine(
+                            key: const ValueKey('lab-detail-preview-detected'),
+                            spec: spec,
+                            resolver: resolver,
+                            background: preview.background,
+                            foreground: preview.foreground,
+                            stateLabel: 'Detected',
+                          ),
+                          // Review change 1: the active state renders ONLY
+                          // where it exists at runtime (verified paths, #990).
+                          if (spec.hasActiveState)
+                            DetectionPreviewLine(
+                              key: const ValueKey('lab-detail-preview-active'),
+                              spec: spec,
+                              resolver: resolver,
+                              background: preview.background,
+                              foreground: preview.foreground,
+                              verified: true,
+                              stateLabel: 'Active (verified)',
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                key: const ValueKey('lab-detail-controls'),
+                padding: const EdgeInsets.only(bottom: 8),
+                children: [
+                  const SettingsSubheader('Style'),
+                  ListTile(
+                    key: const ValueKey('lab-color-row'),
+                    leading: const Icon(Icons.palette_outlined),
+                    title: const Text('Highlight color'),
+                    subtitle: Text(
+                      stored?.colorHex == null
+                          ? 'Session theme'
+                          : stored!.colorHex!,
+                    ),
+                    trailing: Container(
+                      width: 28,
+                      height: 28,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: resolver
+                            .resolveStyle(spec.primaryId, verified: false)
+                            .chipAccent
+                            .withValues(alpha: 1.0),
+                        border: Border.all(
+                          color: theme.colorScheme.outlineVariant,
+                        ),
+                      ),
+                    ),
+                    onTap: () => _pickColor(preview.accent),
+                  ),
+                  const ListTile(
+                    key: ValueKey('lab-inactive-title'),
+                    title: Text('Detected intensity'),
+                    dense: true,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Slider(
+                      key: const ValueKey('lab-inactive-slider'),
+                      // Review change 6: the band IS the slider — every
+                      // position changes something visible; no numeric
+                      // multiplier (the pinned preview is the value).
+                      min: kDetectionIntensityMin,
+                      max: kDetectionIntensityMax,
+                      value: inactiveValue,
+                      onChanged: (v) => _onInactiveChanged(v, stored),
+                      onChangeEnd: (_) => _commitIntensities(),
+                    ),
+                  ),
+                  if (spec.hasActiveState) ...[
+                    const ListTile(
+                      key: ValueKey('lab-active-title'),
+                      title: Text('Active intensity (verified)'),
+                      dense: true,
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Slider(
+                        key: const ValueKey('lab-active-slider'),
+                        min: kDetectionIntensityMin,
+                        max: kDetectionIntensityMax,
+                        value: activeValue,
+                        onChanged: (v) => _onActiveChanged(v, stored),
+                        onChangeEnd: (_) => _commitIntensities(),
+                      ),
+                    ),
+                  ],
+                  // BEHAVIOR: only knobs that are REAL today (review change
+                  // 1). URLs have none → no section at all.
+                  if (spec.key == 'path' || spec.key == 'command')
+                    const SettingsSubheader('Behavior'),
+                  if (spec.key == 'path')
+                    SwitchListTile(
+                      key: const ValueKey('lab-verify-toggle'),
+                      secondary: const Icon(Icons.verified_outlined),
+                      title: const Text('Short-path verification'),
+                      subtitle: const Text(
+                        'Hide one-segment paths (like /config) until SFTP '
+                        'confirms they exist on the host.',
+                      ),
+                      value: stored?.verifyShortPaths ?? true,
+                      onChanged: (v) => ref
+                          .read(detectionStylesProvider.notifier)
+                          // ON is the shipped default → store nothing.
+                          .setVerifyShortPaths(
+                            spec.primaryId,
+                            v ? null : false,
+                          ),
+                    ),
+                  if (spec.key == 'command')
+                    ListTile(
+                      key: const ValueKey('lab-lexicon-row'),
+                      leading: const Icon(Icons.menu_book_outlined),
+                      title: const Text('Command lexicon'),
+                      subtitle: Text(
+                        '${effectiveLexicon.length} words — a first token on '
+                        'this list scores as a command.',
+                      ),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: _openLexiconEditor,
+                    ),
+                  const SizedBox(height: 24),
+                  // Review change 4: per-pattern reset at the page BOTTOM.
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: OutlinedButton.icon(
+                      key: const ValueKey('lab-reset-pattern-button'),
+                      onPressed: _confirmResetPattern,
+                      icon: const Icon(Icons.restart_alt),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: theme.colorScheme.error,
+                      ),
+                      label: const Text('Reset this pattern'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The command-lexicon editor sheet: add a word, remove a word (chip delete),
+/// or restore the app-supplied default list (clears the stored override).
+class _LexiconEditorSheet extends ConsumerStatefulWidget {
+  const _LexiconEditorSheet({required this.spec});
+
+  final DetectionLabPatternSpec spec;
+
+  @override
+  ConsumerState<_LexiconEditorSheet> createState() =>
+      _LexiconEditorSheetState();
+}
+
+class _LexiconEditorSheetState extends ConsumerState<_LexiconEditorSheet> {
+  final TextEditingController _addCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _addCtrl.dispose();
+    super.dispose();
+  }
+
+  List<String> get _effective =>
+      ref.read(detectionStylesProvider).of(widget.spec.primaryId)?.lexicon ??
+      kDefaultCommandLexicon;
+
+  Future<void> _add() async {
+    final word = _addCtrl.text.trim();
+    _addCtrl.clear();
+    if (word.isEmpty) return;
+    final current = _effective;
+    if (current.contains(word)) return;
+    await ref
+        .read(detectionStylesProvider.notifier)
+        .setLexicon(widget.spec.primaryId, [...current, word]);
+  }
+
+  Future<void> _remove(String word) async {
+    await ref.read(detectionStylesProvider.notifier).setLexicon(
+          widget.spec.primaryId,
+          [..._effective]..remove(word),
+        );
+  }
+
+  Future<void> _restoreDefault() async {
+    await ref
+        .read(detectionStylesProvider.notifier)
+        .setLexicon(widget.spec.primaryId, null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final stored = ref
+        .watch(detectionPatternStyleProvider(widget.spec.primaryId))
+        ?.lexicon;
+    final effective = stored ?? kDefaultCommandLexicon;
+    return Padding(
+      // Keep the add field above the soft keyboard.
+      padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
+      child: SafeArea(
+        child: Column(
+          key: const ValueKey('lab-lexicon-editor'),
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Command lexicon',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  Text(
+                    stored == null
+                        ? '${effective.length} words (default list)'
+                        : '${effective.length} words (customized)',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          key: const ValueKey('lab-lexicon-add-field'),
+                          controller: _addCtrl,
+                          autocorrect: false,
+                          enableSuggestions: false,
+                          decoration: const InputDecoration(
+                            labelText: 'Add a word',
+                            hintText: 'kubectl',
+                            border: OutlineInputBorder(),
+                            isDense: true,
+                          ),
+                          onSubmitted: (_) => _add(),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      FilledButton(
+                        key: const ValueKey('lab-lexicon-add-button'),
+                        onPressed: _add,
+                        child: const Text('Add'),
+                      ),
+                    ],
+                  ),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton.icon(
+                      key: const ValueKey('lab-lexicon-restore-default'),
+                      onPressed: _restoreDefault,
+                      icon: const Icon(Icons.restart_alt),
+                      label: const Text('Restore default list'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final word in effective)
+                      InputChip(
+                        key: ValueKey('lab-lexicon-chip-$word'),
+                        label: Text(word),
+                        // Explicit glyph (M3 defaults to clear) so tests and
+                        // the monochrome-icon rule stay stable.
+                        deleteIcon: const Icon(Icons.cancel),
+                        onDeleted: () => _remove(word),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/native/lib/ui/detection_lab_preview.dart
+++ b/native/lib/ui/detection_lab_preview.dart
@@ -1,0 +1,325 @@
+// Detection Lab preview primitives (#1031 slice 2).
+//
+// [detectionLabPatternSpecs] is the lab's pattern registry: one entry per
+// user-facing built-in type (url covers BOTH the regex `url` and `osc8` ids —
+// one toggle gates both and they share id-level style, per the IA). Slice 3
+// appends `custom.<slug>` entries here.
+//
+// [DetectionPreviewLine] renders one sample terminal line with the REAL
+// affordance code — the wash via [GhosttyBubblePainter] fed by the SAME
+// [DetectionStyleResolver] the runtime layers consult, and the chip via the
+// shared [GutterMarkChip] — over a terminal-colored strip. No parallel
+// preview styling exists (IA: preview trust — the preview IS the value).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/detection_providers.dart';
+import '../state/sessions.dart';
+import '../state/ui_prefs_providers.dart';
+import 'detection_style_resolver.dart';
+import 'ghostty_gutter_layer.dart';
+import 'ghostty_terminal_decorators.dart';
+
+/// One lab pattern: identity, labels, sample line, and which stored style ids
+/// it tunes.
+@immutable
+class DetectionLabPatternSpec {
+  const DetectionLabPatternSpec({
+    required this.key,
+    required this.title,
+    required this.icon,
+    required this.styleIds,
+    required this.samplePrefix,
+    required this.sampleMatch,
+    required this.bubble,
+  });
+
+  /// Stable lab key (`url` / `path` / `command`) used in widget keys.
+  final String key;
+
+  /// Front-loaded display name ("URLs", "File paths", "Command lines").
+  final String title;
+
+  /// Monochrome Material glyph — the same one the gutter/Settings use.
+  final IconData icon;
+
+  /// The pattern ids this entry's tuning writes. The URL entry carries BOTH
+  /// `url` and `osc8` (one user-facing type, id-level style kept in lockstep).
+  final List<String> styleIds;
+
+  /// Sample-line text before the match (plain terminal ink).
+  final String samplePrefix;
+
+  /// The matched sample text the wash/chip decorate.
+  final String sampleMatch;
+
+  /// Whether this pattern paints an inline bubble wash. The command pattern
+  /// is GUTTER-ONLY (#998 C) — its preview honestly shows chip-only.
+  final bool bubble;
+
+  /// The id style reads resolve against (the first style id).
+  String get primaryId => styleIds.first;
+
+  /// Whether a REAL active (verified) state exists at runtime today — the
+  /// review's change 1 gate: no controls for a state with no runtime effect.
+  bool get hasActiveState => detectionPatternHasActiveState(primaryId);
+}
+
+/// The lab's built-in pattern registry (root cards render one card per entry).
+const List<DetectionLabPatternSpec> detectionLabPatternSpecs = [
+  DetectionLabPatternSpec(
+    key: 'url',
+    title: 'URLs',
+    icon: Icons.link_outlined,
+    styleIds: [kGhosttyUrlPatternId, kGhosttyOsc8PatternId],
+    samplePrefix: 'visit ',
+    sampleMatch: 'https://example.com/docs',
+    bubble: true,
+  ),
+  DetectionLabPatternSpec(
+    key: 'path',
+    title: 'File paths',
+    icon: Icons.folder_outlined,
+    styleIds: [kGhosttyPathPatternId],
+    samplePrefix: 'see ',
+    sampleMatch: '/etc/ssh/sshd_config',
+    bubble: true,
+  ),
+  DetectionLabPatternSpec(
+    key: 'command',
+    title: 'Command lines',
+    icon: Icons.terminal,
+    styleIds: [kGhosttyCommandPatternId],
+    samplePrefix: r'$ ',
+    sampleMatch: 'curl -sL setup.sh | bash',
+    bubble: false,
+  ),
+];
+
+/// Lookup by lab key. Throws on an unknown key (a programming error).
+DetectionLabPatternSpec detectionLabPatternSpec(String key) =>
+    detectionLabPatternSpecs.firstWhere((s) => s.key == key);
+
+/// Whether [key]'s pattern type is enabled in [d] — the SAME provider bits the
+/// Settings toggles flip (one bit, three surfaces).
+bool detectionLabTypeEnabled(DetectionSettings d, String key) => switch (key) {
+  'url' => d.url,
+  'path' => d.path,
+  'command' => d.command,
+  _ => false,
+};
+
+/// Flip [key]'s pattern type via the existing detection-settings notifier.
+Future<void> detectionLabSetTypeEnabled(WidgetRef ref, String key, bool v) {
+  final n = ref.read(detectionSettingsProvider.notifier);
+  return switch (key) {
+    'url' => n.setUrl(v),
+    'path' => n.setPath(v),
+    'command' => n.setCommand(v),
+    _ => Future<void>.value(),
+  };
+}
+
+/// The preview strip's theme inputs (#1031 IA review change 2: the preview
+/// must SAY which theme it renders against, or it can lie).
+@immutable
+class DetectionLabPreviewTheme {
+  const DetectionLabPreviewTheme({
+    required this.sourceLabel,
+    required this.accent,
+    required this.background,
+    required this.foreground,
+    required this.brightness,
+  });
+
+  /// Front-loaded provenance line ("Previewing: Dark (active session)").
+  final String sourceLabel;
+
+  /// The accent the resolver falls back to (`palette.theme.selection`).
+  final Color accent;
+
+  final Color background;
+  final Color foreground;
+
+  /// The strip's effective luminance (drives the #1000 wash alphas).
+  final Brightness brightness;
+}
+
+/// Neutral terminal strips for the luminance override — used only when the
+/// user flips the preview AWAY from the live theme's own brightness (the
+/// theme's real colors can't honestly render the other luminance).
+const Color _kNeutralDarkBackground = Color(0xFF14181C);
+const Color _kNeutralDarkForeground = Color(0xFFE0E0E0);
+const Color _kNeutralLightBackground = Color(0xFFF6F6F2);
+const Color _kNeutralLightForeground = Color(0xFF202020);
+
+/// Resolve the preview theme: the FRONT (active) session's live palette when
+/// one exists, else the app default theme — labeled either way (review change
+/// 2). [luminanceOverride] flips the strip's brightness from that baseline
+/// (the `[dark|light]` chip); when it flips AWAY from the theme's own
+/// brightness the strip renders neutral colors of the requested luminance,
+/// keeping the accent (which is what the overrides tune against).
+DetectionLabPreviewTheme detectionLabPreviewTheme(
+  WidgetRef ref, {
+  Brightness? luminanceOverride,
+}) {
+  final named = ref.watch(activeSessionThemeProvider);
+  final hasSession = ref.watch(activeSessionIdProvider) != null;
+  var background = named.theme.background;
+  var foreground = named.theme.foreground;
+  final base = ThemeData.estimateBrightnessForColor(background);
+  final effective = luminanceOverride ?? base;
+  if (effective != base) {
+    background = effective == Brightness.dark
+        ? _kNeutralDarkBackground
+        : _kNeutralLightBackground;
+    foreground = effective == Brightness.dark
+        ? _kNeutralDarkForeground
+        : _kNeutralLightForeground;
+  }
+  return DetectionLabPreviewTheme(
+    sourceLabel: hasSession
+        ? 'Previewing: ${named.label} (active session)'
+        : 'Previewing: ${named.label} (default theme)',
+    accent: named.theme.selection,
+    background: background,
+    foreground: foreground,
+    brightness: effective,
+  );
+}
+
+/// One sample terminal line: prefix ink, the match under the REAL wash
+/// ([GhosttyBubblePainter] + resolver output), and the REAL gutter chip
+/// ([GutterMarkChip]) at the right edge — over a terminal-colored strip.
+class DetectionPreviewLine extends StatelessWidget {
+  const DetectionPreviewLine({
+    super.key,
+    required this.spec,
+    required this.resolver,
+    required this.background,
+    required this.foreground,
+    this.verified = false,
+    this.stateLabel,
+  });
+
+  final DetectionLabPatternSpec spec;
+
+  /// The SAME resolver type the runtime layers consult, built over the live
+  /// stored overrides + the preview's accent/luminance.
+  final DetectionStyleResolver resolver;
+
+  /// The terminal strip's background (the preview's luminance baseline).
+  final Color background;
+
+  /// Plain terminal ink for the sample text.
+  final Color foreground;
+
+  /// Render the ACTIVE (verified, #990) state: stronger wash + bold ring chip.
+  final bool verified;
+
+  /// Optional state caption above the line ("Detected" / "Active (verified)").
+  final String? stateLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolved = resolver.resolveStyle(spec.primaryId, verified: verified);
+    final chipStyle = verified ? GutterMarkStyle.bold : GutterMarkStyle.normal;
+    final textStyle = TextStyle(
+      fontFamily: 'monospace',
+      fontSize: 14,
+      color: foreground,
+    );
+
+    Widget match = Text(
+      spec.sampleMatch,
+      style: textStyle,
+      maxLines: 1,
+      softWrap: false,
+      overflow: TextOverflow.clip,
+    );
+    if (spec.bubble) {
+      // Measure the match so the REAL painter gets its exact glyph rect (the
+      // runtime feeds it anchor rects; here the sample text IS the anchor).
+      final tp = TextPainter(
+        text: TextSpan(text: spec.sampleMatch, style: textStyle),
+        textDirection: TextDirection.ltr,
+        maxLines: 1,
+      )..layout();
+      final size = tp.size;
+      tp.dispose();
+      match = SizedBox(
+        width: size.width,
+        height: size.height,
+        child: CustomPaint(
+          painter: GhosttyBubblePainter(
+            specs: [
+              GhosttyBubbleSpec(
+                segments: ghosttyBubbleSegments([
+                  Rect.fromLTWH(0, 0, size.width, size.height),
+                ]),
+                verified: verified,
+                washColor: resolved.washColor,
+              ),
+            ],
+            color: resolver.accent,
+            backgroundBrightness: resolver.backgroundBrightness,
+          ),
+          child: match,
+        ),
+      );
+    }
+
+    return Container(
+      color: background,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (stateLabel != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Text(
+                stateLabel!,
+                style: TextStyle(
+                  fontSize: 11,
+                  color: foreground.withValues(alpha: 0.7),
+                ),
+              ),
+            ),
+          Row(
+            children: [
+              // Scale the whole sample line down rather than overflow on a
+              // narrow phone — the wash stays glued to its glyphs.
+              Expanded(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        spec.samplePrefix,
+                        style: textStyle,
+                        maxLines: 1,
+                        softWrap: false,
+                      ),
+                      match,
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              GutterMarkChip(
+                style: chipStyle,
+                accent: resolved.chipAccent,
+                icon: spec.icon,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/native/lib/ui/detection_lab_screen.dart
+++ b/native/lib/ui/detection_lab_screen.dart
@@ -1,0 +1,201 @@
+// Detection Lab ROOT (#1031 slice 2) — the workbench route reached from the
+// Settings Detection row (and a session-menu detection-glyph long-press, IA
+// review change 7).
+//
+// Zone order per the reviewed IA: global (master + accent note) → one CARD per
+// built-in pattern (enable switch bound to the SAME detectionSettingsProvider
+// bit Settings flips, plus a MINI live preview rendered by the real painter/
+// chip code) → the lab-wide reset at the BOTTOM (review change 4: destructive
+// control out of the thumb-prime zone, matching the Settings Reset
+// convention). Tapping a card opens its detail page.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/detection_providers.dart';
+import '../state/detection_style_providers.dart';
+import 'detection_lab_detail_screen.dart';
+import 'detection_lab_preview.dart';
+import 'detection_style_resolver.dart';
+import 'settings_subheader.dart';
+
+export 'detection_lab_detail_screen.dart' show DetectionLabDetailScreen;
+export 'detection_lab_preview.dart'
+    show
+        DetectionLabPatternSpec,
+        DetectionPreviewLine,
+        detectionLabPatternSpec,
+        detectionLabPatternSpecs;
+
+class DetectionLabScreen extends ConsumerWidget {
+  const DetectionLabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final detection = ref.watch(detectionSettingsProvider);
+    final styles = ref.watch(detectionStylesProvider);
+    final preview = detectionLabPreviewTheme(ref);
+    // The SAME resolver the runtime layers consult — the mini previews recolor
+    // live as the store changes (slice-1 wiring).
+    final resolver = DetectionStyleResolver(
+      styles: styles,
+      accent: preview.accent,
+      backgroundBrightness: preview.brightness,
+    );
+    return Scaffold(
+      appBar: AppBar(title: const Text('Detection lab')),
+      body: SafeArea(
+        child: ListView(
+          key: const ValueKey('detection-lab-list'),
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          children: [
+            // Zone A: global. Master switch — one provider bit, three
+            // surfaces (Settings toggle / session-menu glyph / here).
+            SwitchListTile(
+              key: const ValueKey('lab-master-toggle'),
+              secondary: const Icon(Icons.search_outlined),
+              title: const Text('Detect links & paths'),
+              subtitle: const Text(
+                'Master switch — the same setting as in Settings and the '
+                'session menu.',
+              ),
+              value: detection.enabled,
+              onChanged: (v) =>
+                  ref.read(detectionSettingsProvider.notifier).setEnabled(v),
+            ),
+            ListTile(
+              key: const ValueKey('lab-accent-note'),
+              leading: const Icon(Icons.palette_outlined),
+              title: const Text('Highlight color: session theme'),
+              subtitle: const Text(
+                'Patterns follow the session accent unless a per-pattern '
+                'color below overrides it.',
+              ),
+            ),
+            const SettingsSubheader('Patterns'),
+            for (final spec in detectionLabPatternSpecs)
+              _PatternCard(
+                spec: spec,
+                detection: detection,
+                resolver: resolver,
+                preview: preview,
+              ),
+            const SizedBox(height: 24),
+            // Review change 4: the destructive lab-wide reset lives at the
+            // BOTTOM, styled like the Settings reset (outlined, error color).
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: OutlinedButton.icon(
+                key: const ValueKey('lab-reset-all-button'),
+                onPressed: () => _confirmResetAll(context, ref),
+                icon: const Icon(Icons.restart_alt),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: theme.colorScheme.error,
+                ),
+                label: const Text('Reset lab customizations'),
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmResetAll(BuildContext context, WidgetRef ref) async {
+    final notifier = ref.read(detectionStylesProvider.notifier);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        key: const ValueKey('lab-reset-all-dialog'),
+        title: const Text('Reset lab customizations?'),
+        content: const Text(
+          'Restore every pattern\'s color, intensity, and behavior to the '
+          'shipped defaults. The on/off switches and your saved detection '
+          'exceptions are not affected.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const ValueKey('lab-reset-all-confirm'),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Reset'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await notifier.clearAllTuned();
+  }
+}
+
+/// One pattern card: glyph + front-loaded name, the enable switch at the
+/// right edge (thumb zone), a mini live preview line, chevron → detail.
+class _PatternCard extends ConsumerWidget {
+  const _PatternCard({
+    required this.spec,
+    required this.detection,
+    required this.resolver,
+    required this.preview,
+  });
+
+  final DetectionLabPatternSpec spec;
+  final DetectionSettings detection;
+  final DetectionStyleResolver resolver;
+  final DetectionLabPreviewTheme preview;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enabled = detectionLabTypeEnabled(detection, spec.key);
+    return Card(
+      key: ValueKey('lab-card-${spec.key}'),
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ListTile(
+            key: ValueKey('lab-card-tile-${spec.key}'),
+            leading: Icon(spec.icon),
+            title: Text(spec.title),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Switch(
+                  key: ValueKey('lab-enable-${spec.key}'),
+                  value: enabled,
+                  // Master OFF greys the per-type switches (Settings idiom).
+                  onChanged: detection.enabled
+                      ? (v) => detectionLabSetTypeEnabled(ref, spec.key, v)
+                      : null,
+                ),
+                const Icon(Icons.chevron_right),
+              ],
+            ),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => DetectionLabDetailScreen(spec: spec),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: DetectionPreviewLine(
+                key: ValueKey('lab-preview-${spec.key}'),
+                spec: spec,
+                resolver: resolver,
+                background: preview.background,
+                foreground: preview.foreground,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/native/lib/ui/detection_style_resolver.dart
+++ b/native/lib/ui/detection_style_resolver.dart
@@ -32,6 +32,42 @@ const double kDetectionIntensityMin = 0.25;
 /// Ceiling of the intensity band — keeps glyphs legible inside the wash.
 const double kDetectionIntensityMax = 1.75;
 
+/// The MINIMUM visible margin the ACTIVE intensity keeps above the DETECTED
+/// one (#1031 IA review change 6): "detected < verified by a clearly-visible
+/// margin" (#1000) is the whole affordance grammar, so the lab's sliders may
+/// never invert it.
+const double kDetectionIntensityGap = 0.15;
+
+/// Resolve a (detected, active) intensity pair after a slider drag (#1031 IA
+/// review change 6): both values clamp into the band, then the DRAGGED value
+/// wins and PUSHES the other to preserve `active >= inactive + gap`. At the
+/// band edges the push reverses onto the dragged value (detected caps at
+/// max - gap; active floors at min + gap) so the invariant survives the
+/// extremes. Pure — unit-tested in detection_style_resolver_test.dart.
+({double inactive, double active}) detectionResolveIntensityPair({
+  required double inactive,
+  required double active,
+  required bool activeDragged,
+}) {
+  var i = inactive.clamp(kDetectionIntensityMin, kDetectionIntensityMax);
+  var a = active.clamp(kDetectionIntensityMin, kDetectionIntensityMax);
+  if (a >= i + kDetectionIntensityGap) return (inactive: i, active: a);
+  if (activeDragged) {
+    i = a - kDetectionIntensityGap;
+    if (i < kDetectionIntensityMin) {
+      i = kDetectionIntensityMin;
+      a = kDetectionIntensityMin + kDetectionIntensityGap;
+    }
+  } else {
+    a = i + kDetectionIntensityGap;
+    if (a > kDetectionIntensityMax) {
+      a = kDetectionIntensityMax;
+      i = kDetectionIntensityMax - kDetectionIntensityGap;
+    }
+  }
+  return (inactive: i, active: a);
+}
+
 /// Whether [patternId] has a REAL active state at runtime today. Per #990 the
 /// verified (active) rendering is wired for PATHS only; url/command gain a
 /// pressed state in a later slice. The lab UI reads this so it never offers a

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -684,8 +684,6 @@ class _GutterMarkState extends State<_GutterMark> {
     final style = widget.style;
     final multi = widget.anchors.length > 1;
     final single = widget.registry.forPattern(widget.anchors.first.patternId);
-    final chipFill = style.chipColor(widget.color);
-    final onChip = style.onChipColor(widget.color);
     // Centre the chip inside the visible strip (the hit box is wider).
     final inset = (widget.stripWidth - style.chipSize) / 2;
     return GestureDetector(
@@ -704,45 +702,81 @@ class _GutterMarkState extends State<_GutterMark> {
             scale: _pressed ? 0.85 : 1.0,
             duration: const Duration(milliseconds: 90),
             curve: Curves.easeOut,
-            child: Container(
-              width: style.chipSize,
-              height: style.chipSize,
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: chipFill,
-                // #990: the VERIFIED shade — a contrast ring (bold), absent on
-                // the plain detected chip.
-                border: style.ringWidth > 0
-                    ? Border.all(color: onChip, width: style.ringWidth)
-                    : null,
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.35),
-                    blurRadius: 3,
-                    offset: const Offset(0, 1),
-                  ),
-                ],
-              ),
-              child: multi
-                  ? Text(
-                      '${widget.anchors.length}',
-                      style: TextStyle(
-                        color: onChip,
-                        fontSize: style.glyphSize * 0.75,
-                        height: 1,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    )
-                  : Icon(
-                      single?.icon ?? Icons.adjust,
-                      size: style.glyphSize,
-                      color: onChip,
-                    ),
+            child: GutterMarkChip(
+              style: style,
+              accent: widget.color,
+              icon: multi ? null : (single?.icon ?? Icons.adjust),
+              count: multi ? widget.anchors.length : null,
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// The PAINTED chip: a filled opaque circle behind a monochrome glyph (or a
+/// count badge), with the #990 bold ring when [style] carries one. Extracted
+/// from the private mark so the Detection Lab preview (#1031 slice 2) renders
+/// the REAL chip — same [GutterMarkStyle] derivations, zero styling code
+/// twice. Paint only; the gutter's [_GutterMark] wraps it with the gesture +
+/// press-scale behavior.
+class GutterMarkChip extends StatelessWidget {
+  const GutterMarkChip({
+    super.key,
+    required this.style,
+    required this.accent,
+    this.icon,
+    this.count,
+  }) : assert(icon != null || count != null, 'provide an icon or a count');
+
+  /// Sizing + colour derivation ([GutterMarkStyle.normal] / [.bold]).
+  final GutterMarkStyle style;
+
+  /// The accent HUE — [GutterMarkStyle.chipColor] forces it opaque.
+  final Color accent;
+
+  /// Single-pattern glyph (null for a multi-match count chip).
+  final IconData? icon;
+
+  /// Multi-match count badge (null for a single-pattern glyph chip).
+  final int? count;
+
+  @override
+  Widget build(BuildContext context) {
+    final chipFill = style.chipColor(accent);
+    final onChip = style.onChipColor(accent);
+    return Container(
+      width: style.chipSize,
+      height: style.chipSize,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: chipFill,
+        // #990: the VERIFIED shade — a contrast ring (bold), absent on
+        // the plain detected chip.
+        border: style.ringWidth > 0
+            ? Border.all(color: onChip, width: style.ringWidth)
+            : null,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.35),
+            blurRadius: 3,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      child: count != null
+          ? Text(
+              '$count',
+              style: TextStyle(
+                color: onChip,
+                fontSize: style.glyphSize * 0.75,
+                height: 1,
+                fontWeight: FontWeight.w700,
+              ),
+            )
+          : Icon(icon, size: style.glyphSize, color: onChip),
     );
   }
 }

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -160,6 +160,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -186,6 +187,7 @@ import '../state/ctrl_modifier_provider.dart';
 import '../state/detection_exceptions_providers.dart';
 import '../state/detection_providers.dart';
 import '../state/detection_style_providers.dart';
+import '../storage/detection_styles_store.dart' show DetectionStyles;
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
@@ -1418,7 +1420,12 @@ Future<String?> ghosttyTapMatchAction(
 /// pattern (default [kDefaultCommandLexicon]). Its affordance is GUTTER-ONLY
 /// (no bubble — [kGhosttyCommandPatternId] is not a bubble pattern id) and its
 /// inner url/path/osc8 SPAN anchors coexist inside it (slice A tiering).
-List<TextPattern> ghosttyDetectionPatterns(DetectionSettings detection) => [
+/// [commandLexicon] (#1031 slice 2) is the Detection Lab's stored lexicon
+/// override; null keeps the fork's default list.
+List<TextPattern> ghosttyDetectionPatterns(
+  DetectionSettings detection, {
+  List<String>? commandLexicon,
+}) => [
   if (detection.detectUrls) ...[
     TextPattern.osc8(
       id: kGhosttyOsc8PatternId,
@@ -1427,7 +1434,11 @@ List<TextPattern> ghosttyDetectionPatterns(DetectionSettings detection) => [
     TextPattern.url(id: kGhosttyUrlPatternId, style: kGhosttyUrlHighlightStyle),
   ],
   if (detection.detectPaths) TextPattern.path(id: kGhosttyPathPatternId),
-  if (detection.detectCommands) TextPattern.command(id: kGhosttyCommandPatternId),
+  if (detection.detectCommands)
+    TextPattern.command(
+      id: kGhosttyCommandPatternId,
+      lexicon: commandLexicon ?? kDefaultCommandLexicon,
+    ),
 ];
 
 /// Map a vertical swipe DELTA (logical px the finger moved this update) to a
@@ -2843,6 +2854,14 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       return false;
     }
     if (patternId != kGhosttyPathPatternId) return true;
+    // #1031 slice 2: the lab's "Short-path verification" knob gates the #990
+    // suppression. OFF → single-segment matches show immediately at the
+    // detected shade (the pre-#990 behavior, now an explicit user choice).
+    final verifyShortPaths = ref
+        .read(detectionStylesProvider)
+        .of(kGhosttyPathPatternId)
+        ?.verifyShortPaths;
+    if (verifyShortPaths == false) return true;
     if (!ghosttyPathRequiresVerification(payload)) return true;
     return _pathVerifier?.status(payload) == PathVerification.verified;
   }
@@ -2884,7 +2903,17 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // type (the controller no-ops on an empty pattern set). Master OFF →
     // register nothing.
     final detection = ref.read(detectionSettingsProvider);
-    for (final pattern in ghosttyDetectionPatterns(detection)) {
+    // #1031 slice 2: the command pattern registers with the lab's stored
+    // lexicon override (null = the fork's default list). A lexicon change
+    // re-runs this via the build() styles ref.listen.
+    final commandLexicon = ref
+        .read(detectionStylesProvider)
+        .of(kGhosttyCommandPatternId)
+        ?.lexicon;
+    for (final pattern in ghosttyDetectionPatterns(
+      detection,
+      commandLexicon: commandLexicon,
+    )) {
       controller.registerTextPattern(pattern);
     }
     // #921: tell the render box whether detection is now active. Active means the
@@ -4061,6 +4090,23 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // / didn't detect but failed to paint"). Force ONE coalesced full re-read
       // after re-registration. Post-frame so the keyed render box exists +
       // `_applyDetectionActive` (scheduled in _registerUrlPattern) has landed.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _forceTerminalRepaint();
+      });
+    });
+    // #1031 slice 2: a lab COMMAND-LEXICON change must re-register (the
+    // lexicon is baked into the registered TextPattern's normalize closure).
+    // Compared by CONTENT — color/intensity changes repaint via the resolver
+    // watch below and must NOT churn the pattern registrations.
+    ref.listen<DetectionStyles>(detectionStylesProvider, (prev, next) {
+      final before = prev?.of(kGhosttyCommandPatternId)?.lexicon;
+      final after = next.of(kGhosttyCommandPatternId)?.lexicon;
+      if (listEquals(before, after)) return;
+      final c = _controller;
+      if (c == null) return;
+      c.clearTextPatterns();
+      _registerUrlPattern(c);
+      // Same starvation guard as the settings listen above (#968).
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _forceTerminalRepaint();
       });

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -32,6 +32,7 @@ import '../state/profiles_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart' show ProfilesStore;
+import 'detection_lab_screen.dart';
 import 'favorites_menu_sheet.dart';
 import 'file_browser_screen.dart';
 import 'session_state_dot.dart';
@@ -561,6 +562,21 @@ class _SessionControlsRow extends ConsumerWidget {
             onTap: () => ref
                 .read(detectionSettingsProvider.notifier)
                 .setEnabled(!detectionOn),
+            // #1031 review change 7: the lab's most frequent job ("this
+            // highlight looks wrong") is noticed IN the terminal — long-press
+            // jumps straight to the Detection lab, no Settings scroll. Same
+            // #664 overlay idiom as the pickers: capture the app navigator,
+            // close the menu (its barrier sits above pushed routes), THEN
+            // push on that navigator.
+            onLongPress: () {
+              final navContext = Navigator.of(context).context;
+              onClose();
+              Navigator.of(navContext).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const DetectionLabScreen(),
+                ),
+              );
+            },
           ),
           // 4. Keybar visibility toggle. Filled icon = visible, outlined =
           // hidden, so the glyph itself communicates the toggle state.
@@ -658,6 +674,7 @@ class _StepButton extends StatelessWidget {
     required this.tooltip,
     required this.enabled,
     required this.onTap,
+    this.onLongPress,
     this.icon,
     this.iconWidget,
     this.selected = false,
@@ -676,13 +693,20 @@ class _StepButton extends StatelessWidget {
   final bool selected;
   final VoidCallback onTap;
 
+  /// #1031 review change 7: optional long-press action (the detection glyph
+  /// long-presses into the Detection lab). When set, the IconButton drops its
+  /// tooltip — Tooltip installs its OWN long-press recognizer that would eat
+  /// the gesture (the #943 IconButton-tooltip gotcha) — and an outer
+  /// GestureDetector claims it instead.
+  final VoidCallback? onLongPress;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final color = selected ? theme.colorScheme.primary : null;
-    return IconButton(
+    final button = IconButton(
       key: itemKey,
-      tooltip: tooltip,
+      tooltip: onLongPress == null ? tooltip : null,
       iconSize: 20,
       constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
       padding: EdgeInsets.zero,
@@ -690,6 +714,12 @@ class _StepButton extends StatelessWidget {
       color: color,
       icon: iconWidget ?? Icon(icon),
       onPressed: enabled ? onTap : null,
+    );
+    if (onLongPress == null) return button;
+    return GestureDetector(
+      behavior: HitTestBehavior.deferToChild,
+      onLongPress: enabled ? onLongPress : null,
+      child: Semantics(label: tooltip, child: button),
     );
   }
 }

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -19,6 +19,7 @@ import '../services/battery_optimization.dart';
 import '../services/clipboard.dart';
 import '../state/detection_exceptions_providers.dart';
 import '../state/detection_providers.dart';
+import '../state/detection_style_providers.dart';
 import '../state/keepalive_providers.dart';
 import '../state/sessions.dart';
 import '../state/terminal_backend.dart';
@@ -26,6 +27,7 @@ import '../state/tmux_control_mode_setting.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/detection_exceptions_store.dart';
 import '../util/relative_time.dart';
+import 'detection_lab_screen.dart';
 import 'feedback_overlay.dart' show VersionResolver, resolveBuildVersion;
 import 'settings_subheader.dart';
 import 'top_toast.dart';
@@ -236,6 +238,26 @@ class SettingsPanel extends ConsumerWidget {
                   ref.read(detectionSettingsProvider.notifier).setCommand(v)
               : null,
         ),
+        // #1031 slice 2: the Detection LAB — per-pattern colors, intensity,
+        // live previews, behavior knobs. Its OWN route (a workbench, not a
+        // settings row — the deliberate #897 exception per the reviewed IA);
+        // the everyday toggles above stay here and the lab binds the SAME
+        // providers. Placed after the type toggles, before exceptions, so the
+        // section reads simple → deep.
+        ListTile(
+          key: const ValueKey('detection-lab-tile'),
+          leading: const Icon(Icons.science_outlined),
+          title: const Text('Detection lab'),
+          subtitle: const Text(
+            'Colors, intensity, and live previews per pattern.',
+          ),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) => const DetectionLabScreen(),
+            ),
+          ),
+        ),
         // #995: reviewable detection exceptions — the saved "Not a URL" /
         // "Not a file" reports. Each entry shows the suppressed text + when/
         // where it was reported, with a per-entry remove that restores
@@ -360,8 +382,9 @@ class SettingsPanel extends ConsumerWidget {
         title: const Text('Reset settings?'),
         content: const Text(
           'Restore all MobiSSH settings — font size, terminal engine, '
-          'keep-alive, link/path detection, and tmux control mode — to their '
-          'defaults. Saved profiles and credentials are not affected.',
+          'keep-alive, link/path detection, detection lab tuning, and tmux '
+          'control mode — to their defaults. Saved profiles, credentials, '
+          'and detection exceptions are not affected.',
         ),
         actions: [
           TextButton(
@@ -389,6 +412,10 @@ class SettingsPanel extends ConsumerWidget {
     await detectionNotifier.setUrl(true);
     await detectionNotifier.setPath(true);
     await detectionNotifier.setCommand(true);
+    // #1031 slice 2: lab styles are TUNED settings → reset with the rest.
+    // AUTHORED data survives (detection exceptions here; custom pattern
+    // definitions in slice 3) — the IA's one-sentence reset rule.
+    await ref.read(detectionStylesProvider.notifier).clearAllTuned();
 
     if (context.mounted) {
       showTopToast(context, 'Settings reset to defaults');

--- a/native/test/state/detection_style_providers_test.dart
+++ b/native/test/state/detection_style_providers_test.dart
@@ -92,6 +92,22 @@ void main() {
     expect(container.read(detectionStylesProvider).isEmpty, isTrue);
   });
 
+  test('knob setters (#1031 slice 2) update state and persist', () async {
+    final container = await containerWith({});
+    final notifier = container.read(detectionStylesProvider.notifier);
+    await notifier.setVerifyShortPaths('path', false);
+    await notifier.setLexicon('command', ['git', 'kubectl']);
+
+    final styles = container.read(detectionStylesProvider);
+    expect(styles.of('path')!.verifyShortPaths, isFalse);
+    expect(styles.of('command')!.lexicon, ['git', 'kubectl']);
+
+    // Clearing back to null drops the field (absent = shipped default).
+    await notifier.setVerifyShortPaths('path', null);
+    await notifier.setLexicon('command', null);
+    expect(container.read(detectionStylesProvider).isEmpty, isTrue);
+  });
+
   group('detectionPatternStyleProvider (family)', () {
     test('exposes ONE pattern\'s override', () async {
       final container = await containerWith({

--- a/native/test/storage/detection_styles_store_test.dart
+++ b/native/test/storage/detection_styles_store_test.dart
@@ -128,6 +128,61 @@ void main() {
     });
   });
 
+  group('behavior knobs (#1031 slice 2: verifyShortPaths + lexicon)', () {
+    test('knob fields round-trip alongside style fields', () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'path',
+        const DetectionPatternStyle(verifyShortPaths: false),
+      );
+      await store.setPatternStyle(
+        'command',
+        const DetectionPatternStyle(lexicon: ['git', 'kubectl']),
+      );
+      final styles = await store.load();
+      expect(styles.of('path')!.verifyShortPaths, isFalse);
+      expect(styles.of('path')!.colorHex, isNull);
+      expect(styles.of('command')!.lexicon, ['git', 'kubectl']);
+    });
+
+    test('a knob-only style is NOT empty; clearing the knob removes the entry',
+        () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'path',
+        const DetectionPatternStyle(verifyShortPaths: false),
+      );
+      expect((await store.load()).of('path'), isNotNull);
+      await store.setPatternStyle('path', const DetectionPatternStyle());
+      expect((await store.load()).of('path'), isNull);
+    });
+
+    test('wrong-typed knob fields are dropped field-by-field', () async {
+      final store = await storeWith({
+        detectionStylesPrefsKey:
+            '{"v":1,"styles":{"path":{"color":"#33AA55","verify":"nope"},'
+            '"command":{"lexicon":[1,2],"inactive":0.8}}}',
+      });
+      final styles = await store.load();
+      expect(styles.of('path')!.colorHex, '#33AA55');
+      expect(styles.of('path')!.verifyShortPaths, isNull,
+          reason: 'non-bool verify dropped');
+      expect(styles.of('command')!.inactiveIntensity, 0.8);
+      expect(styles.of('command')!.lexicon, isNull,
+          reason: 'non-string lexicon entries drop the list');
+    });
+
+    test('resetPattern clears knobs too (knobs are TUNED data)', () async {
+      final store = await storeWith({});
+      await store.setPatternStyle(
+        'command',
+        const DetectionPatternStyle(lexicon: ['git']),
+      );
+      await store.resetPattern('command');
+      expect((await store.load()).of('command'), isNull);
+    });
+  });
+
   group('reset seams (#1031 IA review: per-pattern + lab-wide)', () {
     test('resetPattern removes ONE pattern, leaves the rest', () async {
       final store = await storeWith({});

--- a/native/test/ui/detection_lab_screen_test.dart
+++ b/native/test/ui/detection_lab_screen_test.dart
@@ -1,0 +1,434 @@
+// #1031 slice 2 — the Detection Lab UI: root cards + per-pattern detail pages
+// over the merged slice-1 store/resolver and the #1030 shared color picker.
+//
+// Locks the IA review's binding changes:
+//   1. NO dead controls — url/command detail pages show ONE preview state and
+//      ONE intensity slider (verified/active controls are paths-only, per
+//      detectionPatternHasActiveState).
+//   2. Preview labels its theme source (front session accent, fallback default).
+//   3. Preview is PINNED (outside the scrollable controls list).
+//   4. Destructive resets sit at the BOTTOM (root: lab-wide; detail:
+//      per-pattern), both behind confirm dialogs.
+//   6. Sliders' min/max ARE the legibility band (every position does something).
+//
+// Enable switches bind the SAME detectionSettingsProvider Settings uses (one
+// bit, three surfaces). The URL card/detail writes id-level style to BOTH the
+// `url` and `osc8` pattern ids (one user-facing type).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:mobissh/state/detection_style_providers.dart';
+import 'package:mobissh/ui/detection_lab_screen.dart';
+import 'package:mobissh/ui/detection_style_resolver.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 10}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+Future<ProviderContainer> _pumpLab(WidgetTester tester,
+    {Widget home = const DetectionLabScreen()}) async {
+  // Tall viewport: the root list (3 cards + bottom reset) and the detail
+  // controls all lay out hit-testable without scrolling.
+  tester.view.physicalSize = const Size(1000, 3000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(home: home),
+    ),
+  );
+  await _pumpFrames(tester);
+  return container;
+}
+
+Widget _detail(String key) =>
+    DetectionLabDetailScreen(spec: detectionLabPatternSpec(key));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('lab root', () {
+    testWidgets('renders one card per registered pattern with a mini preview',
+        (tester) async {
+      await _pumpLab(tester);
+      for (final key in const ['url', 'path', 'command']) {
+        expect(find.byKey(ValueKey('lab-card-$key')), findsOneWidget,
+            reason: 'card for $key');
+        expect(find.byKey(ValueKey('lab-enable-$key')), findsOneWidget);
+        expect(find.byKey(ValueKey('lab-preview-$key')), findsOneWidget,
+            reason: 'mini live preview for $key');
+      }
+      expect(find.byKey(const ValueKey('lab-master-toggle')), findsOneWidget);
+    });
+
+    testWidgets('enable switches bind the EXISTING detection providers',
+        (tester) async {
+      final container = await _pumpLab(tester);
+      expect(container.read(detectionSettingsProvider).url, isTrue);
+
+      await tester.tap(find.byKey(const ValueKey('lab-enable-url')));
+      await _pumpFrames(tester);
+      expect(container.read(detectionSettingsProvider).url, isFalse,
+          reason: 'the card switch flips the SAME provider Settings uses');
+
+      // External change reflects back into the lab.
+      await container.read(detectionSettingsProvider.notifier).setUrl(true);
+      await _pumpFrames(tester);
+      final sw = tester.widget<Switch>(
+        find.byKey(const ValueKey('lab-enable-url')),
+      );
+      expect(sw.value, isTrue);
+    });
+
+    testWidgets('master OFF disables the per-pattern switches', (tester) async {
+      final container = await _pumpLab(tester);
+      await container
+          .read(detectionSettingsProvider.notifier)
+          .setEnabled(false);
+      await _pumpFrames(tester);
+      final sw = tester.widget<Switch>(
+        find.byKey(const ValueKey('lab-enable-path')),
+      );
+      expect(sw.onChanged, isNull);
+    });
+
+    testWidgets('lab-wide reset sits at the BOTTOM, confirms, then clears '
+        'every tuned override', (tester) async {
+      final container = await _pumpLab(tester);
+      final notifier = container.read(detectionStylesProvider.notifier);
+      await notifier.setColorHex('url', '#e53935');
+      await notifier.setInactiveIntensity('path', 1.4);
+      await _pumpFrames(tester);
+
+      // Review change 4: below the pattern cards, not in the thumb-prime zone.
+      final resetY = tester
+          .getTopLeft(find.byKey(const ValueKey('lab-reset-all-button')))
+          .dy;
+      final lastCardY = tester
+          .getBottomLeft(find.byKey(const ValueKey('lab-card-command')))
+          .dy;
+      expect(resetY, greaterThan(lastCardY));
+
+      await tester.tap(find.byKey(const ValueKey('lab-reset-all-button')));
+      await _pumpFrames(tester);
+      expect(
+        find.byKey(const ValueKey('lab-reset-all-dialog')),
+        findsOneWidget,
+      );
+      await tester.tap(find.byKey(const ValueKey('lab-reset-all-confirm')));
+      await _pumpFrames(tester);
+      expect(container.read(detectionStylesProvider).isEmpty, isTrue);
+    });
+
+    testWidgets('tapping a card opens its detail page', (tester) async {
+      await _pumpLab(tester);
+      await tester.tap(find.byKey(const ValueKey('lab-card-tile-path')));
+      await _pumpFrames(tester);
+      expect(find.byType(DetectionLabDetailScreen), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('lab-detail-preview-detected')),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('detail page — active-state gating (review change 1: no dead '
+      'controls)', () {
+    testWidgets('paths show BOTH states + both sliders', (tester) async {
+      await _pumpLab(tester, home: _detail('path'));
+      expect(
+        find.byKey(const ValueKey('lab-detail-preview-detected')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('lab-detail-preview-active')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const ValueKey('lab-inactive-slider')), findsOneWidget);
+      expect(find.byKey(const ValueKey('lab-active-slider')), findsOneWidget);
+    });
+
+    for (final key in const ['url', 'command']) {
+      testWidgets('$key shows ONE state and NO active slider', (tester) async {
+        await _pumpLab(tester, home: _detail(key));
+        expect(
+          find.byKey(const ValueKey('lab-detail-preview-detected')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('lab-detail-preview-active')),
+          findsNothing,
+        );
+        expect(find.byKey(const ValueKey('lab-active-slider')), findsNothing);
+      });
+    }
+
+    testWidgets('no disabled "coming" rows anywhere on a detail page',
+        (tester) async {
+      await _pumpLab(tester, home: _detail('url'));
+      expect(find.textContaining('coming', findRichText: true), findsNothing);
+    });
+  });
+
+  group('detail page — preview trust (review changes 2+3)', () {
+    testWidgets('the preview block labels its theme source', (tester) async {
+      await _pumpLab(tester, home: _detail('url'));
+      expect(
+        find.byKey(const ValueKey('lab-preview-source')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('the preview is PINNED outside the scrolling controls list',
+        (tester) async {
+      await _pumpLab(tester, home: _detail('path'));
+      final scrollable = find.byKey(const ValueKey('lab-detail-controls'));
+      expect(scrollable, findsOneWidget);
+      // The pinned preview must NOT be a descendant of the scrollable.
+      expect(
+        find.descendant(
+          of: scrollable,
+          matching: find.byKey(const ValueKey('lab-detail-preview-detected')),
+        ),
+        findsNothing,
+        reason: 'preview scrolling away defeats the lab (review change 3)',
+      );
+    });
+
+    testWidgets('a dark/light preview luminance toggle exists', (tester) async {
+      await _pumpLab(tester, home: _detail('url'));
+      expect(
+        find.byKey(const ValueKey('lab-preview-luminance')),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('detail page — color picker round-trip (#1030)', () {
+    testWidgets('picking a preset writes the store for url AND osc8 '
+        '(one user-facing type)', (tester) async {
+      final container = await _pumpLab(tester, home: _detail('url'));
+      await tester.tap(find.byKey(const ValueKey('lab-color-row')));
+      await _pumpFrames(tester);
+      expect(find.byKey(const Key('color-picker-panel')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('color-picker-preset-#e53935')));
+      await _pumpFrames(tester);
+      await tester.tap(find.byKey(const Key('color-picker-apply')));
+      await _pumpFrames(tester);
+
+      final styles = container.read(detectionStylesProvider);
+      expect(styles.of('url')!.colorHex, '#e53935');
+      expect(styles.of('osc8')!.colorHex, '#e53935');
+    });
+
+    testWidgets('the clear action restores "use theme color" (null override)',
+        (tester) async {
+      final container = await _pumpLab(tester, home: _detail('url'));
+      final notifier = container.read(detectionStylesProvider.notifier);
+      await notifier.setColorHex('url', '#e53935');
+      await notifier.setColorHex('osc8', '#e53935');
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(const ValueKey('lab-color-row')));
+      await _pumpFrames(tester);
+      await tester.tap(find.byKey(const Key('color-picker-clear')));
+      await _pumpFrames(tester);
+
+      final styles = container.read(detectionStylesProvider);
+      expect(styles.of('url'), isNull);
+      expect(styles.of('osc8'), isNull);
+    });
+  });
+
+  group('detail page — intensity sliders (review change 6)', () {
+    testWidgets('slider min/max ARE the legibility band', (tester) async {
+      await _pumpLab(tester, home: _detail('path'));
+      final inactive = tester.widget<Slider>(
+        find.byKey(const ValueKey('lab-inactive-slider')),
+      );
+      expect(inactive.min, kDetectionIntensityMin);
+      expect(inactive.max, kDetectionIntensityMax);
+      final active = tester.widget<Slider>(
+        find.byKey(const ValueKey('lab-active-slider')),
+      );
+      expect(active.min, kDetectionIntensityMin);
+      expect(active.max, kDetectionIntensityMax);
+    });
+
+    testWidgets('dragging the detected slider writes the store on release',
+        (tester) async {
+      final container = await _pumpLab(tester, home: _detail('url'));
+      await tester.drag(
+        find.byKey(const ValueKey('lab-inactive-slider')),
+        const Offset(300, 0),
+      );
+      await _pumpFrames(tester);
+      final url = container.read(detectionStylesProvider).of('url');
+      expect(url?.inactiveIntensity, isNotNull);
+      expect(url!.inactiveIntensity, greaterThan(1.0));
+      // The osc8 twin carries the same tuning.
+      expect(
+        container.read(detectionStylesProvider).of('osc8')?.inactiveIntensity,
+        url.inactiveIntensity,
+      );
+    });
+
+    testWidgets('dragging detected past active PUSHES active (no inversion)',
+        (tester) async {
+      final container = await _pumpLab(tester, home: _detail('path'));
+      // Drag detected to the far right (max).
+      await tester.drag(
+        find.byKey(const ValueKey('lab-inactive-slider')),
+        const Offset(600, 0),
+      );
+      await _pumpFrames(tester);
+      final style = container.read(detectionStylesProvider).of('path');
+      expect(style, isNotNull);
+      final inactive = style!.inactiveIntensity ?? 1.0;
+      final active = style.activeIntensity ?? 1.0;
+      expect(
+        active,
+        greaterThanOrEqualTo(inactive + kDetectionIntensityGap - 1e-9),
+        reason: 'active must stay a visible margin above detected',
+      );
+    });
+  });
+
+  group('detail page — behavior knobs (real today only)', () {
+    testWidgets('path: short-path verification toggle binds the store',
+        (tester) async {
+      final container = await _pumpLab(tester, home: _detail('path'));
+      final toggle = find.byKey(const ValueKey('lab-verify-toggle'));
+      expect(toggle, findsOneWidget);
+      expect(
+        tester.widget<SwitchListTile>(toggle).value,
+        isTrue,
+        reason: 'default ON — the #990 shipped behavior',
+      );
+      await tester.tap(toggle);
+      await _pumpFrames(tester);
+      expect(
+        container.read(detectionStylesProvider).of('path')!.verifyShortPaths,
+        isFalse,
+      );
+    });
+
+    testWidgets('url: NO behavior knobs render (nothing real today)',
+        (tester) async {
+      await _pumpLab(tester, home: _detail('url'));
+      expect(find.byKey(const ValueKey('lab-verify-toggle')), findsNothing);
+      expect(find.byKey(const ValueKey('lab-lexicon-row')), findsNothing);
+    });
+
+    testWidgets('command: lexicon editor adds, removes, restores default',
+        (tester) async {
+      final container = await _pumpLab(tester, home: _detail('command'));
+      // Seed a small stored lexicon so the chips are all on-screen.
+      await container
+          .read(detectionStylesProvider.notifier)
+          .setLexicon('command', ['git', 'curl']);
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(const ValueKey('lab-lexicon-row')));
+      await _pumpFrames(tester);
+      expect(find.byKey(const ValueKey('lab-lexicon-editor')), findsOneWidget);
+
+      // Add a word.
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-lexicon-add-field')),
+        'frobnicate',
+      );
+      await tester.tap(find.byKey(const ValueKey('lab-lexicon-add-button')));
+      await _pumpFrames(tester);
+      expect(
+        container.read(detectionStylesProvider).of('command')!.lexicon,
+        containsAll(<String>['git', 'curl', 'frobnicate']),
+      );
+
+      // Remove one.
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(const ValueKey('lab-lexicon-chip-git')),
+          matching: find.byIcon(Icons.cancel),
+        ),
+      );
+      await _pumpFrames(tester);
+      expect(
+        container.read(detectionStylesProvider).of('command')!.lexicon,
+        isNot(contains('git')),
+      );
+
+      // Restore the app-supplied default list (clears the override).
+      await tester.tap(
+        find.byKey(const ValueKey('lab-lexicon-restore-default')),
+      );
+      await _pumpFrames(tester);
+      expect(
+        container.read(detectionStylesProvider).of('command'),
+        isNull,
+        reason: 'restore-default drops the stored lexicon override',
+      );
+    });
+  });
+
+  group('detail page — per-pattern reset (review change 4)', () {
+    testWidgets('resets THIS pattern (both url ids), leaves siblings',
+        (tester) async {
+      final container = await _pumpLab(tester, home: _detail('url'));
+      final notifier = container.read(detectionStylesProvider.notifier);
+      await notifier.setColorHex('url', '#e53935');
+      await notifier.setColorHex('osc8', '#e53935');
+      await notifier.setColorHex('path', '#43a047');
+      await _pumpFrames(tester);
+
+      await tester.tap(
+        find.byKey(const ValueKey('lab-reset-pattern-button')),
+      );
+      await _pumpFrames(tester);
+      expect(
+        find.byKey(const ValueKey('lab-reset-pattern-dialog')),
+        findsOneWidget,
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('lab-reset-pattern-confirm')),
+      );
+      await _pumpFrames(tester);
+
+      final styles = container.read(detectionStylesProvider);
+      expect(styles.of('url'), isNull);
+      expect(styles.of('osc8'), isNull);
+      expect(styles.of('path')!.colorHex, '#43a047');
+    });
+
+    testWidgets('reset does NOT touch the enable bit (preference, not tuning)',
+        (tester) async {
+      final container = await _pumpLab(tester, home: _detail('url'));
+      await container.read(detectionSettingsProvider.notifier).setUrl(false);
+      await _pumpFrames(tester);
+      await tester.tap(
+        find.byKey(const ValueKey('lab-reset-pattern-button')),
+      );
+      await _pumpFrames(tester);
+      await tester.tap(
+        find.byKey(const ValueKey('lab-reset-pattern-confirm')),
+      );
+      await _pumpFrames(tester);
+      expect(container.read(detectionSettingsProvider).url, isFalse);
+    });
+  });
+}

--- a/native/test/ui/detection_style_resolver_test.dart
+++ b/native/test/ui/detection_style_resolver_test.dart
@@ -239,6 +239,75 @@ void main() {
       expect(detectionPatternHasActiveState('custom.jira'), isFalse);
     });
   });
+
+  group('#1031 slice 2 — intensity pair (review change 6: no inversion)', () {
+    test('a non-conflicting pair passes through unchanged', () {
+      final pair = detectionResolveIntensityPair(
+        inactive: 0.8,
+        active: 1.3,
+        activeDragged: false,
+      );
+      expect(pair.inactive, 0.8);
+      expect(pair.active, 1.3);
+    });
+
+    test('dragging DETECTED up past active PUSHES active up by the gap', () {
+      final pair = detectionResolveIntensityPair(
+        inactive: 1.3,
+        active: 1.3,
+        activeDragged: false,
+      );
+      expect(pair.inactive, 1.3);
+      expect(pair.active, closeTo(1.3 + kDetectionIntensityGap, 1e-9));
+    });
+
+    test('dragging ACTIVE down past detected PUSHES detected down by the gap',
+        () {
+      final pair = detectionResolveIntensityPair(
+        inactive: 1.0,
+        active: 0.9,
+        activeDragged: true,
+      );
+      expect(pair.active, 0.9);
+      expect(pair.inactive, closeTo(0.9 - kDetectionIntensityGap, 1e-9));
+    });
+
+    test('the push respects the band: detected caps at max - gap', () {
+      final pair = detectionResolveIntensityPair(
+        inactive: kDetectionIntensityMax,
+        active: 1.0,
+        activeDragged: false,
+      );
+      expect(pair.active, kDetectionIntensityMax);
+      expect(
+        pair.inactive,
+        closeTo(kDetectionIntensityMax - kDetectionIntensityGap, 1e-9),
+      );
+    });
+
+    test('the push respects the band: active floors at min + gap', () {
+      final pair = detectionResolveIntensityPair(
+        inactive: 1.0,
+        active: kDetectionIntensityMin,
+        activeDragged: true,
+      );
+      expect(pair.inactive, kDetectionIntensityMin);
+      expect(
+        pair.active,
+        closeTo(kDetectionIntensityMin + kDetectionIntensityGap, 1e-9),
+      );
+    });
+
+    test('out-of-band inputs clamp into the band first', () {
+      final pair = detectionResolveIntensityPair(
+        inactive: 0.0,
+        active: 9.0,
+        activeDragged: false,
+      );
+      expect(pair.inactive, kDetectionIntensityMin);
+      expect(pair.active, kDetectionIntensityMax);
+    });
+  });
 }
 
 /// The verified-on-dark base alpha via the shipped derivation (keeps the test

--- a/native/test/ui/ghostty_gutter_command_test.dart
+++ b/native/test/ui/ghostty_gutter_command_test.dart
@@ -172,6 +172,23 @@ void main() {
           .firstWhere((p) => p.id == kGhosttyCommandPatternId);
       expect(command.tier, TextTier.block);
     });
+
+    test('#1031 slice 2: a custom command LEXICON reaches the fork pattern '
+        '(weak prompt discriminates)', () {
+      // Weak `$ ` prompt + unknown first token: default lexicon scores 2
+      // (flag + operator, no hit) → suppressed; a lexicon containing the
+      // token scores 4 with the hit → detected.
+      const line = r'$ frobnicate --deep | sort';
+      final byDefault = ghosttyDetectionPatterns(const DetectionSettings())
+          .firstWhere((p) => p.id == kGhosttyCommandPatternId);
+      expect(byDefault.normalize!(line), isNull);
+
+      final byCustom = ghosttyDetectionPatterns(
+        const DetectionSettings(),
+        commandLexicon: const ['frobnicate'],
+      ).firstWhere((p) => p.id == kGhosttyCommandPatternId);
+      expect(byCustom.normalize!(line), 'frobnicate --deep | sort');
+    });
   });
 
   group('command gutter chip (#998 C)', () {

--- a/native/test/widget/session_menu_slim_test.dart
+++ b/native/test/widget/session_menu_slim_test.dart
@@ -26,6 +26,7 @@ import 'package:mobissh/state/detection_providers.dart';
 import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
 import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/ui/detection_lab_screen.dart';
 import 'package:mobissh/ui/session_menu.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -210,6 +211,28 @@ void main() {
         await _pumpFrames(tester);
         expect(container.read(detectionSettingsProvider).enabled, isFalse);
       }
+    });
+
+    testWidgets('#1031 review change 7: long-pressing the detection glyph '
+        'opens the Detection lab (menu closes first)', (tester) async {
+      final container = _makeContainer();
+      _add(container, 'host-a');
+
+      await tester.pumpWidget(_host(container: container));
+      await tester.tap(find.byKey(const Key('open-menu')));
+      await _pumpFrames(tester);
+
+      await tester.longPress(
+        find.byKey(const Key('session-menu-detection-toggle')),
+      );
+      await _pumpFrames(tester);
+
+      // The lab root is pushed on the app navigator and the overlay menu is
+      // gone (a route pushed UNDER the menu's barrier would be un-tappable).
+      expect(find.byType(DetectionLabScreen), findsOneWidget);
+      expect(find.byKey(const Key('session-menu')), findsNothing);
+      // The long-press must NOT have flipped the toggle.
+      expect(container.read(detectionSettingsProvider).enabled, isTrue);
     });
 
     testWidgets('font +/- still mutates only the active session', (

--- a/native/test/widget/settings_page_combined_test.dart
+++ b/native/test/widget/settings_page_combined_test.dart
@@ -14,7 +14,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:mobissh/state/detection_exceptions_providers.dart';
+import 'package:mobissh/state/detection_style_providers.dart';
 import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/ui/detection_lab_screen.dart';
 import 'package:mobissh/ui/settings_screen.dart';
 
 Future<void> _pumpFrames(WidgetTester tester, {int count = 10}) async {
@@ -149,6 +152,58 @@ void main() {
 
     // The sample pref is back to its documented default.
     expect(container.read(fontSizeProvider), fontSizeDefault);
+  });
+
+  testWidgets('#1031 slice 2: a Detection lab row opens the lab route', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await _pumpPage(tester, container);
+
+    final row = find.byKey(const ValueKey('detection-lab-tile'));
+    expect(row, findsOneWidget, reason: 'entry row under Detection');
+
+    await tester.tap(row);
+    await _pumpFrames(tester);
+    expect(find.byType(DetectionLabScreen), findsOneWidget);
+  });
+
+  testWidgets('#1031 slice 2: Reset settings clears TUNED lab styles but '
+      'authored exceptions survive', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await _pumpPage(tester, container);
+
+    // Tune a lab style + author an exception report.
+    await container
+        .read(detectionStylesProvider.notifier)
+        .setColorHex('url', '#e53935');
+    await container.read(detectionExceptionsProvider.notifier).report(
+          patternId: 'url',
+          matchedText: 'https://not.a.link',
+        );
+    await _pumpFrames(tester);
+    expect(container.read(detectionStylesProvider).isEmpty, isFalse);
+    expect(container.read(detectionExceptionsProvider), hasLength(1));
+
+    await tester.tap(find.byKey(const ValueKey('settings-reset-button')));
+    await _pumpFrames(tester);
+    await tester.tap(find.byKey(const ValueKey('settings-reset-confirm')));
+    await _pumpFrames(tester);
+
+    expect(
+      container.read(detectionStylesProvider).isEmpty,
+      isTrue,
+      reason: 'tuned lab styles reset with settings',
+    );
+    expect(
+      container.read(detectionExceptionsProvider),
+      hasLength(1),
+      reason: 'authored exception reports survive every reset (#995 rule)',
+    );
   });
 
   testWidgets('Reset settings can be cancelled (no change)', (tester) async {


### PR DESCRIPTION
Slice 2 of #1031 (Detection Lab): the LAB UI — root cards + per-pattern detail pages — on the merged slice-1 store/resolver and the #1030 shared color picker. Built strictly against the issue's IA draft with the IA review's 7 changes as binding.

## What shipped

- **Settings → Detection → "Detection lab"** row (after the type toggles, before exceptions) pushes the lab route.
- **Lab root**: master switch + accent note, one CARD per built-in pattern (URLs = url+osc8 as one user-facing type; File paths; Command lines) with an enable switch bound to the SAME `detectionSettingsProvider` bits Settings flips, a mini LIVE preview (real `GhosttyBubblePainter` + the extracted real `GutterMarkChip`, fed by the slice-1 `DetectionStyleResolver`), chevron → detail. Lab-wide reset at the BOTTOM behind a confirm.
- **Detail page** per pattern: enable in the app bar; PINNED preview block (outside the scrolling controls list) labeled with its theme source + a dark/light luminance override; color row → shared #1030 picker ("Use theme color" clears); intensity slider(s) whose min/max ARE the 0.25–1.75 legibility band; per-pattern reset at the bottom behind a confirm.
- **Behavior knobs (real today only)**: paths — "Short-path verification" toggle gating the #990 suppression (`_isPayloadVisible`); commands — lexicon editor (add/remove/restore-default) feeding `TextPattern.command(lexicon:)`, live re-registered on change (content-compared so color changes never churn registrations). Knobs live inside the slice-1 style record (`verify`, `lexicon` fields; v1 schema, field-fallback parse) so per-pattern/lab-wide resets cover them for free.
- **Settings "Reset settings"** now also calls `clearAllTuned()`; dialog text names the exclusions (exceptions/profiles survive).
- **Session-menu shortcut**: long-press the detection glyph → lab root (menu closes first, pushed on the app navigator).

## IA review checklist (all 7 binding changes)

1. **No dead controls** — url/command detail pages render ONE preview state ("Detected") and ONE intensity slider; the Active row/slider exists only for paths (gated on `detectionPatternHasActiveState`). Zero disabled "(coming)" rows anywhere (widget test asserts `textContaining('coming')` finds nothing).
2. **Preview theme source labeled** — `detectionLabPreviewTheme`: front (active) session's live palette when one exists, else the app default theme; the strip header says which ("Previewing: Dark (active session)"). The dark/light chip overrides luminance from that baseline (neutral strip when flipped away from the theme's own brightness, accent kept).
3. **Preview pinned** — the preview block is OUTSIDE the scrolling controls ListView (widget test asserts non-descendant), so slider drags/keyboard can never push it off-screen.
4. **Resets at the bottom** — lab-wide reset below the last card on the root; per-pattern reset last on the detail page; both confirm; both wired to the slice-1 store reset seams. Enable bits (preference) and exceptions (authored) survive — asserted.
5. **Immutable custom ids** — slice 3 scope (no custom patterns in this slice); nothing here re-derives an id.
6. **Slider semantics** — band = actual slider min/max (every position visible); no raw multiplier text (the pinned preview is the value); paths: `detectionResolveIntensityPair` push-clamps Active ≥ Detected + 0.15 with band-edge reversal (pure fn, unit-tested).
7. **Shortcut from where the problem is seen** — session-menu detection glyph long-press opens the lab (two taps, zero Settings scroll). The IconButton drops its tooltip in long-press mode (the tooltip's own long-press recognizer would eat the gesture).

## Live-apply proof (emulator, `integration_test/detection_lab_1031_test.dart`)

Connect to test-sshd → URL anchor detected → session-menu long-press → lab → URL detail (asserts change-1 gating) → red preset via the shared picker + intensity drag → store carries `#e53935` on BOTH url+osc8 → pop back → the LIVE `GhosttyBubblePainter` fills a red-dominant wash at alpha ABOVE the shipped detected base — no reconnect, no refresh. PASSED (`All tests passed!`).

Screenshots (test-results/emulator-shots/): detail page pre-recolor (pinned preview, green theme wash + chip, band slider) and the recolored live session — URL bubbles/chips now red at a visibly stronger wash while the path (`/etc/motd`) keeps the green session accent, i.e. per-pattern override isolation on device. Phone-density scanability reviewed on the PNGs.

## Tests

- 22 new widget tests (`test/ui/detection_lab_screen_test.dart`) + store/provider knob tests + resolver pair tests + settings (lab row, reset clears tuned / exceptions survive) + session-menu long-press + `ghosttyDetectionPatterns` lexicon pass-through (weak-prompt discriminator).
- TDD: red compile baseline confirmed before implementation.
- `scripts/native-fast-gate.sh` PASSED (analyze + 1946 tests).

Closes nothing (composite issue — slices 3/4 remain on #1031).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa