### PR TITLE
#1031 slice 3 — user-defined patterns

### DIFF
--- a/native/integration_test/detection_lab_custom_1031_test.dart
+++ b/native/integration_test/detection_lab_custom_1031_test.dart
@@ -1,0 +1,334 @@
+// On-emulator PROOF for #1031 slice 3 — USER-DEFINED patterns end-to-end.
+//
+// Flow: connect to test-sshd → session menu → long-press the detection glyph
+// → lab root → "Add pattern" → create a JIRA-style pattern (name, regex,
+// sample line; the editor's live match echo validates it) → back to the live
+// terminal → echo a matching token → assert the custom anchor appears with
+// the BUBBLE wash + a GUTTER chip → tap the chip and assert the payload is
+// COPIED (toast) → long-press the match and report "Not a match" → assert
+// the affordances disappear (#995 suppression, family = the custom id) →
+// delete the pattern in the lab (confirm discloses the pruning) → assert a
+// fresh token no longer detects (live re-registration removed the pattern).
+//
+// Screenshot windows (the orchestrator runs `scripts/emu-shot.sh <label>`
+// while each marker window is open):
+//   CUSTOM1031_SHOT_EDITOR_OPEN — the creation flow (live match echo)
+//   CUSTOM1031_SHOT_LIVE_OPEN   — the custom anchor live (bubble + chip)
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/detection_lab_custom_1031_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/custom_patterns_providers.dart';
+import 'package:mobissh/state/detection_exceptions_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+Future<void> _pumps(WidgetTester tester, int count, [int ms = 100]) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(Duration(milliseconds: ms));
+  }
+}
+
+Future<void> _shotWindow(
+  WidgetTester tester,
+  String label, {
+  int halfSeconds = 45,
+}) async {
+  debugPrint('CUSTOM1031_SHOT_${label}_OPEN');
+  for (var i = 0; i < halfSeconds; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+  debugPrint('CUSTOM1031_SHOT_${label}_CLOSED');
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'user-defined pattern: create → detect → copy → suppress → delete '
+    '(#1031 slice 3)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller');
+
+      // Wait for a live shell.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // 1. CREATE: session menu → long-press detection glyph → lab root →
+      // Add pattern.
+      await tester.tap(find.byKey(const Key('session-menu-button')));
+      await _pumps(tester, 8);
+      await tester.longPress(
+        find.byKey(const Key('session-menu-detection-toggle')),
+      );
+      await _pumps(tester, 10);
+      expect(find.byKey(const Key('lab-add-pattern')), findsOneWidget,
+          reason: 'lab root must offer Add pattern');
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('lab-add-pattern')),
+        200,
+        scrollable: find
+            .descendant(
+              of: find.byKey(const Key('detection-lab-list')),
+              matching: find.byType(Scrollable),
+            )
+            .first,
+      );
+      await tester.tap(find.byKey(const Key('lab-add-pattern')));
+      await _pumps(tester, 10);
+
+      await tester.enterText(
+        find.byKey(const Key('lab-custom-name')),
+        'Jira tickets',
+      );
+      await tester.enterText(
+        find.byKey(const Key('lab-custom-regex')),
+        r'\b[A-Z]{2,}-\d+\b',
+      );
+      await tester.enterText(
+        find.byKey(const Key('lab-custom-sample')),
+        'fixed in MOBI-4242 yesterday',
+      );
+      await _pumps(tester, 5);
+      // The live echo names the match — the creation-flow validation surface.
+      expect(find.textContaining('MOBI-4242'), findsWidgets);
+
+      await _shotWindow(tester, 'EDITOR');
+
+      await tester.tap(find.byKey(const Key('lab-custom-save')));
+      await _pumps(tester, 10);
+
+      final patterns = container.read(customPatternsProvider);
+      expect(patterns, hasLength(1), reason: 'save must persist the pattern');
+      final patternId = patterns.single.id;
+      expect(find.byKey(Key('lab-card-$patternId')), findsOneWidget,
+          reason: 'the new pattern gets a MY PATTERNS card');
+
+      // Back to the live terminal (lab root → terminal).
+      await tester.pageBack();
+      await _pumps(tester, 12, 250);
+
+      // 2. DETECT: echo a matching token; the live re-registration (customs
+      // listen) must pick it up with NO reconnect.
+      const token = 'MOBI-1337';
+      entry.proxy.sendInput(
+        Uint8List.fromList(utf8.encode('echo ticket $token ok\n')),
+      );
+      bool tokenDetected() => controller!.anchors.any(
+        (a) => a.patternId == patternId && '${a.payload}' == token,
+      );
+      for (var i = 0; i < 40 && !tokenDetected(); i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(tokenDetected(), isTrue,
+          reason: 'custom anchor never appeared for $token');
+
+      // Bubble wash + gutter chip both render for the custom anchor.
+      final bubbleFinder = find.byKey(const Key('ghostty-bubble-paint'));
+      for (var i = 0; i < 20 && bubbleFinder.evaluate().isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(bubbleFinder, findsOneWidget,
+          reason: 'custom span anchors must paint the bubble wash');
+      bool anyGutterMark() => find
+          .byWidgetPredicate(
+            (w) => w.key is Key && '${w.key}'.contains('gutter-mark-'),
+          )
+          .evaluate()
+          .isNotEmpty;
+      for (var i = 0; i < 20 && !anyGutterMark(); i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(anyGutterMark(), isTrue, reason: 'no gutter chip for the anchor');
+
+      await _shotWindow(tester, 'LIVE');
+
+      // The custom anchor's geometry: its bubble rects (Stack coordinates —
+      // the keyed terminal Stack IS the bubble layer's origin) and its OWN
+      // gutter row (the typed `echo …` line above carries a second anchor
+      // for the same token on a different row).
+      final anchor = controller!.anchors.firstWhere(
+        (a) => a.patternId == patternId && '${a.payload}' == token,
+      );
+      final gutterRow = anchor.ranges
+          .map(controller.anchorGutterRow)
+          .whereType<int>()
+          .first;
+      final rects = <Rect>[];
+      for (final range in anchor.ranges) {
+        rects.addAll(controller.anchorRects(range));
+      }
+      expect(rects, isNotEmpty, reason: 'anchor has no on-screen rects');
+      final termRect =
+          tester.getRect(find.byKey(Key('ghostty-terminal-$sessionId')));
+
+      // 3. COPY: a glass TAP on the match copies its payload (the IA's v1
+      // "Copy match" tap action; same path as URL tap-copy, #726).
+      await tester.tapAt(termRect.topLeft + rects.first.center);
+      await _pumps(tester, 10);
+      expect(find.text('Copied match'), findsOneWidget,
+          reason: 'a tap on the custom match must copy its payload');
+      // Let the toast clear before the next gesture.
+      await _pumps(tester, 20, 250);
+
+      // 4. SUPPRESS: the gutter chip opens the generic action menu (the ONLY
+      // plain-shell "Not a match" surface — the long-press match menu is
+      // mouse-mode-only) → report → affordances disappear.
+      await tester.tap(
+        find.byKey(Key('gutter-mark-$gutterRow')),
+        // The mark's hit target extends beyond its painted chip; the tap
+        // lands (the copy path proved it) but the strict center check warns.
+        warnIfMissed: false,
+      );
+      await _pumps(tester, 10);
+      expect(find.byKey(const Key('url-action-menu')), findsOneWidget,
+          reason: 'the custom chip must open the generic action menu');
+      expect(find.text('Not a match'), findsOneWidget,
+          reason: 'a custom match reports as "Not a match", not "Not a URL"');
+      expect(find.byKey(const Key('url-action-open')), findsNothing,
+          reason: 'no browser Open for an arbitrary token');
+      await tester.tap(find.byKey(const Key('url-action-not-url')));
+      await _pumps(tester, 12, 250);
+      expect(
+        container
+            .read(detectionExceptionsProvider)
+            .any((e) => e.family == patternId && e.matchedText == token),
+        isTrue,
+        reason: 'the report must persist under the custom family',
+      );
+      expect(find.byKey(Key('gutter-mark-$gutterRow')), findsNothing,
+          reason: '"Not a match" must remove the row\'s chip immediately');
+
+      // 5. DELETE: lab → card → detail → delete (confirm discloses pruning) →
+      // affordances gone and a NEW token no longer detects.
+      await tester.tap(find.byKey(const Key('session-menu-button')));
+      await _pumps(tester, 8);
+      await tester.longPress(
+        find.byKey(const Key('session-menu-detection-toggle')),
+      );
+      await _pumps(tester, 10);
+      await tester.scrollUntilVisible(
+        find.byKey(Key('lab-card-tile-$patternId')),
+        200,
+        scrollable: find
+            .descendant(
+              of: find.byKey(const Key('detection-lab-list')),
+              matching: find.byType(Scrollable),
+            )
+            .first,
+      );
+      await tester.tap(find.byKey(Key('lab-card-tile-$patternId')));
+      await _pumps(tester, 10);
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('lab-custom-delete-button')),
+        200,
+        scrollable: find
+            .descendant(
+              of: find.byKey(const Key('lab-detail-controls')),
+              matching: find.byType(Scrollable),
+            )
+            .first,
+      );
+      await tester.tap(find.byKey(const Key('lab-custom-delete-button')));
+      await _pumps(tester, 10);
+      // Review change 5: the confirm DISCLOSES the exception pruning.
+      expect(find.textContaining('saved detection exception'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('lab-custom-delete-confirm')));
+      await _pumps(tester, 12, 250);
+      expect(container.read(customPatternsProvider), isEmpty);
+      expect(
+        container
+            .read(detectionExceptionsProvider)
+            .any((e) => e.family == patternId),
+        isFalse,
+        reason: 'delete must prune the pattern\'s exception family',
+      );
+      expect(find.byKey(Key('lab-card-$patternId')), findsNothing);
+
+      // Back to the terminal; a fresh token must NOT detect any more.
+      await tester.pageBack();
+      await _pumps(tester, 12, 250);
+      const token2 = 'MOBI-9999';
+      entry.proxy.sendInput(
+        Uint8List.fromList(utf8.encode('echo later $token2 end\n')),
+      );
+      var seen2 = false;
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (utf8.decode(out, allowMalformed: true).contains(token2)) {
+          seen2 = true;
+        }
+      }
+      expect(seen2, isTrue, reason: 'the follow-up echo never landed');
+      expect(
+        controller.anchors.any((a) => a.patternId == patternId),
+        isFalse,
+        reason: 'a deleted pattern must not anchor new output',
+      );
+    },
+  );
+}

--- a/native/lib/state/custom_patterns_providers.dart
+++ b/native/lib/state/custom_patterns_providers.dart
@@ -1,0 +1,155 @@
+// Riverpod surface for user-defined detection patterns (#1031 slice 3).
+//
+// [customPatternsProvider] holds the hydrated pattern list. The terminal view
+// `ref.listen`s it for live pattern RE-registration (the slice-2 lexicon
+// listen precedent) and the lab renders the MY PATTERNS zone from it.
+//
+// Hydrate AUTO-DISABLES any stored pattern whose regex no longer compiles
+// (hand-edited / corrupt source): registration would skip it anyway, but the
+// honest state is disabled-with-error, surfaced on its lab card — never a
+// silent drop, never a crash.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../storage/custom_patterns_store.dart';
+
+/// Persisted user-defined patterns, creation order. Mutations go through the
+/// notifier; the terminal registers enabled ones via ghosttyDetectionPatterns.
+final customPatternsProvider =
+    StateNotifierProvider<CustomPatternsNotifier, List<CustomPattern>>((ref) {
+      return CustomPatternsNotifier();
+    });
+
+/// One pattern by id (null = unknown/deleted). Watch THIS from per-pattern UI
+/// so sibling changes don't rebuild it.
+final customPatternProvider = Provider.family<CustomPattern?, String>((
+  ref,
+  id,
+) {
+  for (final p in ref.watch(customPatternsProvider)) {
+    if (p.id == id) return p;
+  }
+  return null;
+});
+
+/// Notifier over [CustomPatternsStore]. Best-effort hydrate/persist that
+/// never throws when prefs are unavailable (widget tests without bindings) —
+/// the DetectionStylesNotifier idiom.
+class CustomPatternsNotifier extends StateNotifier<List<CustomPattern>> {
+  CustomPatternsNotifier({CustomPatternsStore? store})
+    : _store = store ?? CustomPatternsStore(),
+      super(const <CustomPattern>[]) {
+    ready = _hydrate();
+  }
+
+  final CustomPatternsStore _store;
+
+  /// Completes when the persisted list has hydrated (tests await this; the
+  /// UI just watches state — the empty default is correct pre-hydrate).
+  late final Future<void> ready;
+
+  Future<void> _hydrate() async {
+    try {
+      var stored = await _store.load();
+      // Auto-disable on compile failure: a source that stopped compiling
+      // can't register; persist the honest bit so every surface agrees.
+      final broken = [
+        for (final p in stored)
+          if (p.enabled && compileCustomPatternRegex(p.source) == null) p.id,
+      ];
+      if (broken.isNotEmpty) {
+        stored = [
+          for (final p in stored)
+            if (broken.contains(p.id)) p.copyWith(enabled: false) else p,
+        ];
+        await _store.saveAll(stored);
+      }
+      if (!mounted) return;
+      state = List<CustomPattern>.unmodifiable(stored);
+    } catch (_) {
+      // best-effort; keep the empty default if prefs are unavailable.
+    }
+  }
+
+  void _set(List<CustomPattern> next) {
+    if (mounted) state = List<CustomPattern>.unmodifiable(next);
+  }
+
+  /// Create a pattern (id minted ONCE here — review change 5) and return it.
+  Future<CustomPattern> create({
+    required String name,
+    required String source,
+    String sampleLine = '',
+  }) async {
+    try {
+      final created = await _store.add(
+        name: name,
+        source: source,
+        sampleLine: sampleLine,
+      );
+      _set(await _store.load());
+      return created;
+    } catch (_) {
+      // Prefs unavailable: still reflect the creation in memory.
+      final created = CustomPattern(
+        id: mintCustomPatternId(state.map((p) => p.id)),
+        name: name,
+        source: source,
+        enabled: true,
+        createdTs: DateTime.now().millisecondsSinceEpoch,
+        sampleLine: sampleLine,
+      );
+      _set([...state, created]);
+      return created;
+    }
+  }
+
+  /// Edit [id]'s definition — the id NEVER changes (review change 5).
+  Future<void> updatePattern(
+    String id, {
+    String? name,
+    String? source,
+    String? sampleLine,
+  }) async {
+    try {
+      await _store.update(id, name: name, source: source, sampleLine: sampleLine);
+      _set(await _store.load());
+    } catch (_) {
+      _set([
+        for (final p in state)
+          if (p.id == id)
+            p.copyWith(name: name, source: source, sampleLine: sampleLine)
+          else
+            p,
+      ]);
+    }
+  }
+
+  /// Flip [id]'s enable bit.
+  Future<void> setEnabled(String id, bool enabled) async {
+    try {
+      await _store.setEnabled(id, enabled);
+      _set(await _store.load());
+    } catch (_) {
+      _set([
+        for (final p in state)
+          if (p.id == id) p.copyWith(enabled: enabled) else p,
+      ]);
+    }
+  }
+
+  /// Delete [id]. The CALLER owns the disclosed side effects (pruning the
+  /// #995 exception family, dropping the style entry) — see the lab's
+  /// delete confirm.
+  Future<void> remove(String id) async {
+    try {
+      await _store.remove(id);
+      _set(await _store.load());
+    } catch (_) {
+      _set([
+        for (final p in state)
+          if (p.id != id) p,
+      ]);
+    }
+  }
+}

--- a/native/lib/state/detection_exceptions_providers.dart
+++ b/native/lib/state/detection_exceptions_providers.dart
@@ -85,6 +85,13 @@ class DetectionExceptionsNotifier
     );
     _setState(entries);
   }
+
+  /// Prune EVERY exception in [patternId]'s family (#1031 slice 3: a deleted
+  /// custom pattern takes its suppressions with it — the lab's delete confirm
+  /// discloses the count first).
+  Future<void> pruneFamily(String patternId) async {
+    _setState(await _store.removeFamily(detectionExceptionFamily(patternId)));
+  }
 }
 
 /// Global detection-exceptions provider (#995). The terminal view watches the

--- a/native/lib/storage/custom_patterns_store.dart
+++ b/native/lib/storage/custom_patterns_store.dart
@@ -1,0 +1,306 @@
+// User-defined detection patterns (#1031 slice 3) — the AUTHORED records
+// behind the lab's MY PATTERNS zone.
+//
+// One record per pattern: {id, name, regex source, enabled, createdTs,
+// sampleLine}. The id is minted ONCE at creation ([mintCustomPatternId]) and
+// NEVER re-derived from the name (#1031 IA review change 5): the style store,
+// the enable bit, and the #995 exception family are all keyed by id, so a
+// rename re-deriving it would silently orphan all three. Name is display-only.
+//
+// The regex is stored as SOURCE text and compiled DEFENSIVELY at every use
+// ([compileCustomPatternRegex] never throws): the editor validates live, the
+// registration path skips a non-compiling pattern, and the card renders a
+// visible error state — never a crash, never a wedged scanner.
+//
+// Storage follows the detection_styles_store precedent: one JSON blob in
+// shared_preferences under [customPatternsPrefsKey], schema version INSIDE
+// the value (never a key bump), corrupt / unknown-version data falls back to
+// empty, malformed entries dropped individually.
+//
+// These are AUTHORED data (like favorites and exception reports): they
+// survive "Reset lab customizations" and Settings "Reset settings"; only an
+// explicit per-pattern delete removes one.
+
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// shared_preferences key. `v1` in the NAME is the storage namespace only;
+/// the migratable schema version lives inside the value.
+const String customPatternsPrefsKey = 'mobissh.detection.custom_patterns.v1';
+
+/// Current in-value schema version.
+const int _schemaVersion = 1;
+
+/// The id namespace for user-defined patterns — can never collide with the
+/// built-in `url` / `osc8` / `path` / `command` ids or future built-ins.
+const String kCustomPatternIdPrefix = 'custom.';
+
+/// Whether [patternId] names a user-defined pattern.
+bool isCustomPatternId(String patternId) =>
+    patternId.startsWith(kCustomPatternIdPrefix);
+
+/// Mint a NEW custom-pattern id, unique against [existingIds]. Called exactly
+/// once, at creation (#1031 IA review change 5) — the id is immutable
+/// thereafter and is never derived from the (renameable) display name.
+/// Timestamp-based with a collision suffix so ids stay unique even for two
+/// creations in the same millisecond.
+String mintCustomPatternId(Iterable<String> existingIds, {int? nowMs}) {
+  final taken = existingIds.toSet();
+  final ts = nowMs ?? DateTime.now().millisecondsSinceEpoch;
+  final base = '${kCustomPatternIdPrefix}p$ts';
+  if (!taken.contains(base)) return base;
+  var n = 2;
+  while (taken.contains('$base-$n')) {
+    n++;
+  }
+  return '$base-$n';
+}
+
+/// Compile a stored regex source, or null when it is empty / invalid. NEVER
+/// throws — this is the single defensive compile every consumer (editor
+/// validation, card error state, pattern registration) goes through.
+RegExp? compileCustomPatternRegex(String source) {
+  if (source.trim().isEmpty) return null;
+  try {
+    return RegExp(source);
+  } catch (_) {
+    return null;
+  }
+}
+
+/// The human-readable compile error for [source], or null when it compiles
+/// (or is still empty — emptiness is "incomplete", not an error). Rendered
+/// inline under the editor's regex field.
+String? customPatternRegexError(String source) {
+  if (source.trim().isEmpty) return null;
+  try {
+    RegExp(source);
+    return null;
+  } on FormatException catch (e) {
+    // FormatException.message carries the useful part ("Unterminated group"
+    // etc.) without the full source dump.
+    final msg = e.message.trim();
+    return msg.isEmpty ? 'Invalid regular expression' : msg;
+  } catch (_) {
+    return 'Invalid regular expression';
+  }
+}
+
+/// One user-defined pattern record. Immutable; edits go through [copyWith]
+/// (which cannot change [id] or [createdTs] — minted/marked once).
+class CustomPattern {
+  const CustomPattern({
+    required this.id,
+    required this.name,
+    required this.source,
+    required this.enabled,
+    required this.createdTs,
+    this.sampleLine = '',
+  });
+
+  /// Immutable identity (see [mintCustomPatternId]) — the key into the style
+  /// store, the exception family, and the registered TextPattern id.
+  final String id;
+
+  /// Display-only name; renaming never touches [id] (review change 5).
+  final String name;
+
+  /// The regex SOURCE text (compiled defensively at use).
+  final String source;
+
+  /// Whether this pattern registers on the terminal (master switch still
+  /// gates it globally). Auto-cleared when the stored source stops compiling.
+  final bool enabled;
+
+  /// Creation time, epoch ms.
+  final int createdTs;
+
+  /// The sample line the editor validated against — kept so the lab card's
+  /// mini preview renders the author's own example.
+  final String sampleLine;
+
+  CustomPattern copyWith({
+    String? name,
+    String? source,
+    bool? enabled,
+    String? sampleLine,
+  }) {
+    return CustomPattern(
+      id: id,
+      name: name ?? this.name,
+      source: source ?? this.source,
+      enabled: enabled ?? this.enabled,
+      createdTs: createdTs,
+      sampleLine: sampleLine ?? this.sampleLine,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'id': id,
+    'name': name,
+    'source': source,
+    'enabled': enabled,
+    'ts': createdTs,
+    if (sampleLine.isNotEmpty) 'sample': sampleLine,
+  };
+
+  /// Parse one stored record; null for anything without a usable custom id +
+  /// source (a bad entry is dropped, not fatal). An INVALID regex source
+  /// still loads — the UI owns showing its error state.
+  static CustomPattern? fromJson(Object? raw) {
+    if (raw is! Map) return null;
+    final id = raw['id'];
+    final source = raw['source'];
+    if (id is! String || !isCustomPatternId(id)) return null;
+    if (source is! String || source.trim().isEmpty) return null;
+    final name = raw['name'];
+    final enabled = raw['enabled'];
+    final ts = raw['ts'];
+    final sample = raw['sample'];
+    return CustomPattern(
+      id: id,
+      name: name is String && name.trim().isNotEmpty ? name : id,
+      source: source,
+      enabled: enabled is bool ? enabled : true,
+      createdTs: ts is int ? ts : 0,
+      sampleLine: sample is String ? sample : '',
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is CustomPattern &&
+      other.id == id &&
+      other.name == name &&
+      other.source == source &&
+      other.enabled == enabled &&
+      other.createdTs == createdTs &&
+      other.sampleLine == sampleLine;
+
+  @override
+  int get hashCode =>
+      Object.hash(id, name, source, enabled, createdTs, sampleLine);
+
+  @override
+  String toString() =>
+      'CustomPattern($id, "$name", /$source/, enabled:$enabled)';
+}
+
+/// Persistence layer for user-defined patterns (#1031 slice 3). UI consumers
+/// go through `customPatternsProvider`. Tests inject a [SharedPreferences]
+/// via [SharedPreferences.setMockInitialValues] and construct directly.
+class CustomPatternsStore {
+  CustomPatternsStore({SharedPreferences? prefs}) : _prefs = prefs;
+
+  // ignore_for_file: prefer_initializing_formals
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> _ensure() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// Read all stored patterns, creation order. Empty on nothing stored /
+  /// malformed JSON / wrong shape / unknown schema version; malformed entries
+  /// dropped individually (validate → fallback, never crash).
+  Future<List<CustomPattern>> load() async {
+    final prefs = await _ensure();
+    final raw = prefs.getString(customPatternsPrefsKey);
+    if (raw == null || raw.isEmpty) return <CustomPattern>[];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return <CustomPattern>[];
+      final version = decoded['v'];
+      if (version is! int || version != _schemaVersion) {
+        return <CustomPattern>[];
+      }
+      final patterns = decoded['patterns'];
+      if (patterns is! List) return <CustomPattern>[];
+      final out = <CustomPattern>[];
+      final seen = <String>{};
+      for (final entry in patterns) {
+        final p = CustomPattern.fromJson(entry);
+        if (p == null) continue;
+        if (seen.add(p.id)) out.add(p);
+      }
+      return out;
+    } on FormatException {
+      return <CustomPattern>[];
+    }
+  }
+
+  Future<void> saveAll(List<CustomPattern> patterns) async {
+    final prefs = await _ensure();
+    if (patterns.isEmpty) {
+      await prefs.remove(customPatternsPrefsKey);
+      return;
+    }
+    final encoded = jsonEncode(<String, dynamic>{
+      'v': _schemaVersion,
+      'patterns': patterns.map((p) => p.toJson()).toList(),
+    });
+    await prefs.setString(customPatternsPrefsKey, encoded);
+  }
+
+  /// Create a new pattern: mint the id (ONCE — review change 5), persist,
+  /// return the created record. Enabled by default.
+  Future<CustomPattern> add({
+    required String name,
+    required String source,
+    String sampleLine = '',
+    int? nowMs,
+  }) async {
+    final patterns = await load();
+    final created = CustomPattern(
+      id: mintCustomPatternId(patterns.map((p) => p.id), nowMs: nowMs),
+      name: name,
+      source: source,
+      enabled: true,
+      createdTs: nowMs ?? DateTime.now().millisecondsSinceEpoch,
+      sampleLine: sampleLine,
+    );
+    await saveAll([...patterns, created]);
+    return created;
+  }
+
+  /// Edit [id]'s definition IN PLACE — the id and createdTs never change.
+  /// Returns the updated record, or null when [id] is unknown.
+  Future<CustomPattern?> update(
+    String id, {
+    String? name,
+    String? source,
+    String? sampleLine,
+  }) async {
+    final patterns = await load();
+    CustomPattern? updated;
+    final next = [
+      for (final p in patterns)
+        if (p.id == id)
+          updated = p.copyWith(name: name, source: source, sampleLine: sampleLine)
+        else
+          p,
+    ];
+    if (updated == null) return null;
+    await saveAll(next);
+    return updated;
+  }
+
+  /// Flip [id]'s enable bit. No-op for an unknown id.
+  Future<void> setEnabled(String id, bool enabled) async {
+    final patterns = await load();
+    await saveAll([
+      for (final p in patterns)
+        if (p.id == id) p.copyWith(enabled: enabled) else p,
+    ]);
+  }
+
+  /// Delete [id]'s record. (The caller owns the disclosed side effects:
+  /// pruning the #995 exception family and dropping the style entry.)
+  Future<void> remove(String id) async {
+    final patterns = await load();
+    await saveAll([
+      for (final p in patterns)
+        if (p.id != id) p,
+    ]);
+  }
+}

--- a/native/lib/storage/detection_exceptions_store.dart
+++ b/native/lib/storage/detection_exceptions_store.dart
@@ -203,6 +203,18 @@ class DetectionExceptionsStore {
     return entries;
   }
 
+  /// Remove EVERY exception in [family] (#1031 slice 3: deleting a custom
+  /// pattern prunes its orphaned suppressions — disclosed in the delete
+  /// confirm, since exception reports are authored data). Returns the
+  /// updated list.
+  Future<List<DetectionException>> removeFamily(String family) async {
+    final entries = await load();
+    final before = entries.length;
+    entries.removeWhere((e) => e.family == family);
+    if (entries.length != before) await _saveAll(entries);
+    return entries;
+  }
+
   /// Clear all exceptions.
   Future<void> clear() async {
     final prefs = await _ensure();

--- a/native/lib/ui/detection_lab_detail_screen.dart
+++ b/native/lib/ui/detection_lab_detail_screen.dart
@@ -23,10 +23,15 @@ import 'package:flterm/flterm.dart' show kDefaultCommandLexicon;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../state/custom_patterns_providers.dart';
+import '../state/detection_exceptions_providers.dart';
 import '../state/detection_providers.dart';
 import '../state/detection_style_providers.dart';
+import '../storage/custom_patterns_store.dart';
+import '../storage/detection_exceptions_store.dart';
 import '../storage/detection_styles_store.dart';
 import 'color_picker_sheet.dart';
+import 'detection_lab_pattern_editor.dart';
 import 'detection_lab_preview.dart';
 import 'detection_style_resolver.dart';
 import 'settings_subheader.dart';
@@ -43,7 +48,16 @@ class DetectionLabDetailScreen extends ConsumerStatefulWidget {
 
 class _DetectionLabDetailScreenState
     extends ConsumerState<DetectionLabDetailScreen> {
-  DetectionLabPatternSpec get spec => widget.spec;
+  /// The live spec. For a USER-DEFINED pattern (#1031 slice 3) it re-derives
+  /// from the CURRENT store record (build watches the provider) so an edit —
+  /// rename, new regex, new sample — reflects immediately; the immutable id
+  /// (`widget.spec.key`) is the stable handle. Falls back to the mount-time
+  /// spec while the record is gone (mid-delete pop).
+  DetectionLabPatternSpec get spec {
+    if (!widget.spec.isCustom) return widget.spec;
+    final live = ref.read(customPatternProvider(widget.spec.key));
+    return live == null ? widget.spec : detectionLabSpecForCustomPattern(live);
+  }
 
   /// Luminance override for the preview strip (null = follow the theme).
   Brightness? _luminance;
@@ -179,10 +193,61 @@ class _DetectionLabDetailScreenState
     );
   }
 
+  /// Delete a USER-DEFINED pattern (#1031 slice 3). The confirm DISCLOSES the
+  /// #995 exception-family pruning (IA review change 5: deleting authored
+  /// data as a side effect must be stated at the moment it happens), then
+  /// prunes the family, drops the TUNED style entry, removes the record, and
+  /// pops back to the lab root.
+  Future<void> _confirmDeleteCustom(CustomPattern custom) async {
+    final family = detectionExceptionFamily(custom.id);
+    final exceptionCount = ref
+        .read(detectionExceptionsProvider)
+        .where((e) => e.family == family)
+        .length;
+    final disclosure = exceptionCount > 0
+        ? 'Also removes $exceptionCount saved detection '
+              'exception${exceptionCount == 1 ? '' : 's'} reported for it.'
+        : 'No saved detection exceptions reference it.';
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        key: const ValueKey('lab-custom-delete-dialog'),
+        title: Text('Delete "${custom.name}"?'),
+        content: Text(
+          'Remove this pattern and its color and intensity tuning. '
+          '$disclosure',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const ValueKey('lab-custom-delete-confirm'),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await ref.read(detectionExceptionsProvider.notifier).pruneFamily(custom.id);
+    await ref.read(detectionStylesProvider.notifier).resetPattern(custom.id);
+    await ref.read(customPatternsProvider.notifier).remove(custom.id);
+    if (mounted) Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final detection = ref.watch(detectionSettingsProvider);
+    // #1031 slice 3: the live custom record (null for built-ins / mid-delete)
+    // — watching keeps title/sample/enable current across edits.
+    final custom = widget.spec.isCustom
+        ? ref.watch(customPatternProvider(widget.spec.key))
+        : null;
+    final customBroken =
+        custom != null && compileCustomPatternRegex(custom.source) == null;
     final styles = ref.watch(detectionStylesProvider);
     final stored = styles.of(spec.primaryId);
     final preview = detectionLabPreviewTheme(ref, luminanceOverride: _luminance);
@@ -191,7 +256,9 @@ class _DetectionLabDetailScreenState
       accent: preview.accent,
       backgroundBrightness: preview.brightness,
     );
-    final enabled = detectionLabTypeEnabled(detection, spec.key);
+    final enabled = widget.spec.isCustom
+        ? (custom?.enabled ?? false) && !customBroken
+        : detectionLabTypeEnabled(detection, spec.key);
     final inactiveValue =
         _clampBand(_draftInactive ?? stored?.inactiveIntensity ?? 1.0);
     final activeValue =
@@ -207,9 +274,17 @@ class _DetectionLabDetailScreenState
             child: Switch(
               key: const ValueKey('lab-detail-enable'),
               value: enabled,
-              onChanged: detection.enabled
-                  ? (v) => detectionLabSetTypeEnabled(ref, spec.key, v)
-                  : null,
+              // Master OFF greys it; a custom pattern flips its OWN store bit
+              // (a broken regex can't be enabled — fix it in the editor).
+              onChanged: !detection.enabled
+                  ? null
+                  : widget.spec.isCustom
+                  ? (custom == null || customBroken
+                        ? null
+                        : (v) => ref
+                              .read(customPatternsProvider.notifier)
+                              .setEnabled(custom.id, v))
+                  : (v) => detectionLabSetTypeEnabled(ref, spec.key, v),
             ),
           ),
         ],
@@ -301,6 +376,38 @@ class _DetectionLabDetailScreenState
                 key: const ValueKey('lab-detail-controls'),
                 padding: const EdgeInsets.only(bottom: 8),
                 children: [
+                  // #1031 slice 3: a custom pattern's DEFINITION — name/regex
+                  // edit via the shared editor (create and edit are one
+                  // screen; the id never changes, review change 5).
+                  if (widget.spec.isCustom) ...[
+                    const SettingsSubheader('Definition'),
+                    ListTile(
+                      key: const ValueKey('lab-custom-edit-row'),
+                      leading: const Icon(Icons.edit_outlined),
+                      title: const Text('Edit pattern'),
+                      subtitle: Text(
+                        customBroken
+                            ? 'Regex no longer compiles — open to fix it.'
+                            : custom?.source ?? '',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: customBroken
+                            ? TextStyle(color: theme.colorScheme.error)
+                            : const TextStyle(fontFamily: 'monospace'),
+                      ),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: custom == null
+                          ? null
+                          : () => Navigator.of(context).push(
+                              MaterialPageRoute<void>(
+                                builder: (_) =>
+                                    DetectionLabPatternEditorScreen(
+                                      existing: custom,
+                                    ),
+                              ),
+                            ),
+                    ),
+                  ],
                   const SettingsSubheader('Style'),
                   ListTile(
                     key: const ValueKey('lab-color-row'),
@@ -412,6 +519,25 @@ class _DetectionLabDetailScreenState
                       label: const Text('Reset this pattern'),
                     ),
                   ),
+                  // #1031 slice 3: delete (custom only) — LAST, below reset;
+                  // the confirm discloses the exception pruning.
+                  if (widget.spec.isCustom) ...[
+                    const SizedBox(height: 8),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: OutlinedButton.icon(
+                        key: const ValueKey('lab-custom-delete-button'),
+                        onPressed: custom == null
+                            ? null
+                            : () => _confirmDeleteCustom(custom),
+                        icon: const Icon(Icons.delete_outline),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: theme.colorScheme.error,
+                        ),
+                        label: const Text('Delete pattern'),
+                      ),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/native/lib/ui/detection_lab_pattern_editor.dart
+++ b/native/lib/ui/detection_lab_pattern_editor.dart
@@ -1,0 +1,225 @@
+// User-defined pattern EDITOR (#1031 slice 3) — one screen for create and
+// edit, per the reviewed IA.
+//
+// Mandatory path = three fields: name, regex, sample line. The regex is
+// compiled LIVE in a defensive try (never a crash): a compile error renders
+// INLINE under the field and blocks Save; an empty sample match is a NOTE,
+// never a block (the sample may simply not contain a hit). The sample line
+// echoes what the pattern matches — the matched spans render highlighted so
+// the author sees exactly what the terminal will decorate.
+//
+// Identity (IA review change 5): the id is minted ONCE at creation, by the
+// store — this screen never touches it. Editing (rename / regex / sample)
+// updates the record IN PLACE under the same id, so the style entry, the
+// enable bit, and the #995 exception family never orphan.
+//
+// Tier is fixed to SPAN in v1 (the #767 default; block + trailing-trim are a
+// later slice) and the tap action is "Copy match" — both deliberate IA cuts.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/custom_patterns_providers.dart';
+import '../storage/custom_patterns_store.dart';
+
+class DetectionLabPatternEditorScreen extends ConsumerStatefulWidget {
+  const DetectionLabPatternEditorScreen({super.key, this.existing});
+
+  /// The pattern being edited, or null to create a new one.
+  final CustomPattern? existing;
+
+  @override
+  ConsumerState<DetectionLabPatternEditorScreen> createState() =>
+      _DetectionLabPatternEditorScreenState();
+}
+
+class _DetectionLabPatternEditorScreenState
+    extends ConsumerState<DetectionLabPatternEditorScreen> {
+  late final TextEditingController _name = TextEditingController(
+    text: widget.existing?.name ?? '',
+  );
+  late final TextEditingController _regex = TextEditingController(
+    text: widget.existing?.source ?? '',
+  );
+  late final TextEditingController _sample = TextEditingController(
+    text: widget.existing?.sampleLine ?? '',
+  );
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _regex.dispose();
+    _sample.dispose();
+    super.dispose();
+  }
+
+  String? get _regexError => customPatternRegexError(_regex.text);
+
+  bool get _canSave =>
+      _name.text.trim().isNotEmpty &&
+      compileCustomPatternRegex(_regex.text) != null;
+
+  Future<void> _save() async {
+    final notifier = ref.read(customPatternsProvider.notifier);
+    final name = _name.text.trim();
+    final source = _regex.text;
+    final sample = _sample.text;
+    final existing = widget.existing;
+    if (existing == null) {
+      await notifier.create(name: name, source: source, sampleLine: sample);
+    } else {
+      // Review change 5: the id NEVER changes on edit.
+      await notifier.updatePattern(
+        existing.id,
+        name: name,
+        source: source,
+        sampleLine: sample,
+      );
+    }
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  /// The non-empty match spans of the current regex over the sample line.
+  List<Match> _sampleMatches() {
+    final regex = compileCustomPatternRegex(_regex.text);
+    final sample = _sample.text;
+    if (regex == null || sample.isEmpty) return const [];
+    return [
+      for (final m in regex.allMatches(sample))
+        if (m.end > m.start) m,
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final regexError = _regexError;
+    final matches = _sampleMatches();
+    final sample = _sample.text;
+    final highlight = theme.colorScheme.primary.withValues(alpha: 0.30);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.existing == null ? 'New pattern' : 'Edit pattern'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: FilledButton(
+              key: const ValueKey('lab-custom-save'),
+              onPressed: _canSave ? _save : null,
+              child: const Text('Save'),
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            TextField(
+              key: const ValueKey('lab-custom-name'),
+              controller: _name,
+              autocorrect: false,
+              decoration: const InputDecoration(
+                labelText: 'Name',
+                hintText: 'Jira tickets',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              key: const ValueKey('lab-custom-regex'),
+              controller: _regex,
+              autocorrect: false,
+              enableSuggestions: false,
+              style: const TextStyle(fontFamily: 'monospace'),
+              decoration: const InputDecoration(
+                labelText: 'Regular expression',
+                hintText: r'[A-Z]{2,}-\d+',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            // Live inline compile error (never a crash; Save stays blocked).
+            if (regexError != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Text(
+                  'Invalid regex: $regexError',
+                  key: const ValueKey('lab-custom-regex-error'),
+                  style: TextStyle(
+                    color: theme.colorScheme.error,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            const SizedBox(height: 16),
+            TextField(
+              key: const ValueKey('lab-custom-sample'),
+              controller: _sample,
+              autocorrect: false,
+              enableSuggestions: false,
+              style: const TextStyle(fontFamily: 'monospace'),
+              decoration: const InputDecoration(
+                labelText: 'Sample line to validate against',
+                hintText: 'fixed in PROJ-1234 yesterday',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            if (sample.isNotEmpty && regexError == null) ...[
+              const SizedBox(height: 8),
+              // The echo: matched payload(s), or the honest no-match NOTE
+              // (a warning, never a Save block — the IA's creation-flow rule).
+              Text(
+                matches.isEmpty
+                    ? 'no match on this line'
+                    : 'matched: ${matches.map((m) => '"${sample.substring(m.start, m.end)}"').join(', ')}',
+                key: const ValueKey('lab-custom-sample-echo'),
+                style: theme.textTheme.bodySmall,
+              ),
+              if (matches.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                // The sample line with the match spans highlighted — the
+                // author sees exactly what the terminal will decorate.
+                Text.rich(
+                  TextSpan(children: _highlightSpans(sample, matches, highlight)),
+                  key: const ValueKey('lab-custom-sample-highlight'),
+                  style: const TextStyle(fontFamily: 'monospace', fontSize: 14),
+                ),
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Split [sample] into plain / highlighted spans at [matches] (non-empty,
+  /// in order, non-overlapping — allMatches guarantees both).
+  static List<TextSpan> _highlightSpans(
+    String sample,
+    List<Match> matches,
+    Color highlight,
+  ) {
+    final spans = <TextSpan>[];
+    var cursor = 0;
+    for (final m in matches) {
+      if (m.start > cursor) {
+        spans.add(TextSpan(text: sample.substring(cursor, m.start)));
+      }
+      spans.add(
+        TextSpan(
+          text: sample.substring(m.start, m.end),
+          style: TextStyle(backgroundColor: highlight),
+        ),
+      );
+      cursor = m.end;
+    }
+    if (cursor < sample.length) {
+      spans.add(TextSpan(text: sample.substring(cursor)));
+    }
+    return spans;
+  }
+}

--- a/native/lib/ui/detection_lab_preview.dart
+++ b/native/lib/ui/detection_lab_preview.dart
@@ -16,6 +16,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../state/detection_providers.dart';
 import '../state/sessions.dart';
+import '../storage/custom_patterns_store.dart';
 import '../state/ui_prefs_providers.dart';
 import 'detection_style_resolver.dart';
 import 'ghostty_gutter_layer.dart';
@@ -33,9 +34,11 @@ class DetectionLabPatternSpec {
     required this.samplePrefix,
     required this.sampleMatch,
     required this.bubble,
+    this.isCustom = false,
   });
 
-  /// Stable lab key (`url` / `path` / `command`) used in widget keys.
+  /// Stable lab key (`url` / `path` / `command`; a custom pattern's ID) used
+  /// in widget keys.
   final String key;
 
   /// Front-loaded display name ("URLs", "File paths", "Command lines").
@@ -57,6 +60,12 @@ class DetectionLabPatternSpec {
   /// Whether this pattern paints an inline bubble wash. The command pattern
   /// is GUTTER-ONLY (#998 C) — its preview honestly shows chip-only.
   final bool bubble;
+
+  /// Whether this entry is a USER-DEFINED pattern (#1031 slice 3): its key is
+  /// the immutable `custom.*` id, its enable bit lives in the custom store
+  /// (not detectionSettingsProvider), and its detail page adds the
+  /// definition/delete affordances.
+  final bool isCustom;
 
   /// The id style reads resolve against (the first style id).
   String get primaryId => styleIds.first;
@@ -100,6 +109,40 @@ const List<DetectionLabPatternSpec> detectionLabPatternSpecs = [
 /// Lookup by lab key. Throws on an unknown key (a programming error).
 DetectionLabPatternSpec detectionLabPatternSpec(String key) =>
     detectionLabPatternSpecs.firstWhere((s) => s.key == key);
+
+/// The generic monochrome glyph every USER-DEFINED pattern renders with
+/// (#1031 slice 3 IA: one generic chip glyph — the gutter fallback uses the
+/// same one).
+const IconData kCustomPatternIcon = Icons.pattern;
+
+/// Build the lab spec for a USER-DEFINED pattern (#1031 slice 3). The sample
+/// line splits at the pattern's OWN first match ([compileCustomPatternRegex],
+/// defensive): prefix = the text before it, match = the matched span the
+/// wash/chip decorate. No match (or a broken regex) leaves [sampleMatch]
+/// empty — the card renders its honest no-match / error state instead of a
+/// fake highlight.
+DetectionLabPatternSpec detectionLabSpecForCustomPattern(CustomPattern p) {
+  final regex = compileCustomPatternRegex(p.source);
+  var prefix = p.sampleLine;
+  var match = '';
+  if (regex != null && p.sampleLine.isNotEmpty) {
+    final m = regex.firstMatch(p.sampleLine);
+    if (m != null && m.end > m.start) {
+      prefix = p.sampleLine.substring(0, m.start);
+      match = p.sampleLine.substring(m.start, m.end);
+    }
+  }
+  return DetectionLabPatternSpec(
+    key: p.id,
+    title: p.name,
+    icon: kCustomPatternIcon,
+    styleIds: [p.id],
+    samplePrefix: prefix,
+    sampleMatch: match,
+    bubble: true,
+    isCustom: true,
+  );
+}
 
 /// Whether [key]'s pattern type is enabled in [d] — the SAME provider bits the
 /// Settings toggles flip (one bit, three surfaces).

--- a/native/lib/ui/detection_lab_screen.dart
+++ b/native/lib/ui/detection_lab_screen.dart
@@ -12,20 +12,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../state/custom_patterns_providers.dart';
 import '../state/detection_providers.dart';
 import '../state/detection_style_providers.dart';
+import '../storage/custom_patterns_store.dart';
 import 'detection_lab_detail_screen.dart';
+import 'detection_lab_pattern_editor.dart';
 import 'detection_lab_preview.dart';
 import 'detection_style_resolver.dart';
 import 'settings_subheader.dart';
 
 export 'detection_lab_detail_screen.dart' show DetectionLabDetailScreen;
+export 'detection_lab_pattern_editor.dart'
+    show DetectionLabPatternEditorScreen;
 export 'detection_lab_preview.dart'
     show
         DetectionLabPatternSpec,
         DetectionPreviewLine,
         detectionLabPatternSpec,
-        detectionLabPatternSpecs;
+        detectionLabPatternSpecs,
+        detectionLabSpecForCustomPattern;
 
 class DetectionLabScreen extends ConsumerWidget {
   const DetectionLabScreen({super.key});
@@ -35,6 +41,7 @@ class DetectionLabScreen extends ConsumerWidget {
     final theme = Theme.of(context);
     final detection = ref.watch(detectionSettingsProvider);
     final styles = ref.watch(detectionStylesProvider);
+    final customPatterns = ref.watch(customPatternsProvider);
     final preview = detectionLabPreviewTheme(ref);
     // The SAME resolver the runtime layers consult — the mini previews recolor
     // live as the store changes (slice-1 wiring).
@@ -81,6 +88,30 @@ class DetectionLabScreen extends ConsumerWidget {
                 resolver: resolver,
                 preview: preview,
               ),
+            // Zone C (#1031 slice 3): USER-DEFINED patterns — same card
+            // anatomy, enable bit from the custom store, creation at the end
+            // of the list it extends (per the IA).
+            const SettingsSubheader('My patterns'),
+            for (final pattern in customPatterns)
+              _CustomPatternCard(
+                pattern: pattern,
+                detection: detection,
+                resolver: resolver,
+                preview: preview,
+              ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 6, 12, 6),
+              child: FilledButton.tonalIcon(
+                key: const ValueKey('lab-add-pattern'),
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const DetectionLabPatternEditorScreen(),
+                  ),
+                ),
+                icon: const Icon(Icons.add),
+                label: const Text('Add pattern'),
+              ),
+            ),
             const SizedBox(height: 24),
             // Review change 4: the destructive lab-wide reset lives at the
             // BOTTOM, styled like the Settings reset (outlined, error color).
@@ -193,6 +224,110 @@ class _PatternCard extends ConsumerWidget {
                 foreground: preview.foreground,
               ),
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A USER-DEFINED pattern's card (#1031 slice 3): same anatomy as a built-in
+/// (generic glyph, front-loaded name, right-edge enable switch, mini preview
+/// over the author's own sample line, chevron → the shared detail page).
+/// A stored regex that no longer compiles renders a visible ERROR state
+/// instead of the preview and cannot be enabled (registration would skip it
+/// anyway — auto-disabled on hydrate; never a silent drop, never a crash).
+class _CustomPatternCard extends ConsumerWidget {
+  const _CustomPatternCard({
+    required this.pattern,
+    required this.detection,
+    required this.resolver,
+    required this.preview,
+  });
+
+  final CustomPattern pattern;
+  final DetectionSettings detection;
+  final DetectionStyleResolver resolver;
+  final DetectionLabPreviewTheme preview;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final spec = detectionLabSpecForCustomPattern(pattern);
+    final broken = compileCustomPatternRegex(pattern.source) == null;
+    return Card(
+      key: ValueKey('lab-card-${pattern.id}'),
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ListTile(
+            key: ValueKey('lab-card-tile-${pattern.id}'),
+            leading: Icon(spec.icon),
+            title: Text(spec.title),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Switch(
+                  key: ValueKey('lab-enable-${pattern.id}'),
+                  value: pattern.enabled && !broken,
+                  // Master OFF greys it (Settings idiom); a broken regex
+                  // can't be enabled (fix it in the editor first).
+                  onChanged: detection.enabled && !broken
+                      ? (v) => ref
+                            .read(customPatternsProvider.notifier)
+                            .setEnabled(pattern.id, v)
+                      : null,
+                ),
+                const Icon(Icons.chevron_right),
+              ],
+            ),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => DetectionLabDetailScreen(spec: spec),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+            child: broken
+                ? Row(
+                    key: ValueKey('lab-card-error-${pattern.id}'),
+                    children: [
+                      Icon(
+                        Icons.error_outline,
+                        size: 18,
+                        color: theme.colorScheme.error,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          'Pattern disabled — its regex no longer compiles. '
+                          'Open it to fix the expression.',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: theme.colorScheme.error,
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                : spec.sampleMatch.isEmpty
+                ? Text(
+                    'No sample match — open the pattern to set a sample line.',
+                    key: ValueKey('lab-card-nosample-${pattern.id}'),
+                    style: theme.textTheme.bodySmall,
+                  )
+                : ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: DetectionPreviewLine(
+                      key: ValueKey('lab-preview-${pattern.id}'),
+                      spec: spec,
+                      resolver: resolver,
+                      background: preview.background,
+                      foreground: preview.foreground,
+                    ),
+                  ),
           ),
         ],
       ),

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -37,6 +37,7 @@ import 'package:flterm/flterm.dart' hide Key;
 import 'package:flutter/material.dart';
 
 import '../services/clipboard.dart';
+import '../storage/custom_patterns_store.dart' show isCustomPatternId;
 import '../util/file_url.dart';
 import 'path_action_overlay.dart';
 import 'top_toast.dart';
@@ -175,9 +176,19 @@ class GutterPatternPresentation {
 }
 
 /// Maps a pattern id to its [GutterPatternPresentation] (#955).
+///
+/// [fallbackFor] (#1031 slice 3): user-defined pattern ids are DYNAMIC
+/// (`custom.*`, created/deleted at runtime), so instead of rebuilding the
+/// registry per change, unknown ids resolve through this builder — the
+/// standard registry serves ONE generic presentation for every custom id.
 class GutterPatternRegistry {
-  GutterPatternRegistry(Iterable<GutterPatternPresentation> presentations)
-    : _byPattern = {for (final p in presentations) p.patternId: p};
+  GutterPatternRegistry(
+    Iterable<GutterPatternPresentation> presentations, {
+    GutterPatternPresentation? Function(String patternId)? fallbackFor,
+  }) : _byPattern = {for (final p in presentations) p.patternId: p},
+       // Named params can't initialize a private field directly.
+       // ignore: prefer_initializing_formals
+       _fallbackFor = fallbackFor;
 
   /// The standard registry: URLs (regex + OSC-8) and absolute file paths.
   ///
@@ -240,6 +251,8 @@ class GutterPatternRegistry {
         icon: switch (label) {
           'Not a file' => Icons.folder_off_outlined,
           'Not a command' => Icons.block,
+          // #1031 slice 3: user-defined pattern reports.
+          'Not a match' => Icons.search_off,
           _ => Icons.link_off,
         },
         label: label,
@@ -379,26 +392,67 @@ class GutterPatternRegistry {
       ],
     );
 
-    return GutterPatternRegistry([
-      url,
-      // OSC-8 hyperlinks render the SAME affordance as a regex URL.
-      GutterPatternPresentation(
-        patternId: kGhosttyOsc8PatternId,
-        icon: url.icon,
-        typeLabel: url.typeLabel,
-        showActions: url.showActions,
-        itemActions: url.itemActions,
-      ),
-      path,
-      command,
-    ]);
+    return GutterPatternRegistry(
+      [
+        url,
+        // OSC-8 hyperlinks render the SAME affordance as a regex URL.
+        GutterPatternPresentation(
+          patternId: kGhosttyOsc8PatternId,
+          icon: url.icon,
+          typeLabel: url.typeLabel,
+          showActions: url.showActions,
+          itemActions: url.itemActions,
+        ),
+        path,
+        command,
+      ],
+      // #1031 slice 3: ONE generic presentation covers every USER-DEFINED
+      // pattern (ids are dynamic — created/deleted at runtime). Following the
+      // url/path chip idiom, a single-match chip tap opens the generic action
+      // overlay — Copy + the LAST "Not a match" (#995, family = the custom
+      // id; no browser Open, the payload is an arbitrary token). The glass
+      // tap on the bubble is already the one-tap "Copy match" (the IA's v1
+      // tap action), and in a PLAIN shell the chip menu is the ONLY reachable
+      // "Not a match" surface (the long-press match menu is mouse-mode-only),
+      // so a copy-only chip would orphan the exceptions path.
+      fallbackFor: (patternId) {
+        if (!isCustomPatternId(patternId)) return null;
+        return GutterPatternPresentation(
+          patternId: patternId,
+          icon: Icons.pattern,
+          typeLabel: 'Match',
+          showActions: (context, anchor, markGlobal) {
+            final payload = '${anchor.payload}';
+            showUrlActions(
+              context,
+              payload,
+              highlightRects: const [],
+              anchor: markGlobal,
+              showOpen: false,
+              notLabel: 'Not a match',
+              onMarkNotDetection: onReportException == null
+                  ? null
+                  : () => onReportException(anchor.patternId, payload),
+            );
+          },
+          itemActions: (payload) => [
+            copyAction(payload),
+            ?notAction(patternId, payload, 'Not a match'),
+          ],
+        );
+      },
+    );
   }
 
   final Map<String, GutterPatternPresentation> _byPattern;
 
+  /// #1031 slice 3: resolves DYNAMIC (user-defined) pattern ids no static
+  /// entry covers. Null for a registry without one.
+  final GutterPatternPresentation? Function(String patternId)? _fallbackFor;
+
   /// The presentation for [patternId], or null when none is registered.
   GutterPatternPresentation? forPattern(String patternId) =>
-      _byPattern[patternId];
+      _byPattern[patternId] ?? _fallbackFor?.call(patternId);
 
   /// The registered pattern ids (for tests / introspection).
   Iterable<String> get patternIds => _byPattern.keys;

--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -22,6 +22,8 @@
 import 'package:flterm/flterm.dart' hide Key;
 import 'package:flutter/widgets.dart';
 
+import '../storage/custom_patterns_store.dart' show isCustomPatternId;
+
 /// The id of the built-in URL pattern. Mirrors the pattern id the view registers
 /// on the controller so the gutter registry can route URL anchors to their mark.
 const String kGhosttyUrlPatternId = 'url';
@@ -303,6 +305,13 @@ class GhosttyBubbleLayer extends StatelessWidget {
     kGhosttyPathPatternId,
   };
 
+  /// Whether [patternId] paints a bubble: the built-in span types plus every
+  /// USER-DEFINED `custom.*` pattern (#1031 slice 3 — customs are span-tier
+  /// inline matches, so they get the same inline affordance; the command
+  /// BLOCK pattern stays gutter-only).
+  static bool _paintsBubble(String patternId) =>
+      _bubblePatternIds.contains(patternId) || isCustomPatternId(patternId);
+
   @override
   Widget build(BuildContext context) {
     final verification = verificationListenable;
@@ -314,7 +323,7 @@ class GhosttyBubbleLayer extends StatelessWidget {
         if (controller.isScrolling) return const SizedBox.shrink();
         final specs = <GhosttyBubbleSpec>[];
         for (final anchor in controller.anchors) {
-          if (!_bubblePatternIds.contains(anchor.patternId)) continue;
+          if (!_paintsBubble(anchor.patternId)) continue;
           // #990 visibility gate: suppressed anchors paint nothing.
           if (!(isVisible?.call(anchor) ?? true)) continue;
           final rects = <Rect>[];

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -184,9 +184,11 @@ import '../ssh/ssh_session.dart';
 import '../ssh/ssh_session_proxy.dart';
 import '../terminal/tmux_control_mode_flag.dart';
 import '../state/ctrl_modifier_provider.dart';
+import '../state/custom_patterns_providers.dart';
 import '../state/detection_exceptions_providers.dart';
 import '../state/detection_providers.dart';
 import '../state/detection_style_providers.dart';
+import '../storage/custom_patterns_store.dart';
 import '../storage/detection_styles_store.dart' show DetectionStyles;
 import '../state/lifecycle_providers.dart';
 import '../state/sessions.dart';
@@ -1319,6 +1321,9 @@ Future<String?> ghosttyTapCopyMatch(
   if (!ghosttyMatchHasCopyablePayload(match)) return null;
   final ok = await copy('${match.payload}');
   if (!ok) return null;
+  // #1031 slice 3: a user-defined pattern's payload is neither a URL nor a
+  // path — the toast says what actually happened.
+  if (isCustomPatternId(match.patternId)) return 'Copied match';
   return match.patternId == kGhosttyPathPatternId ? 'Copied path' : 'Copied URL';
 }
 
@@ -1422,9 +1427,19 @@ Future<String?> ghosttyTapMatchAction(
 /// inner url/path/osc8 SPAN anchors coexist inside it (slice A tiering).
 /// [commandLexicon] (#1031 slice 2) is the Detection Lab's stored lexicon
 /// override; null keeps the fork's default list.
+///
+/// Customs (#1031 slice 3): every ENABLED [customPatterns] entry whose stored
+/// source COMPILES registers a SPAN-tier pattern under its own `custom.*` id,
+/// carrying the same EMPTY highlight style as the built-ins (#864 — the
+/// widget-layer bubble/gutter decorators are the single affordance). The
+/// compile is defensive ([compileCustomPatternRegex] never throws): a source
+/// that stopped compiling is simply not registered — the lab card shows its
+/// error state; the scanner never sees a bad pattern. Gated by the master
+/// switch + the #971 kill switch like every built-in type.
 List<TextPattern> ghosttyDetectionPatterns(
   DetectionSettings detection, {
   List<String>? commandLexicon,
+  List<CustomPattern> customPatterns = const [],
 }) => [
   if (detection.detectUrls) ...[
     TextPattern.osc8(
@@ -1439,7 +1454,28 @@ List<TextPattern> ghosttyDetectionPatterns(
       id: kGhosttyCommandPatternId,
       lexicon: commandLexicon ?? kDefaultCommandLexicon,
     ),
+  if (!kDetectionDisabled971 && detection.enabled)
+    for (final p in customPatterns)
+      if (p.enabled)
+        if (compileCustomPatternRegex(p.source) case final RegExp regex)
+          TextPattern(id: p.id, regex: regex, style: kGhosttyUrlHighlightStyle),
 ];
+
+/// Whether ANY pattern would register for ([detection], [customPatterns]) —
+/// the truth the #921 repaint gating must read. [DetectionSettings.detectionActive]
+/// only knows the built-in toggles, so a config with every built-in OFF but a
+/// custom pattern ON would otherwise report inactive while a pattern is
+/// registered and consuming per-row damage (the #921 stale-paint class).
+bool ghosttyDetectionActiveFor(
+  DetectionSettings detection,
+  List<CustomPattern> customPatterns,
+) =>
+    detection.detectionActive ||
+    (!kDetectionDisabled971 &&
+        detection.enabled &&
+        customPatterns.any(
+          (p) => p.enabled && compileCustomPatternRegex(p.source) != null,
+        ));
 
 /// Map a vertical swipe DELTA (logical px the finger moved this update) to a
 /// scrollback pixel delta to apply to the [TerminalScrollController] (#690).
@@ -2910,9 +2946,14 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         .read(detectionStylesProvider)
         .of(kGhosttyCommandPatternId)
         ?.lexicon;
+    // #1031 slice 3: user-defined patterns register alongside the built-ins
+    // (enabled + compiling only; a change re-runs this via the build()
+    // customs ref.listen).
+    final customPatterns = ref.read(customPatternsProvider);
     for (final pattern in ghosttyDetectionPatterns(
       detection,
       commandLexicon: commandLexicon,
+      customPatterns: customPatterns,
     )) {
       controller.registerTextPattern(pattern);
     }
@@ -2921,8 +2962,12 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // terminal damage, so the PRIMARY screen must force a full re-read on content
     // change to keep repainting. Deferred to a post-frame callback so the keyed
     // render box exists (this runs from initState-time registration before first
-    // layout, where the box lookup would no-op).
-    final detectionActive = detection.detectionActive;
+    // layout, where the box lookup would no-op). #1031 slice 3: customs count
+    // (a custom-only config still competes for the shared damage).
+    final detectionActive = ghosttyDetectionActiveFor(
+      detection,
+      customPatterns,
+    );
     // Detection-saga telemetry (#966-era "URLs not detected" report): record what
     // this registration + the SYNCHRONOUS rescan produced so the next bug report
     // is one-shot diagnosable instead of a blind build loop. Cheap; runs on init
@@ -3273,7 +3318,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final detection = ref.read(detectionSettingsProvider);
-      _applyDetectionActive(detection.detectionActive);
+      _applyDetectionActive(
+        ghosttyDetectionActiveFor(detection, ref.read(customPatternsProvider)),
+      );
     });
     // 4. FORCE REPAINT WHEN FOCUS WAS RETAINED (#720): the #718 re-focus above
     //    only repaints when focus was LOST while backgrounded — the focus CHANGE
@@ -3495,7 +3542,12 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         final detection = ref.read(detectionSettingsProvider);
-        _applyDetectionActive(detection.detectionActive);
+        _applyDetectionActive(
+          ghosttyDetectionActiveFor(
+            detection,
+            ref.read(customPatternsProvider),
+          ),
+        );
       });
     }
     if (ghosttyShouldCaptureKeyboardOnSessionSwitch(
@@ -3832,6 +3884,21 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       );
       return;
     }
+    // #1031 slice 3: a USER-DEFINED match gets the generic menu — Copy + "Not
+    // a match" (the IA's v1 tap-action cut: no Open; the payload is an
+    // arbitrary token, not a URL).
+    if (isCustomPatternId(match.patternId)) {
+      showUrlActions(
+        context,
+        '${match.payload}',
+        highlightRects: rects,
+        anchor: globalAnchor,
+        onMarkNotDetection: markNot,
+        showOpen: false,
+        notLabel: 'Not a match',
+      );
+      return;
+    }
     showUrlActions(
       context,
       '${match.payload}',
@@ -4102,6 +4169,21 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       final before = prev?.of(kGhosttyCommandPatternId)?.lexicon;
       final after = next.of(kGhosttyCommandPatternId)?.lexicon;
       if (listEquals(before, after)) return;
+      final c = _controller;
+      if (c == null) return;
+      c.clearTextPatterns();
+      _registerUrlPattern(c);
+      // Same starvation guard as the settings listen above (#968).
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _forceTerminalRepaint();
+      });
+    });
+    // #1031 slice 3: a USER-DEFINED pattern change (create / edit / enable /
+    // delete) re-registers, exactly like the settings + lexicon listens above
+    // — the regex is baked into the registered TextPattern, so a live change
+    // must clear + re-register (and re-scan the current cells).
+    ref.listen<List<CustomPattern>>(customPatternsProvider, (prev, next) {
+      if (listEquals(prev, next)) return;
       final c = _controller;
       if (c == null) return;
       c.clearTextPatterns();

--- a/native/lib/ui/url_action_overlay.dart
+++ b/native/lib/ui/url_action_overlay.dart
@@ -72,6 +72,10 @@ void debugDismissUrlActions() => _dismiss();
 /// offered (destructive-adjacent placement) — tapping dismisses the menu and
 /// fires the callback (the caller persists the detection exception).
 ///
+/// [showOpen] / [notLabel] (#1031 slice 3): a USER-DEFINED pattern's match is
+/// an arbitrary token, not a URL — its menu drops the Open action and labels
+/// the report item "Not a match". Defaults keep the URL menu exactly as-is.
+///
 /// Safe to call from any context under an [Overlay]. No-op if no overlay.
 void showUrlActions(
   BuildContext context,
@@ -79,6 +83,8 @@ void showUrlActions(
   required List<Rect> highlightRects,
   required Offset anchor,
   VoidCallback? onMarkNotDetection,
+  bool showOpen = true,
+  String notLabel = 'Not a URL',
   Duration timeout = const Duration(seconds: 6),
 }) {
   final overlay = Overlay.maybeOf(context, rootOverlay: true);
@@ -114,6 +120,8 @@ void showUrlActions(
       onDismiss: () {
         if (identical(_activeEntry, entry)) _dismiss();
       },
+      showOpen: showOpen,
+      notLabel: notLabel,
       // #995: dismiss first, then report — the exception write regroups the
       // affordance layers, so the menu must not outlive its anchor.
       onMarkNotDetection: onMarkNotDetection == null
@@ -142,6 +150,8 @@ class _UrlActionLayer extends StatelessWidget {
     required this.onOpen,
     required this.onDismiss,
     this.onMarkNotDetection,
+    this.showOpen = true,
+    this.notLabel = 'Not a URL',
   });
 
   final String url;
@@ -153,6 +163,12 @@ class _UrlActionLayer extends StatelessWidget {
 
   /// #995: persists a "Not a URL" detection exception; null hides the item.
   final VoidCallback? onMarkNotDetection;
+
+  /// #1031 slice 3: false for a user-defined match (no browser Open).
+  final bool showOpen;
+
+  /// #1031 slice 3: "Not a match" for a user-defined pattern's report item.
+  final String notLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -236,20 +252,23 @@ class _UrlActionLayer extends StatelessWidget {
                       label: 'Copy',
                       onTap: onCopy,
                     ),
-                    _ActionButton(
-                      key: const Key('url-action-open'),
-                      icon: Icons.open_in_new,
-                      label: 'Open',
-                      onTap: () {
-                        onOpen();
-                      },
-                    ),
+                    if (showOpen)
+                      _ActionButton(
+                        key: const Key('url-action-open'),
+                        icon: Icons.open_in_new,
+                        label: 'Open',
+                        onTap: () {
+                          onOpen();
+                        },
+                      ),
                     // #995: LAST (destructive-adjacent) — report false positive.
                     if (onMarkNotDetection != null)
                       _ActionButton(
                         key: const Key('url-action-not-url'),
-                        icon: Icons.link_off,
-                        label: 'Not a URL',
+                        icon: notLabel == 'Not a URL'
+                            ? Icons.link_off
+                            : Icons.search_off,
+                        label: notLabel,
                         onTap: onMarkNotDetection!,
                       ),
                   ],

--- a/native/test/state/custom_patterns_providers_test.dart
+++ b/native/test/state/custom_patterns_providers_test.dart
@@ -1,0 +1,88 @@
+// #1031 slice 3 — custom-pattern provider behavior.
+//
+// The notifier hydrates the persisted list, mints ids ONCE on create (review
+// change 5), keeps ids stable across edits, and AUTO-DISABLES a stored
+// pattern whose regex no longer compiles (a hand-edited / corrupt source must
+// degrade to a visible error state, never a crash or a wedged scanner).
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/custom_patterns_providers.dart';
+import 'package:mobissh/storage/custom_patterns_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  Future<CustomPatternsNotifier> notifier() async {
+    final n = CustomPatternsNotifier(
+      store: CustomPatternsStore(prefs: await SharedPreferences.getInstance()),
+    );
+    await n.ready;
+    return n;
+  }
+
+  test('create mints a custom.* id and enables the pattern', () async {
+    final n = await notifier();
+    final p = await n.create(
+      name: 'Jira',
+      source: r'[A-Z]{2,}-\d+',
+      sampleLine: 'PROJ-1',
+    );
+    expect(p.id, startsWith(kCustomPatternIdPrefix));
+    expect(n.state.single.enabled, isTrue);
+  });
+
+  test('updatePattern keeps the id across rename + regex edit', () async {
+    final n = await notifier();
+    final p = await n.create(name: 'Jira', source: r'\d+', sampleLine: '');
+    await n.updatePattern(p.id, name: 'Renamed', source: r'\w+');
+    expect(n.state.single.id, p.id);
+    expect(n.state.single.name, 'Renamed');
+    expect(n.state.single.source, r'\w+');
+  });
+
+  test('setEnabled + remove round-trip', () async {
+    final n = await notifier();
+    final p = await n.create(name: 'x', source: r'\d+', sampleLine: '');
+    await n.setEnabled(p.id, false);
+    expect(n.state.single.enabled, isFalse);
+    await n.remove(p.id);
+    expect(n.state, isEmpty);
+  });
+
+  test('hydrate AUTO-DISABLES a pattern whose stored regex no longer '
+      'compiles (visible error state, never a crash)', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      customPatternsPrefsKey: jsonEncode({
+        'v': 1,
+        'patterns': [
+          {
+            'id': 'custom.broken',
+            'name': 'broken',
+            'source': '(',
+            'enabled': true,
+            'ts': 5,
+          },
+          {
+            'id': 'custom.fine',
+            'name': 'fine',
+            'source': r'\d+',
+            'enabled': true,
+            'ts': 6,
+          },
+        ],
+      }),
+    });
+    final n = await notifier();
+    final broken = n.state.firstWhere((p) => p.id == 'custom.broken');
+    final fine = n.state.firstWhere((p) => p.id == 'custom.fine');
+    expect(broken.enabled, isFalse, reason: 'auto-disabled on compile failure');
+    expect(fine.enabled, isTrue);
+  });
+}

--- a/native/test/storage/custom_patterns_store_test.dart
+++ b/native/test/storage/custom_patterns_store_test.dart
@@ -1,0 +1,202 @@
+// #1031 slice 3 — user-defined pattern store.
+//
+// Locks the IA review's binding change 5: a custom pattern's id is minted
+// ONCE at creation and NEVER re-derived from the name — renaming keeps the id
+// stable so the style store, the enable bit, and the #995 exception family
+// (all keyed by id) never orphan. Plus the standard storage contract:
+// schema-in-value, corrupt→empty, bad entries dropped individually, and the
+// defensive regex compile that can never throw.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/storage/custom_patterns_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<CustomPatternsStore> _store([Map<String, Object> seed = const {}]) async {
+  SharedPreferences.setMockInitialValues(seed);
+  return CustomPatternsStore(prefs: await SharedPreferences.getInstance());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('id minting (IA review change 5)', () {
+    test('mints ids in the custom. namespace', () {
+      final id = mintCustomPatternId(const []);
+      expect(id, startsWith(kCustomPatternIdPrefix));
+      expect(isCustomPatternId(id), isTrue);
+    });
+
+    test('never collides with existing ids', () {
+      final existing = <String>{};
+      for (var i = 0; i < 5; i++) {
+        final id = mintCustomPatternId(existing, nowMs: 1234567);
+        expect(existing.contains(id), isFalse);
+        existing.add(id);
+      }
+    });
+
+    test('built-in ids are not custom', () {
+      expect(isCustomPatternId('url'), isFalse);
+      expect(isCustomPatternId('osc8'), isFalse);
+      expect(isCustomPatternId('path'), isFalse);
+      expect(isCustomPatternId('command'), isFalse);
+    });
+  });
+
+  group('regex compile (safe failure)', () {
+    test('valid source compiles', () {
+      expect(compileCustomPatternRegex(r'[A-Z]{2,}-\d+'), isNotNull);
+    });
+
+    test('invalid source returns null, never throws', () {
+      expect(compileCustomPatternRegex('('), isNull);
+      expect(compileCustomPatternRegex(r'[a-'), isNull);
+    });
+
+    test('empty / whitespace source returns null', () {
+      expect(compileCustomPatternRegex(''), isNull);
+      expect(compileCustomPatternRegex('   '), isNull);
+    });
+
+    test('error text: message for invalid, null for valid', () {
+      expect(customPatternRegexError(r'[A-Z]{2,}-\d+'), isNull);
+      expect(customPatternRegexError('('), isNotNull);
+    });
+  });
+
+  group('store round-trip', () {
+    test('add → load preserves every field', () async {
+      final store = await _store();
+      final added = await store.add(
+        name: 'Jira tickets',
+        source: r'\b[A-Z]{2,}-\d+\b',
+        sampleLine: 'fixed in PROJ-1234 yesterday',
+      );
+      expect(added.id, startsWith(kCustomPatternIdPrefix));
+      expect(added.enabled, isTrue);
+
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      final p = loaded.single;
+      expect(p.id, added.id);
+      expect(p.name, 'Jira tickets');
+      expect(p.source, r'\b[A-Z]{2,}-\d+\b');
+      expect(p.sampleLine, 'fixed in PROJ-1234 yesterday');
+      expect(p.enabled, isTrue);
+      expect(p.createdTs, greaterThan(0));
+    });
+
+    test('update (rename + regex edit) KEEPS the id', () async {
+      final store = await _store();
+      final added = await store.add(
+        name: 'Jira tickets',
+        source: r'\b[A-Z]{2,}-\d+\b',
+        sampleLine: 'PROJ-1',
+      );
+      await store.update(
+        added.id,
+        name: 'Issue keys',
+        source: r'[A-Z]+-\d+',
+        sampleLine: 'ISS-2',
+      );
+      final loaded = await store.load();
+      expect(loaded.single.id, added.id,
+          reason: 'rename must NOT re-derive the id (review change 5)');
+      expect(loaded.single.name, 'Issue keys');
+      expect(loaded.single.source, r'[A-Z]+-\d+');
+      expect(loaded.single.createdTs, added.createdTs);
+    });
+
+    test('setEnabled flips only the bit', () async {
+      final store = await _store();
+      final added = await store.add(name: 'x', source: r'\d+', sampleLine: '');
+      await store.setEnabled(added.id, false);
+      final loaded = await store.load();
+      expect(loaded.single.enabled, isFalse);
+      expect(loaded.single.source, r'\d+');
+    });
+
+    test('remove drops the record', () async {
+      final store = await _store();
+      final a = await store.add(name: 'a', source: r'\d+', sampleLine: '');
+      final b = await store.add(name: 'b', source: r'\w+', sampleLine: '');
+      await store.remove(a.id);
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      expect(loaded.single.id, b.id);
+    });
+
+    test('two adds mint two distinct ids', () async {
+      final store = await _store();
+      final a = await store.add(name: 'a', source: r'\d+', sampleLine: '');
+      final b = await store.add(name: 'b', source: r'\w+', sampleLine: '');
+      expect(a.id, isNot(b.id));
+    });
+  });
+
+  group('corrupt-resilience (validate → fallback, never crash)', () {
+    test('non-JSON value → empty', () async {
+      final store =
+          await _store({customPatternsPrefsKey: 'not json at all {'});
+      expect(await store.load(), isEmpty);
+    });
+
+    test('wrong shape → empty', () async {
+      final store = await _store({customPatternsPrefsKey: '[1,2,3]'});
+      expect(await store.load(), isEmpty);
+    });
+
+    test('unknown schema version → empty', () async {
+      final store = await _store({
+        customPatternsPrefsKey:
+            jsonEncode({'v': 99, 'patterns': <Object>[]}),
+      });
+      expect(await store.load(), isEmpty);
+    });
+
+    test('bad entries dropped individually; good ones survive', () async {
+      final store = await _store({
+        customPatternsPrefsKey: jsonEncode({
+          'v': 1,
+          'patterns': [
+            42,
+            {'name': 'no id', 'source': r'\d+'},
+            {
+              'id': 'custom.p1',
+              'name': 'good',
+              'source': r'\d+',
+              'enabled': true,
+              'ts': 5,
+            },
+          ],
+        }),
+      });
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      expect(loaded.single.id, 'custom.p1');
+    });
+
+    test('a stored INVALID regex still loads (the UI shows the error state; '
+        'registration skips it)', () async {
+      final store = await _store({
+        customPatternsPrefsKey: jsonEncode({
+          'v': 1,
+          'patterns': [
+            {
+              'id': 'custom.p1',
+              'name': 'broken',
+              'source': '(',
+              'enabled': true,
+              'ts': 5,
+            },
+          ],
+        }),
+      });
+      final loaded = await store.load();
+      expect(loaded, hasLength(1));
+      expect(compileCustomPatternRegex(loaded.single.source), isNull);
+    });
+  });
+}

--- a/native/test/ui/detection_lab_custom_patterns_test.dart
+++ b/native/test/ui/detection_lab_custom_patterns_test.dart
@@ -1,0 +1,287 @@
+// #1031 slice 3 — user-defined patterns in the Detection Lab UI.
+//
+// Locks: the creation flow (live regex validation with an INLINE error —
+// never a crash — and a sample-line echo highlighting the match), custom
+// cards in the MY PATTERNS zone (generic glyph, enable switch bound to the
+// custom store, a visible ERROR state for a non-compiling stored regex),
+// id stability across an edit (review change 5), style edits persisting
+// under the custom id (string-keyed store), and the delete confirm that
+// DISCLOSES + performs the #995 exception-family pruning.
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/custom_patterns_providers.dart';
+import 'package:mobissh/state/detection_exceptions_providers.dart';
+import 'package:mobissh/state/detection_style_providers.dart';
+import 'package:mobissh/storage/custom_patterns_store.dart';
+import 'package:mobissh/ui/detection_lab_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _pumpFrames(WidgetTester tester, {int count = 10}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+Future<ProviderContainer> _pumpLab(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(1000, 3000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: DetectionLabScreen()),
+    ),
+  );
+  await _pumpFrames(tester);
+  return container;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('creation flow', () {
+    testWidgets('lab root offers Add pattern under MY PATTERNS',
+        (tester) async {
+      await _pumpLab(tester);
+      expect(find.byKey(const ValueKey('lab-add-pattern')), findsOneWidget);
+    });
+
+    testWidgets(
+        'invalid regex shows an INLINE error and blocks Save; a valid one '
+        'clears it and the sample echo highlights the match', (tester) async {
+      final container = await _pumpLab(tester);
+      await tester.tap(find.byKey(const ValueKey('lab-add-pattern')));
+      await _pumpFrames(tester);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-custom-name')),
+        'Jira tickets',
+      );
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-custom-regex')),
+        '(',
+      );
+      await _pumpFrames(tester);
+      expect(
+        find.byKey(const ValueKey('lab-custom-regex-error')),
+        findsOneWidget,
+        reason: 'compile errors render inline, never crash',
+      );
+      final saveDisabled = tester.widget<FilledButton>(
+        find.byKey(const ValueKey('lab-custom-save')),
+      );
+      expect(saveDisabled.onPressed, isNull, reason: 'Save blocked while invalid');
+
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-custom-regex')),
+        r'[A-Z]{2,}-\d+',
+      );
+      await _pumpFrames(tester);
+      expect(
+        find.byKey(const ValueKey('lab-custom-regex-error')),
+        findsNothing,
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-custom-sample')),
+        'fixed in PROJ-1234 yesterday',
+      );
+      await _pumpFrames(tester);
+      // The echo names the matched payload…
+      expect(
+        find.byKey(const ValueKey('lab-custom-sample-echo')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('PROJ-1234'), findsWidgets);
+      // …and the sample line renders with the match span highlighted.
+      expect(
+        find.byKey(const ValueKey('lab-custom-sample-highlight')),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('lab-custom-save')));
+      await _pumpFrames(tester);
+
+      final patterns = container.read(customPatternsProvider);
+      expect(patterns, hasLength(1));
+      final p = patterns.single;
+      expect(p.id, startsWith(kCustomPatternIdPrefix));
+      expect(p.name, 'Jira tickets');
+      expect(p.enabled, isTrue);
+      // Back on the root, the new pattern has a card.
+      expect(find.byKey(ValueKey('lab-card-${p.id}')), findsOneWidget);
+    });
+
+    testWidgets('no sample match is a note, not an error (never blocks Save)',
+        (tester) async {
+      await _pumpLab(tester);
+      await tester.tap(find.byKey(const ValueKey('lab-add-pattern')));
+      await _pumpFrames(tester);
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-custom-name')),
+        'x',
+      );
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-custom-regex')),
+        r'[A-Z]{2,}-\d+',
+      );
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-custom-sample')),
+        'nothing to see here',
+      );
+      await _pumpFrames(tester);
+      expect(find.textContaining('no match', findRichText: true), findsWidgets);
+      final save = tester.widget<FilledButton>(
+        find.byKey(const ValueKey('lab-custom-save')),
+      );
+      expect(save.onPressed, isNotNull);
+    });
+  });
+
+  group('custom cards', () {
+    testWidgets('enable switch binds the custom store', (tester) async {
+      final container = await _pumpLab(tester);
+      final p = await container
+          .read(customPatternsProvider.notifier)
+          .create(name: 'Jira', source: r'[A-Z]{2,}-\d+', sampleLine: 'AB-1');
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(ValueKey('lab-enable-${p.id}')));
+      await _pumpFrames(tester);
+      expect(
+        container.read(customPatternsProvider).single.enabled,
+        isFalse,
+      );
+    });
+
+    testWidgets('a non-compiling stored regex renders a visible ERROR state',
+        (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        customPatternsPrefsKey: jsonEncode({
+          'v': 1,
+          'patterns': [
+            {
+              'id': 'custom.broken',
+              'name': 'broken',
+              'source': '(',
+              'enabled': true,
+              'ts': 5,
+            },
+          ],
+        }),
+      });
+      await _pumpLab(tester);
+      expect(
+        find.byKey(const ValueKey('lab-card-error-custom.broken')),
+        findsOneWidget,
+        reason: 'a broken pattern is visibly flagged, never silently dropped',
+      );
+    });
+  });
+
+  group('detail page for a custom pattern', () {
+    testWidgets('style edits persist under the custom id (string-keyed store)',
+        (tester) async {
+      final container = await _pumpLab(tester);
+      final p = await container
+          .read(customPatternsProvider.notifier)
+          .create(name: 'Jira', source: r'[A-Z]{2,}-\d+', sampleLine: 'AB-1');
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(ValueKey('lab-card-tile-${p.id}')));
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(const ValueKey('lab-color-row')));
+      await _pumpFrames(tester);
+      await tester.tap(find.byKey(const Key('color-picker-preset-#e53935')));
+      await _pumpFrames(tester);
+      await tester.tap(find.byKey(const Key('color-picker-apply')));
+      await _pumpFrames(tester);
+
+      expect(
+        container.read(detectionStylesProvider).of(p.id)?.colorHex,
+        '#e53935',
+      );
+    });
+
+    testWidgets('editing (rename + regex) keeps the id (review change 5)',
+        (tester) async {
+      final container = await _pumpLab(tester);
+      final p = await container
+          .read(customPatternsProvider.notifier)
+          .create(name: 'Jira', source: r'[A-Z]{2,}-\d+', sampleLine: 'AB-1');
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(ValueKey('lab-card-tile-${p.id}')));
+      await _pumpFrames(tester);
+      await tester.tap(find.byKey(const ValueKey('lab-custom-edit-row')));
+      await _pumpFrames(tester);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('lab-custom-name')),
+        'Issue keys',
+      );
+      await tester.tap(find.byKey(const ValueKey('lab-custom-save')));
+      await _pumpFrames(tester);
+
+      final updated = container.read(customPatternsProvider).single;
+      expect(updated.id, p.id, reason: 'ids are minted once, never re-derived');
+      expect(updated.name, 'Issue keys');
+    });
+
+    testWidgets(
+        'delete confirm DISCLOSES exception pruning, prunes ONLY this '
+        'family, and drops the style entry', (tester) async {
+      final container = await _pumpLab(tester);
+      final p = await container
+          .read(customPatternsProvider.notifier)
+          .create(name: 'Jira', source: r'[A-Z]{2,}-\d+', sampleLine: 'AB-1');
+      final exceptions = container.read(detectionExceptionsProvider.notifier);
+      await exceptions.report(patternId: p.id, matchedText: 'AB-1');
+      await exceptions.report(patternId: p.id, matchedText: 'CD-2');
+      await exceptions.report(patternId: 'url', matchedText: 'https://x.y');
+      await container
+          .read(detectionStylesProvider.notifier)
+          .setColorHex(p.id, '#e53935');
+      await _pumpFrames(tester);
+
+      await tester.tap(find.byKey(ValueKey('lab-card-tile-${p.id}')));
+      await _pumpFrames(tester);
+      await tester.tap(find.byKey(const ValueKey('lab-custom-delete-button')));
+      await _pumpFrames(tester);
+      expect(
+        find.byKey(const ValueKey('lab-custom-delete-dialog')),
+        findsOneWidget,
+      );
+      // Review change 5: the dialog states it removes the saved exceptions.
+      expect(
+        find.textContaining('2 saved detection exception'),
+        findsOneWidget,
+        reason: 'pruning authored data must be disclosed at the moment it happens',
+      );
+
+      await tester.tap(find.byKey(const ValueKey('lab-custom-delete-confirm')));
+      await _pumpFrames(tester);
+
+      expect(container.read(customPatternsProvider), isEmpty);
+      final remaining = container.read(detectionExceptionsProvider);
+      expect(remaining, hasLength(1));
+      expect(remaining.single.patternId, 'url');
+      expect(container.read(detectionStylesProvider).of(p.id), isNull);
+      // Back on the lab root; the card is gone.
+      expect(find.byKey(ValueKey('lab-card-${p.id}')), findsNothing);
+    });
+  });
+}

--- a/native/test/ui/ghostty_custom_patterns_registration_test.dart
+++ b/native/test/ui/ghostty_custom_patterns_registration_test.dart
@@ -1,0 +1,154 @@
+// #1031 slice 3 — custom-pattern REGISTRATION gating (pure, headless).
+//
+// ghosttyDetectionPatterns is the whole registration contract, so these lock:
+// an enabled custom pattern registers a SPAN-tier TextPattern under its own
+// id; a disabled one does not; an INVALID stored regex is skipped defensively
+// (never a throw, never a wedged scanner); the master switch gates customs
+// like every built-in. ghosttyDetectionActiveFor keeps the #921 repaint
+// gating honest when ONLY a custom pattern is on. The gutter registry serves
+// a generic presentation for any custom.* id (copy + "Not a match" → the
+// #995 exception store, family = the custom id).
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:mobissh/storage/custom_patterns_store.dart';
+import 'package:mobissh/storage/detection_exceptions_store.dart';
+import 'package:mobissh/ui/ghostty_gutter_layer.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+CustomPattern _pattern({
+  String id = 'custom.p1',
+  String source = r'[A-Z]{2,}-\d+',
+  bool enabled = true,
+}) =>
+    CustomPattern(
+      id: id,
+      name: 'Jira',
+      source: source,
+      enabled: enabled,
+      createdTs: 1,
+      sampleLine: 'PROJ-1234',
+    );
+
+void main() {
+  group('ghosttyDetectionPatterns — customs', () {
+    test('an enabled custom pattern registers span-tier under its id', () {
+      final patterns = ghosttyDetectionPatterns(
+        const DetectionSettings(),
+        customPatterns: [_pattern()],
+      );
+      final custom = patterns.where((p) => p.id == 'custom.p1');
+      expect(custom, hasLength(1));
+      expect(custom.single.tier, TextTier.span);
+      expect(custom.single.regex.hasMatch('PROJ-1234'), isTrue);
+    });
+
+    test('a disabled custom pattern is NOT registered', () {
+      final patterns = ghosttyDetectionPatterns(
+        const DetectionSettings(),
+        customPatterns: [_pattern(enabled: false)],
+      );
+      expect(patterns.any((p) => p.id == 'custom.p1'), isFalse);
+    });
+
+    test('an invalid stored regex is skipped defensively (no throw)', () {
+      final patterns = ghosttyDetectionPatterns(
+        const DetectionSettings(),
+        customPatterns: [_pattern(source: '(')],
+      );
+      expect(patterns.any((p) => p.id == 'custom.p1'), isFalse);
+    });
+
+    test('master OFF gates customs like every built-in', () {
+      final patterns = ghosttyDetectionPatterns(
+        const DetectionSettings(enabled: false),
+        customPatterns: [_pattern()],
+      );
+      expect(patterns, isEmpty);
+    });
+
+    test('customs coexist with the built-ins', () {
+      final patterns = ghosttyDetectionPatterns(
+        const DetectionSettings(),
+        customPatterns: [_pattern()],
+      );
+      expect(
+        patterns.map((p) => p.id),
+        containsAll(<String>['osc8', 'url', 'path', 'command', 'custom.p1']),
+      );
+    });
+  });
+
+  group('ghosttyDetectionActiveFor (#921 repaint gating)', () {
+    test('true when ONLY a custom pattern is on', () {
+      const detection =
+          DetectionSettings(url: false, path: false, command: false);
+      expect(detection.detectionActive, isFalse);
+      expect(ghosttyDetectionActiveFor(detection, [_pattern()]), isTrue);
+    });
+
+    test('false when the only custom is disabled or invalid', () {
+      const detection =
+          DetectionSettings(url: false, path: false, command: false);
+      expect(
+        ghosttyDetectionActiveFor(detection, [_pattern(enabled: false)]),
+        isFalse,
+      );
+      expect(
+        ghosttyDetectionActiveFor(detection, [_pattern(source: '(')]),
+        isFalse,
+      );
+    });
+
+    test('master OFF wins over customs', () {
+      const detection = DetectionSettings(enabled: false);
+      expect(ghosttyDetectionActiveFor(detection, [_pattern()]), isFalse);
+    });
+  });
+
+  group('exception family (#995 interplay)', () {
+    test('a custom id is its OWN family', () {
+      expect(detectionExceptionFamily('custom.p1'), 'custom.p1');
+    });
+  });
+
+  group('gutter registry — generic custom presentation', () {
+    GutterPatternRegistry registry({
+      void Function(String patternId, String payload)? onReportException,
+    }) =>
+        GutterPatternRegistry.standard(
+          openPath: (_) async => true,
+          onReportException: onReportException,
+        );
+
+    test('any custom.* id resolves to a generic presentation', () {
+      final p = registry().forPattern('custom.whatever');
+      expect(p, isNotNull);
+      expect(p!.patternId, 'custom.whatever');
+    });
+
+    test('unknown NON-custom ids still resolve to nothing', () {
+      expect(registry().forPattern('mystery'), isNull);
+    });
+
+    test('item actions: copy + "Not a match" reporting the custom family',
+        () {
+      final reports = <(String, String)>[];
+      final p = registry(
+        onReportException: (patternId, payload) =>
+            reports.add((patternId, payload)),
+      ).forPattern('custom.p1')!;
+      final actions = p.itemActions('PROJ-1234');
+      expect(
+        actions.map((a) => a.keyLabel),
+        containsAll(<String>['copy', 'not']),
+      );
+    });
+
+    test('without a report callback there is no "not" item', () {
+      final p = registry().forPattern('custom.p1')!;
+      expect(p.itemActions('X-1').map((a) => a.keyLabel), isNot(contains('not')));
+    });
+  });
+}


### PR DESCRIPTION
Closes #1031 (slice 3 of 3 — completes the lab scope; v2 fork-plumbing knobs stay in the issue's inventory).

USER-DEFINED PATTERNS end-to-end, per the reviewed IA (review change 5 binding).

## What ships
- **Store** (`storage/custom_patterns_store.dart`): `{id, name, regex source, enabled, createdTs, sampleLine}`, schema-in-value v1, corrupt→empty, bad entries dropped individually. **Ids are minted ONCE at creation** (`custom.p<ts>` + collision suffix) and never re-derived from the name — rename keeps the style entry, enable bit, and #995 exception family attached (review change 5). Regex compiles through ONE defensive helper (`compileCustomPatternRegex`, never throws).
- **Provider** (`state/custom_patterns_providers.dart`): hydrate auto-DISABLES a stored pattern whose regex no longer compiles (persisted, surfaced as a card error state — never a silent drop, never a crash).
- **Creation/edit flow** (`ui/detection_lab_pattern_editor.dart`): name + regex (LIVE inline compile error, Save blocked while invalid) + sample line with a live "matched:" echo and the match spans highlighted. No sample match = a note, never a block. Tier fixed to span, tap action = Copy match (the IA's v1 cuts).
- **Lab root**: MY PATTERNS zone — same card anatomy (generic `Icons.pattern` glyph, enable switch bound to the custom store, mini preview over the author's own sample line), "+ Add pattern" at the end of the list it extends, error-state card for a broken stored regex.
- **Detail page**: same page as built-ins via the string-keyed style store (color picker, intensity slider — all just work on a `custom.*` id), plus DEFINITION (edit via the shared editor) and DELETE. The delete confirm **discloses the exception pruning** ("Also removes N saved detection exceptions reported for it") and prunes the family + drops the style entry (review change 5's disclosure rule).
- **Registration** (`ghosttyDetectionPatterns`): enabled+compiling customs register span-tier under their own id, gated by the master switch + #971 kill switch; a `customPatternsProvider` listen clears+re-registers live (the slice-2 lexicon-listen precedent). `ghosttyDetectionActiveFor` makes customs count toward the #921 repaint gating (a custom-only config would otherwise report inactive while a pattern is registered).
- **Affordances**: bubble layer paints `custom.*` span anchors; gutter registry serves ONE generic fallback presentation for any custom id — the chip opens the generic action menu (Copy + "Not a match"; no browser Open), the glass tap copies ("Copied match" toast). In a plain shell the chip menu is the only reachable "Not a match" surface (the long-press match menu is mouse-mode-only), matching the url/path chip idiom.
- **Exceptions (#995)**: family = the custom id (existing pass-through); new `removeFamily`/`pruneFamily` seam used by delete.

## Safety note (documented, not built)
Dart `RegExp` has no timeout. The main gate is compile-time validation (live in the editor; defensive at registration — a non-compiling pattern is skipped and auto-disabled). Scanner work is bounded per scan by the viewport+scrollback window (`StructuredTextScanner.scan` runs `allMatches` per logical line), but a catastrophically-backtracking user regex on a long line could still stall a scan pass — there is no per-pattern time budget in the fork. Flagging for a possible v2 follow-up (e.g. a length cap per logical line or an isolate-side scan) rather than building it into this slice.

## Tests
- Unit (42 new): store round-trip / corrupt fallback / **id stability across rename** / mint collision; regex compile valid/invalid/empty; provider auto-disable on hydrate; registration gating (enabled/disabled/invalid/master-off) + `ghosttyDetectionActiveFor`; gutter fallback presentation (custom ids resolve, unknown non-custom ids don't; Copy + Not-a-match items).
- Widget (8 new): creation flow (inline error blocks Save; sample echo + highlighted spans; no-match is a note), card enable binding + error state, style edits persist under the custom id, edit keeps the id, **delete confirm discloses the count, prunes ONLY this family, drops the style entry**.
- Emulator (`integration_test/detection_lab_custom_1031_test.dart`): create a JIRA-style pattern in the lab → echo `MOBI-1337` on test-sshd → custom anchor + bubble + chip appear live (no reconnect) → glass tap copies → chip menu "Not a match" suppresses (chip disappears) → delete (disclosure asserted) → a fresh token no longer detects.
- `scripts/native-fast-gate.sh` PASSED (1988 tests).

## Screenshots (on fd-dev, reviewed during the run)
Creation flow — name/regex/sample with the live `matched: "MOBI-4242"` echo and the highlighted match span:
`test-results/emulator-shots/20260710T154951+0000-custom1031-editor_.png`

Custom anchor live — `MOBI-1337` bubble-washed on both lines with generic pattern chips in the gutter (URL/path affordances intact alongside):
`test-results/emulator-shots/20260710T155015+0000-custom1031-live_.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa