### PR TITLE
feat(native): rendered HTML viewer with SFTP loopback resolver (#1037)

### DIFF
--- a/native/android/app/src/main/AndroidManifest.xml
+++ b/native/android/app/src/main/AndroidManifest.xml
@@ -25,10 +25,14 @@
          is never requested on modern devices. -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28"/>
+    <!-- networkSecurityConfig (#1037): permit cleartext HTTP to 127.0.0.1 ONLY
+         (the HTML viewer's on-device SFTP loopback resolver); everything else
+         stays cleartext-blocked. See res/xml/network_security_config.xml. -->
     <application
         android:label="mobissh"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".mobissh.MainActivity"
             android:exported="true"

--- a/native/android/app/src/main/res/xml/network_security_config.xml
+++ b/native/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- #1037: the rendered HTML viewer loads http://127.0.0.1:<port> from the
+     per-viewer SFTP loopback resolver (services/html_loopback_server.dart).
+     Android blocks ALL cleartext HTTP by default (targetSdk 28+), including
+     loopback, so without this the WebView shows ERR_CLEARTEXT_NOT_PERMITTED.
+     Cleartext is permitted for 127.0.0.1 ONLY — traffic that never leaves the
+     device; everything else stays cleartext-blocked (explicit base-config). -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/native/integration_test/html_render_sftp_test.dart
+++ b/native/integration_test/html_render_sftp_test.dart
@@ -1,0 +1,314 @@
+// On-emulator rendered-HTML viewer smoke (#1037, epic #944).
+//
+// Headless widget tests stub the WebView + byte fetcher, so they prove the
+// browser → registry → HtmlFileViewerScreen routing but not that a REAL page's
+// relative references resolve over the session's SFTP. This test runs the real
+// app against test-sshd: it seeds an html file whose RELATIVE css (background
+// color + marker) and RELATIVE image live next to it, plus a `../escape.css`
+// reference above the served root, opens it through the SFTP browser, and
+// asserts:
+//   - the rendered viewer opens with a live WebView surface (not raw source),
+//   - the loopback resolver serves the page, the relative css, and the
+//     relative image over SFTP (probed with real HTTP GETs against the
+//     viewer's 127.0.0.1 server from inside the app process — the same origin
+//     the WebView loads from),
+//   - traversal misses 404 (`/escape.css` after browser normalization of
+//     `../escape.css`, an encoded `%2e%2e` escape, and a plain miss) while the
+//     page keeps rendering,
+//   - the loopback port closes when the viewer route is popped.
+//
+// DEVICE GATE: actual pinch-zoom + pan are the WebView's built-in gestures on
+// a PlatformView — a synthetic multi-touch can't assert rendered-pixel zoom
+// (same posture as markdown_media_fill_test.dart). The zoom config
+// (enableZoom + full-bleed, the #949 selfZooming shape) is code-asserted; the
+// gesture itself is owner-validated. The test holds the rendered page on
+// screen at the end for an emu-shot screenshot window.
+//
+// Network + bridge: identical setup to markdown_media_fill_test.dart.
+
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/ui/html_file_viewer.dart';
+import 'package:mobissh/ui/text_file_viewer.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+
+// A minimal valid 1x1 transparent PNG (base64) — seeded as the relative image.
+const _pngB64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+    '+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const _html =
+    '<!doctype html>\n'
+    '<html><head>\n'
+    '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+    '<link rel="stylesheet" href="css/style.css">\n'
+    '<link rel="stylesheet" href="../escape.css">\n'
+    '<title>itest 1037</title>\n'
+    '</head><body>\n'
+    '<h1>MOBISSH_HTML_1037</h1>\n'
+    '<p>styled via relative css; image below via relative path</p>\n'
+    '<img src="img/a.png" alt="relative image">\n'
+    '</body></html>\n';
+
+const _css =
+    '/* MOBISSH_CSS_MARKER_1037 */\n'
+    'body { background: #1a5c2a; color: #ffffff; font-size: 28px; }\n'
+    'h1 { color: #ffd54f; }\n';
+
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+Future<bool> _reachTerminal(WidgetTester tester) {
+  return _pumpUntil(
+    tester,
+    () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+  );
+}
+
+Future<void> _seedFiles(
+  WidgetTester tester,
+  SessionEntry entry, {
+  required String root,
+}) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  addTearDown(sub.cancel);
+
+  const done = 'MOBISSH_SEED_DONE_1037';
+  final htmlB64 = base64Encode(utf8.encode(_html));
+  final cssB64 = base64Encode(utf8.encode(_css));
+  final script = StringBuffer()
+    ..write('rm -rf $root; ')
+    ..write('mkdir -p $root/site/css $root/site/img; ')
+    // escape.css lives ABOVE the served root ($root/site) — the traversal
+    // target that must never be served.
+    ..write("printf '%s' 'SECRET_ESCAPE_1037' > $root/escape.css; ")
+    ..write("printf '%s' '$htmlB64' | base64 -d > $root/site/index.html; ")
+    ..write("printf '%s' '$cssB64' | base64 -d > $root/site/css/style.css; ")
+    ..write("printf '%s' '$_pngB64' | base64 -d > $root/site/img/a.png; ")
+    ..write('echo $done\n');
+
+  // Let the remote shell finish its first-connect prompt/resize churn before
+  // typing (the input can otherwise race shell readiness — seed flaked once).
+  await tester.pump(const Duration(seconds: 2));
+
+  var seeded = false;
+  for (var attempt = 0; attempt < 2 && !seeded; attempt++) {
+    entry.proxy.sendInput(Uint8List.fromList(utf8.encode(script.toString())));
+    seeded = await _pumpUntil(
+      tester,
+      () => utf8.decode(out, allowMalformed: true).contains(done),
+      maxSlices: 60,
+    );
+  }
+  expect(seeded, isTrue, reason: 'html seed never completed on test-sshd');
+}
+
+Future<void> _openBrowserAt(
+  WidgetTester tester,
+  BuildContext context,
+  String sessionId,
+  String path,
+) async {
+  unawaited(
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FileBrowserScreen(
+          key: const Key('itest-file-browser'),
+          sessionId: sessionId,
+          initialPath: path,
+        ),
+      ),
+    ),
+  );
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('file-browser-list')).evaluate().isNotEmpty,
+  );
+}
+
+/// GET [path] against the viewer's live loopback server; returns
+/// (status, body). Runs in the app process — the same 127.0.0.1 origin the
+/// WebView resolves against, so a 200 proves the SFTP round-trip.
+Future<(int, String)> _probe(int port, String path) async {
+  final client = HttpClient();
+  try {
+    final req = await client.getUrl(
+      Uri.parse('http://127.0.0.1:$port$path'),
+    );
+    final res = await req.close();
+    final body = await utf8.decodeStream(res).catchError((_) => '');
+    return (res.statusCode, body);
+  } finally {
+    client.close(force: true);
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('html renders via the SFTP loopback resolver; escapes 404', (
+    tester,
+  ) async {
+    FlutterForegroundTask.initCommunicationPort();
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MobisshApp(),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    await adhocPasswordConnect(
+      tester,
+      host: '127.0.0.1',
+      port: '2222',
+      user: 'testuser',
+      pass: 'testpass',
+    );
+    expect(
+      await _reachTerminal(tester),
+      isTrue,
+      reason: 'never reached the terminal screen',
+    );
+    final entry = container.read(sessionsProvider).active;
+    expect(entry, isNotNull, reason: 'no active session after connect');
+
+    const root = '/tmp/mobissh_itest_1037';
+    await _seedFiles(tester, entry!, root: root);
+
+    final ctx = tester.element(find.byKey(const Key('session-menu-button')));
+    await _openBrowserAt(tester, ctx, entry.id, '$root/site');
+    expect(
+      find.byKey(const Key('file-entry-index.html')),
+      findsOneWidget,
+      reason: 'seeded html file not listed',
+    );
+
+    // Tap the .html entry → the RENDERED viewer (not the text viewer).
+    await tester.tap(find.byKey(const Key('file-entry-index.html')));
+    expect(
+      await _pumpUntil(
+        tester,
+        () => find.byType(HtmlFileViewerScreen).evaluate().isNotEmpty,
+      ),
+      isTrue,
+      reason: 'html viewer did not open',
+    );
+    expect(find.byType(TextFileViewerScreen), findsNothing);
+    expect(
+      await _pumpUntil(
+        tester,
+        () =>
+            find.byKey(const Key('html-webview-surface')).evaluate().isNotEmpty,
+      ),
+      isTrue,
+      reason: 'webview surface never mounted (loopback server not ready)',
+    );
+    expect(find.byKey(const Key('html-view-source')), findsOneWidget);
+
+    final server = debugLastHtmlLoopbackServer;
+    expect(server, isNotNull, reason: 'no live loopback server');
+    final port = server!.port!;
+
+    // The WEBVIEW itself must fetch the page from the loopback origin. This
+    // is the assertion that caught the cleartext-blocked WebView on the first
+    // run (Android blocks http:// by default; fixed via
+    // network_security_config.xml scoped to 127.0.0.1) — every out-of-process
+    // probe succeeds while the WebView silently renders an error page.
+    expect(
+      await _pumpUntil(tester, () => server.requestCount > 0, maxSlices: 40),
+      isTrue,
+      reason: 'WebView never contacted the loopback origin '
+          '(cleartext blocked? navigation blocked?)',
+    );
+    // Let the page finish pulling its relative assets, then probe the SAME
+    // loopback origin ourselves.
+    await tester.pump(const Duration(seconds: 2));
+
+    final (pageStatus, pageBody) = await _probe(port, '/index.html');
+    expect(pageStatus, 200);
+    expect(pageBody, contains('MOBISSH_HTML_1037'));
+
+    // Relative css + image resolve over SFTP (this is what styles the page).
+    final (cssStatus, cssBody) = await _probe(port, '/css/style.css');
+    expect(cssStatus, 200, reason: 'relative css did not resolve over SFTP');
+    expect(cssBody, contains('MOBISSH_CSS_MARKER_1037'));
+    final (imgStatus, _) = await _probe(port, '/img/a.png');
+    expect(imgStatus, 200, reason: 'relative image did not resolve over SFTP');
+
+    // Traversal: the page's `../escape.css` normalizes browser-side to
+    // `/escape.css` — a miss under the root → 404, and the secret above the
+    // root is never served. Encoded escapes and plain misses 404 too.
+    final (escStatus, escBody) = await _probe(port, '/escape.css');
+    expect(escStatus, 404, reason: 'escape ref must 404');
+    expect(escBody, isNot(contains('SECRET_ESCAPE_1037')));
+    final (encStatus, encBody) = await _probe(
+      port,
+      '/%2e%2e/escape.css',
+    );
+    expect(encStatus, anyOf(404, 200));
+    expect(encBody, isNot(contains('SECRET_ESCAPE_1037')));
+    final (missStatus, _) = await _probe(port, '/nope.css');
+    expect(missStatus, 404);
+
+    // Hold the rendered page on screen for the emu-shot window — the
+    // screenshot shows the css-styled background + heading + image, which is
+    // the visual proof of SFTP-backed rendering (and the pinch-zoom target
+    // for manual validation). The marker line lets the orchestrator time the
+    // shot (a Flutter screenshot can't capture a PlatformView surface).
+    debugPrint('MOBISSH_HOLD_FOR_SHOT_1037');
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+
+    // Popping the viewer closes the loopback port.
+    tester.state<NavigatorState>(find.byType(Navigator).first).pop();
+    expect(
+      await _pumpUntil(
+        tester,
+        () => find.byType(HtmlFileViewerScreen).evaluate().isEmpty,
+      ),
+      isTrue,
+      reason: 'html viewer did not close',
+    );
+    await tester.pump(const Duration(seconds: 1));
+    expect(server.port, isNull, reason: 'loopback port must close on dispose');
+  });
+}

--- a/native/lib/services/html_loopback_server.dart
+++ b/native/lib/services/html_loopback_server.dart
@@ -1,0 +1,246 @@
+// HTML loopback resolver (#1037, epic #944).
+//
+// A per-viewer dart:io [HttpServer] that lets the WebView-rendered HTML
+// viewer resolve RELATIVE references (linked CSS, images, scripts) against
+// the opened file's REMOTE directory: the WebView loads
+// `http://127.0.0.1:<port>/<file>.html`, and every request the page makes is
+// mapped to an SFTP read rooted at that directory. Relative refs — including
+// nested dirs — then "just work" without rewriting the document.
+//
+// SECURITY POSTURE (rules/security.md):
+//   - binds 127.0.0.1 ONLY, on an EPHEMERAL (random) port — unreachable off
+//     device; no other app origin is granted anything it could not already
+//     get by running on the same device as a debuggable local socket, and the
+//     served tree is limited (below);
+//   - serves ONLY the directory tree rooted at the opened HTML file's remote
+//     directory. Every request path is normalized ([resolveLoopbackAssetPath])
+//     and verified to stay UNDER that root — `..` escapes (including
+//     percent-encoded dot segments, which are decoded before resolution)
+//     answer 404 and never reach SFTP;
+//   - content is fetched on demand over the user's OWN authenticated SFTP
+//     session (files they can already read), never cached to disk;
+//   - session-scoped lifetime: started when the viewer route opens, closed on
+//     its dispose. Nothing outlives the viewer.
+//
+// Reads are capped per asset ([maxAssetBytes], default 8 MiB — matching the
+// SftpImageFetcher cap) so one huge referenced asset can't exhaust memory;
+// past the cap the server answers 413. The byte source is injected
+// ([LoopbackByteFetcher]) so unit tests exercise the full HTTP surface with a
+// fake fetcher and production wires the SFTP image fetcher (raw bytes, no
+// binary-reject).
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+/// Fetches the raw bytes of [remotePath] (an absolute POSIX path on the SFTP
+/// host). Throws on miss — the server answers 404.
+typedef LoopbackByteFetcher = Future<Uint8List> Function(String remotePath);
+
+/// Per-asset size cap (8 MiB — the SftpImageFetcher default). One page asset
+/// larger than this answers 413 instead of ballooning memory.
+const int kLoopbackAssetCap = 8 * 1024 * 1024;
+
+/// Resolves a decoded request path (e.g. `/css/style.css`) against the served
+/// [rootDir] (absolute POSIX directory). Returns the absolute remote path to
+/// fetch, or `null` when the request escapes the root (path traversal), names
+/// the root itself, or is empty — all of which the server answers with 404.
+///
+/// `.`/`..`/empty segments are collapsed BEFORE the containment check, so a
+/// path that dips out and back in (`/sub/../x.css`) is fine while a genuine
+/// escape (`/../secrets`) — or a sibling-prefix escape (`/../site-secrets/…`)
+/// — is rejected.
+String? resolveLoopbackAssetPath(String rootDir, String requestPath) {
+  final root = _normalizeAbsolutePosix(
+    rootDir.startsWith('/') ? rootDir : '/$rootDir',
+  );
+  var rel = requestPath;
+  while (rel.startsWith('/')) {
+    rel = rel.substring(1);
+  }
+  if (rel.isEmpty) return null;
+  final base = root == '/' ? '' : root;
+  final resolved = _normalizeAbsolutePosix('$base/$rel');
+  if (resolved == root) return null; // the root itself is a directory
+  final prefix = root == '/' ? '/' : '$root/';
+  if (!resolved.startsWith(prefix)) return null; // traversal escape
+  return resolved;
+}
+
+/// Collapses `.` / `..` / empty segments in an absolute POSIX path. `..` is
+/// clamped at the root (an absolute path cannot escape `/`).
+String _normalizeAbsolutePosix(String p) {
+  final out = <String>[];
+  for (final seg in p.split('/')) {
+    if (seg.isEmpty || seg == '.') continue;
+    if (seg == '..') {
+      if (out.isNotEmpty) out.removeLast();
+      continue;
+    }
+    out.add(seg);
+  }
+  return '/${out.join('/')}';
+}
+
+/// Directory part of an absolute POSIX [path] (`/a/b/c.html` → `/a/b`).
+String dirnamePosix(String path) {
+  final i = path.lastIndexOf('/');
+  if (i <= 0) return '/';
+  return path.substring(0, i);
+}
+
+/// Content types for the common web asset extensions; anything unknown is
+/// `application/octet-stream`. Text types carry `charset=utf-8`.
+const Map<String, String> _contentTypes = {
+  'html': 'text/html; charset=utf-8',
+  'htm': 'text/html; charset=utf-8',
+  'css': 'text/css; charset=utf-8',
+  'js': 'text/javascript; charset=utf-8',
+  'mjs': 'text/javascript; charset=utf-8',
+  'json': 'application/json; charset=utf-8',
+  'txt': 'text/plain; charset=utf-8',
+  'md': 'text/markdown; charset=utf-8',
+  'xml': 'application/xml; charset=utf-8',
+  'svg': 'image/svg+xml; charset=utf-8',
+  'png': 'image/png',
+  'jpg': 'image/jpeg',
+  'jpeg': 'image/jpeg',
+  'gif': 'image/gif',
+  'webp': 'image/webp',
+  'ico': 'image/x-icon',
+  'avif': 'image/avif',
+  'woff': 'font/woff',
+  'woff2': 'font/woff2',
+  'ttf': 'font/ttf',
+  'otf': 'font/otf',
+  'wasm': 'application/wasm',
+  'pdf': 'application/pdf',
+  'mp4': 'video/mp4',
+  'webm': 'video/webm',
+  'mp3': 'audio/mpeg',
+};
+
+/// Maps a file [name] to its response content-type by extension
+/// (case-insensitive); unknown/missing extensions default to octet-stream.
+String contentTypeForName(String name) {
+  final dot = name.lastIndexOf('.');
+  if (dot <= 0 || dot == name.length - 1) return 'application/octet-stream';
+  final ext = name.substring(dot + 1).toLowerCase();
+  return _contentTypes[ext] ?? 'application/octet-stream';
+}
+
+/// The loopback micro-server. One instance per open HTML viewer:
+/// [start] on route mount, [close] on dispose.
+class HtmlLoopbackServer {
+  HtmlLoopbackServer({
+    required this.rootDir,
+    required this.fetch,
+    this.maxAssetBytes = kLoopbackAssetCap,
+  });
+
+  /// Absolute remote directory the served tree is rooted at (the opened HTML
+  /// file's directory).
+  final String rootDir;
+
+  /// Byte source (production: the session's SFTP image fetcher).
+  final LoopbackByteFetcher fetch;
+
+  /// Per-asset response cap; larger fetches answer 413.
+  final int maxAssetBytes;
+
+  HttpServer? _server;
+
+  /// Total requests answered (any status). Lets tests assert the WebView
+  /// actually reached the loopback origin — e.g. catching a cleartext-blocked
+  /// WebView config, which otherwise renders a blank/error page while every
+  /// out-of-process probe still succeeds (#1037 emulator run caught exactly
+  /// this: Android blocks cleartext HTTP by default, see
+  /// android/app/src/main/res/xml/network_security_config.xml).
+  int requestCount = 0;
+
+  /// The bound ephemeral port, or null before [start] / after [close].
+  int? get port => _server?.port;
+
+  /// Loopback URI for a file directly under [rootDir] (the opened page).
+  Uri uriFor(String fileName) {
+    final p = port;
+    if (p == null) {
+      throw StateError('HtmlLoopbackServer is not running');
+    }
+    return Uri(
+      scheme: 'http',
+      host: '127.0.0.1',
+      port: p,
+      pathSegments: [fileName],
+    );
+  }
+
+  /// Binds 127.0.0.1 on an ephemeral port and starts answering requests.
+  Future<void> start() async {
+    if (_server != null) return;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    _server = server;
+    server.listen(_handle, cancelOnError: false);
+  }
+
+  /// Stops the server and closes the port (in-flight requests are aborted —
+  /// the viewer is going away).
+  Future<void> close() async {
+    final server = _server;
+    _server = null;
+    await server?.close(force: true);
+  }
+
+  Future<void> _handle(HttpRequest request) async {
+    requestCount++;
+    try {
+      if (request.method != 'GET' && request.method != 'HEAD') {
+        await _respondStatus(request, HttpStatus.methodNotAllowed);
+        return;
+      }
+      // pathSegments are percent-DECODED per segment, so encoded dot segments
+      // (%2e%2e) are visible to the traversal guard below.
+      final decodedPath = '/${request.uri.pathSegments.join('/')}';
+      final remote = resolveLoopbackAssetPath(rootDir, decodedPath);
+      if (remote == null) {
+        await _respondStatus(request, HttpStatus.notFound);
+        return;
+      }
+      Uint8List bytes;
+      try {
+        bytes = await fetch(remote);
+      } catch (_) {
+        // Miss / SFTP error → 404; the page keeps rendering without the asset.
+        await _respondStatus(request, HttpStatus.notFound);
+        return;
+      }
+      if (bytes.length > maxAssetBytes) {
+        await _respondStatus(request, HttpStatus.requestEntityTooLarge);
+        return;
+      }
+      final response = request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.set(HttpHeaders.contentTypeHeader, contentTypeForName(remote))
+        ..headers.set(HttpHeaders.cacheControlHeader, 'no-store')
+        ..contentLength = bytes.length;
+      if (request.method == 'GET') {
+        response.add(bytes);
+      }
+      await response.close();
+    } catch (_) {
+      // Never let one bad request take the server down; best-effort close.
+      try {
+        await request.response.close();
+      } catch (_) {
+        // socket already gone
+      }
+    }
+  }
+
+  Future<void> _respondStatus(HttpRequest request, int status) async {
+    request.response
+      ..statusCode = status
+      ..contentLength = 0;
+    await request.response.close();
+  }
+}

--- a/native/lib/services/text_file_detect.dart
+++ b/native/lib/services/text_file_detect.dart
@@ -124,3 +124,32 @@ bool isMarkdownEntry(SftpEntry entry, {String? mime}) {
   if (entry.isDirectory) return false;
   return hasMarkdownExtension(entry.name) || isMarkdownMime(mime);
 }
+
+/// HTML extensions (lowercase, no leading dot). A subset of [_textExtensions]
+/// that the rendered HTML viewer handles (#1037).
+const Set<String> _htmlExtensions = {'html', 'htm'};
+
+/// True when [name] ends with an HTML extension (`.html` / `.htm`,
+/// case-insensitive).
+bool hasHtmlExtension(String name) {
+  final dot = name.lastIndexOf('.');
+  if (dot <= 0 || dot == name.length - 1) return false;
+  return _htmlExtensions.contains(name.substring(dot + 1).toLowerCase());
+}
+
+/// True when [mime] denotes HTML content (`text/html` /
+/// `application/xhtml+xml`). MIME parameters (`; charset=…`) are ignored.
+bool isHtmlMime(String? mime) {
+  if (mime == null || mime.isEmpty) return false;
+  final base = mime.split(';').first.trim().toLowerCase();
+  return base == 'text/html' || base == 'application/xhtml+xml';
+}
+
+/// True when [entry] is a regular HTML file, by extension or an explicit HTML
+/// [mime]. Directories are never HTML. Used by the viewer registry to route
+/// `.html`/`.htm` to the rendered WebView viewer (#1037) BEFORE the generic
+/// monospace text viewer (first-match-wins).
+bool isHtmlEntry(SftpEntry entry, {String? mime}) {
+  if (entry.isDirectory) return false;
+  return hasHtmlExtension(entry.name) || isHtmlMime(mime);
+}

--- a/native/lib/ui/file_viewer_registry.dart
+++ b/native/lib/ui/file_viewer_registry.dart
@@ -22,6 +22,7 @@ import '../services/pdf_detect.dart';
 import '../services/session_messages.dart';
 import '../services/text_file_detect.dart';
 import 'file_browser_screen.dart';
+import 'html_file_viewer.dart';
 import 'markdown_file_viewer.dart';
 import 'text_file_viewer.dart';
 
@@ -86,6 +87,22 @@ final fileViewerRegistryProvider = Provider<FileViewerRegistry>((ref) {
             settings: const RouteSettings(name: kFileBrowserRouteName),
             builder: (_) =>
                 MarkdownFileViewerScreen(sessionId: sessionId, entry: entry),
+          ),
+        );
+      },
+    ),
+    // HTML (#1037): rendered in a WebView with SFTP-backed relative
+    // resolution (loopback resolver). MUST precede the generic text viewer —
+    // `.html`/`.htm` are also text, first match wins. "View source" in its
+    // app bar escapes to the text viewer.
+    FileViewer(
+      matches: (entry, {mime}) => isHtmlEntry(entry, mime: mime),
+      open: (context, sessionId, entry) {
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            settings: const RouteSettings(name: kFileBrowserRouteName),
+            builder: (_) =>
+                HtmlFileViewerScreen(sessionId: sessionId, entry: entry),
           ),
         );
       },

--- a/native/lib/ui/html_file_viewer.dart
+++ b/native/lib/ui/html_file_viewer.dart
@@ -1,0 +1,259 @@
+// In-app rendered HTML viewer (#1037, epic #944).
+//
+// Opened from the SFTP file browser when a `.html` / `.htm` file is tapped
+// (via the [fileViewerRegistryProvider], routed BEFORE the generic monospace
+// text viewer). Instead of showing raw source, the page is RENDERED in a
+// WebView that loads `http://127.0.0.1:<port>/<name>.html` from a per-viewer
+// [HtmlLoopbackServer]: relative references inside the page (linked CSS,
+// images, scripts — including nested dirs) resolve against the file's REMOTE
+// directory, fetched over the session's SFTP on demand. See
+// html_loopback_server.dart for the full security posture (127.0.0.1-only,
+// random port, serves only the opened tree, viewer-scoped lifetime).
+//
+// Navigation policy (v1, simple): same-loopback-origin loads are allowed;
+// ANY other navigation (external links, other schemes) is blocked with a
+// toast. JS is enabled — wireframes / self-contained pages need it.
+//
+// Pinch-zoom + pan are the WebView's own (#949 selfZooming shape): the
+// surface is full-bleed and NEVER wrapped in an InteractiveViewer (an
+// InteractiveViewer cannot drive a PlatformView — they fight). Dark pages
+// render as the page dictates — no forced theming.
+//
+// The app bar's "view source" pushes the EXISTING monospace text viewer for
+// the same entry (read-only), so the raw-source escape hatch is one tap away.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../services/html_loopback_server.dart';
+import '../services/session_messages.dart';
+import '../services/sftp_image_fetcher.dart';
+import 'file_browser_screen.dart';
+import 'text_file_viewer.dart';
+import 'top_toast.dart';
+
+/// Builds the live render surface for the loopback [uri]. Swapped out in
+/// widget tests (no platform WebView there) via [htmlWebViewBuilder] — the
+/// public [HtmlFileViewerScreen] type stays stable so routing assertions hold.
+/// [onBlocked] is invoked with the URL of any blocked (non-loopback)
+/// navigation.
+typedef HtmlWebViewBuilder =
+    Widget Function(Uri uri, void Function(String url) onBlocked);
+
+Widget _defaultHtmlWebView(Uri uri, void Function(String url) onBlocked) =>
+    _HtmlWebView(uri: uri, onBlocked: onBlocked);
+
+/// Seam: production builds a real WebView; tests override this to a stub so
+/// the screen mounts without a platform channel.
+HtmlWebViewBuilder htmlWebViewBuilder = _defaultHtmlWebView;
+
+/// Test-only handle to the production builder, so a test can restore
+/// [htmlWebViewBuilder] after overriding it with a stub.
+@visibleForTesting
+HtmlWebViewBuilder get defaultHtmlWebViewBuilderForTest => _defaultHtmlWebView;
+
+/// Test-only handle to the screen's live loopback server (the most recently
+/// started one), so integration tests can probe the resolver end-to-end
+/// (asset 200s, escape 404s) without reaching into private state.
+@visibleForTesting
+HtmlLoopbackServer? debugLastHtmlLoopbackServer;
+
+/// Full-screen rendered HTML route for a single remote [entry] on [sessionId].
+class HtmlFileViewerScreen extends ConsumerStatefulWidget {
+  const HtmlFileViewerScreen({
+    super.key,
+    required this.sessionId,
+    required this.entry,
+  });
+
+  final String sessionId;
+  final SftpEntry entry;
+
+  @override
+  ConsumerState<HtmlFileViewerScreen> createState() =>
+      _HtmlFileViewerScreenState();
+}
+
+enum _Phase { starting, ready, error }
+
+class _HtmlFileViewerScreenState extends ConsumerState<HtmlFileViewerScreen> {
+  _Phase _phase = _Phase.starting;
+  String? _errorMessage;
+  HtmlLoopbackServer? _server;
+  Uri? _uri;
+  bool _started = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_started) return;
+    _started = true;
+    unawaited(_start());
+  }
+
+  Future<void> _start() async {
+    // The loopback server's byte source is the session's SFTP image fetcher —
+    // raw bytes, no binary-reject, per-asset cap — the same seam the markdown
+    // viewer's inline images use (#946). Reads happen on demand per request.
+    final fetcher = ref.read(sftpImageFetcherProvider);
+    final server = HtmlLoopbackServer(
+      rootDir: dirnamePosix(widget.entry.path),
+      fetch: (remotePath) => fetcher.fetch(widget.sessionId, remotePath),
+    );
+    try {
+      await server.start();
+    } catch (e) {
+      if (!mounted) {
+        unawaited(server.close());
+        return;
+      }
+      setState(() {
+        _phase = _Phase.error;
+        _errorMessage = e.toString();
+      });
+      return;
+    }
+    if (!mounted) {
+      unawaited(server.close());
+      return;
+    }
+    _server = server;
+    debugLastHtmlLoopbackServer = server;
+    setState(() {
+      _uri = server.uriFor(widget.entry.name);
+      _phase = _Phase.ready;
+    });
+  }
+
+  @override
+  void dispose() {
+    // Viewer-scoped lifetime: the loopback port closes with the route.
+    unawaited(_server?.close());
+    if (identical(debugLastHtmlLoopbackServer, _server)) {
+      debugLastHtmlLoopbackServer = null;
+    }
+    super.dispose();
+  }
+
+  void _onBlocked(String url) {
+    if (!mounted) return;
+    showTopToast(context, 'Blocked external link');
+  }
+
+  void _openSource() {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        settings: const RouteSettings(name: kFileBrowserRouteName),
+        builder: (_) => TextFileViewerScreen(
+          sessionId: widget.sessionId,
+          entry: widget.entry,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.entry.name, overflow: TextOverflow.ellipsis),
+        actions: [
+          // View source: the existing monospace text viewer for this entry.
+          // Monochrome Material glyph (no emoji).
+          IconButton(
+            key: const Key('html-view-source'),
+            tooltip: 'View source',
+            icon: const Icon(Icons.code),
+            onPressed: _openSource,
+          ),
+          // #855: one-tap return to the terminal (collapses the whole
+          // browser/viewer stack) — conventional top-right close, rightmost.
+          IconButton(
+            key: const Key('html-viewer-close-to-terminal'),
+            tooltip: 'Close — back to terminal',
+            icon: const Icon(Icons.close),
+            onPressed: () => dismissFileBrowserStack(context),
+          ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    switch (_phase) {
+      case _Phase.starting:
+        return const Center(
+          key: Key('html-viewer-loading'),
+          child: CircularProgressIndicator(),
+        );
+      case _Phase.error:
+        return Center(
+          key: const Key('html-viewer-error'),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              _errorMessage ?? 'Could not open this file',
+              textAlign: TextAlign.center,
+            ),
+          ),
+        );
+      case _Phase.ready:
+        // Full-bleed; the WebView owns zoom/pan (#949 selfZooming shape).
+        return SizedBox.expand(
+          key: const Key('html-webview-surface'),
+          child: htmlWebViewBuilder(_uri!, _onBlocked),
+        );
+    }
+  }
+}
+
+/// The real WebView-backed renderer: JS on, zoom on, navigation locked to the
+/// loopback origin.
+class _HtmlWebView extends StatefulWidget {
+  const _HtmlWebView({required this.uri, required this.onBlocked});
+
+  final Uri uri;
+  final void Function(String url) onBlocked;
+
+  @override
+  State<_HtmlWebView> createState() => _HtmlWebViewState();
+}
+
+class _HtmlWebViewState extends State<_HtmlWebView> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    final origin = 'http://${widget.uri.host}:${widget.uri.port}/';
+    _controller = WebViewController()
+      // JS enabled: wireframes / self-contained pages need it. The page can
+      // only reach the loopback tree (navigation locked below; the server
+      // itself only resolves under the opened directory).
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..enableZoom(true)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onNavigationRequest: (request) {
+            // v1 policy: same-loopback-origin only; everything else blocked
+            // with a toast (no system-browser handoff yet).
+            if (request.url.startsWith(origin)) {
+              return NavigationDecision.navigate;
+            }
+            widget.onBlocked(request.url);
+            return NavigationDecision.prevent;
+          },
+        ),
+      )
+      ..loadRequest(widget.uri);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WebViewWidget(controller: _controller);
+  }
+}

--- a/native/test/services/html_loopback_server_test.dart
+++ b/native/test/services/html_loopback_server_test.dart
@@ -1,0 +1,272 @@
+// Unit tests for the HTML loopback resolver (#1037, epic #944).
+//
+// Covers:
+//   - path resolution + the traversal guard matrix (`..` escapes, encoded
+//     dot segments, absolute-ish requests, root edge cases) — escapes resolve
+//     to null (the server answers 404),
+//   - content-type mapping for the common web asset types (+ the
+//     octet-stream default),
+//   - server lifecycle: bind on 127.0.0.1 with an ephemeral port, serve bytes
+//     from the injected fetcher with the mapped content-type, 404 on miss /
+//     escape, 413 past the per-asset cap, and the port is CLOSED after close().
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/html_loopback_server.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/text_file_detect.dart';
+
+Future<HttpClientResponse> _get(int port, String pathAndQuery) async {
+  final client = HttpClient();
+  addTearDown(client.close);
+  final request = await client.get('127.0.0.1', port, pathAndQuery);
+  return request.close();
+}
+
+void main() {
+  group('resolveLoopbackAssetPath', () {
+    const root = '/home/u/site';
+
+    test('plain file resolves under the root', () {
+      expect(
+        resolveLoopbackAssetPath(root, '/index.html'),
+        '/home/u/site/index.html',
+      );
+    });
+
+    test('nested path resolves under the root', () {
+      expect(
+        resolveLoopbackAssetPath(root, '/css/style.css'),
+        '/home/u/site/css/style.css',
+      );
+    });
+
+    test('inner dot segments collapse but stay under the root', () {
+      expect(
+        resolveLoopbackAssetPath(root, '/a/./b/../c.png'),
+        '/home/u/site/a/c.png',
+      );
+    });
+
+    test('.. escape above the root is rejected', () {
+      expect(resolveLoopbackAssetPath(root, '/../escape.css'), isNull);
+    });
+
+    test('deep .. escape is rejected', () {
+      expect(
+        resolveLoopbackAssetPath(root, '/../../../../etc/passwd'),
+        isNull,
+      );
+    });
+
+    test('.. that dips out and back in is rejected (no sneaking)', () {
+      // Normalizes to /home/u/site/x.css — same final path, but via the
+      // parent. The normalized result IS under the root, so it's allowed:
+      // normalization happens before the guard.
+      expect(
+        resolveLoopbackAssetPath(root, '/sub/../x.css'),
+        '/home/u/site/x.css',
+      );
+    });
+
+    test('sibling-prefix escape is rejected (site vs site-secrets)', () {
+      expect(resolveLoopbackAssetPath(root, '/../site-secrets/k.pem'), isNull);
+    });
+
+    test('empty and root request resolve to null (no directory serving)', () {
+      expect(resolveLoopbackAssetPath(root, '/'), isNull);
+      expect(resolveLoopbackAssetPath(root, ''), isNull);
+    });
+
+    test('root directory / serves absolute tree', () {
+      expect(resolveLoopbackAssetPath('/', '/etc/hosts'), '/etc/hosts');
+    });
+  });
+
+  group('contentTypeForName', () {
+    test('maps common web types', () {
+      expect(contentTypeForName('a.html'), startsWith('text/html'));
+      expect(contentTypeForName('a.HTM'), startsWith('text/html'));
+      expect(contentTypeForName('a.css'), startsWith('text/css'));
+      expect(contentTypeForName('a.js'), startsWith('text/javascript'));
+      expect(contentTypeForName('a.mjs'), startsWith('text/javascript'));
+      expect(contentTypeForName('a.json'), startsWith('application/json'));
+      expect(contentTypeForName('a.png'), 'image/png');
+      expect(contentTypeForName('a.jpg'), 'image/jpeg');
+      expect(contentTypeForName('a.jpeg'), 'image/jpeg');
+      expect(contentTypeForName('a.gif'), 'image/gif');
+      expect(contentTypeForName('a.svg'), startsWith('image/svg+xml'));
+      expect(contentTypeForName('a.webp'), 'image/webp');
+      expect(contentTypeForName('a.ico'), 'image/x-icon');
+      expect(contentTypeForName('a.woff2'), 'font/woff2');
+      expect(contentTypeForName('a.txt'), startsWith('text/plain'));
+    });
+
+    test('unknown / missing extension defaults to octet-stream', () {
+      expect(contentTypeForName('a.bin'), 'application/octet-stream');
+      expect(contentTypeForName('noext'), 'application/octet-stream');
+    });
+  });
+
+  group('isHtmlEntry', () {
+    test('matches .html/.htm by extension, case-insensitive', () {
+      const a = SftpEntry(name: 'x.html', path: '/x.html', isDirectory: false);
+      const b = SftpEntry(name: 'X.HTM', path: '/X.HTM', isDirectory: false);
+      const c = SftpEntry(name: 'x.md', path: '/x.md', isDirectory: false);
+      expect(isHtmlEntry(a), isTrue);
+      expect(isHtmlEntry(b), isTrue);
+      expect(isHtmlEntry(c), isFalse);
+    });
+
+    test('directories never match', () {
+      const d = SftpEntry(name: 'x.html', path: '/x.html', isDirectory: true);
+      expect(isHtmlEntry(d), isFalse);
+    });
+
+    test('matches by html mime', () {
+      const e = SftpEntry(name: 'page', path: '/page', isDirectory: false);
+      expect(isHtmlEntry(e, mime: 'text/html; charset=utf-8'), isTrue);
+      expect(isHtmlEntry(e, mime: 'text/plain'), isFalse);
+    });
+  });
+
+  group('HtmlLoopbackServer', () {
+    test('serves fetched bytes with the mapped content-type', () async {
+      final fetched = <String>[];
+      final server = HtmlLoopbackServer(
+        rootDir: '/srv/www',
+        fetch: (path) async {
+          fetched.add(path);
+          return Uint8List.fromList(utf8.encode('body { color: red }'));
+        },
+      );
+      await server.start();
+      addTearDown(server.close);
+
+      final res = await _get(server.port!, '/css/style.css');
+      expect(res.statusCode, 200);
+      expect(res.headers.contentType.toString(), startsWith('text/css'));
+      final body = await utf8.decodeStream(res);
+      expect(body, 'body { color: red }');
+      expect(fetched, ['/srv/www/css/style.css']);
+      expect(server.requestCount, 1);
+    });
+
+    test('404 on fetch miss (fetcher throws)', () async {
+      final server = HtmlLoopbackServer(
+        rootDir: '/srv/www',
+        fetch: (path) async => throw Exception('no such file'),
+      );
+      await server.start();
+      addTearDown(server.close);
+
+      final res = await _get(server.port!, '/missing.png');
+      expect(res.statusCode, 404);
+    });
+
+    test('traversal requests never reach the fetcher outside the root', () async {
+      // Raw socket: a client would normalize dot segments before sending,
+      // which would test the CLIENT, not the server. An attacker controls the
+      // raw request line, so that's what we send.
+      //
+      // Empirically (asserted here), dart:io's HTTP stack applies FULL RFC
+      // 3986 normalization — percent-decoding of unreserved chars (%2e → '.')
+      // AND remove_dot_segments — before the handler runs, so both literal
+      // and encoded traversal arrive as an in-root path (`/etc/passwd` →
+      // `/srv/www/etc/passwd`). The resolver's own `..` rejection (unit
+      // matrix above) is defense in depth for any path that DOES get through
+      // with dot segments intact. The end-to-end invariant: the fetcher only
+      // ever sees paths under the root.
+      final fetched = <String>[];
+      final server = HtmlLoopbackServer(
+        rootDir: '/srv/www',
+        fetch: (path) async {
+          fetched.add(path);
+          return Uint8List(0);
+        },
+      );
+      await server.start();
+      addTearDown(server.close);
+
+      Future<String> rawStatus(String target) async {
+        final socket = await Socket.connect('127.0.0.1', server.port!);
+        socket.write(
+          'GET $target HTTP/1.1\r\nHost: 127.0.0.1\r\n'
+          'Connection: close\r\n\r\n',
+        );
+        await socket.flush();
+        final response = await utf8.decodeStream(socket);
+        socket.destroy();
+        return response.split('\r\n').first;
+      }
+
+      final statuses = <String>[
+        await rawStatus('/../../etc/passwd'),
+        await rawStatus('/%2e%2e/%2e%2e/etc/passwd'),
+        await rawStatus('/a/../../../etc/passwd'),
+      ];
+      // Every request either 404s outright or is served from UNDER the root —
+      // never the real /etc/passwd.
+      expect(fetched, everyElement(startsWith('/srv/www/')));
+      expect(fetched, isNot(contains('/etc/passwd')));
+      for (final status in statuses) {
+        expect(status, anyOf(contains('404'), contains('200')));
+      }
+    });
+
+    test('413 past the per-asset cap', () async {
+      final server = HtmlLoopbackServer(
+        rootDir: '/srv/www',
+        maxAssetBytes: 8,
+        fetch: (path) async => Uint8List(64),
+      );
+      await server.start();
+      addTearDown(server.close);
+
+      final res = await _get(server.port!, '/big.bin');
+      expect(res.statusCode, 413);
+    });
+
+    test('uriFor points at the loopback origin with an encoded name', () async {
+      final server = HtmlLoopbackServer(
+        rootDir: '/srv/www',
+        fetch: (path) async => Uint8List(0),
+      );
+      await server.start();
+      addTearDown(server.close);
+
+      final uri = server.uriFor('my page.html');
+      expect(uri.scheme, 'http');
+      expect(uri.host, '127.0.0.1');
+      expect(uri.port, server.port);
+      expect(uri.path, '/my%20page.html');
+    });
+
+    test('port is closed after close()', () async {
+      final server = HtmlLoopbackServer(
+        rootDir: '/srv/www',
+        fetch: (path) async => Uint8List(0),
+      );
+      await server.start();
+      final port = server.port!;
+      await server.close();
+
+      await expectLater(
+        () async {
+          final client = HttpClient();
+          client.connectionTimeout = const Duration(seconds: 2);
+          try {
+            final req = await client.get('127.0.0.1', port, '/x.html');
+            await req.close();
+          } finally {
+            client.close(force: true);
+          }
+        }(),
+        throwsA(isA<SocketException>()),
+      );
+    });
+  });
+}

--- a/native/test/widget/html_file_viewer_widget_test.dart
+++ b/native/test/widget/html_file_viewer_widget_test.dart
@@ -1,0 +1,245 @@
+// Widget tests for the rendered HTML viewer + its registry routing (#1037).
+//
+// Assert:
+//   - tapping a `.html` / `.htm` entry in the file browser routes to
+//     [HtmlFileViewerScreen] (via the registry, ordered BEFORE the generic
+//     text viewer — first match wins), NOT the text viewer and NOT download,
+//   - the screen starts its loopback resolver and hands the stubbed WebView a
+//     127.0.0.1 URI pointing at the opened file,
+//   - the app bar's "view source" pushes the EXISTING monospace text viewer,
+//   - disposing the route closes the loopback port.
+//
+// Mirrors markdown_file_viewer_widget_test.dart's wiring (InMemoryGatewayPair
+// + FileBrowserScreen + injected fetchers). The platform WebView is stubbed
+// via [htmlWebViewBuilder] — widget tests have no platform channel; the real
+// HTTP surface is covered by the unit tests and the emulator test.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/sftp_image_fetcher.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/services/text_file_fetcher.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/ui/html_file_viewer.dart';
+import 'package:mobissh/ui/markdown_file_viewer.dart';
+import 'package:mobissh/ui/text_file_viewer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+class _ScriptedSftpSession implements SftpSession {
+  _ScriptedSftpSession(this._byPath);
+  final Map<String, List<SftpEntry>> _byPath;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async => _byPath[path] ?? const [];
+  @override
+  Future<int?> sizeOf(String path) async => 0;
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async => 0;
+  @override
+  Future<int> upload(String path, Uint8List bytes) async => bytes.length;
+  @override
+  Future<int> uploadFile(
+    String localPath,
+    String remotePath, {
+    required void Function(int sent, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+class _CannedTextFetcher implements TextFileFetcher {
+  _CannedTextFetcher(this.text);
+  final String text;
+
+  @override
+  Future<String> fetch(
+    String sessionId,
+    SftpEntry entry, {
+    int maxBytes = 2 * 1024 * 1024,
+    void Function(int received, int? total)? onProgress,
+  }) async => text;
+}
+
+class _CannedByteFetcher implements SftpImageFetcher {
+  @override
+  Future<Uint8List> fetch(
+    String sessionId,
+    String path, {
+    int maxBytes = 8 * 1024 * 1024,
+  }) async => Uint8List(0);
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+({ProviderContainer container, SessionEntry session, SessionHost host}) _wire(
+  WidgetTester tester, {
+  required Map<String, List<SftpEntry>> byPath,
+}) {
+  final pair = InMemoryGatewayPair();
+  addTearDown(pair.dispose);
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: _stubControllerFactory,
+    sftpOpener: (_) async => _ScriptedSftpSession(byPath),
+    snapshotInterval: const Duration(hours: 1),
+  );
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      textFileFetcherProvider.overrideWithValue(
+        _CannedTextFetcher('<html><body>hi</body></html>'),
+      ),
+      sftpImageFetcherProvider.overrideWithValue(_CannedByteFetcher()),
+    ],
+  );
+  addTearDown(container.dispose);
+  const params = SshConnectParams(
+    host: 'h',
+    port: 22,
+    username: 'u',
+    auth: SshAuth.password('p'),
+  );
+  final session = container.read(sessionsProvider.notifier).addOrActivate(
+    params,
+  );
+  session.proxy.connect(params);
+  return (container: container, session: session, host: host);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final loadedUris = <Uri>[];
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    loadedUris.clear();
+    htmlWebViewBuilder = (uri, onBlocked) {
+      loadedUris.add(uri);
+      return const Text('stub-html-webview');
+    };
+  });
+
+  tearDown(() {
+    htmlWebViewBuilder = defaultHtmlWebViewBuilderForTest;
+  });
+
+  Future<SessionHost> openHtml(WidgetTester tester, String name) async {
+    final w = _wire(
+      tester,
+      byPath: {
+        '/': [
+          SftpEntry(name: name, path: '/$name', isDirectory: false, size: 20),
+        ],
+      },
+    );
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: w.container,
+        child: MaterialApp(home: FileBrowserScreen(sessionId: w.session.id)),
+      ),
+    );
+    await _pump(tester);
+    await tester.tap(find.byKey(Key('file-entry-$name')));
+    await _pump(tester);
+    return w.host;
+  }
+
+  testWidgets('.html routes to the rendered HTML viewer, not the text viewer', (
+    tester,
+  ) async {
+    final host = await openHtml(tester, 'wireframes.html');
+    expect(find.byType(HtmlFileViewerScreen), findsOneWidget);
+    expect(find.byType(TextFileViewerScreen), findsNothing);
+    expect(find.byType(MarkdownFileViewerScreen), findsNothing);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('.htm routes to the rendered HTML viewer', (tester) async {
+    final host = await openHtml(tester, 'page.HTM');
+    expect(find.byType(HtmlFileViewerScreen), findsOneWidget);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('the WebView is handed a loopback URI for the opened file', (
+    tester,
+  ) async {
+    final host = await openHtml(tester, 'wireframes.html');
+    expect(find.text('stub-html-webview'), findsOneWidget);
+    expect(loadedUris, hasLength(1));
+    final uri = loadedUris.single;
+    expect(uri.scheme, 'http');
+    expect(uri.host, '127.0.0.1');
+    expect(uri.port, greaterThan(0));
+    expect(uri.pathSegments, ['wireframes.html']);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('view-source pushes the existing text viewer', (tester) async {
+    final host = await openHtml(tester, 'wireframes.html');
+    expect(find.byKey(const Key('html-view-source')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('html-view-source')));
+    await _pump(tester);
+    expect(find.byType(TextFileViewerScreen), findsOneWidget);
+    // The raw source is shown by the text viewer's own fetch path.
+    expect(find.textContaining('<html>'), findsOneWidget);
+
+    // Back returns to the rendered viewer. (Not pageBack(): two stacked
+    // routes each expose a back tooltip, which pageBack refuses.)
+    tester.state<NavigatorState>(find.byType(Navigator)).pop();
+    await _pump(tester);
+    expect(find.byType(HtmlFileViewerScreen), findsOneWidget);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('closing the viewer route shuts the loopback server down', (
+    tester,
+  ) async {
+    final host = await openHtml(tester, 'wireframes.html');
+    expect(debugLastHtmlLoopbackServer, isNotNull);
+    final server = debugLastHtmlLoopbackServer!;
+    expect(server.port, isNotNull);
+
+    tester.state<NavigatorState>(find.byType(Navigator)).pop();
+    await _pump(tester);
+    await tester.pump(const Duration(seconds: 1));
+    await _pump(tester);
+    expect(find.byType(HtmlFileViewerScreen), findsNothing);
+    expect(server.port, isNull, reason: 'loopback port must close on dispose');
+    expect(debugLastHtmlLoopbackServer, isNull);
+    host.disposeSyncForTest();
+  });
+}


### PR DESCRIPTION
Closes #1037 (epic #944).

`.html`/`.htm` files tapped in the SFTP file browser now open RENDERED in a WebView instead of showing raw source, with relative references (linked CSS, images, scripts, nested dirs) resolved against the file's REMOTE directory over the session's SFTP.

## How

- **`services/html_loopback_server.dart`** — per-viewer dart:io HttpServer on `127.0.0.1:<ephemeral>`, rooted at the opened file's remote dir. Request path → decode + normalize + traversal guard (`resolveLoopbackAssetPath`: resolved path must stay under the root; `..` escapes → 404, fetcher never consulted) → SFTP read (the existing #946 `SftpImageFetcher` raw-byte seam) → response with mapped content-type (common web types; octet-stream default). Per-asset cap 8 MiB → 413. Started on viewer open, closed on route dispose.
- **`ui/html_file_viewer.dart`** — WebView loads `http://127.0.0.1:<port>/<name>.html`; JS enabled; navigation locked to the loopback origin — anything else is blocked with a toast (v1). Pinch-zoom/pan are the WebView's own (#949 selfZooming shape: full-bleed, never wrapped in InteractiveViewer). Dark pages render as the page dictates. App-bar "view source" pushes the existing monospace text viewer.
- **Registry** — `isHtmlEntry` routes before the generic text viewer (first match wins).

## Security posture (documented in code)

- Binds 127.0.0.1 ONLY, random ephemeral port — unreachable off-device.
- Serves ONLY the tree rooted at the opened HTML file's directory; every request path normalized and containment-checked (encoded `%2e%2e` decoded before the guard); escapes 404.
- Content fetched on demand over the user's own authenticated SFTP session (files they can already read); nothing cached to disk; `Cache-Control: no-store`.
- Viewer-scoped lifetime: port closes with the route (widget-tested + emulator-tested).
- Note: the Dart HTTP stack additionally applies full RFC 3986 normalization (percent-decode + remove_dot_segments) before the handler; the resolver's own `..` rejection is defense in depth. The unit test asserts the end-to-end invariant with raw-socket request lines: the fetcher never sees an out-of-root path.

## Tests

- **Unit** (`test/services/html_loopback_server_test.dart`, 20): resolver traversal matrix (literal/encoded/sibling-prefix/root edge cases), content-type map, 404 miss, 413 cap, lifecycle (port closed after `close()`), raw-socket traversal invariant, `isHtmlEntry` detection.
- **Widget** (`test/widget/html_file_viewer_widget_test.dart`, 5): `.html`/`.htm` route to the rendered viewer (not text/markdown), stubbed WebView receives the loopback URI for the opened file, view-source pushes the existing text viewer and back returns, popping the route closes the loopback port.
- **Emulator** (`integration_test/html_render_sftp_test.dart`): seeds on test-sshd a site with a relative CSS (background color marker), relative image, and a `../escape.css` ref plus a secret file ABOVE the served root; opens it through the browser → rendered viewer; probes the live loopback origin in-process: page/css/image 200 over SFTP, escape + encoded escape + miss 404 and the secret is never served; port closes on pop. Screenshot of the rendered (styled) page attached.

DEVICE GATE: the pinch-zoom gesture itself is WebView-native on a PlatformView (same posture as #946/#949) — config is code-asserted; the gesture is owner-validated on hardware.

## Screenshot (emulator, during the test's hold window)

The seeded `index.html` rendered in the viewer: green page background + yellow H1 from the RELATIVE `css/style.css`, white body text, escape-ref 404 did not break rendering. Local shot for reviewer:

`test-results/emulator-shots/20260711T005950+0000-html-1037-rendered_.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa