### PR TITLE
feat(native): relative-path detection via per-session cwd tracking, verification-gated (#1036)

### DIFF
--- a/native/integration_test/relpath_cwd_1036_test.dart
+++ b/native/integration_test/relpath_cwd_1036_test.dart
@@ -1,0 +1,364 @@
+// On-emulator acceptance for #1036 — RELATIVE paths detected via per-session
+// cwd tracking, VERIFICATION-GATED visibility.
+//
+// Flow (test-sshd):
+//   1. Prepare /tmp/relpath1036/sub/real.txt, `cd` into /tmp/relpath1036 and
+//      advertise the cwd (OSC 7 printf + a strong `user@host:$PWD$` PS1 — the
+//      tracker's ladder accepts either).
+//   2. Echo `sub/real.txt` (delivered base64 so the typed command echo never
+//      contains the token) → a `relpath` anchor appears, the tracker's cwd is
+//      /tmp/relpath1036, and the verifier confirms the RESOLVED
+//      /tmp/relpath1036/sub/real.txt → the anchor is verified (visible).
+//   3. Echo `no/such.txt` → anchored at the shape level but its resolved path
+//      stats MISSING → never verified (never visible). This is the design:
+//      shape-level recall is broad; the stat is the precision gate.
+//   4. `cd /tmp` and re-echo `sub/real.txt` → the tracker follows the cwd and
+//      the NEW resolved key /tmp/sub/real.txt stats missing (cwd tracked).
+//   5. `cd` back, single TAP on the verified anchor → the file browser opens
+//      at the RESOLVED parent dir /tmp/relpath1036/sub with real.txt listed;
+//      the clipboard is untouched (#999 navigate semantics on the resolved
+//      path). Hold for the screenshot.
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/relpath_cwd_1036_test.dart
+
+import 'dart:convert';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/path_verifier.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'a relative path verifies against the tracked cwd, a fake one never '
+    'shows, a cd re-resolves, and a tap opens the browser at the resolved '
+    'dir (#1036)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller for session');
+
+      // Wait for a live shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // Let the first-connect resize storm settle before echoing.
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      void send(String line) {
+        entry.proxy.sendInput(Uint8List.fromList(utf8.encode('$line\n')));
+      }
+
+      Future<void> settle([int ticks = 4]) async {
+        for (var i = 0; i < ticks; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+        }
+      }
+
+      // 1. Prepare the fixture dir, cd into it, advertise the cwd through BOTH
+      // ladder sources: an OSC 7 printf (file://host$PWD) and a strong
+      // `user@host:$PWD$ ` PS1 (ash expands PS1 variables at display time).
+      // The tracker accepts whichever the terminal surfaces.
+      const dir = '/tmp/relpath1036';
+      send('mkdir -p $dir/sub; touch $dir/sub/real.txt');
+      await settle();
+      send(r"export PS1='testuser@relhost:$PWD$ '");
+      await settle();
+      send('cd $dir');
+      await settle();
+      send(r"printf '\033]7;file://t%s\033\\' " '"\$PWD"; echo cwdset');
+      await settle();
+
+      // 2. Deliver the RELATIVE tokens via base64 variables (the typed command
+      // echo must never contain the token — exactly one anchor per echo; the
+      // short `echo "$v"` row also stays clear of the inferred-wrap-col
+      // heuristic, see path_tap_navigate_999_test).
+      const realRel = 'sub/real.txt';
+      const fakeRel = 'no/such.txt';
+      final realB64 = base64Encode(utf8.encode('$realRel\n'));
+      final fakeB64 = base64Encode(utf8.encode('$fakeRel\n'));
+      send('v=\$(echo $realB64 | base64 -d)');
+      await settle();
+      send('echo "\$v"');
+
+      // The scanner must anchor the relative token under the relpath id.
+      StructuredAnchor? relAnchorOf(String payload) {
+        StructuredAnchor? last;
+        for (final a in controller!.anchors) {
+          if (a.patternId == 'relpath' && '${a.payload}' == payload) last = a;
+        }
+        return last;
+      }
+
+      for (var i = 0; i < 60 && relAnchorOf(realRel) == null; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      final anchorDump = [
+        for (final a in controller!.anchors) '${a.patternId}:"${a.payload}"',
+      ];
+      final visibleDump = controller
+          .visibleRowsText(0, controller.scrollbar.visible - 1)
+          .split('\n')
+          .where((l) => l.trim().isNotEmpty)
+          .join(' | ');
+      expect(
+        relAnchorOf(realRel),
+        isNotNull,
+        reason: 'the echoed $realRel was never detected as a relpath anchor — '
+            'anchors: $anchorDump; visible rows: "$visibleDump"',
+      );
+
+      // The cwd tracker must have followed the cd (OSC 7 or prompt ladder;
+      // the refresh runs on the same decoration notify that noted the anchor).
+      final tracker = GhosttyTerminalView.debugCwdTrackers[sessionId];
+      expect(tracker, isNotNull, reason: 'no cwd tracker for session');
+      var cwdTracked = false;
+      for (var i = 0; i < 40 && !cwdTracked; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        cwdTracked = tracker!.cwd == dir;
+      }
+      expect(
+        cwdTracked,
+        isTrue,
+        reason: 'cwd ladder never tracked the cd — tracker.cwd="${tracker!.cwd}" '
+            '(expected $dir); controller.pwd="${controller.pwd}"',
+      );
+
+      // The verifier confirms the RESOLVED absolute → the anchor is verified.
+      final verifier = GhosttyTerminalView.debugPathVerifiers[sessionId];
+      expect(verifier, isNotNull, reason: 'no path verifier for session');
+      const resolvedReal = '$dir/sub/real.txt';
+      var realVerified = false;
+      for (var i = 0; i < 40 && !realVerified; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        realVerified = verifier!.isVerified(resolvedReal);
+      }
+      expect(
+        realVerified,
+        isTrue,
+        reason: '$resolvedReal exists on test-sshd — the relative anchor must '
+            'verify (and only then become visible)',
+      );
+
+      // 3. A FAKE relative token: anchored at the shape level, but its
+      // resolved path stats MISSING → never verified, never visible.
+      send('w=\$(echo $fakeB64 | base64 -d)');
+      await settle();
+      send('echo "\$w"');
+      for (var i = 0; i < 60 && relAnchorOf(fakeRel) == null; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(
+        relAnchorOf(fakeRel),
+        isNotNull,
+        reason: 'shape-level recall is broad by design — $fakeRel must anchor '
+            '(the verifier, not the shape, hides it)',
+      );
+      const resolvedFake = '$dir/no/such.txt';
+      var fakeResolvedMissing = false;
+      for (var i = 0; i < 40 && !fakeResolvedMissing; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        fakeResolvedMissing =
+            verifier!.status(resolvedFake) == PathVerification.missing;
+      }
+      expect(
+        fakeResolvedMissing,
+        isTrue,
+        reason: '$resolvedFake must stat MISSING so the anchor stays hidden',
+      );
+      expect(verifier!.isVerified(resolvedFake), isFalse);
+
+      // 4. cd ELSEWHERE and re-echo the real token: the tracker follows, the
+      // new resolved key /tmp/sub/real.txt stats missing (cwd is tracked, not
+      // frozen at first sight).
+      send('cd /tmp');
+      await settle();
+      send(r"printf '\033]7;file://t%s\033\\' " '"\$PWD"; echo cwdset2');
+      await settle();
+      send('echo "\$v"');
+      var movedTracked = false;
+      for (var i = 0; i < 40 && !movedTracked; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        movedTracked = tracker.cwd == '/tmp';
+      }
+      expect(
+        movedTracked,
+        isTrue,
+        reason: 'cwd ladder never tracked the second cd — '
+            'tracker.cwd="${tracker.cwd}"',
+      );
+      var movedMissing = false;
+      for (var i = 0; i < 40 && !movedMissing; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        movedMissing =
+            verifier.status('/tmp/sub/real.txt') == PathVerification.missing;
+      }
+      expect(
+        movedMissing,
+        isTrue,
+        reason: 'after cd /tmp the re-resolved /tmp/sub/real.txt must stat '
+            'MISSING — the anchor must not show against the stale cwd',
+      );
+
+      // 5. cd BACK, re-echo, and TAP the verified anchor: the browser opens
+      // at the RESOLVED parent dir; the clipboard stays untouched.
+      send('cd $dir');
+      await settle();
+      send(r"printf '\033]7;file://t%s\033\\' " '"\$PWD"; echo cwdset3');
+      await settle();
+      send('echo "\$v"');
+      var backTracked = false;
+      for (var i = 0; i < 40 && !backTracked; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        backTracked = tracker.cwd == dir && verifier.isVerified(resolvedReal);
+      }
+      expect(
+        backTracked,
+        isTrue,
+        reason: 'cwd never tracked back to $dir with the anchor verified — '
+            'tracker.cwd="${tracker.cwd}"',
+      );
+
+      List<Rect> anchorRects() => [
+        for (final range in relAnchorOf(realRel)!.ranges)
+          ...controller.anchorRects(range),
+      ];
+      for (var i = 0;
+          i < 30 && (controller.isScrolling || anchorRects().isEmpty);
+          i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      final rects = anchorRects();
+      expect(rects, isNotEmpty, reason: 'no on-screen rect for the anchor');
+
+      // Hold BEFORE the tap so the host can screenshot the VERIFIED relative
+      // anchor (wash + gutter chip) on the terminal itself.
+      debugPrint('RELPATH1036_ANCHOR_WINDOW_OPEN');
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      debugPrint('RELPATH1036_ANCHOR_WINDOW_CLOSED');
+
+      const sentinel = 'SEED-1036-NAVIGATE';
+      await Clipboard.setData(const ClipboardData(text: sentinel));
+
+      final viewOrigin = tester.getTopLeft(find.byType(TerminalView));
+      await tester.tapAt(viewOrigin + rects.first.center);
+
+      var browserOpen = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(const Key('file-browser-path')).evaluate().isNotEmpty) {
+          browserOpen = true;
+          break;
+        }
+      }
+      expect(
+        browserOpen,
+        isTrue,
+        reason: 'the relpath tap never opened the file browser',
+      );
+      final pathText = tester.widget<Text>(
+        find.byKey(const Key('file-browser-path')),
+      );
+      expect(
+        pathText.data,
+        '$dir/sub',
+        reason: 'a relpath tap must navigate to the RESOLVED parent dir',
+      );
+
+      var listMounted = false;
+      for (var i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(const Key('file-browser-list')).evaluate().isNotEmpty) {
+          listMounted = true;
+          break;
+        }
+      }
+      expect(listMounted, isTrue, reason: 'the $dir/sub listing never rendered');
+      expect(
+        find.text('real.txt'),
+        findsWidgets,
+        reason: 'the resolved dir listing never showed real.txt',
+      );
+
+      final clip = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
+      expect(
+        clip,
+        sentinel,
+        reason: 'a relpath tap must navigate, not copy; clipboard changed',
+      );
+
+      // Hold for the external emu-shot (verified relative anchor + browser).
+      debugPrint('RELPATH1036_SHOT_WINDOW_OPEN');
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      debugPrint('RELPATH1036_SHOT_WINDOW_CLOSED');
+    },
+  );
+}

--- a/native/lib/services/session_cwd_tracker.dart
+++ b/native/lib/services/session_cwd_tracker.dart
@@ -1,0 +1,158 @@
+// session_cwd_tracker.dart — per-session WORKING-DIRECTORY tracking (#1036).
+//
+// Relative-path anchors (`relpath`, the fork's TextPattern.relativePath) only
+// mean something against the session's cwd. This tracker keeps a best-effort
+// cwd per terminal session from a LADDER of sources:
+//
+//   1. OSC 7 — the shell's `file://host/path` cwd advisory, surfaced by
+//      libghostty as `TerminalController.pwd` (empty when never set). The
+//      strongest signal: shells that emit it do so on every prompt.
+//   2. Prompt-derived — the #998 STRONG bash prompt shape `user@host:PATH$ `
+//      scanned off the visible rows; PATH is extracted verbatim (`~`-relative
+//      forms kept as-is).
+//   3. Last-known — both sources are STICKY: a non-prompt line or an empty
+//      advisory never clears an earlier answer.
+//   4. Home — represented UI-side as `~`. No realpath IPC exists (and none is
+//      added): the task-side SFTP layer (#867 expandTilde in sftp_session.dart)
+//      expands `~`/`~/x` at the single seam every stat/list/download routes
+//      through, so a `~`-prefixed resolved path verifies and navigates
+//      correctly without the UI ever knowing the literal home directory.
+//
+// STALENESS IS TOLERATED BY DESIGN (#1036): a wrong cwd only means the
+// resolved candidate fails its #990 SFTP stat, and the relpath anchor simply
+// never shows an affordance. Precision lives in the verifier, not here.
+//
+// Pure Dart (no FFI, no widgets) so the ladder, the OSC 7 / prompt parsing,
+// and the resolution join are unit-testable headless.
+
+/// Parse an OSC 7 cwd advisory [raw] (the `TerminalController.pwd` string)
+/// to an absolute path, or null when it is unset / unusable.
+///
+/// Accepts `file://host/path`, `file:///path`, and a bare `/path` (some
+/// terminals store the already-stripped path). Percent-decodes the path.
+/// Anything else — empty, relative junk, malformed encoding — is null (the
+/// ladder treats it as "no advisory"), never a throw.
+String? osc7Cwd(String raw) {
+  final s = raw.trim();
+  if (s.isEmpty) return null;
+  String path;
+  if (s.startsWith('file://')) {
+    final rest = s.substring('file://'.length);
+    final slash = rest.indexOf('/');
+    if (slash < 0) return null; // no path component at all
+    path = rest.substring(slash);
+  } else if (s.startsWith('/')) {
+    path = s;
+  } else {
+    return null;
+  }
+  try {
+    path = Uri.decodeComponent(path);
+  } catch (_) {
+    return null; // malformed percent-encoding — treat as unset
+  }
+  return path.startsWith('/') ? path : null;
+}
+
+/// The #998 STRONG bash-prompt shape, anchored at line START, with the PATH
+/// captured: `user@host:PATH$ ` / `user@host:PATH# `. Mirrors the fork's
+/// `_kStrongPromptAlt` first alternative (`[\w.\-]+@[\w.\-]+:[^\s#$]*[#$]\s`)
+/// — the weak `$`/`❯` shapes carry no path, so only the strong shape feeds
+/// the cwd ladder.
+final RegExp _kStrongPromptPath = RegExp(r'^[\w.\-]+@[\w.\-]+:([^\s#$]*)[#$]');
+
+/// Extract the PATH from a strong `user@host:PATH$` prompt [line], or null
+/// when the line is not a strong prompt. `~` / `~/sub` forms are returned
+/// verbatim (resolution keeps the `~`; the task-side SFTP seam expands it).
+/// An empty PATH (degenerate `user@host:$`) is null.
+String? promptCwd(String line) {
+  final m = _kStrongPromptPath.firstMatch(line);
+  if (m == null) return null;
+  final path = m.group(1)!;
+  if (path.isEmpty) return null;
+  // Only absolute or home-relative prompt paths are usable as a cwd.
+  if (!path.startsWith('/') && !path.startsWith('~')) return null;
+  return path;
+}
+
+/// Join [cwd] and a RELATIVE [relative] into one normalized path (#1036).
+///
+/// Collapses `.` and `..` segments; `..` never pops past the root (`/`) or
+/// the `~` home marker. A trailing slash on [relative] survives (the
+/// dir-vs-file browse rule keys off it, #999). [cwd] may be absolute or a
+/// `~`-prefixed home form (expanded task-side, #867).
+String resolveRelativePath(String cwd, String relative) {
+  var base = cwd.isEmpty ? '~' : cwd;
+  while (base.length > 1 && base.endsWith('/')) {
+    base = base.substring(0, base.length - 1);
+  }
+  final trailingSlash = relative.endsWith('/');
+  // The root/home HEAD is fixed: `..` never pops it.
+  final String head;
+  String rest;
+  if (base.startsWith('/')) {
+    head = '/';
+    rest = base.substring(1);
+  } else if (base.startsWith('~')) {
+    final slash = base.indexOf('/');
+    head = slash < 0 ? base : base.substring(0, slash);
+    rest = slash < 0 ? '' : base.substring(slash + 1);
+  } else {
+    head = '';
+    rest = base;
+  }
+  final segments = [
+    for (final s in rest.split('/'))
+      if (s.isNotEmpty) s,
+  ];
+  for (final s in relative.split('/')) {
+    if (s.isEmpty || s == '.') continue;
+    if (s == '..') {
+      if (segments.isNotEmpty) segments.removeLast();
+      continue; // never pops past the head
+    }
+    segments.add(s);
+  }
+  final joined = segments.join('/');
+  var out = head == '/' ? '/$joined' : (joined.isEmpty ? head : '$head/$joined');
+  if (trailingSlash && !out.endsWith('/')) out = '$out/';
+  return out;
+}
+
+/// Per-session cwd state: feed it OSC 7 advisories + candidate prompt lines,
+/// read [cwd] / [resolve]. One instance per terminal view == per session, so
+/// host A's cwd never bleeds onto host B (the same scoping as the #990
+/// SessionPathVerifier).
+class SessionCwdTracker {
+  String? _osc7;
+  String? _prompt;
+
+  /// The current best-effort cwd: OSC 7 > prompt-derived > home (`~`).
+  /// Both sources are sticky (last-known wins over nothing).
+  String get cwd => _osc7 ?? _prompt ?? '~';
+
+  /// Note an OSC 7 advisory (the controller's `pwd` string). Unparseable /
+  /// empty values are ignored (sticky last-known). Returns true when the
+  /// effective [cwd] changed.
+  bool noteOsc7(String raw) {
+    final parsed = osc7Cwd(raw);
+    if (parsed == null) return false;
+    final before = cwd;
+    _osc7 = parsed;
+    return cwd != before;
+  }
+
+  /// Note a candidate PROMPT line (a visible row's text). Non-prompt lines
+  /// are ignored (sticky last-known). Returns true when the effective [cwd]
+  /// changed.
+  bool notePromptLine(String line) {
+    final parsed = promptCwd(line);
+    if (parsed == null) return false;
+    final before = cwd;
+    _prompt = parsed;
+    return cwd != before;
+  }
+
+  /// Resolve a RELATIVE detected payload against the current [cwd].
+  String resolve(String relative) => resolveRelativePath(cwd, relative);
+}

--- a/native/lib/state/detection_providers.dart
+++ b/native/lib/state/detection_providers.dart
@@ -67,6 +67,7 @@ class DetectionSettings {
     this.url = true,
     this.path = true,
     this.command = true,
+    this.relpath = true,
   });
 
   /// The schema version this instance was built from (defaults to current).
@@ -86,6 +87,12 @@ class DetectionSettings {
   /// the field-by-field fallback below).
   final bool command;
 
+  /// Detect RELATIVE file paths (#1036). Default TRUE (purely additive):
+  /// safe because a relpath anchor is INVISIBLE until its cwd-resolved
+  /// absolute path passes the #990 SFTP-stat verification — turning the
+  /// pattern on changes nothing visible for a token that doesn't resolve.
+  final bool relpath;
+
   /// Whether the URL patterns should be registered (master AND url), UNLESS the
   /// #971 kill switch has force-disabled detection (see [kDetectionDisabled971]).
   bool get detectUrls => !kDetectionDisabled971 && enabled && url;
@@ -98,16 +105,22 @@ class DetectionSettings {
   /// under the same #971 kill switch (#998 slice C).
   bool get detectCommands => !kDetectionDisabled971 && enabled && command;
 
+  /// Whether the RELATIVE-path pattern should be registered (master AND
+  /// relpath), under the same #971 kill switch (#1036).
+  bool get detectRelPaths => !kDetectionDisabled971 && enabled && relpath;
+
   /// Whether ANY pattern is registered — the single truth the terminal view's
   /// repaint gating reads (#921), instead of re-deriving boolean combinations
   /// per call site (#998 C added a third type; state-management rule).
-  bool get detectionActive => detectUrls || detectPaths || detectCommands;
+  bool get detectionActive =>
+      detectUrls || detectPaths || detectCommands || detectRelPaths;
 
   DetectionSettings copyWith({
     bool? enabled,
     bool? url,
     bool? path,
     bool? command,
+    bool? relpath,
   }) {
     return DetectionSettings(
       schemaVersion: detectionSettingsSchemaVersion,
@@ -115,6 +128,7 @@ class DetectionSettings {
       url: url ?? this.url,
       path: path ?? this.path,
       command: command ?? this.command,
+      relpath: relpath ?? this.relpath,
     );
   }
 
@@ -126,6 +140,7 @@ class DetectionSettings {
     'url': url,
     'path': path,
     'command': command,
+    'relpath': relpath,
   });
 
   /// Parse a stored JSON string, FIELD-BY-FIELD with a per-field default
@@ -154,6 +169,8 @@ class DetectionSettings {
         path: field('path', def.path),
         // Absent in pre-#998 stored values → defaults TRUE (additive).
         command: field('command', def.command),
+        // Absent in pre-#1036 stored values → defaults TRUE (additive).
+        relpath: field('relpath', def.relpath),
       );
     } catch (_) {
       // Corrupt / non-JSON value → safe all-true default (no silent disable).
@@ -168,15 +185,17 @@ class DetectionSettings {
       other.enabled == enabled &&
       other.url == url &&
       other.path == path &&
-      other.command == command;
+      other.command == command &&
+      other.relpath == relpath;
 
   @override
-  int get hashCode => Object.hash(schemaVersion, enabled, url, path, command);
+  int get hashCode =>
+      Object.hash(schemaVersion, enabled, url, path, command, relpath);
 
   @override
   String toString() =>
       'DetectionSettings(v:$schemaVersion, enabled:$enabled, url:$url, '
-      'path:$path, command:$command)';
+      'path:$path, command:$command, relpath:$relpath)';
 }
 
 /// Persisted GLOBAL detection settings (#888 Part A). Synchronous default
@@ -234,6 +253,12 @@ class DetectionSettingsNotifier extends StateNotifier<DetectionSettings> {
   /// Toggle command-line detection (#998 slice C).
   Future<void> setCommand(bool value) async {
     state = state.copyWith(command: value);
+    await _persist();
+  }
+
+  /// Toggle RELATIVE-path detection (#1036).
+  Future<void> setRelpath(bool value) async {
+    state = state.copyWith(relpath: value);
     await _persist();
   }
 }

--- a/native/lib/ui/detection_lab_preview.dart
+++ b/native/lib/ui/detection_lab_preview.dart
@@ -95,6 +95,18 @@ const List<DetectionLabPatternSpec> detectionLabPatternSpecs = [
     sampleMatch: '/etc/ssh/sshd_config',
     bubble: true,
   ),
+  // #1036: relative paths — verification-gated (an anchor is INVISIBLE until
+  // its cwd-resolved absolute passes the SFTP stat), so the preview's sample
+  // renders the VERIFIED state, the only visible one this pattern has.
+  DetectionLabPatternSpec(
+    key: 'relpath',
+    title: 'Relative paths',
+    icon: Icons.subdirectory_arrow_right,
+    styleIds: [kGhosttyRelPathPatternId],
+    samplePrefix: 'wrote ',
+    sampleMatch: 'specs/001/spec.md',
+    bubble: true,
+  ),
   DetectionLabPatternSpec(
     key: 'command',
     title: 'Command lines',
@@ -149,6 +161,7 @@ DetectionLabPatternSpec detectionLabSpecForCustomPattern(CustomPattern p) {
 bool detectionLabTypeEnabled(DetectionSettings d, String key) => switch (key) {
   'url' => d.url,
   'path' => d.path,
+  'relpath' => d.relpath,
   'command' => d.command,
   _ => false,
 };
@@ -159,6 +172,7 @@ Future<void> detectionLabSetTypeEnabled(WidgetRef ref, String key, bool v) {
   return switch (key) {
     'url' => n.setUrl(v),
     'path' => n.setPath(v),
+    'relpath' => n.setRelpath(v),
     'command' => n.setCommand(v),
     _ => Future<void>.value(),
   };

--- a/native/lib/ui/detection_style_resolver.dart
+++ b/native/lib/ui/detection_style_resolver.dart
@@ -74,7 +74,9 @@ const double kDetectionIntensityGap = 0.15;
 /// control that tunes a state with no runtime effect (#1031 IA review change
 /// 1: no dead controls). Unknown / custom ids have no active state.
 bool detectionPatternHasActiveState(String patternId) =>
-    patternId == kGhosttyPathPatternId;
+    patternId == kGhosttyPathPatternId ||
+    // #1036: a relative-path anchor's ONLY visible state is verified (active).
+    patternId == kGhosttyRelPathPatternId;
 
 /// Parse a `#RRGGBB` (or bare `RRGGBB`) hex string to an opaque [Color].
 /// Anything else — wrong length, non-hex digits, empty — returns null so a

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -209,10 +209,15 @@ class GutterPatternRegistry {
   /// same. The payload handed back is ALWAYS the ORIGINAL matched text (a
   /// file:// anchor reports its file:// URI, not the derived bare path) —
   /// suppression matches the anchor payload exactly.
+  /// [resolveRelative] (#1036) maps a RELATIVE anchor payload to its
+  /// cwd-resolved ABSOLUTE path (the view passes the session cwd tracker's
+  /// resolve). Called at ACTION time so a menu opened after a `cd` resolves
+  /// against the live cwd. Null → relative payloads act on their raw text.
   factory GutterPatternRegistry.standard({
     required Future<bool> Function(String path) openPath,
     String? Function(String path)? sftpUrlOf,
     void Function(String patternId, String payload)? onReportException,
+    String Function(String relative)? resolveRelative,
   }) {
     GutterItemAction copyAction(String payload) => GutterItemAction(
       keyLabel: 'copy',
@@ -365,6 +370,56 @@ class GutterPatternRegistry {
       ],
     );
 
+    // #1036: the RELATIVE-path anchor. Same affordance family as `path`, but
+    // every action works in RESOLVED-ABSOLUTE semantics (Open navigates to
+    // the cwd-resolved path; Copy path copies the absolute; Copy relative
+    // copies the matched text; sftp:// uses the absolute). Only VERIFIED
+    // anchors ever reach these (the visibility gate suppresses the rest).
+    String resolveRel(String relative) =>
+        resolveRelative?.call(relative) ?? relative;
+    final relpath = GutterPatternPresentation(
+      patternId: kGhosttyRelPathPatternId,
+      icon: Icons.folder_open,
+      typeLabel: 'Path',
+      showActions: (context, anchor, markGlobal) {
+        final payload = '${anchor.payload}';
+        final resolved = resolveRel(payload);
+        showPathActions(
+          context,
+          resolved,
+          relativeText: payload,
+          highlightRects: const [],
+          anchor: markGlobal,
+          onOpen: openPath,
+          sftpUrl: sftpUrlOf?.call(resolved),
+          // #995: report the ORIGINAL relative payload — suppression keys on
+          // the matched text, not the resolved form.
+          onMarkNotDetection: onReportException == null
+              ? null
+              : () => onReportException(anchor.patternId, payload),
+        );
+      },
+      itemActions: (payload) {
+        final resolved = resolveRel(payload);
+        return [
+          openPathAction(resolved),
+          GutterItemAction(
+            keyLabel: 'copy',
+            icon: Icons.content_copy,
+            label: 'Copy path',
+            onInvoke: (context) => _copyWithToast(context, resolved),
+          ),
+          GutterItemAction(
+            keyLabel: 'copy-relative',
+            icon: Icons.content_copy,
+            label: 'Copy relative',
+            onInvoke: (context) => _copyWithToast(context, payload),
+          ),
+          ?notAction(kGhosttyRelPathPatternId, payload, 'Not a file'),
+        ];
+      },
+    );
+
     // #998 slice C: the COMMAND-LINE block anchor. GUTTER-ONLY affordance —
     // no bubble, no glass tap. A single-match chip tap COPIES the whole
     // command payload paste-exact (the copy IS the primary use; no action
@@ -404,6 +459,7 @@ class GutterPatternRegistry {
           itemActions: url.itemActions,
         ),
         path,
+        relpath,
         command,
       ],
       // #1031 slice 3: ONE generic presentation covers every USER-DEFINED

--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -39,6 +39,15 @@ const String kGhosttyOsc8PatternId = 'osc8';
 /// the path mark (a distinct glyph + action set from the URL).
 const String kGhosttyPathPatternId = 'path';
 
+/// The id of the RELATIVE FILE PATH pattern (#1036) — the fork's
+/// `TextPattern.relativePath` over bare `a/b` tokens. Distinct from
+/// [kGhosttyPathPatternId] so gating can treat it separately: a relpath anchor
+/// is INVISIBLE until its cwd-resolved absolute path passes the #990 SFTP-stat
+/// verification (there is no "detected but unverified" visible state for this
+/// class — shape-level recall is deliberately broad, the verifier is the
+/// precision gate).
+const String kGhosttyRelPathPatternId = 'relpath';
+
 /// The id of the COMMAND-LINE pattern (#998 slice C) — the fork's BLOCK-tier
 /// `TextPattern.command` over a whole prompt-anchored command line, for
 /// copy-to-paste. Matches the factory's default id. Deliberately ABSENT from
@@ -303,6 +312,9 @@ class GhosttyBubbleLayer extends StatelessWidget {
     kGhosttyUrlPatternId,
     kGhosttyOsc8PatternId,
     kGhosttyPathPatternId,
+    // #1036: relative paths share the path bubble; the visibility gate keeps
+    // them invisible until their cwd-resolved absolute verifies.
+    kGhosttyRelPathPatternId,
   };
 
   /// Whether [patternId] paints a bubble: the built-in span types plus every

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -178,6 +178,7 @@ import '../diagnostics/paint_stats.dart';
 import '../diagnostics/session_byte_recorder.dart';
 import '../services/clipboard.dart';
 import '../services/path_verifier.dart';
+import '../services/session_cwd_tracker.dart';
 import '../services/session_messages.dart'
     show SftpStatResultEvent, SshTaskEvent, TmuxWindowGesture;
 import '../ssh/ssh_session.dart';
@@ -1287,7 +1288,12 @@ bool ghosttyLongPressShowsUrlMenu(StructuredMatch? urlAtCell) =>
 /// false for those (the URL menu owns them) — the two are mutually exclusive at
 /// a single cell. Pure, so the routing decision is unit-testable headless.
 bool ghosttyLongPressShowsPathMenu(StructuredMatch? matchAtCell) =>
-    matchAtCell != null && matchAtCell.patternId == kGhosttyPathPatternId;
+    matchAtCell != null &&
+    (matchAtCell.patternId == kGhosttyPathPatternId ||
+        // #1036: a VERIFIED relative-path anchor gets the same path menu
+        // (unverified ones never reach a long-press — the visibility gate
+        // suppresses their hit-test entirely).
+        matchAtCell.patternId == kGhosttyRelPathPatternId);
 
 /// Whether a detected [match]'s payload is a real, copyable string (#810).
 ///
@@ -1391,10 +1397,22 @@ Future<String?> ghosttyTapMatchAction(
   StructuredMatch match, {
   required Future<bool> Function(String text) copy,
   required Future<bool> Function(String path) openPath,
+  String Function(String relative)? resolveRelative,
 }) async {
   if (match.patternId == kGhosttyPathPatternId) {
     if (!ghosttyMatchHasCopyablePayload(match)) return null;
     await openPath('${match.payload}'.trim());
+    return null;
+  }
+  // #1036: a RELATIVE path anchor navigates with RESOLVED-ABSOLUTE semantics
+  // (the #999 rule applied to the cwd-resolved path). The resolver is injected
+  // (production: the session's SessionCwdTracker) so this stays pure; a tap
+  // can only arrive on a VERIFIED anchor (the #990-style visibility gate
+  // suppresses hit-testing otherwise), so the resolved path exists.
+  if (match.patternId == kGhosttyRelPathPatternId) {
+    if (!ghosttyMatchHasCopyablePayload(match)) return null;
+    final relative = '${match.payload}'.trim();
+    await openPath(resolveRelative?.call(relative) ?? relative);
     return null;
   }
   final filePath = ghosttyFileUrlPath(match);
@@ -1449,6 +1467,10 @@ List<TextPattern> ghosttyDetectionPatterns(
     TextPattern.url(id: kGhosttyUrlPatternId, style: kGhosttyUrlHighlightStyle),
   ],
   if (detection.detectPaths) TextPattern.path(id: kGhosttyPathPatternId),
+  // #1036: bare relative paths (`a/b`), verification-gated at the widget
+  // layer — an anchor is invisible until its cwd-resolved absolute verifies.
+  if (detection.detectRelPaths)
+    TextPattern.relativePath(id: kGhosttyRelPathPatternId),
   if (detection.detectCommands)
     TextPattern.command(
       id: kGhosttyCommandPatternId,
@@ -2405,6 +2427,13 @@ class GhosttyTerminalView extends ConsumerStatefulWidget {
   static final Map<String, SessionPathVerifier> debugPathVerifiers =
       <String, SessionPathVerifier>{};
 
+  /// #1036: the live per-session cwd tracker, exposed so the on-emulator
+  /// integration test can assert the cwd ladder (OSC 7 / prompt-derived)
+  /// tracked a `cd` before resolving a relative anchor. Test-only.
+  @visibleForTesting
+  static final Map<String, SessionCwdTracker> debugCwdTrackers =
+      <String, SessionCwdTracker>{};
+
   @override
   ConsumerState<GhosttyTerminalView> createState() =>
       _GhosttyTerminalViewState();
@@ -2485,6 +2514,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         sftpUrlOf: _sftpUrlFor,
         // #995: "Not a URL" / "Not a file" — persist a detection exception.
         onReportException: _reportDetectionException,
+        // #1036: resolves a RELATIVE anchor payload against the live session
+        // cwd at ACTION time (the tracker is read fresh on every dispatch).
+        resolveRelative: (relative) => _cwdTracker.resolve(relative),
       );
 
   /// #705: the long-press selection ANCHOR — the 1-based VIEWPORT cell of the
@@ -2632,6 +2664,13 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// the file browser's listener) into [_pathVerifier]. Cancelled on dispose.
   StreamSubscription<SshTaskEvent>? _sftpStatSub;
 
+  /// #1036: per-session working-directory tracker (OSC 7 > prompt-derived >
+  /// last-known > home). Refreshed lazily in [_notePathAnchors] whenever a
+  /// relative-path anchor is live; read by the visibility gate / tap / menu
+  /// dispatch to resolve a relative payload to the absolute path the #990
+  /// verifier keys on. Scoped to this view == this session, like the verifier.
+  final SessionCwdTracker _cwdTracker = SessionCwdTracker();
+
   @override
   void initState() {
     super.initState();
@@ -2765,6 +2804,9 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // #990 (test-only): expose the verifier so the on-emulator integration
       // test can assert the real-path/fake-path shade split.
       GhosttyTerminalView.debugPathVerifiers[widget.sessionId] = _pathVerifier!;
+      // #1036 (test-only): expose the cwd tracker so the emulator test can
+      // assert the ladder followed a `cd`.
+      GhosttyTerminalView.debugCwdTrackers[widget.sessionId] = _cwdTracker;
       // Paint replay harness: let the stats snapshot probe the live render-box
       // boundary counters (notifies / paints / frame syncs) at read time.
       _paintStats.boxProbe = _probePaintBox;
@@ -2858,10 +2900,49 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     if (controller == null || verifier == null) return;
     final proxy = _proxy;
     if (proxy == null || proxy.data.state != SshSessionState.connected) return;
+    final anchors = controller.anchors;
+    // #1036: RELATIVE anchors are noted under their cwd-RESOLVED absolute path
+    // — the verifier cache is keyed on the resolved path, so a later `cd`
+    // re-resolves to a fresh key that starts pending (hidden) again. Refresh
+    // the cwd ladder first, and only when a relative anchor is actually live
+    // (the refresh reads controller text — cheap, but not free).
+    final hasRelative = anchors.any(
+      (a) => a.patternId == kGhosttyRelPathPatternId,
+    );
+    if (hasRelative) _refreshCwd(controller);
     verifier.notePaths([
-      for (final anchor in controller.anchors)
-        if (anchor.patternId == kGhosttyPathPatternId) '${anchor.payload}',
+      for (final anchor in anchors)
+        if (anchor.patternId == kGhosttyPathPatternId)
+          '${anchor.payload}'
+        else if (anchor.patternId == kGhosttyRelPathPatternId)
+          _cwdTracker.resolve('${anchor.payload}'),
     ]);
+  }
+
+  /// #1036: refresh the session cwd ladder from the live terminal — the OSC 7
+  /// advisory ([TerminalController.pwd], strongest) and the most recent
+  /// on-screen strong prompt (`user@host:PATH$`, scanned bottom-up over the
+  /// visible rows). Defensive on every FFI read: a hiccup must never crash the
+  /// session, and a failed refresh just leaves the sticky last-known cwd (the
+  /// #990 verifier absorbs staleness).
+  void _refreshCwd(TerminalController controller) {
+    try {
+      _cwdTracker.noteOsc7(controller.pwd);
+    } catch (_) {}
+    try {
+      // One verbatim viewport read (row 0 = top visible row), scanned
+      // BOTTOM-UP: the lowest strong prompt is the current one; rows above it
+      // belong to older commands, so stop at the first hit either way.
+      final lines = controller
+          .visibleRowsText(0, controller.scrollbar.visible - 1)
+          .split('\n');
+      for (var i = lines.length - 1; i >= 0; i--) {
+        if (promptCwd(lines[i]) != null) {
+          _cwdTracker.notePromptLine(lines[i]);
+          return;
+        }
+      }
+    } catch (_) {}
   }
 
   /// #990: the OPAQUE verification predicate handed to the gutter + bubble
@@ -2870,6 +2951,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
   /// layers never learn WHY — the predicate could later mean "downloaded
   /// locally" without any paint change.
   bool _isAnchorVerified(StructuredAnchor anchor) {
+    // #1036: a relative anchor is verified iff its cwd-RESOLVED absolute is —
+    // and since the visibility gate hides it otherwise, every VISIBLE relpath
+    // anchor renders in the verified shade by construction.
+    if (anchor.patternId == kGhosttyRelPathPatternId) {
+      return _pathVerifier?.isVerified(
+            _cwdTracker.resolve('${anchor.payload}'),
+          ) ??
+          false;
+    }
     if (anchor.patternId != kGhosttyPathPatternId) return false;
     return _pathVerifier?.isVerified('${anchor.payload}') ?? false;
   }
@@ -2888,6 +2978,16 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         .read(detectionExceptionsProvider.notifier)
         .isSuppressed(patternId, payload)) {
       return false;
+    }
+    // #1036: a RELATIVE-path anchor is suppressed until its cwd-RESOLVED
+    // absolute path verifies. Unconditional (no lab knob bypass): hidden-
+    // until-verified IS the contract for this class — shape-level recall is
+    // deliberately broad (`and/or` matches), the stat is the precision gate.
+    // Both `pending` and `missing` stay hidden (hide-on-fail, unlike
+    // multi-segment absolutes which show at the detected shade).
+    if (patternId == kGhosttyRelPathPatternId) {
+      return _pathVerifier?.status(_cwdTracker.resolve(payload)) ==
+          PathVerification.verified;
     }
     if (patternId != kGhosttyPathPatternId) return true;
     // #1031 slice 2: the lab's "Short-path verification" knob gates the #990
@@ -3815,6 +3915,8 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       match,
       copy: copyToClipboard,
       openPath: _openPath,
+      // #1036: relative anchors navigate to their cwd-RESOLVED absolute.
+      resolveRelative: _cwdTracker.resolve,
     );
     if (toast != null && mounted) showTopToast(context, toast);
   }
@@ -3865,6 +3967,25 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         highlightRects: rects,
         anchor: globalAnchor,
         onOpen: _openPath,
+        onMarkNotDetection: markNot,
+      );
+      return;
+    }
+    // #1036: a RELATIVE anchor's menu works in RESOLVED-ABSOLUTE semantics —
+    // Open navigates to the resolved path, "Copy path" copies the resolved
+    // absolute, an extra "Copy relative" copies the matched text verbatim,
+    // and the sftp:// form uses the absolute. The exception report keeps the
+    // ORIGINAL relative payload (suppression keys on the matched text).
+    if (match.patternId == kGhosttyRelPathPatternId) {
+      final resolved = _cwdTracker.resolve('${match.payload}');
+      showPathActions(
+        context,
+        resolved,
+        relativeText: '${match.payload}',
+        highlightRects: rects,
+        anchor: globalAnchor,
+        onOpen: _openPath,
+        sftpUrl: _sftpUrlFor(resolved),
         onMarkNotDetection: markNot,
       );
       return;
@@ -4090,6 +4211,11 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     if (GhosttyTerminalView.debugPathVerifiers[widget.sessionId] ==
         _pathVerifier) {
       GhosttyTerminalView.debugPathVerifiers.remove(widget.sessionId);
+    }
+    // #1036: drop the cwd tracker's debug seam with its session view.
+    if (GhosttyTerminalView.debugCwdTrackers[widget.sessionId] ==
+        _cwdTracker) {
+      GhosttyTerminalView.debugCwdTrackers.remove(widget.sessionId);
     }
     _controller?.decorationListenable.removeListener(_notePathAnchors);
     _sftpStatSub?.cancel();

--- a/native/lib/ui/path_action_overlay.dart
+++ b/native/lib/ui/path_action_overlay.dart
@@ -65,6 +65,11 @@ void debugDismissPathActions() => _dismiss();
 /// offered (destructive-adjacent placement) — tapping dismisses the menu and
 /// fires the callback (the caller persists the detection exception).
 ///
+/// [relativeText] (#1036): the ORIGINAL relative matched text for a
+/// relative-path anchor whose [path] is the cwd-RESOLVED absolute. When
+/// non-null an extra "Copy relative" action copies it verbatim; "Copy path"
+/// stays the resolved absolute (and Open / sftp:// already use it).
+///
 /// Safe to call from any context under an [Overlay]. No-op if no overlay.
 void showPathActions(
   BuildContext context,
@@ -73,6 +78,7 @@ void showPathActions(
   required Offset anchor,
   Future<bool> Function(String path)? onOpen,
   String? sftpUrl,
+  String? relativeText,
   VoidCallback? onMarkNotDetection,
   Duration timeout = const Duration(seconds: 6),
 }) {
@@ -107,6 +113,18 @@ void showPathActions(
                 final ok = await copyToClipboard(sftpUrl);
                 if (identical(_activeEntry, entry)) _dismiss();
                 if (ok) showTopToastInOverlay(overlay, 'Copied: $sftpUrl');
+              }());
+            },
+      // #1036: the original relative text, only for relative-path anchors.
+      onCopyRelative: relativeText == null
+          ? null
+          : () {
+              unawaited(() async {
+                final ok = await copyToClipboard(relativeText);
+                if (identical(_activeEntry, entry)) _dismiss();
+                if (ok) {
+                  showTopToastInOverlay(overlay, 'Copied: $relativeText');
+                }
               }());
             },
       onOpen: () async {
@@ -147,6 +165,7 @@ class _PathActionLayer extends StatelessWidget {
     required this.onOpen,
     required this.onDismiss,
     this.onCopySftp,
+    this.onCopyRelative,
     this.onMarkNotDetection,
   });
 
@@ -159,6 +178,9 @@ class _PathActionLayer extends StatelessWidget {
 
   /// #994: copies the canonical sftp:// URL; null hides the action.
   final VoidCallback? onCopySftp;
+
+  /// #1036: copies the ORIGINAL relative matched text; null hides the action.
+  final VoidCallback? onCopyRelative;
 
   /// #995: persists a "Not a file" detection exception; null hides the item.
   final VoidCallback? onMarkNotDetection;
@@ -241,6 +263,15 @@ class _PathActionLayer extends StatelessWidget {
                       label: 'Copy path',
                       onTap: onCopy,
                     ),
+                    // #1036: for a relative anchor, the original matched text
+                    // (Copy path above copies the resolved absolute).
+                    if (onCopyRelative != null)
+                      _ActionButton(
+                        key: const Key('path-action-copy-relative'),
+                        icon: Icons.content_copy,
+                        label: 'Copy relative',
+                        onTap: onCopyRelative!,
+                      ),
                     if (onCopySftp != null)
                       _ActionButton(
                         key: const Key('path-action-copy-sftp'),

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -221,6 +221,23 @@ class SettingsPanel extends ConsumerWidget {
               ? (v) => ref.read(detectionSettingsProvider.notifier).setPath(v)
               : null,
         ),
+        // #1036: relative-path detection — cwd-resolved and VERIFICATION-gated
+        // (an anchor only ever shows once its resolved path exists on the host).
+        SwitchListTile(
+          key: const ValueKey('detection-relpath-toggle'),
+          secondary: const Icon(Icons.subdirectory_arrow_right),
+          contentPadding: const EdgeInsets.only(left: 32, right: 16),
+          title: const Text('Relative paths'),
+          subtitle: const Text(
+            'Detect paths relative to the shell directory; shown only after '
+            'they verify on the host.',
+          ),
+          value: detection.relpath,
+          onChanged: detection.enabled
+              ? (v) =>
+                  ref.read(detectionSettingsProvider.notifier).setRelpath(v)
+              : null,
+        ),
         // #998 slice C: command-line detection — a gutter chip that copies the
         // whole prompt-anchored command line paste-exact.
         SwitchListTile(
@@ -412,6 +429,7 @@ class SettingsPanel extends ConsumerWidget {
     await detectionNotifier.setUrl(true);
     await detectionNotifier.setPath(true);
     await detectionNotifier.setCommand(true);
+    await detectionNotifier.setRelpath(true);
     // #1031 slice 2: lab styles are TUNED settings → reset with the rest.
     // AUTHORED data survives (detection exceptions here; custom pattern
     // definitions in slice 3) — the IA's one-sentence reset rule.

--- a/native/test/services/session_cwd_tracker_test.dart
+++ b/native/test/services/session_cwd_tracker_test.dart
@@ -1,0 +1,166 @@
+// SessionCwdTracker unit tests (#1036) — the per-session cwd ladder that
+// resolves RELATIVE detected paths to absolutes for the #990 verifier.
+//
+// Ladder: OSC 7 (controller.pwd advisory) > prompt-derived (#998 strong
+// `user@host:PATH$` shape) > last-known (both sources are sticky) > home.
+// "Home" is represented as `~` UI-side — the task-side SFTP layer (#867
+// expandTilde) expands it at the single seam every stat/list routes through,
+// so no realpath IPC is needed. Staleness is tolerated by design: the #990
+// verifier absorbs a wrong cwd (the resolved path just never verifies).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_cwd_tracker.dart';
+
+void main() {
+  group('osc7Cwd — OSC 7 advisory parsing', () {
+    test('file:// URI with host → path', () {
+      expect(osc7Cwd('file://myhost/tmp/work'), '/tmp/work');
+    });
+
+    test('file:// URI without host → path', () {
+      expect(osc7Cwd('file:///tmp/work'), '/tmp/work');
+    });
+
+    test('bare absolute path passes through', () {
+      expect(osc7Cwd('/home/user/x'), '/home/user/x');
+    });
+
+    test('percent-encoded path decodes', () {
+      expect(osc7Cwd('file://h/tmp/a%20b'), '/tmp/a b');
+    });
+
+    test('empty / non-path values → null (unset)', () {
+      expect(osc7Cwd(''), isNull);
+      expect(osc7Cwd('   '), isNull);
+      expect(osc7Cwd('not-a-path'), isNull);
+      // A malformed file URI must not crash — null, not throw.
+      expect(osc7Cwd('file://%ZZ'), isNull);
+    });
+  });
+
+  group('promptCwd — #998 strong-prompt PATH extraction', () {
+    test('user@host:absolute-path\$ shape', () {
+      expect(promptCwd(r'dev@fd-dev:/tmp/work$ echo hi'), '/tmp/work');
+    });
+
+    test('user@host:~\$ home shape', () {
+      expect(promptCwd(r'dev@fd-dev:~$ '), '~');
+    });
+
+    test('user@host:~/sub\$ shape', () {
+      expect(promptCwd(r'dev@fd-dev:~/sub$ ls'), '~/sub');
+    });
+
+    test('root # prompt', () {
+      expect(promptCwd('root@box:/etc# '), '/etc');
+    });
+
+    test('non-prompt lines → null', () {
+      expect(promptCwd('just some output'), isNull);
+      expect(promptCwd(r'$ echo weak-prompt'), isNull);
+      // A weak `user@host` without the :path$ tail is not a strong prompt.
+      expect(promptCwd('mail user@host.com please'), isNull);
+    });
+
+    test('mid-line prompt does not extract (anchored at line start)', () {
+      expect(promptCwd(r'echo dev@fd-dev:/tmp$ fake'), isNull);
+    });
+  });
+
+  group('resolveRelativePath — join + normalize', () {
+    test('plain join', () {
+      expect(resolveRelativePath('/tmp/work', 'sub/real.txt'),
+          '/tmp/work/sub/real.txt');
+    });
+
+    test('trailing-slash cwd joins without doubling', () {
+      expect(resolveRelativePath('/tmp/', 'a/b'), '/tmp/a/b');
+    });
+
+    test('root cwd', () {
+      expect(resolveRelativePath('/', 'a/b'), '/a/b');
+    });
+
+    test('dot segments normalize', () {
+      expect(resolveRelativePath('/tmp/work', 'a/./b'), '/tmp/work/a/b');
+      expect(resolveRelativePath('/tmp/work', 'a/../b'), '/tmp/work/b');
+    });
+
+    test('.. never pops past root', () {
+      expect(resolveRelativePath('/', 'a/../../b'), '/b');
+    });
+
+    test('~ cwd resolves under home (expanded task-side, #867)', () {
+      expect(resolveRelativePath('~', 'a/b'), '~/a/b');
+      expect(resolveRelativePath('~/sub', 'x/y.md'), '~/sub/x/y.md');
+    });
+
+    test('.. never pops the ~ home marker itself', () {
+      expect(resolveRelativePath('~', 'a/../../b'), '~/b');
+    });
+
+    test('trailing slash on the relative is preserved', () {
+      expect(resolveRelativePath('/tmp', 'src/util/'), '/tmp/src/util/');
+    });
+  });
+
+  group('SessionCwdTracker — ladder precedence + isolation', () {
+    test('defaults to home (~) before any evidence', () {
+      final t = SessionCwdTracker();
+      expect(t.cwd, '~');
+      expect(t.resolve('a/b'), '~/a/b');
+    });
+
+    test('prompt-derived cwd beats home', () {
+      final t = SessionCwdTracker();
+      t.notePromptLine(r'dev@fd-dev:/tmp/work$ ');
+      expect(t.cwd, '/tmp/work');
+      expect(t.resolve('sub/real.txt'), '/tmp/work/sub/real.txt');
+    });
+
+    test('OSC 7 beats prompt-derived', () {
+      final t = SessionCwdTracker();
+      t.notePromptLine(r'dev@fd-dev:/from-prompt$ ');
+      t.noteOsc7('file://h/from-osc7');
+      expect(t.cwd, '/from-osc7');
+    });
+
+    test('sources are sticky (last-known survives non-prompt output)', () {
+      final t = SessionCwdTracker();
+      t.notePromptLine(r'dev@fd-dev:/tmp/work$ ');
+      t.notePromptLine('plain output, no prompt'); // must not clear
+      expect(t.cwd, '/tmp/work');
+    });
+
+    test('a fresh prompt replaces the previous prompt cwd', () {
+      final t = SessionCwdTracker();
+      t.notePromptLine(r'dev@fd-dev:/a$ ');
+      t.notePromptLine(r'dev@fd-dev:/b$ ');
+      expect(t.cwd, '/b');
+    });
+
+    test('an EMPTY OSC 7 does not clobber a seen advisory', () {
+      final t = SessionCwdTracker();
+      t.noteOsc7('file://h/keep');
+      t.noteOsc7('');
+      expect(t.cwd, '/keep');
+    });
+
+    test('per-session isolation: trackers never share state', () {
+      final a = SessionCwdTracker();
+      final b = SessionCwdTracker();
+      a.notePromptLine(r'dev@a:/only-a$ ');
+      expect(a.cwd, '/only-a');
+      expect(b.cwd, '~');
+    });
+
+    test('noteOsc7/notePromptLine report whether the cwd changed', () {
+      final t = SessionCwdTracker();
+      expect(t.notePromptLine(r'dev@h:/x$ '), isTrue);
+      expect(t.notePromptLine(r'dev@h:/x$ '), isFalse); // unchanged
+      expect(t.noteOsc7('file://h/y'), isTrue);
+      expect(t.noteOsc7('file://h/y'), isFalse);
+      expect(t.notePromptLine('no prompt here'), isFalse);
+    });
+  });
+}

--- a/native/test/state/detection_providers_test.dart
+++ b/native/test/state/detection_providers_test.dart
@@ -80,7 +80,13 @@ void main() {
       const onlyCommand = DetectionSettings(url: false, path: false);
       expect(onlyCommand.detectCommands, !kDetectionDisabled971);
       expect(onlyCommand.detectionActive, !kDetectionDisabled971);
-      const allOff = DetectionSettings(url: false, path: false, command: false);
+      // #1036 added a fourth type — "all off" must turn it off too.
+      const allOff = DetectionSettings(
+        url: false,
+        path: false,
+        command: false,
+        relpath: false,
+      );
       expect(allOff.detectionActive, isFalse);
     });
 

--- a/native/test/state/detection_relpath_settings_test.dart
+++ b/native/test/state/detection_relpath_settings_test.dart
@@ -1,0 +1,109 @@
+// #1036 — the RELATIVE-path detection toggle: a fourth per-type gate on
+// DetectionSettings (default ON, purely additive) and its registration
+// contract (`relpath` pattern registers iff master AND relpath are on).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _settle() async {
+  await Future<void>.delayed(const Duration(milliseconds: 10));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('DetectionSettings.relpath (#1036)', () {
+    test('defaults ON (purely additive)', () {
+      const s = DetectionSettings();
+      expect(s.relpath, isTrue);
+      expect(s.detectRelPaths, !kDetectionDisabled971);
+    });
+
+    test('master off gates relpath too', () {
+      const s = DetectionSettings(enabled: false);
+      expect(s.detectRelPaths, isFalse);
+    });
+
+    test('per-type off gates only relpath', () {
+      const s = DetectionSettings(relpath: false);
+      expect(s.detectRelPaths, isFalse);
+      expect(s.detectPaths, !kDetectionDisabled971);
+      expect(s.detectUrls, !kDetectionDisabled971);
+    });
+
+    test('relpath participates in detectionActive', () {
+      const onlyRel = DetectionSettings(
+        url: false,
+        path: false,
+        command: false,
+      );
+      expect(onlyRel.detectionActive, !kDetectionDisabled971);
+      const allOff = DetectionSettings(
+        url: false,
+        path: false,
+        command: false,
+        relpath: false,
+      );
+      expect(allOff.detectionActive, isFalse);
+    });
+
+    test('JSON round-trip carries relpath', () {
+      const s = DetectionSettings(relpath: false, url: false);
+      final back = DetectionSettings.fromJsonString(s.toJsonString());
+      expect(back, s);
+      expect(back.relpath, isFalse);
+    });
+
+    test('a stored pre-#1036 value (no relpath field) defaults relpath TRUE',
+        () {
+      final s = DetectionSettings.fromJsonString(
+        '{"v":1,"enabled":true,"url":false,"path":true,"command":true}',
+      );
+      expect(s.relpath, isTrue);
+      expect(s.url, isFalse);
+    });
+
+    test('setRelpath persists and hydrates back', () async {
+      final n =
+          DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      await n.setRelpath(false);
+      expect(n.state.relpath, isFalse);
+      final n2 =
+          DetectionSettingsNotifier(prefs: SharedPreferences.getInstance());
+      await _settle();
+      expect(n2.state.relpath, isFalse);
+      expect(n2.state.path, isTrue);
+    });
+  });
+
+  group('ghosttyDetectionPatterns relpath registration (#1036)', () {
+    test('relpath registers by default under its own id', () {
+      final ids =
+          ghosttyDetectionPatterns(const DetectionSettings()).map((p) => p.id);
+      expect(ids, contains(kGhosttyRelPathPatternId));
+    });
+
+    test('relpath OFF removes only the relpath pattern', () {
+      final ids = ghosttyDetectionPatterns(
+        const DetectionSettings(relpath: false),
+      ).map((p) => p.id).toList();
+      expect(ids, isNot(contains(kGhosttyRelPathPatternId)));
+      expect(ids, containsAll(<String>['osc8', 'url', 'path', 'command']));
+    });
+
+    test('master OFF removes relpath too', () {
+      final ids = ghosttyDetectionPatterns(
+        const DetectionSettings(enabled: false),
+      ).map((p) => p.id);
+      expect(ids, isEmpty);
+    });
+  });
+}

--- a/native/test/ui/ghostty_custom_patterns_registration_test.dart
+++ b/native/test/ui/ghostty_custom_patterns_registration_test.dart
@@ -82,15 +82,24 @@ void main() {
 
   group('ghosttyDetectionActiveFor (#921 repaint gating)', () {
     test('true when ONLY a custom pattern is on', () {
-      const detection =
-          DetectionSettings(url: false, path: false, command: false);
+      // #1036 added the relpath type — "only a custom on" turns it off too.
+      const detection = DetectionSettings(
+        url: false,
+        path: false,
+        command: false,
+        relpath: false,
+      );
       expect(detection.detectionActive, isFalse);
       expect(ghosttyDetectionActiveFor(detection, [_pattern()]), isTrue);
     });
 
     test('false when the only custom is disabled or invalid', () {
-      const detection =
-          DetectionSettings(url: false, path: false, command: false);
+      const detection = DetectionSettings(
+        url: false,
+        path: false,
+        command: false,
+        relpath: false,
+      );
       expect(
         ghosttyDetectionActiveFor(detection, [_pattern(enabled: false)]),
         isFalse,

--- a/native/test/ui/ghostty_relpath_actions_1036_test.dart
+++ b/native/test/ui/ghostty_relpath_actions_1036_test.dart
@@ -1,0 +1,157 @@
+// #1036 — RELATIVE-path anchor actions work in RESOLVED-ABSOLUTE semantics.
+//
+// Headless (no flterm native .so):
+//   1. PURE tap dispatch: a `relpath` match navigates to the RESOLVED path
+//      (the injected cwd resolver), never the clipboard.
+//   2. Long-press menu: showPathActions with `relativeText` offers BOTH
+//      "Copy relative" (the matched text) and "Copy path" (the resolved
+//      absolute), plus Open.
+//   3. Gutter registry: the relpath presentation exists and its list-sheet
+//      actions carry open / copy / copy-relative / not-a-file.
+//   4. Long-press routing: a relpath match qualifies for the path menu.
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/ui/ghostty_gutter_layer.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+import 'package:mobissh/ui/path_action_overlay.dart';
+
+void main() {
+  const relMatch = StructuredMatch(
+    patternId: kGhosttyRelPathPatternId,
+    payload: 'sub/real.txt',
+    ranges: [
+      HighlightRange(startRow: 2, startCol: 4, endRow: 2, endCol: 16),
+    ],
+  );
+
+  group('#1036 tap dispatch: relpath navigates to the RESOLVED absolute', () {
+    test('openPath receives cwd-resolved path; clipboard untouched', () async {
+      final opened = <String>[];
+      var copyCalls = 0;
+      final toast = await ghosttyTapMatchAction(
+        relMatch,
+        copy: (_) async {
+          copyCalls++;
+          return true;
+        },
+        openPath: (path) async {
+          opened.add(path);
+          return true;
+        },
+        resolveRelative: (rel) => '/tmp/work/$rel',
+      );
+      expect(opened, ['/tmp/work/sub/real.txt']);
+      expect(copyCalls, 0);
+      expect(toast, isNull, reason: 'navigation IS the feedback');
+    });
+
+    test('without a resolver the raw relative still reaches openPath', () async {
+      final opened = <String>[];
+      await ghosttyTapMatchAction(
+        relMatch,
+        copy: (_) async => true,
+        openPath: (path) async {
+          opened.add(path);
+          return true;
+        },
+      );
+      expect(opened, ['sub/real.txt']);
+    });
+  });
+
+  group('#1036 long-press routing', () {
+    test('a relpath match qualifies for the PATH menu (not selection)', () {
+      expect(ghosttyLongPressShowsPathMenu(relMatch), isTrue);
+    });
+  });
+
+  group('#1036 path menu offers Copy relative AND Copy path', () {
+    testWidgets('relativeText adds the Copy relative action', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showPathActions(
+                  context,
+                  '/tmp/work/sub/real.txt',
+                  relativeText: 'sub/real.txt',
+                  highlightRects: const [],
+                  anchor: const Offset(200, 200),
+                ),
+                child: const Text('menu'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('menu'));
+      await tester.pump();
+      expect(find.byKey(const Key('path-action-menu')), findsOneWidget);
+      expect(find.byKey(const Key('path-action-copy')), findsOneWidget);
+      expect(
+        find.byKey(const Key('path-action-copy-relative')),
+        findsOneWidget,
+        reason: 'the menu must offer the relative text AND the absolute',
+      );
+      expect(find.text('Copy relative'), findsOneWidget);
+      expect(find.byKey(const Key('path-action-open')), findsOneWidget);
+      debugDismissPathActions();
+      await tester.pump();
+    });
+
+    testWidgets('without relativeText the extra action is absent', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showPathActions(
+                  context,
+                  '/etc/hosts',
+                  highlightRects: const [],
+                  anchor: const Offset(200, 200),
+                ),
+                child: const Text('menu'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('menu'));
+      await tester.pump();
+      expect(
+        find.byKey(const Key('path-action-copy-relative')),
+        findsNothing,
+      );
+      debugDismissPathActions();
+      await tester.pump();
+    });
+  });
+
+  group('#1036 gutter registry relpath presentation', () {
+    test('registered under the relpath id with resolved-absolute actions', () {
+      final registry = GutterPatternRegistry.standard(
+        openPath: (_) async => true,
+        resolveRelative: (rel) => '/cwd/$rel',
+        onReportException: (_, _) {},
+      );
+      final presentation = registry.forPattern(kGhosttyRelPathPatternId);
+      expect(presentation, isNotNull);
+      final actions = presentation!.itemActions('sub/real.txt');
+      expect(
+        actions.map((a) => a.keyLabel),
+        containsAll(<String>['open', 'copy', 'copy-relative', 'not']),
+      );
+      expect(
+        actions.map((a) => a.label),
+        containsAll(<String>['Open', 'Copy path', 'Copy relative', 'Not a file']),
+      );
+    });
+  });
+}

--- a/native/third_party/flterm/lib/src/foundation/structured_text.dart
+++ b/native/third_party/flterm/lib/src/foundation/structured_text.dart
@@ -188,6 +188,41 @@ final class TextPattern {
     );
   }
 
+  /// The built-in RELATIVE FILE PATH pattern (paths Slice 3 — MobiSSH #1036).
+  ///
+  /// Matches BARE >=2-segment relative tokens (`specs/x/spec.md`, `a/b.txt`)
+  /// that [TextPattern.path] deliberately defers: tokens with no leading `/`,
+  /// `~/`, `./` or `../` anchor. The shape is DELIBERATELY BROAD — `and/or`
+  /// matches it — because the CONSUMER is expected to gate visibility on an
+  /// out-of-band precision check (MobiSSH resolves the token against the
+  /// session cwd and only shows an affordance once an SFTP stat verifies the
+  /// resolved absolute path; a prose token simply never verifies). What the
+  /// shape itself excludes is anything ANOTHER pattern owns or that cannot be
+  /// cwd-relative:
+  ///   * absolute / home / explicit-relative starts (`/`, `~/`, `./`, `../`)
+  ///     — [TextPattern.path]'s territory (a `(?!(?:\.{1,2}|~)/)` lookahead;
+  ///     the shared lookbehind already blocks mid-token anchoring);
+  ///   * `://` contexts — the same lookbehind rejects a start after `/` or
+  ///     `:`, so `https://example.com/docs` never yields `example.com/docs`;
+  ///   * `~user/...` — the first segment excludes a leading `~`;
+  ///   * glob / shell-var / command-sub contamination — the #826 swallow +
+  ///     #874 terminator machinery, REUSED via [_validateRelativePath].
+  ///
+  /// Distinct id (`relpath`) and [TextTier.span] so gating / telemetry /
+  /// decorators treat it separately from absolute paths. Reuses the scanner's
+  /// wrap-join + `_rangesFor` machinery unchanged; the existing
+  /// [TextPattern.path] is untouched.
+  factory TextPattern.relativePath({String id = 'relpath',
+      HighlightStyle style = const HighlightStyle()}) {
+    return TextPattern(
+      id: id,
+      regex: _kRelativePathPattern,
+      style: style,
+      trailingTrim: _kPathTrailingTrim,
+      normalize: _validateRelativePath,
+    );
+  }
+
   /// The built-in COMMAND-LINE pattern (#998 slice B) — a BLOCK-tier anchor
   /// over a whole prompt-anchored command line, for copy-to-paste.
   ///
@@ -402,6 +437,44 @@ String? _validatePath(String raw) {
   if (path.isEmpty) return null;
   // #826: a surviving glob/var/command-sub token is not an openable path.
   if (_kPathRejectProbe.hasMatch(path)) return null;
+  return path;
+}
+
+/// The RELATIVE FILE PATH regex (paths Slice 3 — MobiSSH #1036). Matches a
+/// BARE >=2-segment relative token:
+///   * the SAME negative lookbehind as [_kPathPattern] — no mid-token anchor,
+///     no start after `/` or `:` (so `https://example.com/docs` never yields
+///     `example.com/docs`), no start after a glob/var metachar;
+///   * a lookahead excluding the starts [TextPattern.path] owns (`./`, `../`)
+///     — `~/` cannot occur because the FIRST segment excludes a leading `~`
+///     (which also keeps `~user/x` — a home reference, not cwd-relative — out);
+///     a dot-LEADING first segment (`.claude/rules`) still matches;
+///   * first segment + one-or-more `/`-joined further segments (>=2 segments
+///     total — a single token or a lone `src/` never anchors), optional
+///     trailing slash;
+///   * the #826 trailing swallow group, so a glob/var-contaminated token
+///     reaches [_validateRelativePath] whole and is suppressed (backtracking
+///     can't carve a clean-looking sub-path out of it).
+final RegExp _kRelativePathPattern = RegExp(
+  '(?<![\\w.\\-~@+:/$_kPathLookbehindMeta])'
+  r'(?!\.{1,2}/)' // ./ and ../ starts belong to TextPattern.path
+  r'[\w.\-@+]+' // first segment (no leading ~ — see doc above)
+  r'(?:/[\w.\-~@+]+)+' // >=1 further segment → >=2 segments total
+  r'/?'
+  '(?:[$_kPathReject][^\\s]*)?', // #826 swallow → validate sees the whole token
+);
+
+/// Validate a raw RELATIVE path match (#1036). Reuses [_validatePath]'s #874
+/// terminator trim + quote strip + #826 reject gate, then RE-CHECKS the
+/// >=2-segment shape: the trim can leave a single segment (`a` out of `a/;b`
+/// is not a relative path anymore), which must suppress rather than anchor a
+/// bare word.
+String? _validateRelativePath(String raw) {
+  final path = _validatePath(raw);
+  if (path == null) return null;
+  final core = path.endsWith('/') ? path.substring(0, path.length - 1) : path;
+  final slash = core.indexOf('/');
+  if (slash <= 0 || slash >= core.length - 1) return null;
   return path;
 }
 

--- a/native/third_party/flterm/test/foundation/structured_text_relpath_test.dart
+++ b/native/third_party/flterm/test/foundation/structured_text_relpath_test.dart
@@ -1,0 +1,167 @@
+// TextPattern.relativePath() matrix (#1036, MobiSSH issue).
+//
+// The RELATIVE-path pattern is deliberately BROAD at the shape level: any
+// >=2-segment `a/b` token in the path charset matches (`and/or` included) —
+// the app-side #990 SFTP-stat verifier is the precision gate (a relpath anchor
+// shows NO affordance until its cwd-resolved absolute path verifies, so a
+// prose token that never resolves simply never shows). What the shape DOES
+// exclude is anything another pattern already owns or that cannot be a
+// cwd-relative path: absolute (`/a/b`), home (`~/x`), explicit-relative
+// (`./x`, `../x` — TextPattern.path matches those), scheme contexts
+// (`https://x/y` must stay one URL), and glob/shell-var contaminated tokens
+// (#826 reject class, mirrored from the absolute pattern).
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Minimal single/multi-row [CellReader] fake (mirrors structured_text_test).
+class _FakeCellReader implements CellReader {
+  _FakeCellReader(List<String> rowTexts, {required this.cols, List<bool>? wraps})
+      : _rows = [
+          for (final t in rowTexts)
+            List<String>.generate(cols, (c) => c < t.length ? t[c] : ' '),
+        ],
+        _wraps = wraps ?? List<bool>.filled(rowTexts.length, false);
+
+  final List<List<String>> _rows;
+  final List<bool> _wraps;
+
+  @override
+  final int cols;
+
+  @override
+  int get baseAbsRow => 0;
+
+  @override
+  int get rows => _rows.length;
+
+  @override
+  String cellContent(int row, int col) {
+    final ch = _rows[row][col];
+    return ch == ' ' ? '' : ch;
+  }
+
+  @override
+  bool rowWrap(int row) => row >= 0 && row < _wraps.length && _wraps[row];
+
+  @override
+  String? hyperlinkAt(int row, int col) => null;
+}
+
+void main() {
+  const scanner = StructuredTextScanner();
+  final relPattern = TextPattern.relativePath();
+
+  List<String> payloadsIn(String row, {int? cols}) {
+    final reader = _FakeCellReader([row], cols: cols ?? (row.length + 2));
+    return [
+      for (final m in scanner.scan(reader, [relPattern])) '${m.payload}',
+    ];
+  }
+
+  group('TextPattern.relativePath() — matches (#1036)', () {
+    test('the owner-report shape: specs/001-sound-foundation/spec.md', () {
+      expect(
+        payloadsIn('wrote specs/001-sound-foundation/spec.md today'),
+        ['specs/001-sound-foundation/spec.md'],
+      );
+    });
+
+    test('two bare segments with an extension', () {
+      expect(payloadsIn('cat a/b.txt'), ['a/b.txt']);
+    });
+
+    test('two bare segments without extension (prose-shaped is FINE — the '
+        'verifier is the precision gate)', () {
+      expect(payloadsIn('use and/or here'), ['and/or']);
+    });
+
+    test('dot-leading first segment (.claude/rules)', () {
+      expect(payloadsIn('see .claude/rules now'), ['.claude/rules']);
+    });
+
+    test('trailing slash on a >=2-segment token is kept', () {
+      expect(payloadsIn('ls src/util/'), ['src/util/']);
+    });
+
+    test('trailing sentence punctuation is trimmed', () {
+      expect(payloadsIn('open a/b.txt.'), ['a/b.txt']);
+      expect(payloadsIn('(see specs/x/y.md)'), ['specs/x/y.md']);
+    });
+
+    test('quoted relative path matches with quotes stripped', () {
+      expect(payloadsIn('cat "a/b.txt"'), ['a/b.txt']);
+    });
+
+    test('distinct id relpath, span tier', () {
+      final reader = _FakeCellReader(['x a/b y'], cols: 10);
+      final matches = scanner.scan(reader, [relPattern]);
+      expect(matches, hasLength(1));
+      expect(matches.first.patternId, 'relpath');
+      expect(matches.first.tier, TextTier.span);
+    });
+  });
+
+  group('TextPattern.relativePath() — rejections', () {
+    test('absolute path never matches (owned by TextPattern.path)', () {
+      expect(payloadsIn('see /etc/hosts now'), isEmpty);
+    });
+
+    test('home path never matches (~/x owned by TextPattern.path)', () {
+      expect(payloadsIn('see ~/notes/todo.md'), isEmpty);
+    });
+
+    test('explicit-relative never matches (./x ../x owned by TextPattern.path)',
+        () {
+      expect(payloadsIn('run ./scripts/gate.sh'), isEmpty);
+      expect(payloadsIn('cd ../lib/src'), isEmpty);
+    });
+
+    test('~user/rest never matches (another user home, not cwd-relative)', () {
+      expect(payloadsIn('see ~bob/notes'), isEmpty);
+    });
+
+    test('a scheme URL never yields a relpath fragment', () {
+      // `example.com/docs` sits after `https://` — the :// context must not
+      // anchor a relative path inside a URL.
+      expect(payloadsIn('open https://example.com/docs now'), isEmpty);
+      expect(payloadsIn('file://host/tmp/x'), isEmpty);
+    });
+
+    test('single segment never matches (no slash)', () {
+      expect(payloadsIn('cat notes.txt'), isEmpty);
+    });
+
+    test('trailing-slash-only single segment never matches', () {
+      expect(payloadsIn('ls src/'), isEmpty);
+    });
+
+    test('glob/shell-var contaminated token is suppressed (#826 class)', () {
+      expect(payloadsIn(r'rm logs/*.log'), isEmpty);
+      expect(payloadsIn(r'echo tmp/${UID}_x'), isEmpty);
+    });
+
+    test('shell-delimiter terminates the path (#874 class)', () {
+      expect(payloadsIn('cat a/b.txt;echo x'), ['a/b.txt']);
+    });
+
+    test('never anchors mid-token after a path char', () {
+      // `b/c` inside `a/b/c`… the whole token is one match, not two.
+      expect(payloadsIn('x a/b/c y'), ['a/b/c']);
+    });
+  });
+
+  group('TextPattern.relativePath() — wrap join', () {
+    test('a soft-wrapped relative path joins to one match', () {
+      final reader = _FakeCellReader(
+        ['see specs/001-sound', '-foundation/spec.md'],
+        cols: 19,
+        wraps: [true, false],
+      );
+      final matches = scanner.scan(reader, [relPattern]);
+      expect(matches, hasLength(1));
+      expect('${matches.first.payload}', 'specs/001-sound-foundation/spec.md');
+      expect(matches.first.ranges, hasLength(2));
+    });
+  });
+}


### PR DESCRIPTION
Detects RELATIVE paths (`specs/001-sound-foundation/spec.md`, `a/b.txt`) in terminal output via per-session cwd tracking, with VERIFICATION-GATED visibility (closes #1036).

## Design
Shape-level recall is deliberately broad — any `>=2`-segment `a/b` token in the path charset anchors, `and/or` included. The precision gate is the existing #990 SFTP-stat verifier: a `relpath` anchor shows NO affordance (no bubble, no gutter chip, no tap) until its cwd-RESOLVED absolute path stats as existing on the host. Pending AND missing both stay hidden (hide-on-fail — unlike multi-segment absolutes). `and/or` never verifying is the design working.

## CWD ladder (per session, `SessionCwdTracker`)
1. **OSC 7** — surfaced by the fork already: `TerminalController.pwd` (libghostty stores the shell's `file://host/path` advisory; empty when unset). No fork change was needed for this rung.
2. **Prompt-derived** — the #998 STRONG `user@host:PATH$` shape, scanned bottom-up over the visible rows (one `visibleRowsText` read, only while a relpath anchor is live).
3. **Last-known** — both sources are sticky; a non-prompt line or empty advisory never clears an earlier answer.
4. **Home** — represented UI-side as `~`. Deliberate deviation from the issue's "fetch home via SFTP realpath at connect": no realpath IPC exists, and the task-side SFTP layer (#867 `expandTilde`) already expands `~`/`~/x` at the single seam every stat/list/download routes through — so a `~`-prefixed resolved path verifies, navigates, and uploads correctly without a new IPC round-trip. (Caveat: "Copy path" for a home-ladder resolution copies a `~/...` form, which is shell-usable.)

Staleness is tolerated by design: a wrong cwd only means the resolved candidate never verifies. A `cd` re-resolves anchors to a NEW verifier cache key (keyed on the resolved path), so the old verification never leaks across directories.

## Changes
- **Fork** (`structured_text.dart`): `TextPattern.relativePath()` (`relpath` id, span tier) — same lookbehind/#826 swallow/#874 terminator machinery as the absolute pattern; excludes `/`, `~/`, `./`, `../`, `~user/`, and `://` contexts. `TextPattern.path` untouched.
- **Settings**: `DetectionSettings.relpath` (default ON — safe because unverified anchors are invisible), JSON schema-in-value round-trip, settings toggle + reset, registration in `ghosttyDetectionPatterns`.
- **View**: `_cwdTracker` per session (debug seam `debugCwdTrackers`); `_notePathAnchors` notes RESOLVED relpaths; `_isPayloadVisible` verified-only for relpath; verified shade; tap navigates to the resolved path (#999 semantics); long-press + gutter menus offer Open (resolved), **Copy path** (resolved absolute), **Copy relative** (matched text), Copy sftp URL (absolute), Not a file.
- **Detection Lab**: `relpath` card (enable + style, default ON, `Icons.subdirectory_arrow_right`), active-state styling enabled.

## Tests
- Fork matrix (20): matches `specs/x/spec.md`, `a/b.txt`, `.claude/rules`, wrap-join; rejects `/abs`, `~/x`, `./x`, `../x`, `~user/x`, `scheme://x`, single segment, trailing-slash-only, glob/var contamination.
- Unit (28): OSC 7 parsing, prompt PATH extraction, resolution join + `..`/`~` normalization, ladder precedence, stickiness, per-session isolation.
- Unit: relpath settings round-trip + registration gating; resolved-absolute action dispatch; "Copy relative" menu wiring; gutter presentation.
- Emulator (`relpath_cwd_1036_test.dart`): on test-sshd — cd into a prepared dir, echo `sub/real.txt` → anchor verifies against the resolved path; echo `no/such.txt` → anchored but stats missing (never shows); `cd /tmp` + re-echo → re-resolved key stats missing (cwd tracked); cd back → tap opens the file browser at the resolved dir with `real.txt` listed, clipboard untouched.

Gates: fork suite 848/848, `flutter analyze` clean, full unit suite green (2 pre-existing tests updated to turn the NEW type off in their "all off" premises), emulator test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa