### PR TITLE
feat(native): Download + Share actions in every file preview state (#1038)

### DIFF
--- a/native/integration_test/viewer_actions_1038_test.dart
+++ b/native/integration_test/viewer_actions_1038_test.dart
@@ -1,0 +1,273 @@
+// On-emulator smoke for the viewer Download + Share actions (#1038).
+//
+// The headless widget tests spy the action service; this test drives the REAL
+// app against test-sshd and asserts the production pipeline end to end:
+//   - open a seeded text file → the TEXT VIEWER (registry route) shows both
+//     app-bar actions,
+//   - hold a screenshot window (orchestrator runs `scripts/emu-shot.sh
+//     viewer-actions-1038` during the hold) so the app bar is reviewable,
+//   - tap Download → the bytes round-trip into the download sink (the same
+//     capturing-sink override pattern as sftp_browse_smoke_test.dart — the
+//     MediaStore publish itself is device-owner validated),
+//   - tap Share → the staged temp FILE exists with the seeded content and the
+//     correct mime when the launcher fires (the launcher provider is the ONLY
+//     stubbed hop: the system share sheet can't be dismissed from
+//     integration_test, so the real sheet is device-owner validated).
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/viewer_actions_1038_test.dart
+
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/sftp_download.dart';
+import 'package:mobissh/services/viewer_file_actions.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/ui/text_file_viewer.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+
+/// In-memory offset-honoring sink (same contract as sftp_browse_smoke_test).
+class _CapturingSink implements FileDownloadSink {
+  final List<int> _buf = <int>[];
+  bool finished = false;
+
+  Uint8List get bytes => Uint8List.fromList(_buf);
+
+  @override
+  Future<void> addChunk(Uint8List bytes, int offset) async {
+    final end = offset + bytes.length;
+    while (_buf.length < end) {
+      _buf.add(0);
+    }
+    for (var i = 0; i < bytes.length; i++) {
+      _buf[offset + i] = bytes[i];
+    }
+  }
+
+  @override
+  Future<String> finish({int? expectedTotal}) async {
+    finished = true;
+    return 'memory://capture';
+  }
+
+  @override
+  Future<void> abort() async {}
+}
+
+class _SinkRegistry {
+  final Map<String, _CapturingSink> sinks = <String, _CapturingSink>{};
+
+  Future<FileDownloadSink> factory(String fileName) async {
+    final sink = _CapturingSink();
+    sinks[fileName] = sink;
+    return sink;
+  }
+}
+
+/// Records the share launcher invocation + a snapshot of the staged file's
+/// content AT LAUNCH TIME (the contract: the FILE exists when shared).
+class _ShareRecorder {
+  String? path;
+  String? mime;
+  String? name;
+  String? contentAtLaunch;
+
+  Future<void> launch(String p, String m, String n) async {
+    path = p;
+    mime = m;
+    name = n;
+    contentAtLaunch = await File(p).readAsString();
+  }
+}
+
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+/// Seed `root/<fileName>` with [content] through the live shell; confirm via
+/// sentinel echo (same in-fixture pattern as sftp_browse_smoke_test).
+Future<void> _seedFile(
+  WidgetTester tester,
+  SessionEntry entry, {
+  required String root,
+  required String fileName,
+  required String content,
+}) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  addTearDown(sub.cancel);
+
+  const done = 'MOBISSH_SEED_DONE_1038';
+  final b64 = base64Encode(utf8.encode(content));
+  final script = StringBuffer()
+    ..write('rm -rf $root; ')
+    ..write('mkdir -p $root; ')
+    ..write("printf '%s' '$b64' | base64 -d > $root/$fileName; ")
+    ..write('echo $done\n');
+
+  // Input sent before the PTY's shellReady is silently dropped (observed on
+  // the first run of this test: `send input` landed 2 events before
+  // `shellReady`). The seed script is idempotent (rm/mkdir/printf), so RETRY
+  // it until the sentinel echoes instead of racing the shell.
+  var seeded = false;
+  for (var attempt = 0; attempt < 4 && !seeded; attempt++) {
+    entry.proxy.sendInput(Uint8List.fromList(utf8.encode(script.toString())));
+    seeded = await _pumpUntil(
+      tester,
+      () => utf8.decode(out, allowMalformed: true).contains(done),
+      maxSlices: 20,
+    );
+  }
+  expect(seeded, isTrue, reason: 'seed never completed on test-sshd ($root)');
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'viewer Download + Share act on the open preview (#1038)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final registry = _SinkRegistry();
+      final share = _ShareRecorder();
+      final container = ProviderContainer(
+        overrides: [
+          downloadSinkFactoryProvider.overrideWithValue(registry.factory),
+          viewerShareLauncherProvider.overrideWithValue(share.launch),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Connect + reach the terminal.
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      final connected = await _pumpUntil(
+        tester,
+        () =>
+            find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+      );
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+
+      // Seed a known text file.
+      const root = '/tmp/mobissh_itest_1038';
+      const fileName = 'hello.txt';
+      const content = 'hello from test-sshd 1038\nsecond line\n';
+      await _seedFile(
+        tester,
+        entry!,
+        root: root,
+        fileName: fileName,
+        content: content,
+      );
+
+      // Open the browser at the seeded dir and tap the file → text viewer.
+      final ctx = tester.element(find.byKey(const Key('session-menu-button')));
+      unawaited(
+        Navigator.of(ctx).push(
+          MaterialPageRoute<void>(
+            builder: (_) => FileBrowserScreen(
+              sessionId: entry.id,
+              initialPath: root,
+            ),
+          ),
+        ),
+      );
+      final listed = await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('file-entry-$fileName')).evaluate().isNotEmpty,
+      );
+      expect(listed, isTrue, reason: 'seeded file not listed');
+
+      await tester.tap(find.byKey(const Key('file-entry-$fileName')));
+      final viewerOpen = await _pumpUntil(
+        tester,
+        () => find.byType(TextFileViewerScreen).evaluate().isNotEmpty,
+      );
+      expect(viewerOpen, isTrue, reason: 'text viewer never opened');
+
+      // Both actions present in the open preview's app bar.
+      expect(find.byKey(const Key('viewer-action-download')), findsOneWidget);
+      expect(find.byKey(const Key('viewer-action-share')), findsOneWidget);
+
+      // Screenshot HOLD: orchestrator runs emu-shot during this window.
+      debugPrint('VIEWER1038_SHOT_WINDOW_OPEN');
+      for (var i = 0; i < 24; i++) {
+        await tester.pump(_slice);
+      }
+      debugPrint('VIEWER1038_SHOT_WINDOW_CLOSED');
+
+      // Download from the viewer — bytes round-trip into the sink.
+      await tester.tap(find.byKey(const Key('viewer-action-download')));
+      final downloaded = await _pumpUntil(
+        tester,
+        () => registry.sinks[fileName]?.finished == true,
+      );
+      expect(downloaded, isTrue, reason: 'viewer download never completed');
+      expect(
+        utf8.decode(registry.sinks[fileName]!.bytes, allowMalformed: true),
+        content,
+        reason: 'downloaded bytes do not match the seeded file',
+      );
+
+      // Share from the viewer — a REAL staged temp file reaches the launcher.
+      await tester.tap(find.byKey(const Key('viewer-action-share')));
+      final sharedFired = await _pumpUntil(
+        tester,
+        () => share.path != null,
+      );
+      expect(sharedFired, isTrue, reason: 'share launcher never invoked');
+      expect(
+        share.contentAtLaunch,
+        content,
+        reason: 'staged share file content mismatch',
+      );
+      expect(share.mime, 'text/plain');
+      expect(share.name, fileName);
+    },
+  );
+}

--- a/native/lib/services/sftp_download.dart
+++ b/native/lib/services/sftp_download.dart
@@ -27,6 +27,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'downloads_publisher.dart';
@@ -59,6 +60,15 @@ typedef DownloadSinkFactory =
 Future<FileDownloadSink> defaultDownloadSinkFactory(String fileName) async {
   return AppDownloadsSink.create(fileName);
 }
+
+/// Resolves the destination sink for downloads. Overridden in widget/emulator
+/// tests to avoid touching the real filesystem; production uses the Downloads
+/// pipeline above. Lives here (not in the browser) since #1038: the browser
+/// AND every viewer's Download action share this seam — one override covers
+/// both. Re-exported by file_browser_screen.dart for existing importers.
+final downloadSinkFactoryProvider = Provider<DownloadSinkFactory>(
+  (ref) => defaultDownloadSinkFactory,
+);
 
 /// Offset-honoring core sink: writes chunks at their byte offset into a given
 /// [File] via a [RandomAccessFile], tracks the highest end position written,
@@ -231,7 +241,8 @@ class AppDownloadsSink implements FileDownloadSink {
 
 /// Writes a download into a private app TEMP directory rather than Downloads.
 /// Used by the in-app PDF viewer (#557): the file is fetched to temp, rendered,
-/// then deleted on close. [finish] returns the temp file path; [file] exposes
+/// then deleted on close; and by the viewer Share staging (#1038, [subdir]
+/// `mobissh_share`). [finish] returns the temp file path; [file] exposes
 /// the [File] so the caller can delete it explicitly. Delegates offset-honoring
 /// assembly + length verification to [OffsetFileSink].
 class TempFileSink implements FileDownloadSink {
@@ -242,10 +253,13 @@ class TempFileSink implements FileDownloadSink {
   /// The temp file being written. The caller deletes this when done.
   File get file => _inner.file;
 
-  static Future<TempFileSink> create(String fileName) async {
+  static Future<TempFileSink> create(
+    String fileName, {
+    String subdir = 'mobissh_pdf',
+  }) async {
     final base = await getTemporaryDirectory();
     final dir = await Directory(
-      '${base.path}/mobissh_pdf',
+      '${base.path}/$subdir',
     ).create(recursive: true);
     final safeName = _sanitizeTemp(fileName);
     final stamp = DateTime.now().microsecondsSinceEpoch;

--- a/native/lib/services/viewer_file_actions.dart
+++ b/native/lib/services/viewer_file_actions.dart
@@ -1,0 +1,278 @@
+// Shared Download + Share pipeline for every in-app file viewer (#1038).
+//
+// Every preview state (text/code #776, markdown #854, HTML #1037, PDF #557,
+// tap-to-fill media #946) offers the same two actions without navigating back
+// to the browser:
+//   - DOWNLOAD: stream the file to the device's Downloads through the SAME
+//     sink pipeline the file browser uses (`downloadSinkFactoryProvider` →
+//     [AppDownloadsSink] → MediaStore publish, #559/#952),
+//   - SHARE: stage a LOCAL temp copy (the share sheet receives a FILE with a
+//     correct mime type, never a path string) and hand it to share_plus.
+//
+// Two source shapes:
+//   - [RemoteFileSource]: the viewed remote entry — streamed over the session
+//     proxy's sftpDownload/sftpEvents, chunks written at their byte offset
+//     (#591 semantics). The stream→sink loop mirrors pdf_fetcher.dart; the
+//     proven PDF fetch path is deliberately left untouched rather than
+//     refactored under it.
+//   - [BytesFileSource]: content the viewer ALREADY holds in memory (an
+//     inline markdown image's fetched bytes, a mermaid diagram's source) —
+//     written straight through the sink, no second fetch.
+//
+// Injectable seams: the download sink factory (browser's provider), the share
+// staging sink, and the share launcher ([viewerShareLauncherProvider]) — so
+// widget tests spy the service, unit tests capture sinks, and the emulator
+// test intercepts the final platform call.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../ssh/ssh_session_proxy.dart';
+import '../state/sessions.dart';
+import 'html_loopback_server.dart' show contentTypeForName;
+import 'session_messages.dart';
+import 'sftp_download.dart';
+
+/// A file a viewer can download/share. Sealed: viewers either reference the
+/// remote entry they are previewing or the bytes they already fetched.
+sealed class ViewerFileSource {
+  const ViewerFileSource();
+
+  /// Display/destination file name (basename).
+  String get fileName;
+}
+
+/// The remote SFTP entry a viewer is previewing on [sessionId].
+class RemoteFileSource extends ViewerFileSource {
+  const RemoteFileSource({required this.sessionId, required this.entry});
+
+  final String sessionId;
+  final SftpEntry entry;
+
+  @override
+  String get fileName => entry.name;
+}
+
+/// In-memory content a viewer already holds (inline image bytes, mermaid
+/// source). Written through the sink directly — no re-fetch.
+class BytesFileSource extends ViewerFileSource {
+  const BytesFileSource({required this.fileName, required this.bytes});
+
+  @override
+  final String fileName;
+  final Uint8List bytes;
+}
+
+/// Plain (parameter-free) mime type for sharing [name] by extension. Delegates
+/// to the loopback server's content-type table (single source of truth) with
+/// the `; charset=…` parameter stripped — Android share intents want a bare
+/// type. `.mmd` (mermaid source) shares as text; unknown → octet-stream.
+String viewerShareMimeType(String name) {
+  final dot = name.lastIndexOf('.');
+  final ext = (dot <= 0 || dot == name.length - 1)
+      ? ''
+      : name.substring(dot + 1).toLowerCase();
+  if (ext == 'mmd') return 'text/plain';
+  final full = contentTypeForName(name);
+  final semi = full.indexOf(';');
+  return semi == -1 ? full : full.substring(0, semi).trim();
+}
+
+/// Launches the platform share sheet with a staged local file. Injected via
+/// [viewerShareLauncherProvider] so tests never open the real sheet.
+typedef ViewerShareLauncher =
+    Future<void> Function(String path, String mimeType, String fileName);
+
+/// Production launcher: share_plus with the FILE + mime (same idiom as the
+/// diagnostics crash-report share).
+Future<void> defaultViewerShareLauncher(
+  String path,
+  String mimeType,
+  String fileName,
+) async {
+  await Share.shareXFiles([XFile(path, mimeType: mimeType, name: fileName)]);
+}
+
+/// The active share launcher. The emulator test overrides this final hop to
+/// assert the staged file + mime without automating system UI.
+final viewerShareLauncherProvider = Provider<ViewerShareLauncher>(
+  (ref) => defaultViewerShareLauncher,
+);
+
+/// Resolves the staging sink for a share (a private temp file the share sheet
+/// reads). Separate from the DOWNLOAD sink factory: shares must never land in
+/// the user-visible Downloads.
+typedef ShareStageFactory = Future<FileDownloadSink> Function(String fileName);
+
+Future<FileDownloadSink> _defaultShareStageFactory(String fileName) =>
+    TempFileSink.create(fileName, subdir: 'mobissh_share');
+
+/// Download + Share entry points for the viewer actions widget. Widget tests
+/// substitute a spy via [fileViewerActionServiceProvider].
+abstract class FileViewerActionService {
+  /// Saves [source] to the device Downloads (browser pipeline). Returns the
+  /// human-readable location for the success toast.
+  Future<String> downloadToDevice(
+    ViewerFileSource source, {
+    void Function(int received, int? total)? onProgress,
+  });
+
+  /// Stages [source] as a local temp file and opens the share sheet with it
+  /// (correct mime type — the FILE is shared, not its path).
+  Future<void> shareFile(
+    ViewerFileSource source, {
+    void Function(int received, int? total)? onProgress,
+  });
+}
+
+/// Production service. All seams injectable for tests.
+class ProxyFileViewerActionService implements FileViewerActionService {
+  ProxyFileViewerActionService(
+    this._ref, {
+    this.downloadSinkFactory,
+    ShareStageFactory? shareStageFactory,
+    this.shareLauncher,
+  }) : _shareStageFactory = shareStageFactory ?? _defaultShareStageFactory;
+
+  final Ref _ref;
+
+  /// Test seam: overrides the provider-resolved download sink factory.
+  final DownloadSinkFactory? downloadSinkFactory;
+  final ShareStageFactory _shareStageFactory;
+
+  /// Test seam: overrides the provider-resolved share launcher.
+  final ViewerShareLauncher? shareLauncher;
+  int _seq = 0;
+
+  @override
+  Future<String> downloadToDevice(
+    ViewerFileSource source, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    // Default at CALL time so a test's provider override applies (the browser
+    // and the viewer actions honor the same override — emulator tests rely
+    // on this).
+    final DownloadSinkFactory sinkFactory =
+        downloadSinkFactory ?? _ref.read(downloadSinkFactoryProvider);
+    final sink = await sinkFactory(source.fileName);
+    return _fill(source, sink, onProgress);
+  }
+
+  @override
+  Future<void> shareFile(
+    ViewerFileSource source, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    final sink = await _shareStageFactory(source.fileName);
+    final path = await _fill(source, sink, onProgress);
+    final ViewerShareLauncher launcher =
+        shareLauncher ?? _ref.read(viewerShareLauncherProvider);
+    // The staged temp copy is deliberately KEPT after the launcher returns:
+    // the receiving app may still be reading the content URI. Files live in
+    // the app's temp dir under mobissh_share/ where the OS may reclaim them.
+    await launcher(path, viewerShareMimeType(source.fileName), source.fileName);
+  }
+
+  /// Writes [source] through [sink]; returns [FileDownloadSink.finish]'s
+  /// location. Aborts the sink on any failure so partial files are cleaned.
+  Future<String> _fill(
+    ViewerFileSource source,
+    FileDownloadSink sink,
+    void Function(int received, int? total)? onProgress,
+  ) async {
+    switch (source) {
+      case BytesFileSource():
+        try {
+          await sink.addChunk(source.bytes, 0);
+          onProgress?.call(source.bytes.length, source.bytes.length);
+          return await sink.finish(expectedTotal: source.bytes.length);
+        } catch (e) {
+          await sink.abort();
+          rethrow;
+        }
+      case RemoteFileSource():
+        return _fetchRemote(source, sink, onProgress);
+    }
+  }
+
+  /// Streams the remote entry into [sink] via the session proxy — the same
+  /// sftpDownload/sftpEvents flow as the browser and pdf_fetcher. Chunk writes
+  /// are chained so `done` runs after every write and write errors surface;
+  /// each chunk lands at its byte offset (#591: arrival order is not offset
+  /// order).
+  Future<String> _fetchRemote(
+    RemoteFileSource source,
+    FileDownloadSink sink,
+    void Function(int received, int? total)? onProgress,
+  ) async {
+    final proxy = _resolveProxy(source.sessionId);
+    if (proxy == null) {
+      await sink.abort();
+      throw StateError('Session is no longer available');
+    }
+
+    final requestId = '${source.sessionId}#vact${_seq++}';
+    final completer = Completer<String>();
+    var received = 0;
+    Future<void> pending = Future<void>.value();
+
+    late final StreamSubscription<SshTaskEvent> sub;
+    Future<void> cleanupAndFail(Object error) async {
+      await sink.abort();
+      if (!completer.isCompleted) completer.completeError(error);
+    }
+
+    sub = proxy.sftpEvents.listen((event) {
+      switch (event) {
+        case SftpDownloadChunkEvent():
+          if (event.requestId != requestId) return;
+          received += event.bytes.length;
+          onProgress?.call(received, event.totalBytes);
+          final bytes = event.bytes;
+          final offset = event.offset;
+          pending = pending.then((_) => sink.addChunk(bytes, offset));
+        case SftpDownloadDoneEvent():
+          if (event.requestId != requestId) return;
+          final expected = event.totalBytes;
+          unawaited(() async {
+            try {
+              await pending; // drain all chunk writes first
+              final location = await sink.finish(expectedTotal: expected);
+              if (!completer.isCompleted) completer.complete(location);
+            } catch (e) {
+              await cleanupAndFail(e);
+            }
+          }());
+        case SftpErrorEvent():
+          if (event.requestId != requestId) return;
+          unawaited(cleanupAndFail(Exception(event.message)));
+        default:
+          break;
+      }
+    });
+
+    proxy.sftpDownload(requestId: requestId, path: source.entry.path);
+
+    try {
+      return await completer.future;
+    } finally {
+      await sub.cancel();
+    }
+  }
+
+  SshSessionProxy? _resolveProxy(String sessionId) {
+    final entries = _ref.read(sessionsProvider).entries;
+    for (final e in entries) {
+      if (e.id == sessionId) return e.proxy;
+    }
+    return null;
+  }
+}
+
+/// The active service. Widget tests override with a spy.
+final fileViewerActionServiceProvider = Provider<FileViewerActionService>(
+  (ref) => ProxyFileViewerActionService(ref),
+);

--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -34,11 +34,11 @@ import 'file_viewer_registry.dart';
 import 'pdf_viewer_screen.dart';
 import 'top_toast.dart';
 
-/// Resolves the destination sink for downloads. Overridden in widget tests to
-/// avoid touching the real filesystem; production uses the app Downloads dir.
-final downloadSinkFactoryProvider = Provider<DownloadSinkFactory>(
-  (ref) => defaultDownloadSinkFactory,
-);
+// `downloadSinkFactoryProvider` moved to services/sftp_download.dart (#1038):
+// the browser AND every viewer's Download action resolve the same seam, so a
+// single test override covers both. Re-exported here so existing importers
+// (tests) keep working unchanged.
+export '../services/sftp_download.dart' show downloadSinkFactoryProvider;
 
 /// Picks a single LOCAL file to upload (#960). Returns its on-device path +
 /// display name, or null when the user cancels. The task isolate reads the path

--- a/native/lib/ui/file_viewer_actions.dart
+++ b/native/lib/ui/file_viewer_actions.dart
@@ -1,0 +1,127 @@
+// Shared Download + Share app-bar actions for every file viewer (#1038).
+//
+// One widget, dropped into each viewer's AppBar (and the tap-to-fill viewer's
+// overlay), so viewers can't drift: the registry drift-guard test asserts its
+// presence for every registered viewer type. Monochrome Material glyphs (no
+// emoji), standard 48dp IconButton targets.
+//
+// While an action runs, its button becomes a small progress ring —
+// determinate when the transfer reports a total (big files), indeterminate
+// otherwise — and the other button is disabled (one transfer at a time,
+// matching the browser's policy). Results surface as top toasts: "Saved to …"
+// / failure messages; a successful share needs no toast (the sheet itself is
+// the feedback).
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/viewer_file_actions.dart';
+import 'top_toast.dart';
+
+enum _ViewerAction { download, share }
+
+/// Download + Share buttons for [source]. Place in an AppBar's `actions` (or
+/// any overlay row). [iconColor] overrides the theme color for dark-scrim
+/// hosts (the fill viewer).
+class FileViewerActions extends ConsumerStatefulWidget {
+  const FileViewerActions({super.key, required this.source, this.iconColor});
+
+  final ViewerFileSource source;
+  final Color? iconColor;
+
+  @override
+  ConsumerState<FileViewerActions> createState() => _FileViewerActionsState();
+}
+
+class _FileViewerActionsState extends ConsumerState<FileViewerActions> {
+  _ViewerAction? _busy;
+  int _received = 0;
+  int? _total;
+
+  void _onProgress(int received, int? total) {
+    if (!mounted) return;
+    setState(() {
+      _received = received;
+      _total = total;
+    });
+  }
+
+  Future<void> _run(_ViewerAction action) async {
+    if (_busy != null) return; // one transfer at a time
+    setState(() {
+      _busy = action;
+      _received = 0;
+      _total = null;
+    });
+    final service = ref.read(fileViewerActionServiceProvider);
+    try {
+      switch (action) {
+        case _ViewerAction.download:
+          final location = await service.downloadToDevice(
+            widget.source,
+            onProgress: _onProgress,
+          );
+          if (mounted) showTopToast(context, 'Saved to $location');
+        case _ViewerAction.share:
+          await service.shareFile(widget.source, onProgress: _onProgress);
+        // No success toast — the share sheet itself is the feedback.
+      }
+    } catch (e) {
+      if (mounted) {
+        final verb = action == _ViewerAction.download ? 'Download' : 'Share';
+        showTopToast(context, '$verb failed: $e');
+      }
+    } finally {
+      if (mounted) setState(() => _busy = null);
+    }
+  }
+
+  Widget _button(_ViewerAction action) {
+    if (_busy == action) {
+      final t = _total;
+      final value = (t != null && t > 0)
+          ? (_received / t).clamp(0.0, 1.0)
+          : null;
+      return SizedBox(
+        width: 48,
+        height: 48,
+        child: Center(
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(
+              value: value,
+              strokeWidth: 2.5,
+              color: widget.iconColor,
+            ),
+          ),
+        ),
+      );
+    }
+    final isDownload = action == _ViewerAction.download;
+    return IconButton(
+      key: Key(
+        isDownload ? 'viewer-action-download' : 'viewer-action-share',
+      ),
+      tooltip: isDownload ? 'Download' : 'Share',
+      icon: Icon(
+        isDownload ? Icons.download : Icons.share,
+        color: widget.iconColor,
+      ),
+      onPressed: _busy == null ? () => unawaited(_run(action)) : null,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _button(_ViewerAction.download),
+        _button(_ViewerAction.share),
+      ],
+    );
+  }
+}

--- a/native/lib/ui/file_viewer_registry.dart
+++ b/native/lib/ui/file_viewer_registry.dart
@@ -45,6 +45,11 @@ class FileViewerRegistry {
 
   final List<FileViewer> _viewers;
 
+  /// The registered viewers, in match order. Exposed for the #1038 drift
+  /// guard: every registered viewer must render the shared Download + Share
+  /// actions, and the guard pins this list's size.
+  List<FileViewer> get viewers => List.unmodifiable(_viewers);
+
   /// Returns the first viewer that matches [entry], or null if none do (the
   /// browser then falls back to download).
   FileViewer? viewerFor(SftpEntry entry, {String? mime}) {

--- a/native/lib/ui/fill_media_viewer.dart
+++ b/native/lib/ui/fill_media_viewer.dart
@@ -20,6 +20,9 @@
 
 import 'package:flutter/material.dart';
 
+import '../services/viewer_file_actions.dart';
+import 'file_viewer_actions.dart';
+
 /// Pushes the shared [FillMediaViewer] route with [child] as the zoomable
 /// surface. Returns when the user closes the viewer.
 ///
@@ -27,17 +30,28 @@ import 'package:flutter/material.dart';
 /// whose built-in zoom is crisp and which a Flutter [InteractiveViewer] can't
 /// drive anyway). For those we present the child full-bleed and defer all
 /// gestures to it. Plain images (the default) get the [InteractiveViewer].
+///
+/// [source] (#1038): the underlying file, when the caller has one — enables
+/// the shared Download + Share actions in the overlay. Callers that hold the
+/// bytes already (inline SFTP images, mermaid source) pass a
+/// [BytesFileSource]; media without a file (network-URL images) pass null and
+/// get no actions.
 Future<void> showFillMediaViewer(
   BuildContext context, {
   required Widget child,
   String? label,
   bool selfZooming = false,
+  ViewerFileSource? source,
 }) {
   return Navigator.of(context).push(
     MaterialPageRoute<void>(
       fullscreenDialog: true,
-      builder: (_) =>
-          FillMediaViewer(label: label, selfZooming: selfZooming, child: child),
+      builder: (_) => FillMediaViewer(
+        label: label,
+        selfZooming: selfZooming,
+        source: source,
+        child: child,
+      ),
     ),
   );
 }
@@ -49,6 +63,7 @@ class FillMediaViewer extends StatefulWidget {
     required this.child,
     this.label,
     this.selfZooming = false,
+    this.source,
   });
 
   /// The media surface — an image widget, or a self-zooming diagram surface.
@@ -60,6 +75,9 @@ class FillMediaViewer extends StatefulWidget {
   /// When true the child owns its zoom/pan (WebView) — presented full-bleed
   /// without the [InteractiveViewer]. See the file header (#949).
   final bool selfZooming;
+
+  /// The viewed file, when known — surfaces Download + Share (#1038).
+  final ViewerFileSource? source;
 
   @override
   State<FillMediaViewer> createState() => _FillMediaViewerState();
@@ -142,15 +160,32 @@ class _FillMediaViewerState extends State<FillMediaViewer> {
             Positioned(
               top: 8,
               right: 8,
-              child: Material(
-                color: Colors.black54,
-                shape: const CircleBorder(),
-                child: IconButton(
-                  key: const Key('fill-media-close'),
-                  tooltip: 'Close',
-                  icon: const Icon(Icons.close, color: Colors.white),
-                  onPressed: () => Navigator.of(context).maybePop(),
-                ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // #1038: Download + Share when the media has a file source.
+                  if (widget.source != null) ...[
+                    Material(
+                      color: Colors.black54,
+                      shape: const StadiumBorder(),
+                      child: FileViewerActions(
+                        source: widget.source!,
+                        iconColor: Colors.white,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                  Material(
+                    color: Colors.black54,
+                    shape: const CircleBorder(),
+                    child: IconButton(
+                      key: const Key('fill-media-close'),
+                      tooltip: 'Close',
+                      icon: const Icon(Icons.close, color: Colors.white),
+                      onPressed: () => Navigator.of(context).maybePop(),
+                    ),
+                  ),
+                ],
               ),
             ),
           ],

--- a/native/lib/ui/html_file_viewer.dart
+++ b/native/lib/ui/html_file_viewer.dart
@@ -31,7 +31,9 @@ import 'package:webview_flutter/webview_flutter.dart';
 import '../services/html_loopback_server.dart';
 import '../services/session_messages.dart';
 import '../services/sftp_image_fetcher.dart';
+import '../services/viewer_file_actions.dart';
 import 'file_browser_screen.dart';
+import 'file_viewer_actions.dart';
 import 'text_file_viewer.dart';
 import 'top_toast.dart';
 
@@ -161,6 +163,13 @@ class _HtmlFileViewerScreenState extends ConsumerState<HtmlFileViewerScreen> {
       appBar: AppBar(
         title: Text(widget.entry.name, overflow: TextOverflow.ellipsis),
         actions: [
+          // #1038: Download + Share from any open preview.
+          FileViewerActions(
+            source: RemoteFileSource(
+              sessionId: widget.sessionId,
+              entry: widget.entry,
+            ),
+          ),
           // View source: the existing monospace text viewer for this entry.
           // Monochrome Material glyph (no emoji).
           IconButton(

--- a/native/lib/ui/markdown_file_viewer.dart
+++ b/native/lib/ui/markdown_file_viewer.dart
@@ -30,7 +30,9 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../services/session_messages.dart';
 import '../services/text_file_fetcher.dart';
+import '../services/viewer_file_actions.dart';
 import 'file_browser_screen.dart';
+import 'file_viewer_actions.dart';
 import 'mermaid_diagram_view.dart';
 import 'sftp_markdown_image.dart';
 
@@ -127,6 +129,13 @@ class _MarkdownFileViewerScreenState
       appBar: AppBar(
         title: Text(widget.entry.name, overflow: TextOverflow.ellipsis),
         actions: [
+          // #1038: Download + Share from any open preview.
+          FileViewerActions(
+            source: RemoteFileSource(
+              sessionId: widget.sessionId,
+              entry: widget.entry,
+            ),
+          ),
           if (_phase == _Phase.ready)
             IconButton(
               key: const Key('markdown-raw-toggle'),

--- a/native/lib/ui/mermaid_diagram_view.dart
+++ b/native/lib/ui/mermaid_diagram_view.dart
@@ -22,10 +22,12 @@
 // source plus a small note, mirroring the raw/source toggle.
 
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import '../services/viewer_file_actions.dart';
 import 'fill_media_viewer.dart';
 
 /// Builds the live render surface for a mermaid [source]. Swapped out in widget
@@ -83,6 +85,12 @@ class MermaidDiagramView extends StatelessWidget {
       context,
       child: mermaidFillBuilder(source),
       selfZooming: true,
+      // #1038: the diagram has no remote file — share/download its SOURCE as
+      // a mermaid text file.
+      source: BytesFileSource(
+        fileName: 'diagram.mmd',
+        bytes: Uint8List.fromList(utf8.encode(source)),
+      ),
     );
   }
 

--- a/native/lib/ui/pdf_viewer_screen.dart
+++ b/native/lib/ui/pdf_viewer_screen.dart
@@ -21,7 +21,9 @@ import 'package:pdfrx/pdfrx.dart';
 
 import '../services/pdf_fetcher.dart';
 import '../services/session_messages.dart';
+import '../services/viewer_file_actions.dart';
 import 'file_browser_screen.dart';
+import 'file_viewer_actions.dart';
 
 /// Builds the actual page-rendering widget for a fetched [file]. Production
 /// returns a pdfium-backed [PdfViewer.file]; widget tests override this seam
@@ -167,6 +169,13 @@ class _PdfViewerScreenState extends ConsumerState<PdfViewerScreen> {
       appBar: AppBar(
         title: Text(widget.entry.name, overflow: TextOverflow.ellipsis),
         actions: [
+          // #1038: Download + Share from any open preview.
+          FileViewerActions(
+            source: RemoteFileSource(
+              sessionId: widget.sessionId,
+              entry: widget.entry,
+            ),
+          ),
           if (_phase == _Phase.ready && pages != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/native/lib/ui/sftp_markdown_image.dart
+++ b/native/lib/ui/sftp_markdown_image.dart
@@ -22,6 +22,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/sftp_image_fetcher.dart';
+import '../services/viewer_file_actions.dart';
 import 'fill_media_viewer.dart';
 
 /// Max height of the inline thumbnail; the full image is shown in the fill
@@ -62,6 +63,10 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
   String? _networkUrl;
   bool _started = false;
 
+  /// Basename of the resolved remote image path — names the Download/Share
+  /// copy in the fill viewer (#1038).
+  String? _remoteName;
+
   /// Pointer-down position for the raw-pointer tap detection below.
   Offset? _tapDownPos;
 
@@ -90,6 +95,8 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
       setState(() => _phase = _ImgPhase.broken);
       return;
     }
+    final base = path.split('/').last;
+    _remoteName = base.isEmpty ? 'image' : base;
     _fetchSftp(path);
   }
 
@@ -113,7 +120,10 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
     // top-left/overflowing); FilterQuality.medium keeps it crisp when zoomed
     // via the InteractiveViewer (#949).
     final Widget full;
+    ViewerFileSource? source;
     if (_isNetwork && _networkUrl != null) {
+      // Network-URL image: a web resource, not a file we hold — no
+      // Download/Share source (#1038 caveat).
       full = Image.network(
         _networkUrl!,
         fit: BoxFit.contain,
@@ -127,10 +137,16 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
         filterQuality: FilterQuality.medium,
         errorBuilder: (_, _, _) => _fillBroken(),
       );
+      // #1038: the bytes are already in memory — share/download them
+      // directly, no second SFTP fetch.
+      source = BytesFileSource(
+        fileName: _remoteName ?? 'image',
+        bytes: _bytes!,
+      );
     } else {
       return;
     }
-    showFillMediaViewer(context, child: full, label: widget.alt);
+    showFillMediaViewer(context, child: full, label: widget.alt, source: source);
   }
 
   Widget _fillBroken() => const Icon(

--- a/native/lib/ui/text_file_viewer.dart
+++ b/native/lib/ui/text_file_viewer.dart
@@ -17,7 +17,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/session_messages.dart';
 import '../services/text_file_fetcher.dart';
+import '../services/viewer_file_actions.dart';
 import 'file_browser_screen.dart';
+import 'file_viewer_actions.dart';
 
 /// Full-screen read-only preview route for a single remote text [entry] on
 /// [sessionId].
@@ -88,6 +90,13 @@ class _TextFileViewerScreenState extends ConsumerState<TextFileViewerScreen> {
       appBar: AppBar(
         title: Text(widget.entry.name, overflow: TextOverflow.ellipsis),
         actions: [
+          // #1038: Download + Share from any open preview.
+          FileViewerActions(
+            source: RemoteFileSource(
+              sessionId: widget.sessionId,
+              entry: widget.entry,
+            ),
+          ),
           // #855: one-tap return to the terminal (collapses the whole
           // browser/viewer stack), not viewer→browser→…→terminal.
           IconButton(

--- a/native/test/services/viewer_file_actions_test.dart
+++ b/native/test/services/viewer_file_actions_test.dart
@@ -1,0 +1,244 @@
+// Unit tests for the shared viewer Download + Share service (#1038).
+//
+// Assert:
+//   - mime mapping for share (delegates to the loopback content-type table,
+//     parameters stripped, `.mmd` covered, unknown → octet-stream),
+//   - a BytesFileSource download writes the bytes through the injected
+//     download sink (offset 0, verified total) and returns the sink's
+//     location,
+//   - shareFile stages a REAL local temp file and hands its path + mime + name
+//     to the share launcher seam (the file must exist with the exact content
+//     when the launcher runs — the share sheet receives a file, not a path
+//     string),
+//   - a RemoteFileSource streams over the live proxy machinery (the same
+//     InMemoryGatewayPair harness the browser tests use) and assembles
+//     out-of-order chunks correctly (#591 semantics).
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/sftp_download.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/services/viewer_file_actions.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// In-memory offset-honoring sink (same contract as the emulator tests').
+class _CapturingSink implements FileDownloadSink {
+  final List<int> _buf = <int>[];
+  bool finished = false;
+  int? expectedTotalSeen;
+
+  Uint8List get bytes => Uint8List.fromList(_buf);
+
+  @override
+  Future<void> addChunk(Uint8List bytes, int offset) async {
+    final end = offset + bytes.length;
+    while (_buf.length < end) {
+      _buf.add(0);
+    }
+    for (var i = 0; i < bytes.length; i++) {
+      _buf[offset + i] = bytes[i];
+    }
+  }
+
+  @override
+  Future<String> finish({int? expectedTotal}) async {
+    finished = true;
+    expectedTotalSeen = expectedTotal;
+    return 'memory://capture';
+  }
+
+  @override
+  Future<void> abort() async {}
+}
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+/// Scripted SFTP session whose download emits [content] in two chunks in
+/// REVERSE order — the service must reassemble by offset (#591).
+class _ChunkedSftpSession implements SftpSession {
+  _ChunkedSftpSession(this.content);
+  final Uint8List content;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async => const [];
+  @override
+  Future<int?> sizeOf(String path) async => content.length;
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async {
+    final split = content.length ~/ 2;
+    onChunk(content.sublist(split), split); // tail FIRST
+    onChunk(content.sublist(0, split), 0); // head second
+    return content.length;
+  }
+
+  @override
+  Future<int> upload(String path, Uint8List bytes) async => bytes.length;
+  @override
+  Future<int> uploadFile(
+    String localPath,
+    String remotePath, {
+    required void Function(int sent, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async => 0;
+  @override
+  Future<void> close() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('viewerShareMimeType', () {
+    test('maps common extensions and strips charset parameters', () {
+      expect(viewerShareMimeType('a.txt'), 'text/plain');
+      expect(viewerShareMimeType('b.PNG'), 'image/png');
+      expect(viewerShareMimeType('c.pdf'), 'application/pdf');
+      expect(viewerShareMimeType('d.md'), 'text/markdown');
+      expect(viewerShareMimeType('e.html'), 'text/html');
+    });
+
+    test('covers mermaid sources and falls back to octet-stream', () {
+      expect(viewerShareMimeType('diagram.mmd'), 'text/plain');
+      expect(viewerShareMimeType('mystery.zzz'), 'application/octet-stream');
+      expect(viewerShareMimeType('noext'), 'application/octet-stream');
+    });
+  });
+
+  test('BytesFileSource download writes through the download sink', () async {
+    final sink = _CapturingSink();
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final service = ProxyFileViewerActionService(
+      container.read(_refProvider),
+      downloadSinkFactory: (name) async => sink,
+      shareStageFactory: (name) async => throw UnimplementedError(),
+      shareLauncher: (path, mime, name) async => throw UnimplementedError(),
+    );
+
+    final bytes = Uint8List.fromList(utf8.encode('graph TD;\nA-->B;\n'));
+    final location = await service.downloadToDevice(
+      BytesFileSource(fileName: 'diagram.mmd', bytes: bytes),
+    );
+
+    expect(location, 'memory://capture');
+    expect(sink.finished, isTrue);
+    expect(sink.bytes, bytes);
+    expect(sink.expectedTotalSeen, bytes.length);
+  });
+
+  test('shareFile stages a real temp file and launches with mime + name', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final stageDir = await Directory.systemTemp.createTemp('mobissh_1038_');
+    addTearDown(() => stageDir.delete(recursive: true));
+
+    String? launchedPath;
+    String? launchedMime;
+    String? launchedName;
+    String? contentAtLaunch;
+
+    final service = ProxyFileViewerActionService(
+      container.read(_refProvider),
+      downloadSinkFactory: (name) async => throw UnimplementedError(),
+      shareStageFactory: (name) async =>
+          OffsetFileSink.create(File('${stageDir.path}/$name')),
+      shareLauncher: (path, mime, name) async {
+        launchedPath = path;
+        launchedMime = mime;
+        launchedName = name;
+        contentAtLaunch = await File(path).readAsString();
+      },
+    );
+
+    const content = 'hello share 1038';
+    await service.shareFile(
+      BytesFileSource(
+        fileName: 'note.txt',
+        bytes: Uint8List.fromList(utf8.encode(content)),
+      ),
+    );
+
+    expect(launchedPath, isNotNull);
+    expect(contentAtLaunch, content, reason: 'the FILE must exist when shared');
+    expect(launchedMime, 'text/plain');
+    expect(launchedName, 'note.txt');
+  });
+
+  test('RemoteFileSource streams via the proxy, reassembling by offset', () async {
+    SharedPreferences.setMockInitialValues({});
+    final content = Uint8List.fromList(
+      utf8.encode('0123456789abcdefghij REMOTE 1038'),
+    );
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+    final host = SessionHost(
+      gateway: pair.taskSide,
+      controllerFactory: _stubControllerFactory,
+      sftpOpener: (_) async => _ChunkedSftpSession(content),
+      snapshotInterval: const Duration(hours: 1),
+    );
+    addTearDown(host.disposeSyncForTest);
+    final container = ProviderContainer(
+      overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+    );
+    addTearDown(container.dispose);
+    const params = SshConnectParams(
+      host: 'h',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    );
+    final session = container.read(sessionsProvider.notifier).addOrActivate(
+      params,
+    );
+    session.proxy.connect(params);
+
+    final sink = _CapturingSink();
+    final progress = <int>[];
+    final service = ProxyFileViewerActionService(
+      container.read(_refProvider),
+      downloadSinkFactory: (name) async => sink,
+      shareStageFactory: (name) async => throw UnimplementedError(),
+      shareLauncher: (path, mime, name) async => throw UnimplementedError(),
+    );
+
+    final location = await service.downloadToDevice(
+      RemoteFileSource(
+        sessionId: session.id,
+        entry: const SftpEntry(
+          name: 'remote.txt',
+          path: '/remote.txt',
+          isDirectory: false,
+        ),
+      ),
+      onProgress: (received, total) => progress.add(received),
+    );
+
+    expect(location, 'memory://capture');
+    expect(sink.bytes, content, reason: 'chunks must reassemble by offset');
+    expect(progress, isNotEmpty, reason: 'progress must be reported');
+  });
+}
+
+/// Expose a [Ref] for constructing the production service directly in tests.
+final _refProvider = Provider<Ref>((ref) => ref);

--- a/native/test/widget/file_viewer_actions_test.dart
+++ b/native/test/widget/file_viewer_actions_test.dart
@@ -1,0 +1,462 @@
+// Widget tests for the shared Download + Share viewer actions (#1038).
+//
+// Assert:
+//   - DRIFT GUARD: every viewer registered in [fileViewerRegistryProvider]
+//     renders BOTH app-bar actions (a viewer without them is a bug), and the
+//     registry size is pinned so adding a viewer type without covering it here
+//     fails loudly,
+//   - tapping Download / Share invokes the [FileViewerActionService] seam with
+//     the viewed file (spy service — no filesystem, no share sheet),
+//   - the tap-to-fill viewer (#946) carries the actions when it has a file
+//     source: inline SFTP images pass their already-fetched bytes, mermaid
+//     passes its diagram source as `diagram.mmd`.
+//
+// Mirrors html_file_viewer_widget_test.dart's wiring (InMemoryGatewayPair +
+// FileBrowserScreen + injected fetchers). Platform surfaces (WebView, pdfium)
+// are stubbed exactly as the per-viewer tests do.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/pdf_fetcher.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/sftp_image_fetcher.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/services/text_file_fetcher.dart';
+import 'package:mobissh/services/viewer_file_actions.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:mobissh/ui/file_viewer_registry.dart';
+import 'package:mobissh/ui/fill_media_viewer.dart';
+import 'package:mobissh/ui/html_file_viewer.dart';
+import 'package:mobissh/ui/markdown_file_viewer.dart';
+import 'package:mobissh/ui/mermaid_diagram_view.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// A minimal valid 1x1 transparent PNG.
+final Uint8List _png = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+  '+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+);
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+class _ScriptedSftpSession implements SftpSession {
+  _ScriptedSftpSession(this._byPath);
+  final Map<String, List<SftpEntry>> _byPath;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async => _byPath[path] ?? const [];
+  @override
+  Future<int?> sizeOf(String path) async => 0;
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async => 0;
+  @override
+  Future<int> upload(String path, Uint8List bytes) async => bytes.length;
+  @override
+  Future<int> uploadFile(
+    String localPath,
+    String remotePath, {
+    required void Function(int sent, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+class _CannedTextFetcher implements TextFileFetcher {
+  _CannedTextFetcher(this.text);
+  final String text;
+
+  @override
+  Future<String> fetch(
+    String sessionId,
+    SftpEntry entry, {
+    int maxBytes = 2 * 1024 * 1024,
+    void Function(int received, int? total)? onProgress,
+  }) async => text;
+}
+
+class _CannedImageFetcher implements SftpImageFetcher {
+  _CannedImageFetcher(this.bytes);
+  final Uint8List bytes;
+
+  @override
+  Future<Uint8List> fetch(
+    String sessionId,
+    String path, {
+    int maxBytes = 8 * 1024 * 1024,
+  }) async => bytes;
+}
+
+/// PDF fetch that never completes — the actions must be present in EVERY
+/// viewer phase, including while fetching, so this is sufficient (and keeps
+/// pdfium/path_provider out of the harness).
+class _HangingPdfFetcher implements PdfFetcher {
+  @override
+  Future<File> fetch(
+    String sessionId,
+    SftpEntry entry, {
+    void Function(int received, int? total)? onProgress,
+  }) => Completer<File>().future;
+}
+
+/// Spy action service: records the sources each action was invoked with.
+class _SpyActionService implements FileViewerActionService {
+  final List<ViewerFileSource> downloads = [];
+  final List<ViewerFileSource> shares = [];
+
+  @override
+  Future<String> downloadToDevice(
+    ViewerFileSource source, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    downloads.add(source);
+    return 'Downloads/spy';
+  }
+
+  @override
+  Future<void> shareFile(
+    ViewerFileSource source, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    shares.add(source);
+  }
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+({ProviderContainer container, SessionEntry session, SessionHost host}) _wire(
+  WidgetTester tester, {
+  required Map<String, List<SftpEntry>> byPath,
+  required _SpyActionService spy,
+  String cannedText = 'hello world',
+}) {
+  final pair = InMemoryGatewayPair();
+  addTearDown(pair.dispose);
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: _stubControllerFactory,
+    sftpOpener: (_) async => _ScriptedSftpSession(byPath),
+    snapshotInterval: const Duration(hours: 1),
+  );
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      textFileFetcherProvider.overrideWithValue(_CannedTextFetcher(cannedText)),
+      sftpImageFetcherProvider.overrideWithValue(_CannedImageFetcher(_png)),
+      pdfFetcherProvider.overrideWithValue(_HangingPdfFetcher()),
+      fileViewerActionServiceProvider.overrideWithValue(spy),
+    ],
+  );
+  addTearDown(container.dispose);
+  const params = SshConnectParams(
+    host: 'h',
+    port: 22,
+    username: 'u',
+    auth: SshAuth.password('p'),
+  );
+  final session = container.read(sessionsProvider.notifier).addOrActivate(
+    params,
+  );
+  session.proxy.connect(params);
+  return (container: container, session: session, host: host);
+}
+
+/// Open the file browser for a single [name] entry and tap it, routing through
+/// the REAL viewer registry.
+Future<
+  ({ProviderContainer container, SessionEntry session, SessionHost host})
+>
+_openViewer(WidgetTester tester, String name, _SpyActionService spy) async {
+  final w = _wire(
+    tester,
+    byPath: {
+      '/': [
+        SftpEntry(name: name, path: '/$name', isDirectory: false, size: 11),
+      ],
+    },
+    spy: spy,
+  );
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: w.container,
+      child: MaterialApp(home: FileBrowserScreen(sessionId: w.session.id)),
+    ),
+  );
+  await _pump(tester);
+  await tester.tap(find.byKey(Key('file-entry-$name')));
+  await _pump(tester);
+  return w;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    htmlWebViewBuilder = (uri, onBlocked) => const Text('stub-html-webview');
+    mermaidWebViewBuilder = (source) => const Text('stub-mermaid');
+    mermaidFillBuilder = (source) => const Text('stub-mermaid-fill');
+  });
+
+  tearDown(() {
+    htmlWebViewBuilder = defaultHtmlWebViewBuilderForTest;
+    mermaidWebViewBuilder = defaultMermaidWebViewBuilderForTest;
+    mermaidFillBuilder = defaultMermaidFillBuilderForTest;
+  });
+
+  testWidgets(
+    'DRIFT GUARD: every registered viewer renders Download + Share',
+    (tester) async {
+      // One fixture per registered viewer, in registry terms:
+      //   PDF (#557), markdown (#854), HTML (#1037), text/code (#776).
+      const fixtures = ['report.pdf', 'notes.md', 'page.html', 'script.txt'];
+
+      for (final name in fixtures) {
+        final spy = _SpyActionService();
+        final w = await _openViewer(tester, name, spy);
+        expect(
+          find.byKey(const Key('viewer-action-download')),
+          findsOneWidget,
+          reason: '$name viewer is missing the Download action (#1038)',
+        );
+        expect(
+          find.byKey(const Key('viewer-action-share')),
+          findsOneWidget,
+          reason: '$name viewer is missing the Share action (#1038)',
+        );
+        // Pin the registry size: a NEW viewer type must be added to `fixtures`
+        // above (and must include FileViewerActions) or this fails.
+        expect(
+          w.container.read(fileViewerRegistryProvider).viewers.length,
+          fixtures.length,
+          reason:
+              'viewer registry grew — cover the new viewer in this drift '
+              'guard and give it FileViewerActions (#1038)',
+        );
+        w.host.disposeSyncForTest();
+        await tester.pumpWidget(const SizedBox.shrink());
+        await _pump(tester, count: 4);
+      }
+    },
+  );
+
+  testWidgets('Download invokes the service with the viewed file', (
+    tester,
+  ) async {
+    final spy = _SpyActionService();
+    final w = await _openViewer(tester, 'script.txt', spy);
+
+    await tester.tap(find.byKey(const Key('viewer-action-download')));
+    await _pump(tester, count: 4);
+
+    expect(spy.downloads, hasLength(1));
+    final source = spy.downloads.single;
+    expect(source, isA<RemoteFileSource>());
+    final remote = source as RemoteFileSource;
+    expect(remote.entry.path, '/script.txt');
+    expect(remote.sessionId, w.session.id);
+    expect(spy.shares, isEmpty);
+    w.host.disposeSyncForTest();
+  });
+
+  testWidgets('Share invokes the service with the viewed file', (
+    tester,
+  ) async {
+    final spy = _SpyActionService();
+    final w = await _openViewer(tester, 'notes.md', spy);
+
+    await tester.tap(find.byKey(const Key('viewer-action-share')));
+    await _pump(tester, count: 4);
+
+    expect(spy.shares, hasLength(1));
+    final source = spy.shares.single;
+    expect(source, isA<RemoteFileSource>());
+    expect((source as RemoteFileSource).entry.name, 'notes.md');
+    expect(spy.downloads, isEmpty);
+    w.host.disposeSyncForTest();
+  });
+
+  testWidgets('fill viewer with a source shows the actions and routes them', (
+    tester,
+  ) async {
+    final spy = _SpyActionService();
+    final source = BytesFileSource(fileName: 'a.png', bytes: _png);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [fileViewerActionServiceProvider.overrideWithValue(spy)],
+        child: MaterialApp(
+          home: FillMediaViewer(
+            source: source,
+            child: const SizedBox(width: 10, height: 10),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('viewer-action-download')), findsOneWidget);
+    expect(find.byKey(const Key('viewer-action-share')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('viewer-action-share')));
+    await _pump(tester, count: 4);
+    expect(spy.shares, hasLength(1));
+    final shared = spy.shares.single as BytesFileSource;
+    expect(shared.fileName, 'a.png');
+    expect(shared.bytes, _png);
+  });
+
+  testWidgets('fill viewer without a source shows no actions', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: FillMediaViewer(child: SizedBox(width: 10, height: 10)),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byKey(const Key('viewer-action-download')), findsNothing);
+    expect(find.byKey(const Key('viewer-action-share')), findsNothing);
+    expect(find.byKey(const Key('fill-media-close')), findsOneWidget);
+  });
+
+  testWidgets('inline SFTP image fill passes the fetched image bytes', (
+    tester,
+  ) async {
+    final spy = _SpyActionService();
+    final w = _wire(
+      tester,
+      byPath: {
+        '/': [
+          const SftpEntry(
+            name: 'doc.md',
+            path: '/doc.md',
+            isDirectory: false,
+            size: 10,
+          ),
+        ],
+      },
+      spy: spy,
+      cannedText: '![alt](img/a.png)',
+    );
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: w.container,
+        child: MaterialApp(
+          home: MarkdownFileViewerScreen(
+            sessionId: w.session.id,
+            entry: const SftpEntry(
+              name: 'doc.md',
+              path: '/doc.md',
+              isDirectory: false,
+            ),
+          ),
+        ),
+      ),
+    );
+    await _pump(tester);
+
+    final image = find.byKey(const Key('markdown-inline-image'));
+    expect(image, findsOneWidget);
+    // Raw-pointer tap (the inline image uses a Listener, not GestureDetector).
+    final center = tester.getCenter(image);
+    final gesture = await tester.startGesture(center);
+    await gesture.up();
+    await _pump(tester, count: 6);
+
+    expect(find.byKey(const Key('fill-media-viewer')), findsOneWidget);
+    // Scope to the fill overlay — the markdown app bar underneath carries its
+    // own (correct) pair of actions.
+    final fillDownload = find.descendant(
+      of: find.byKey(const Key('fill-media-viewer')),
+      matching: find.byKey(const Key('viewer-action-download')),
+    );
+    expect(fillDownload, findsOneWidget);
+    await tester.tap(fillDownload);
+    await _pump(tester, count: 4);
+
+    expect(spy.downloads, hasLength(1));
+    final source = spy.downloads.single as BytesFileSource;
+    expect(source.fileName, 'a.png');
+    expect(source.bytes, _png);
+    w.host.disposeSyncForTest();
+  });
+
+  testWidgets('mermaid fill passes the diagram source as diagram.mmd', (
+    tester,
+  ) async {
+    final spy = _SpyActionService();
+    const mermaidSource = 'graph TD;\n  A-->B;\n';
+    final w = _wire(
+      tester,
+      byPath: {'/': const []},
+      spy: spy,
+      cannedText: '```mermaid\n$mermaidSource```\n',
+    );
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: w.container,
+        child: MaterialApp(
+          home: MarkdownFileViewerScreen(
+            sessionId: w.session.id,
+            entry: const SftpEntry(
+              name: 'diagram.md',
+              path: '/diagram.md',
+              isDirectory: false,
+            ),
+          ),
+        ),
+      ),
+    );
+    await _pump(tester);
+
+    await tester.tap(find.byKey(const Key('mermaid-tap-to-fill')));
+    await _pump(tester, count: 6);
+
+    expect(find.byKey(const Key('fill-media-viewer')), findsOneWidget);
+    // Scope to the fill overlay — the markdown app bar underneath carries its
+    // own (correct) pair of actions.
+    final fillShare = find.descendant(
+      of: find.byKey(const Key('fill-media-viewer')),
+      matching: find.byKey(const Key('viewer-action-share')),
+    );
+    expect(fillShare, findsOneWidget);
+    await tester.tap(fillShare);
+    await _pump(tester, count: 4);
+
+    expect(spy.shares, hasLength(1));
+    final source = spy.shares.single as BytesFileSource;
+    expect(source.fileName, 'diagram.mmd');
+    expect(utf8.decode(source.bytes), contains('A-->B'));
+    w.host.disposeSyncForTest();
+  });
+}


### PR DESCRIPTION
Closes #1038.

## What

Every file preview state now carries the same two app-bar actions — no back-navigation needed:

- **Download** — streams the open file to the device via the browser's existing download pipeline (`downloadSinkFactoryProvider` → `AppDownloadsSink` → MediaStore publish, #559/#952), with determinate progress for big files.
- **Share** — stages a local temp copy (temp dir `mobissh_share/`, offset-verified assembly) and opens the Android share sheet with the FILE + a correct plain mime type via share_plus, never a path string.

Covered viewers: text/code (#776), markdown (#854), rendered HTML (#1037, alongside view-source), PDF (#557), and the tap-to-fill media viewer (#946): inline SFTP images share their already-fetched bytes (no second fetch); mermaid diagrams share their source as `diagram.mmd`.

## How

- `native/lib/services/viewer_file_actions.dart` — one shared service: sealed `ViewerFileSource` (`RemoteFileSource` = viewed SFTP entry, streamed with #591 offset semantics; `BytesFileSource` = in-memory content), `viewerShareMimeType` (delegates to the loopback content-type table, params stripped), injectable download-sink / share-stage / share-launcher seams.
- `native/lib/ui/file_viewer_actions.dart` — one shared widget (monochrome `Icons.download`/`Icons.share`, 48dp targets, busy → progress ring, results as top toasts) dropped into every viewer.
- `downloadSinkFactoryProvider` moved from the browser into `services/sftp_download.dart` (re-exported for existing importers) so ONE test override covers the browser and every viewer.
- `FileViewerRegistry.viewers` getter for the drift guard.

## Tests

- **Drift guard** (`test/widget/file_viewer_actions_test.dart`): every registered viewer must render both actions AND the registry size is pinned — adding a viewer type without covering it (or without the actions) fails.
- Widget: spy-service invocation per action (right source, right session/path); fill-viewer sources (image bytes, mermaid `.mmd`); no actions when fill media has no file source.
- Service unit (`test/services/viewer_file_actions_test.dart`): mime mapping, bytes-source download through the sink, share stages a REAL temp file that exists with exact content at launch time, remote fetch reassembles out-of-order chunks (#591) with progress.
- Emulator (`integration_test/viewer_actions_1038_test.dart`): real app against test-sshd — open seeded text file, Download round-trips exact bytes into the sink, Share hands the launcher a real staged file with correct mime/name, plus a screenshot hold window.

TDD red → green; `scripts/native-fast-gate.sh` PASSED (analyze + full test suite).

## Screenshot

Text viewer app bar with Download + Share glyphs (emulator, reviewed — `hello.txt` open, download + share right of the title, close rightmost):

`test-results/emulator-shots/20260711T015827+0000-viewer-actions-1038_.png` (local, gitignored)

## Honest caveats

- The Android share **sheet itself** is not automatable from integration_test (system UI); the emulator test stubs only the final launcher hop and verifies the staged file + mime. The real sheet needs owner device validation.
- Network-URL images inside markdown get no Download/Share in the fill viewer (they're web resources; we never hold their bytes).
- Share progress is reported, and the staged temp copy is kept after the sheet closes (the receiving app may still read the content URI); it lives in the OS-reclaimable temp dir.
- The remote fetch loop in the new service mirrors `pdf_fetcher.dart` rather than refactoring it — kept the proven PDF path untouched (smallest-diff call; noted in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa