### PR TITLE
fix(native): command anchors at unjoinable wraps — in-block joins + honest "may be incomplete" (#1042)

### DIFF
--- a/native/integration_test/command_incomplete_1042_test.dart
+++ b/native/integration_test/command_incomplete_1042_test.dart
@@ -1,0 +1,300 @@
+// On-emulator #1042 — command wrap recall + the maybeIncomplete affordances.
+//
+// Drives the real chain (SSH → shell echo → flterm scanner → gutter layer)
+// against test-sshd:
+//   1. CASE A (full copy, NO mark): a strong bash prompt, then a REAL long
+//      command typed at the prompt that SOFT-WRAPS across the grid (length
+//      derived from the live $COLUMNS so the last row lands mid-grid). The
+//      anchor's payload must be the FULL typed line (the wrap flag join),
+//      maybeIncomplete=false, the chip is the normal terminal glyph, and the
+//      tap toast is the plain "Copied: …".
+//   2. CASE B (unjoinable → honest mark): printf paints the OWNER-TRACE shape
+//      (2026-07-11T02-32-14): a `⎿  $ echo …` strong-prompt line whose
+//      genuinely multi-line command continues at a DEEPER band no boundary
+//      evidence can join. The anchor stays first-line-only, carries
+//      maybeIncomplete=true, the chip renders the ellipsis variant, and the
+//      tap toast reads "Copied — may be incomplete".
+//      (A plain-shell PS2/heredoc does NOT mark — bare `>` is excluded by
+//      design (#998) and a heredoc's `cat <<EOF` head shows no wrap evidence;
+//      the owner's actual construct is this TUI band, reproduced verbatim.)
+//
+// SHOT1042 debugPrints mark screenshot hold windows (scripts/emu-shot.sh).
+//
+// Run: scripts/native-connect-test.sh integration_test/command_incomplete_1042_test.dart
+
+import 'dart:convert';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart' show Icon, Icons;
+import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/clipboard.dart' show clipboardChannel;
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_gutter_layer.dart'
+    show kGutterIncompleteIcon;
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+const _caseBFirstLine = 'echo "one two three"';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'a soft-wrapped command copies FULLY unmarked; the owner-trace TUI band '
+    'marks maybeIncomplete with the ellipsis chip + hedged toast (#1042)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      String? copied;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        clipboardChannel,
+        (call) async {
+          if (call.method == 'setText') {
+            copied = (call.arguments as Map)['text'] as String?;
+            return true;
+          }
+          return null;
+        },
+      );
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied = (call.arguments as Map)['text'] as String?;
+          }
+          if (call.method == 'Clipboard.getData') {
+            return <String, dynamic>{'text': copied ?? ''};
+          }
+          return null;
+        },
+      );
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          clipboardChannel,
+          null,
+        );
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        );
+      });
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active!;
+      final sessionId = entry.id;
+      TerminalController? ctrlOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && ctrlOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = ctrlOf()!;
+
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'dead PTY — no shell prompt');
+
+      void send(String line) {
+        entry.proxy.sendInput(Uint8List.fromList(utf8.encode('$line\n')));
+      }
+
+      // Strong prompt under the test's control (#998 precedent), then clear.
+      send(r"export PS1='testuser@test-sshd:~$ '");
+      await tester.pump(const Duration(milliseconds: 800));
+      send('clear');
+      await tester.pump(const Duration(milliseconds: 800));
+
+      // Grid width from the live shell, so CASE A's soft-wrapped command can
+      // deterministically land its LAST row mid-grid (a boundary-hugging last
+      // row is exactly the honesty signal — this test wants the clean case).
+      send(r'echo "COLS=$COLUMNS"');
+      int? cols;
+      for (var i = 0; i < 30 && cols == null; i++) {
+        await tester.pump(const Duration(milliseconds: 400));
+        final m = RegExp(r'COLS=(\d{2,3})\b')
+            .firstMatch(utf8.decode(out, allowMalformed: true));
+        if (m != null) cols = int.parse(m.group(1)!);
+      }
+      expect(cols, isNotNull, reason: r'shell never reported $COLUMNS');
+      debugPrint('CHIP1042 cols=$cols');
+
+      // ---- CASE A: a REAL soft-wrapped command → FULL copy, no mark. ----
+      // Prompt is 22 chars; size the command so it wraps once and its last
+      // row ends near mid-grid: total (prompt+command) = 2.5 * cols.
+      const promptLen = 22; // 'testuser@test-sshd:~$ '
+      const fixedA = 'echo m1042'; // lexicon hit (+2) behind a strong prompt
+      const tailA = ' | tail -1'; // flag + operator for good measure
+      var pad = (cols! * 5) ~/ 2 - promptLen - fixedA.length - tailA.length - 1;
+      if (pad < 8) pad = 8;
+      final commandA = '$fixedA ${'a' * pad}$tailA';
+      send(commandA);
+
+      StructuredAnchor? anchorWhere(bool Function(String payload) test) {
+        for (final a in controller.anchors) {
+          if (a.patternId == kGhosttyCommandPatternId &&
+              test('${a.payload}')) {
+            return a;
+          }
+        }
+        return null;
+      }
+
+      StructuredAnchor? anchorA() =>
+          anchorWhere((p) => p == commandA);
+      for (var i = 0; i < 60 && anchorA() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      final cmdA = anchorA();
+      expect(cmdA, isNotNull,
+          reason: 'the soft-wrapped command must anchor with its FULL '
+              'payload (found: '
+              '${controller.anchors.map((a) => a.payload).toList()})');
+      expect(cmdA!.maybeIncomplete, isFalse,
+          reason: 'a flag-joined wrap left nothing behind — no hedge');
+
+      int? rowOf(StructuredAnchor a) {
+        for (final r in a.ranges) {
+          final row = controller.anchorGutterRow(r);
+          if (row != null) return row;
+        }
+        return null;
+      }
+
+      final rowA = rowOf(cmdA);
+      expect(rowA, isNotNull, reason: 'case-A anchor has no on-screen row');
+      final iconA = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(Key('gutter-mark-$rowA')),
+          matching: find.byType(Icon),
+        ),
+      );
+      expect(iconA.icon, Icons.terminal,
+          reason: 'a complete command keeps the normal chip glyph');
+
+      debugPrint('SHOT1042 full-chip hold');
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+
+      copied = null;
+      await tester.tap(find.byKey(Key('gutter-mark-$rowA')));
+      for (var i = 0; i < 10 && copied == null; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(copied, commandA,
+          reason: 'the chip must copy the FULL soft-wrapped command');
+      // The toast overlay inserts AFTER the async clipboard write resolves —
+      // give it frames to build before asserting its text.
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.textContaining('may be incomplete'), findsNothing,
+          reason: 'the clean case gets the plain toast');
+      expect(find.textContaining('Copied:'), findsOneWidget);
+      // Drain the toast.
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // ---- CASE B: the owner-trace TUI band → honest incomplete mark. ----
+      send('clear');
+      await tester.pump(const Duration(milliseconds: 800));
+      // Paint the 2026-07-11 owner shape: strong `⎿  $ ` head, then the
+      // deeper continuation band a boundary-gated join must reject. The `⎿`
+      // is sent as its literal UTF-8 bytes (portable across printf builds);
+      // inside single quotes the `$` and quotes are literal, `\n` is printf's.
+      send("printf '  ⎿  \$ echo \"one two three\"\\n"
+          "     ssh pve rest of the block here\\n\\n'");
+
+      StructuredAnchor? anchorB() =>
+          anchorWhere((p) => p == _caseBFirstLine);
+      for (var i = 0; i < 60 && anchorB() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      final cmdB = anchorB();
+      expect(cmdB, isNotNull,
+          reason: 'the painted `⎿  \$ echo …` head must anchor first-line-only '
+              '(found: '
+              '${controller.anchors.map((a) => a.payload).toList()})');
+      expect(cmdB!.maybeIncomplete, isTrue,
+          reason: 'the deeper-band successor was rejected as a continuation '
+              '— the anchor must carry the honesty flag (#1042)');
+
+      final rowB = rowOf(cmdB);
+      expect(rowB, isNotNull, reason: 'case-B anchor has no on-screen row');
+      final iconB = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(Key('gutter-mark-$rowB')),
+          matching: find.byType(Icon),
+        ),
+      );
+      expect(iconB.icon, kGutterIncompleteIcon,
+          reason: 'the likely-truncated anchor renders the ellipsis variant');
+
+      debugPrint('SHOT1042 incomplete-chip hold');
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+
+      copied = null;
+      await tester.tap(find.byKey(Key('gutter-mark-$rowB')));
+      for (var i = 0; i < 10 && copied == null; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(copied, _caseBFirstLine,
+          reason: 'the copy is still the best honest payload (line 1)');
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Copied — may be incomplete'), findsOneWidget,
+          reason: 'the toast must hedge (#1042)');
+
+      debugPrint('SHOT1042 incomplete-toast hold');
+      for (var i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+    },
+  );
+}

--- a/native/lib/ui/ghostty_gutter_layer.dart
+++ b/native/lib/ui/ghostty_gutter_layer.dart
@@ -50,6 +50,14 @@ import 'ghostty_terminal_decorators.dart';
 /// (`kGutterSelectStripWidth`) so the bigger chip fits inside it.
 const double kGutterStripWidth = 28.0;
 
+/// The INCOMPLETE chip variant glyph (#1042): an anchor whose payload is
+/// likely truncated ([StructuredAnchor.maybeIncomplete] — today only command
+/// anchors at an unjoinable wrap) renders this ellipsis mark instead of its
+/// pattern glyph, same chip size. Monochrome Material glyph per
+/// feedback_monochrome_icons_no_emoji; the ellipsis IS the semantics ("there
+/// is more than the copy will carry").
+const IconData kGutterIncompleteIcon = Icons.more_horiz;
+
 /// Sizing + colour derivation for the gutter detection mark chip (#989).
 ///
 /// The mark is a FILLED opaque chip behind a bigger glyph so it reads as a
@@ -172,7 +180,12 @@ class GutterPatternPresentation {
   ) showActions;
 
   /// The action buttons for this pattern's row in the multi-match list sheet.
-  final List<GutterItemAction> Function(String payload) itemActions;
+  ///
+  /// #1042: [anchor] is the full anchor when the sheet invokes this (so a
+  /// command copy can hedge its toast off [StructuredAnchor.maybeIncomplete]);
+  /// callers that only have the payload text (tests, previews) may omit it.
+  final List<GutterItemAction> Function(String payload,
+      {StructuredAnchor? anchor}) itemActions;
 }
 
 /// Maps a pattern id to its [GutterPatternPresentation] (#955).
@@ -318,7 +331,7 @@ class GutterPatternRegistry {
           onMarkNotDetection: markNot,
         );
       },
-      itemActions: (payload) {
+      itemActions: (payload, {anchor}) {
         final barePath = fileUrlToRemotePath(payload);
         // #995: the 'not' action reports the ORIGINAL payload (the file://
         // URI for a file:// anchor) — suppression keys on the matched text.
@@ -363,7 +376,7 @@ class GutterPatternRegistry {
             ? null
             : () => onReportException(anchor.patternId, '${anchor.payload}'),
       ),
-      itemActions: (payload) => [
+      itemActions: (payload, {anchor}) => [
         openPathAction(payload),
         copyAction(payload),
         ?notAction(kGhosttyPathPatternId, payload, 'Not a file'),
@@ -399,7 +412,7 @@ class GutterPatternRegistry {
               : () => onReportException(anchor.patternId, payload),
         );
       },
-      itemActions: (payload) {
+      itemActions: (payload, {anchor}) {
         final resolved = resolveRel(payload);
         return [
           openPathAction(resolved),
@@ -433,15 +446,20 @@ class GutterPatternRegistry {
       patternId: kGhosttyCommandPatternId,
       icon: Icons.terminal,
       typeLabel: 'Command',
+      // #1042: an anchor flagged maybeIncomplete (an unjoinable wrap left
+      // evidence the payload is truncated) hedges the copy toast — the copy
+      // itself is unchanged (still the best payload we honestly have).
       showActions: (context, anchor, markGlobal) {
-        unawaited(_copyWithToast(context, '${anchor.payload}'));
+        unawaited(_copyWithToast(context, '${anchor.payload}',
+            mayBeIncomplete: anchor.maybeIncomplete));
       },
-      itemActions: (payload) => [
+      itemActions: (payload, {anchor}) => [
         GutterItemAction(
           keyLabel: 'copy',
           icon: Icons.content_copy,
           label: 'Copy command',
-          onInvoke: (context) => _copyWithToast(context, payload),
+          onInvoke: (context) => _copyWithToast(context, payload,
+              mayBeIncomplete: anchor?.maybeIncomplete ?? false),
         ),
         ?notAction(kGhosttyCommandPatternId, payload, 'Not a command'),
       ],
@@ -491,7 +509,7 @@ class GutterPatternRegistry {
                   : () => onReportException(anchor.patternId, payload),
             );
           },
-          itemActions: (payload) => [
+          itemActions: (payload, {anchor}) => [
             copyAction(payload),
             ?notAction(patternId, payload, 'Not a match'),
           ],
@@ -518,10 +536,22 @@ class GutterPatternRegistry {
 ///
 /// The overlay is captured BEFORE the async clipboard write so the toast still
 /// lands after the list sheet has popped (the root overlay outlives the sheet).
-Future<void> _copyWithToast(BuildContext context, String text) async {
+/// #1042: [mayBeIncomplete] switches the toast to the honesty hedge — the
+/// anchor's payload is likely truncated (an unjoinable wrap), so the toast
+/// says so instead of implying a clean copy.
+Future<void> _copyWithToast(
+  BuildContext context,
+  String text, {
+  bool mayBeIncomplete = false,
+}) async {
   final overlay = Overlay.maybeOf(context, rootOverlay: true);
   final ok = await copyToClipboard(text);
-  if (ok && overlay != null) showTopToastInOverlay(overlay, 'Copied: $text');
+  if (ok && overlay != null) {
+    showTopToastInOverlay(
+      overlay,
+      mayBeIncomplete ? 'Copied — may be incomplete' : 'Copied: $text',
+    );
+  }
 }
 
 /// Group detected [anchors] by the VIEWPORT row their gutter mark belongs on
@@ -815,7 +845,13 @@ class _GutterMarkState extends State<_GutterMark> {
             child: GutterMarkChip(
               style: style,
               accent: widget.color,
-              icon: multi ? null : (single?.icon ?? Icons.adjust),
+              // #1042: a likely-truncated anchor renders the ellipsis-marked
+              // incomplete variant — same chip, same size, honest glyph.
+              icon: multi
+                  ? null
+                  : (widget.anchors.first.maybeIncomplete
+                      ? kGutterIncompleteIcon
+                      : (single?.icon ?? Icons.adjust)),
               count: multi ? widget.anchors.length : null,
             ),
           ),
@@ -940,12 +976,17 @@ class _GutterPatternListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final payload = '${anchor.payload}';
-    final actions = presentation.itemActions(payload);
+    final actions = presentation.itemActions(payload, anchor: anchor);
+    // #1042: a likely-truncated anchor gets the ellipsis glyph and the sheet's
+    // one-line note in the subtitle.
+    final incomplete = anchor.maybeIncomplete;
     return ListTile(
       key: Key('gutter-item-$index'),
-      leading: Icon(presentation.icon),
+      leading: Icon(incomplete ? kGutterIncompleteIcon : presentation.icon),
       title: Text(payload, maxLines: 2, overflow: TextOverflow.ellipsis),
-      subtitle: Text(presentation.typeLabel),
+      subtitle: Text(incomplete
+          ? '${presentation.typeLabel} — may be incomplete'
+          : presentation.typeLabel),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/native/test/fixtures/replay/claude_tool_result_multiline_cmd_55x32.byte-trace.json
+++ b/native/test/fixtures/replay/claude_tool_result_multiline_cmd_55x32.byte-trace.json
@@ -1,0 +1,1266 @@
+{
+  "grid": {
+    "cols": 55,
+    "rows": 32
+  },
+  "byteTrace": [
+    {
+      "tMs": 25716,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 25804,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 25996,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 26397,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbQxtbOTNtQxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 26443,
+      "b64": "G1syNTs0SBtbOTNtG1s0ODsyOzMxOzEwOzEwbWFyG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 26500,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 26506,
+      "b64": "G1szQRtbOTFtG1s0ODsyOzMxOzEwOzEwbUMbWzJDG1s5M21hG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 26575,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzJDYRtbMkMbWzkzbW0bWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 26638,
+      "b64": "G1syNTs1SBtbOTFtG1s0ODsyOzMxOzEwOzEwbXIbWzJDG1s5M21lG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 26708,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbNENhbRtbQxtbOTNtbGkbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 26772,
+      "b64": "G1syNTs4SBtbOTFtG1s0ODsyOzMxOzEwOzEwbWUbWzJDG1s5M216G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 26847,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbN0NsG1syQxtbOTNtaRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 26901,
+      "b64": "G1syNTsxMEgbWzkxbRtbNDg7MjszMTsxMDsxMG1pehtbQxtbOTNtbmcbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 26967,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMTBDaRtbMkMbWzkzbeKAphtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 27031,
+      "b64": "G1syNTsxM0gbWzkxbRtbNDg7MjszMTsxMDsxMG1uG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 27060,
+      "b64": "G1syNTsxNEgbWzkxbRtbNDg7MjszMTsxMDsxMG1n4oCmG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 27463,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 27465,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 27568,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 27679,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 27741,
+      "b64": "G1syNTsxN0gbWzM3bRtbNDg7MjszMTsxMDsxMG0oOXMgwrcgG1szODs1OzI0OW10aGlua2luZxtbMzdtKRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 27802,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 27912,
+      "b64": "G1syNTsxOEgbWzM3bRtbNDg7MjszMTsxMDsxMG0xMHMgwrcgG1szODs1OzI0OW10aGlua2luZxtbMzdtKRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 28020,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1syMkMbWzM4OzU7MjQ4bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 28236,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 28353,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 28418,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 28467,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ2bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 28581,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 28690,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 28802,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 28919,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG0xG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 29031,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMjJDG1szODs1OzI0N210aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 29143,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ4bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 29361,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjJDG1szODs1OzI0OW10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 29378,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 29586,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMTNDG1s5M23igKYbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 29695,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzIyQxtbMzdt4oaTG1szOW0gG1szN20yNSB0b2tlbnMgwrcgG1szODs1OzI0OW10aGlua2luZxtbMzdtKRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 29714,
+      "b64": "G1s0ODsyOzMxOzEwOzEwbRtbMWQbW0sKSSBjYW4bW0NmaXgbW0N0aGUgY2wbW0NhbiB3aW5zIG5vdyB3aXRoIHlvdXIbW0NnbxtbQ+KAlBtbQxtbMW1kaXNhYmxlIBtbMzszSFJEUBsoQhtbbRtbNDg7MjszMTsxMDsxMG0sG1tDG1sxbXJlYmluZCBmaW5hbmNlLXBnIGFuZCBTeW5jdGhpbmctR1VJIHRvIBtbNDszSGxvY2FsaG9zdBsoQhtbbRtbNDg7MjszMTsxMDsxMG0sIBtbMW1sb2NrIGRvd24gT3BlbldlYlJYGyhCG1ttG1s0ODsyOzMxOzEwOzEwbSDigJQgYWxsIGxvdy1yaXNrIGFuZBtbSxtbNTszSHJldmVyc2libGUuIEknZCBob2xkIHRoZSAbWzFtaG9zdCBmaXJld2FsbBsoQhtbbRtbNDg7MjszMTsxMDsxMG0gKHVmdykbW0Nmb3IbW0NhG1s2OzNIY2FyZWZ1bCBwYXNzIHNpbmNlIGEgd3JvbmcgcnVsZSBvbiBhG1tDZHVhbC1ob21lZCBib3gbWzc7M0hjYW4gbG9jayBvdXQgU1NILCBhbmQgSSdkIGNvbmZpcm0geW91chtbQ2tleSB3b3JrcxtbQxtbSxtbODszSGJlZm9yZSB0b3VjaGluZyAbWzFtU1NIIHBhc3N3b3JkIGF1dGgbKEIbW20bWzQ4OzI7MzE7MTA7MTBtLhtbQ1dhbnQgbWUgdG8gYXBwbHkbWzk7M0h0aGUbW0NmG1tDdXIbW0NjbGVhbiBmaXhlcywbW0NhbhtbMkNpZGVudGlmeSAbWzk0bTIwMjExLzIwMjEyG1szOW0gd2l0aBtbMTA7M0hzdWQbW0M/G1tLG1sxMTszSBtbSw0KG1szN23inLsbW0NDcnVuY2hlZCBmb3IgMW0gNTFzIMK3IDEgbW9uaXRvciBzdGlsbCBydW5uaW5nG1sxNDsxSOKAuxtbQxtbMW1yZWNhcDogGyhCG1ttG1szN20bWzQ4OzI7MzE7MTA7MTBtG1szbUF1ZGl0aW5nIHJhc2VydmVyJ3Mgc2VjdXJpdHkgdG8gZXhwbGFpbiB0aGUgG1sxNTszSHJvdXRlcidzIEFybW9yIHZ1bG5lcmFiaWxpdHkgYWxlcnRzOyBJIGZvdW5kIGFuIA0KGyhCG1ttG1s0ODsyOzMxOzEwOzEwbSAbW0MbWzM3bRtbM21leHBvc2VkIGZpbmFuY2UbW0NkG1tDdGFiYXNlIGFuZCBvcGVuIFJEUCBhcyB0aGUgbWFpbiAbKEIbW20bWzQ4OzI7MzE7MTA7MTBtG1tLG1sxNzszSBtbMzdtG1szbWlzc3UbW0NzLiBOZXh0IGFjdGlvG1tDLCBwZW5kG1tDbmcbW0N5b3UbW0MgZ286IGFwcGx5IHRoZRtbQ2ZvdXIgG1sxODszSGxvdy1yaXNrIGZpeGVzIGFuZCBpZGVudGlmeSB0d28gdW5rbm93biBsaXN0ZW5pbmcbWzE5OzNIcG9ydHMuGyhCG1ttG1s0ODsyOzMxOzEwOzEwbRtbSxtbMjA7M0gbW0sNChtbMzdtG1sxMDBt4p2vIBtbOTdtY2FuJ3QgY29ubmVjdCB0byB0aHJlYWQgZXZhbDYbWzM5bSAgICAgICAgICAgICAgICAgICAgICAgIBtbMjM7MUgbWzk3bRtbNDg7MjszMTsxMDsxMG3il48bWzM5bSBMZXQgbWUgZGlhZ25vc2Ug4oCUIGNoZWNrIHdoZXRoZXIgdGhlIHRocmVhZGV2YWwgTFhDIGlzG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 29727,
+      "b64": "G1syNTszOEgbWzM3bRtbNDg7MjszMTsxMDsxMG10aG91Z2h0IGZvciAycykbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 29835,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMTJDG1s5M21nG1sxMUMbWzM3bTUwG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 29930,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG0yG1s2Qzc1G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 30034,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1sxMUMbWzkzbW4bWzEwQxtbMzdtdGhvdWdodCBmb3IbW0MycykbWzM5bRtbSxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 30146,
+      "b64": "G1syNTsxMkgbWzkzbRtbNDg7MjszMTsxMDsxMG1pG1syQxtbOTFt4oCmG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 30197,
+      "b64": "G1syZBtbNDg7MjszMTsxMDsxMG0bWzFtUkRQGyhCG1ttG1s0ODsyOzMxOzEwOzEwbSwgG1sxbXJlYmluZCBmaW5hbmNlLXBnIGFuZCBTeW5jdGhpbmctR1VJIHRvIBsoQhtbbRtbNDg7MjszMTsxMDsxMG0bW0sbWzM7M0gbWzFtbG9jYWxob3N0GyhCG1ttG1s0ODsyOzMxOzEwOzEwbSwgG1sxbWxvY2sgZG93biBPcGUbW0NXZWJSWBsoQhtbbRtbNDg7MjszMTsxMDsxMG0g4oCUIGFsbCBsb3ctcmlzaxtbQ2FuZBtbNDszSHJldmVyc2libGUuIEknZCBob2xkIHRoZSAbWzFtaG9zdCBmaXJld2FsbBsoQhtbbRtbNDg7MjszMTsxMDsxMG0gKHVmdykgZm9yIGEbWzU7M0hjYXIbW0NmdWwgcGFzcyBzaW5jZSBhG1tDd3JvbmcgcnVsZSBvbiBhIGR1YWwtaG9tZWQgYm94G1s2OzVIbiBsb2NrIG91dBtbQ1NTSCwgYW5kIEknZCBjb25maXJtIHlvdXIga2V5IHdvcmtzG1tLG1s3OzNIYmVmb3JlIHRvdWNoaW5nIBtbMW1TU0ggcGFzc3dvcmQgYXV0aBsoQhtbbRtbNDg7MjszMTsxMDsxMG0uIFdhbnQgbWUbW0N0G1tDIGFwcGx5G1s4OzNIdGhlIGZvdXIgY2xlYRtbQyBmaXhlcywgYW5kIGlkZW50aWZ5G1tDG1s5NG0yMDIxMS8yMDIxMhtbMzltIHdpdGgbWzk7M0hzdWRvPxtbSxtbMTA7M0gbW0sNChtbMzdt4py7G1tDQ3J1bmNoZWQgZm9yIDFtIDUxcyDCtyAxIG1vbml0b3Igc3RpbGwgcnVubmluZxtbMzltDQobW0sNChtbMzdt4oC7G1tDG1sxbXJlY2FwOiAbKEIbW20bWzM3bRtbNDg7MjszMTsxMDsxMG0bWzNtQXVkaXRpbmcgcmFzZXJ2ZXIncyBzZWN1cml0eSB0byBleHBsYWluIHRoZSANChsoQhtbbRtbNDg7MjszMTsxMDsxMG0gG1tDG1szN20bWzNtcm91dGVyJ3MgQXJtb3IgdnVsbhtbMkNhYmlsaXR5IGFsZXIbW0NzOyBJG1tDZm91bmQgYW4gGyhCG1ttG1s0ODsyOzMxOzEwOzEwbRtbSxtbMTU7M0gbWzM3bRtbM21leHBvc2VkIGZpbmFuY2UgZGF0YWIbW0NzZSBhbmQbW0NvcBtbQ24gUkRQIGFzIHRoZRtbQ21haW4gG1sxNjszSGlzc3Vlcy4bW0NOZXh0IGFjdGlvbiwgcGVuZGkbW0NnG1tDeW91chtbQ2dvOhtbMkNwcGx5IHRoZSBmb3VyIBtbMTc7M0hsb3ctcmlzayBmaXhlcyBhbmQgaWRlbnRpZnkgdHcbW0MgdW5rbm93biBsaXN0ZW5pbmcgGyhCG1ttG1s0ODsyOzMxOzEwOzEwbRtbSxtbMTg7M0gbWzM3bRtbM21wG1tDcnRzLhsoQhtbbRtbNDg7MjszMTsxMDsxMG0bW0sbWzE5OzNIG1tLDQobWzM3bRtbMTAwbeKdryAbWzk3bWNhbid0IGNvbm5lY3QgdG8gdGhyZWFkIGV2YWw2G1szOW0gICAgICAgICAgICAgICAgICAgICAgICAbWzQ4OzI7MzE7MTA7MTBtG1syMTsxSBtbSw0KG1s5N23il48bW0MbWzM5bUxldBtbQ21lG1tDZGlhZ25vc2UbW0PigJQbW0NjaGVjaxtbQ3doZXRoZXIbW0N0aGUbW0N0aHJlYWRldmFsG1tDTFhDG1tDaXMbWzIzOzFIIBtbQ3VwIGFuZBtbQ29uIHRoZSB0YWlsbmV0OhtbSxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 30218,
+      "b64": "G1sxZBtbNDg7MjszMTsxMDsxMG0bWzFtbG9jYWxob3N0GyhCG1ttG1s0ODsyOzMxOzEwOzEwbSwbW0MbWzFtbG9jayBkb3duIE9wZW5XZWJSWBtbQxsoQhtbbRtbNDg7MjszMTsxMDsxMG3igJQbW0NhbGwbW0Nsb3ctcmlzaxtbQ2FuZBtbMjszSHJldmVyc2libGUuIEknZCBob2xkIHRoZSAbWzFtaG9zdCBmaXJld2FsbBsoQhtbbRtbNDg7MjszMTsxMDsxMG0gKHVmdykbW0Nmb3IbW0NhG1szOzNIY2FyZWZ1bCBwYXNzIHNpbmNlIGEgd3JvbmcgcnVsZSBvbiBhG1tDZHVhbC1ob21lZCBib3gbWzQ7M0hjYW4gbG9jayBvdXQgU1NILCBhbmQgSSdkIGNvbmZpcm0geW91chtbQ2tleSB3b3JrcxtbQxtbSxtbNTszSGJlZm9yZSB0b3VjaGluZyAbWzFtU1NIIHBhc3N3b3JkIGF1dGgbKEIbW20bWzQ4OzI7MzE7MTA7MTBtLhtbQ1dhbnQgbWUgdG8gYXBwbHkbWzY7M0h0aGUbW0NmG1tDdXIbW0NjbGVhbiBmaXhlcywbW0NhbhtbMkNpZGVudGlmeSAbWzk0bTIwMjExLzIwMjEyG1szOW0gd2l0aBtbNzszSHN1ZBtbQz8bW0sbWzg7M0gbW0sNChtbMzdt4py7G1tDQ3J1bmNoZWQgZm9yIDFtIDUxcyDCtyAxIG1vbml0b3Igc3RpbGwgcnVubmluZxtbMTE7MUjigLsbW0MbWzFtcmVjYXA6IBsoQhtbbRtbMzdtG1s0ODsyOzMxOzEwOzEwbRtbM21BdWRpdGluZyByYXNlcnZlcidzIHNlY3VyaXR5IHRvIGV4cGxhaW4gdGhlIBtbMTI7M0hyb3V0ZXIncyBBcm1vciB2dWxuZXJhYmlsaXR5IGFsZXJ0czsgSSBmb3VuZCBhbiANChsoQhtbbRtbNDg7MjszMTsxMDsxMG0gG1tDG1szN20bWzNtZXhwb3NlZCBmaW5hbmNlG1tDZBtbQ3RhYmFzZSBhbmQgb3BlbiBSRFAgYXMgdGhlIG1haW4gGyhCG1ttG1s0ODsyOzMxOzEwOzEwbRtbSxtbMTQ7M0gbWzM3bRtbM21pc3N1G1tDcy4gTmV4dCBhY3RpbxtbQywgcGVuZBtbQ25nG1tDeW91G1tDIGdvOiBhcHBseSB0aGUbW0Nmb3VyIBtbMTU7M0hsb3ctcmlzayBmaXhlcyBhbmQgaWRlbnRpZnkgdHdvIHVua25vd24gbGlzdGVuaW5nG1sxNjszSHBvcnRzLhsoQhtbbRtbNDg7MjszMTsxMDsxMG0bW0sbWzE3OzNIG1tLDQobWzM3bRtbMTAwbeKdryAbWzk3bWNhbid0IGNvbm5lY3QgdG8gdGhyZWFkIGV2YWw2G1szOW0gICAgICAgICAgICAgICAgICAgICAgICAbWzIwOzFIG1s5N20bWzQ4OzI7MzE7MTA7MTBt4pePG1szOW0gTGV0IG1lIGRpYWdub3NlIOKAlCBjaGVjayB3aGV0aGVyIHRoZSB0aHJlYWRldmFsIExYQyBpcxtbMjE7M0h1cBtbQ2FuZBtbQ29uG1tDdGhlG1tDdGFpbG5ldDoNChtbSw0KG1szN23il48bW0MbWzM5bVJ1bm5pbmcgG1sxbTEbW0MbKEIbW20bWzQ4OzI7MzE7MTA7MTBtcxtbMkNsbCBjb21tYW5k4oCmG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 30372,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 30373,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbOUMbWzkzbXobWzJDG1s5MW1nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 30481,
+      "b64": "G1syMzsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 30640,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzhDG1s5M21pG1syQxtbOTFtbhtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 30712,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 30814,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbN0MbWzkzbWwbWzJDG1s5MW1pG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 30925,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG0zG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 31039,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbNkMbWzkzbWUbWzJDG1s5MW16G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 31095,
+      "b64": "G1syMzsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 31159,
+      "b64": "G1syNTs3SBtbOTNtG1s0ODsyOzMxOzEwOzEwbW0bWzJDG1s5MW1pG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 31319,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 31376,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbNEMbWzkzbWEbWzJDG1s5MW1sG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 31608,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbM0MbWzkzbXIbWzJDG1s5MW1lG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 31705,
+      "b64": "G1syMzsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 31716,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 31756,
+      "b64": "G1syNTsyNEgbWzM3bRtbNDg7MjszMTsxMDsxMG3ihpMbWzM5bSAbWzM3bTIwOSAbW0Nva2VucykbWzM5bRtbSxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 31830,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMkMbWzkzbWEbWzJDG1s5MW1tG1sxOUMbWzM3bTEzG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 31951,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG00G1s4QzUbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 32050,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1tDG1s5M21DG1syQxtbOTFtYRtbMjFDG1szN202G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 32161,
+      "b64": "G1syNTs1SBtbOTFtG1s0ODsyOzMxOzEwOzEwbXIbWzIyQxtbMzdtOBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 32264,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 32279,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG05G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 32315,
+      "b64": "G1syMzsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 32387,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMkNhG1syMkMbWzM3bTIyG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 32501,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG0zG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 32613,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobW0NDG1syNEMbWzM3bTUbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 32734,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjVDG1szN20zOBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 32831,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjVDG1szN201MhtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 32921,
+      "b64": "G1syMzsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 32991,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMTdDG1szN201G1s4QzYbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 33059,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG03G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 33178,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG05G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 33227,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 33292,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG02MRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 33393,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjZDG1szN20yG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 33510,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG00G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 33525,
+      "b64": "G1syMzsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 33611,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjZDG1szN201G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 33730,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI1QxtbMzdtODAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 33891,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjZDG1szN203G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 33963,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1sxN0MbWzM3bTYbWzhDOBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 34074,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG05MBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 34130,
+      "b64": "G1syMzsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 34179,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG0yG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 34217,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 34302,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG00G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 34396,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjZDG1szN201G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 34514,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG03G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 34658,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI2QxtbMzdtORtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 34743,
+      "b64": "G1syMzsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjU7MUgbWzkxbeKcthtbMjRDG1szN20zMDAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 34843,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjZDG1szN20yG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 34964,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMTdDG1szN203G1s3QzE1G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 35073,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG0yG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 35148,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 35209,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG0zMxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 35304,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG00G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 35403,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjZDG1szN202G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 35522,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjZDG1szN203G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 35630,
+      "b64": "G1s0ODsyOzMxOzEwOzEwbRtbMWQbW0sNChtbMzdt4py7G1tDQ3J1bmNoZWQgZm9yIDFtIDUxcyDCtyAxIG1vbml0b3Igc3RpbGwgcnVubmluZxtbMzltG1tLG1szOzNIG1tLDQobWzM3beKAuxtbQxtbMW1yZWNhcDogGyhCG1ttG1szN20bWzQ4OzI7MzE7MTA7MTBtG1szbUF1ZGl0aW5nIHJhc2VydmVyJ3Mgc2VjdXJpdHkgdG8gZXhwbGFpbiB0aGUgG1s1OzNIcm91dGVyJ3MgQXJtb3IgdnVsbmVyYWJpbGl0eSBhbGVydHM7IEkgZm91bmQgYW4gGyhCG1ttG1s0ODsyOzMxOzEwOzEwbRtbSxtbNjszSBtbMzdtG1szbWV4cG9zZWQgZmluYW5jZSBkYXRhYmFzZSBhbmQgb3BlbiBSRFAgYXMgdGhlIG1haW4gGyhCG1ttG1s0ODsyOzMxOzEwOzEwbRtbSxtbNzszSBtbMzdtG1szbWlzc3Vlcy4gTmV4dCBhY3Rpb24sIHBlbmRpbmcgeW91ciBnbzogYXBwbHkgdGhlIGZvdXIgG1s4OzNIbG93LXJpc2sgZml4ZXMgYW5kIGlkZW50aWZ5IHR3byB1bmtub3duIGxpc3RlbmluZyANChsoQhtbbRtbNDg7MjszMTsxMDsxMG0gG1tDG1szN20bWzNtcG9ydHMuGyhCG1ttG1s0ODsyOzMxOzEwOzEwbRtbSxtbMTE7MUgbWzM3bRtbMTAwbeKdryAbWzk3bWNhbid0IGNvbm5lY3QgdG8gdGhyZWFkIGV2YWw2G1szOW0gICAgICAgICAgICAgICAgICAgICAgICAbWzQ4OzI7MzE7MTA7MTBtG1sxMjszSBtbSw0KG1s5N23il48bW0MbWzM5bUxldCBtZSBkaWFnbm9zZSDigJQgY2hlY2sgd2hldGhlciB0aGUgdGhyZWFkZXZhbCBMWEMbW0NpcxtbMTQ7M0h1cCBhbmQgb24gdGhlIHRhaWxuZXQ6G1tLG1sxNTszSBtbSw0KG1szN23il48bW0MbWzM5bVJ1bm5pbmcbW0MbWzFtMRtbQxsoQhtbbRtbNDg7MjszMTsxMDsxMG1zaGVsbBtbQ2NvbW1hbmTigKYNChtbMzdtICDijr8gICQgZWNobyAiPT09IExYQyAxMDkgc3RhdHVzIG9uIHB2ZSA9PT0iDQobWzM5bSAgICAgG1szN21zc2ggcHZlICdwY3Qgc3RhdHVzIDEwOSAyPiYxOyBwY3QgZXhlYyAxMDkgLS0gG1szOW0bW0sbWzE5OzZIG1szN210YWlsc2NhbGUgc3RhdHVzIC0tc2VsZiAtLWpzb24gMj4vZGV2L251bGwgfCBqcSAtchtbMjA7MUgbWzM5bSAbW0MgICAbWzM3bSJbLlNlbGYuSG9zdE5hbWUsLlNlbGYuVGFpbHNjYWxlSVBzWzBdLC5TZWxmLk9ubGkbWzM5bRtbSxtbMjE7M0ggIBtbQxtbMzdtbmUsKC5TZWxmLkNhcE1hcHxoYXMoXCJodHRwczovL3RhaWxzY2FsZS5jb20vY2FwL3MbWzIyOzZIc2hcIikpXXxAdHN2IiAyPi9kZXYvbnVsbCB8fCBlY2hvICJ0YWlsc2NhbGUgbm90IA0KG1szOW0gG1tDICAgG1szN21yZXNwb25kaW5nIGluIGfigKYbWzM5bRtbSxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 35686,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG01NRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 35752,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI1QxtbMzdtNjMbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 35854,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjZDG1szN203G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 35961,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 35975,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1sxN0MbWzM3bTgbWzhDOBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 36087,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG03MRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 36112,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 36192,
+      "b64": "G1szQRtbOTNtG1s0ODsyOzMxOzEwOzEwbUNhcmFtZWxpemluZ+KAphtbMTJDG1szN20yG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 36332,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG00G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 36417,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjZDG1szN201G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 36556,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI2QxtbMzdtNxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 36563,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 36646,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG05G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 36763,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjVDG1szN204MBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 36884,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMTdDG1szN205G1s2QzQwNRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 36923,
+      "b64": "G1szQRtbOTFtG1s0ODsyOzMxOzEwOzEwbUNhcmFtZWxpemkbWzExQxtbMzdt4oaRG1syQzE4G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 36969,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMTFDbmcbWzEyQxtbMzdtMzAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 37011,
+      "b64": "G1syNTsxNUgbWzkxbRtbNDg7MjszMTsxMDsxMG3igKYbWzExQxtbMzdtNDMbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 37068,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 37075,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG01NRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37141,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG04MBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37173,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 37208,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG05MxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37262,
+      "b64": "G1syNTsyNkgbWzM3bRtbNDg7MjszMTsxMDsxMG01MDUbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 37337,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG0zMBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37399,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjVDG1szN200MxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37471,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG01NRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37529,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjVDG1szN202OBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37593,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG05MxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37647,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI0QxtbMzdtNjA1G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 37709,
+      "b64": "G1syNTsyN0gbWzM3bRtbNDg7MjszMTsxMDsxMG0xMhtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37779,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjU7MUgbWzkxbeKcohtbMjVDG1szN20yMxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 37848,
+      "b64": "G1syNTsyOEgbWzM3bRtbNDg7MjszMTsxMDsxMG03G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 37912,
+      "b64": "G1szQRtbOTNtG1s0ODsyOzMxOzEwOzEwbUMbWzE0QxtbMzdtMjAbWzdDMzAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 37983,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1syQxtbOTNtYRtbMjNDG1szN20zG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 38029,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 38041,
+      "b64": "G1syNTs1SBtbOTNtG1s0ODsyOzMxOzEwOzEwbXIbWzIyQxtbMzdtNRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 38107,
+      "b64": "G1szQRtbOTFtG1s0ODsyOzMxOzEwOzEwbUNhG1tDG1s5M21hbRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 38175,
+      "b64": "G1syNTs1SBtbOTFtG1s0ODsyOzMxOzEwOzEwbXIbWzJDG1s5M21lG1sxOUMbWzM3bTYbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 38219,
+      "b64": "G1syNTs2SBtbOTFtG1s0ODsyOzMxOzEwOzEwbWEbWzJDG1s5M21sG1sxOEMbWzM3bTgbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 38290,
+      "b64": "G1syNTs3SBtbOTFtG1s0ODsyOzMxOzEwOzEwbW0bWzJDG1s5M21pG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 38352,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbNkNlbBtbQxtbOTNtemkbWzE1QxtbMzdtORtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 38383,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 38421,
+      "b64": "G1syNTsxMEgbWzkxbRtbNDg7MjszMTsxMDsxMG1pG1syQxtbOTNtbhtbMTNDG1szN200MBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 38490,
+      "b64": "G1syNTsxMUgbWzkxbRtbNDg7MjszMTsxMDsxMG16G1syQxtbOTNtZxtbMTNDG1szN20xG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 38556,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzEwQ2luG1tDG1s5M23igKYbWzEyQxtbMzdtMhtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 38602,
+      "b64": "G1syNTsxNEgbWzkxbRtbNDg7MjszMTsxMDsxMG1nG1sxM0MbWzM3bTMbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 38669,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMTND4oCmG1sxMkMbWzM3bTQbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 38727,
+      "b64": "G1szQRtbOTNtG1s0ODsyOzMxOzEwOzEwbUNhchtbMThDG1szN23ihpMbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 38774,
+      "b64": "G1syNTs1SBtbOTFtG1s0ODsyOzMxOzEwOzEwbXIbWzIyQxtbMzdtNRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 38878,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjZDG1szN203G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 38994,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 38995,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjU7MUgbWzkxbeKcvRtbMkNhG1sxNEMbWzM3bTEbWzhDORtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 39214,
+      "b64": "G1szQRtbOTFtG1s0ODsyOzMxOzEwOzEwbUMbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 39247,
+      "b64": "G1syNTszNkgbWzM3bRtbNDg7MjszMTsxMDsxMG0gwrcgG1szODs1OzI0OG10aGlua2luZxtbMzdtKRtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 39442,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMzdDG1szODs1OzI0OW10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 39557,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 39607,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 39677,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 39784,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 39891,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG0yG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 39953,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 39997,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1szN0MbWzM4OzU7MjQ4bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 40209,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 40225,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 40446,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMzdDG1szODs1OzI0Nm10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 40559,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 40672,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 40785,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 40817,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 40907,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG0zG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 40917,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 41008,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMzdDG1szODs1OzI0N210aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 41124,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ4bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 41422,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 41455,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMzdDG1szODs1OzI0OW10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 41572,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 41685,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 41804,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 41873,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 41902,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG00G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 42014,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1szN0MbWzM4OzU7MjQ4bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 42030,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 42244,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 42359,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 42464,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ2bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 42573,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 42643,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 42687,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 42805,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMTNDG1s5M23igKYbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 42831,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 42909,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG01G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 43020,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMTJDG1s5M21nG1syNEMbWzM4OzU7MjQ3bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 43142,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ4bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 43248,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI1OzEzSBtbOTNtbhtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 43367,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMTBDG1s5M21pG1syQxtbOTFt4oCmG1syM0MbWzM4OzU7MjQ5bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 43595,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbOUMbWzkzbXobWzJDG1s5MW1nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 43705,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 43793,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 43818,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbOEMbWzkzbWkbWzJDG1s5MW1uG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 43867,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 43919,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG02G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 44030,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1s3QxtbOTNtbBtbMkMbWzkxbWkbWzI2QxtbMzg7NTsyNDhtdGhpbmtpbmcbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 44185,
+      "b64": "G1syNTs4SBtbOTNtG1s0ODsyOzMxOzEwOzEwbWUbWzJDG1s5MW16G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 44265,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 44370,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbNUMbWzkzbW0bWzJDG1s5MW1pG1syOEMbWzM4OzU7MjQ2bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 44466,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 44621,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzRDG1s5M21hG1syQxtbOTFtbBtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 44707,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 44755,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 44823,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbM0MbWzkzbXIbWzJDG1s5MW1lG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 44928,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG03G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 45044,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMkMbWzkzbWEbWzJDG1s5MW1tG1szMUMbWzM4OzU7MjQ3bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 45075,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 45158,
+      "b64": "G1szQRtbOTNtG1s0ODsyOzMxOzEwOzEwbUMbWzJDG1s5MW1hG1szMkMbWzM4OzU7MjQ4bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 45373,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbM0NyG1szM0MbWzM4OzU7MjQ5bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 45601,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMkNhG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 45690,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 45721,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 45723,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 45832,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbQ0MbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 45936,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG04G1sxOUMbWzM4OzU7MjQ4bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 46089,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 46278,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 46302,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 46399,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMzdDG1szODs1OzI0Nm10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 46605,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 46675,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 46717,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 46831,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 46899,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 46947,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMTdDG1szN205G1sxOUMbWzM4OzU7MjQ3bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 47171,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ4bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 47397,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMzdDG1szODs1OzI0OW10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 47514,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 47624,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 47637,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 47743,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 47845,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 47960,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1sxNkMbWzM3bTMwG1sxOUMbWzM4OzU7MjQ4bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 48147,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 48331,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 48398,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMzdDG1szODs1OzI0Nm10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 48600,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 48627,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 48729,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 48744,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 48856,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 48975,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMTdDG1szN20xG1sxOUMbWzM4OzU7MjQ3bXRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 49195,
+      "b64": "G1syNTszOUgbWzM4OzU7MjQ4bRtbNDg7MjszMTsxMDsxMG10aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 49311,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ4bRtbNDg7MjszMTsxMDsxMG1zdGlsbCB0aGlua2luZxtbMzdtKRtbMzltG1tLG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 49338,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 49410,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjJDG1szODs1OzI0OW1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 49520,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 49558,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 49749,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 49857,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 49946,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 49976,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1sxN0MbWzM3bTIbWzRDG1szODs1OzI0OG1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 50203,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 50426,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjJDG1szODs1OzI0Nm1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 50521,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 50534,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 50550,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 50759,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 50864,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 51017,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMTdDG1szN20zG1s0QxtbMzg7NTsyNDdtc3RpbGwgdGhpbmtpbmcbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 51168,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 51199,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ4bRtbNDg7MjszMTsxMDsxMG1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 51434,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjJDG1szODs1OzI0OW1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 51480,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 51549,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 51657,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 51772,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 51872,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 52033,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1sxN0MbWzM3bTQbWzRDG1szODs1OzI0OG1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 52209,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 52377,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 52476,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 52477,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjJDG1szODs1OzI0Nm1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 52556,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 52652,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 52916,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMTdDG1szN201G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 52976,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 52992,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcvRtbMjJDG1szODs1OzI0N21zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 53216,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ4bRtbNDg7MjszMTsxMDsxMG1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 53403,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 53445,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcuxtbMjJDG1szODs1OzI0OW1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 53558,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 53591,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 53675,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 53783,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 53891,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG02G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 54041,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbcK3G1syMkMbWzM4OzU7MjQ4bXN0aWxsIHRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 54199,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 54221,
+      "b64": "G1syNTsyNEgbWzM4OzU7MjQ3bRtbNDg7MjszMTsxMDsxMG1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 54382,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 54457,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcohtbMjJDG1szODs1OzI0Nm1zdGlsbCB0aGlua2luZxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 54572,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbSobWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 54680,
+      "b64": "G1syNTsxSBtbOTFtG1s0ODsyOzMxOzEwOzEwbeKcthtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 54780,
+      "b64": "G1syNTsxSBtbOTNtG1s0ODsyOzMxOzEwOzEwbRtbMW3inLsbW0MbKEIbW20bWzkzbRtbNDg7MjszMTsxMDsxMG1DYXJhbWVsaXppbmfigKYgG1s3Q3N0aWxsIHRoaW5raW5nG1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 54834,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbeKXjxtbMjg7M0gbKEIbW20="
+    },
+    {
+      "tMs": 54897,
+      "b64": "G1syNTsxOUgbWzM3bRtbNDg7MjszMTsxMDsxMG03G1syODszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 55016,
+      "b64": "G1syNTsxSBtbOTNtG1s0ODsyOzMxOzEwOzEwbRtbMW3inL0bWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 55328,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 55416,
+      "b64": "G1sxNjsxSBtbMzdtG1s0ODsyOzMxOzEwOzEwbSAbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 55466,
+      "b64": "G1syNTsxSBtbOTNtG1s0ODsyOzMxOzEwOzEwbRtbMW3inLsbWzI4OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 55574,
+      "b64": "G1syNTsxSBtbOTNtG1s0ODsyOzMxOzEwOzEwbRtbMW3inLYbWzI4OzNIGyhCG1tt"
+    }
+  ],
+  "scrollTrace": [
+    {
+      "tMs": 69,
+      "offset": 0
+    }
+  ]
+}

--- a/native/test/terminal/replay_command_truncation_1042_test.dart
+++ b/native/test/terminal/replay_command_truncation_1042_test.dart
@@ -1,0 +1,102 @@
+@Tags(['ffi'])
+library;
+
+// REPLAY coverage for #1042 — command anchors at unjoinable wraps.
+//
+// FIXTURE (the owner's +134 report, 2026-07-11T02-32-14, verbatim):
+//   claude_tool_result_multiline_cmd_55x32 — a Claude tool-result showing a
+//   genuinely MULTI-LINE command under one `⎿  $ ` prompt:
+//     `  ⎿  $ echo "=== LXC 109 status on pve ==="`   (row ends at col 43)
+//     `     ssh pve 'pct status 109 2>&1; …`          (deeper band, col 5)
+//     … four more hard-wrapped rows, the last TUI-truncated with `…`.
+//   OUTCOME for this trace: the anchor payload stays the FIRST line. The
+//   `⎿  $ echo …` head ends at col 43 — nowhere near the 55-col grid edge or
+//   any corroborated wrap column — so the seam onto the `ssh pve` band has NO
+//   boundary evidence, and a REAL newline separates the lines (joining would
+//   paste `…==="ssh pve…`, corrupted). This is the "genuinely unjoinable"
+//   case: the fix is HONESTY — the anchor carries maybeIncomplete=true (its
+//   successor is the block's deeper continuation band, rejected as a
+//   continuation), so the chip/toast can say so instead of silently handing
+//   over a partial command.
+//
+// RED→GREEN recall bonus on the EXISTING 07-02 fixture
+// (claude_tool_result_cmd_58x32): its wrangler command IS a single logical
+// line the TUI word-wrapped at col 56 (= cols-2) into the `⎿` band — before
+// #1042 the anchor truncated at `|| echo`; the in-block continuation join now
+// recovers the FULL command with the consumed space reinserted, and the blank
+// successor row keeps it UNMARKED.
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'replay_trace_harness.dart';
+
+Future<TerminalController> _replay(String fixture) async {
+  final trace = loadByteTrace('test/fixtures/replay/$fixture');
+  final controller = TerminalController(
+    config: TerminalConfig(cols: trace.cols, rows: trace.rows),
+  );
+  controller.registerTextPattern(TextPattern.osc8());
+  controller.registerTextPattern(TextPattern.url());
+  controller.registerTextPattern(TextPattern.path());
+  controller.registerTextPattern(TextPattern.command());
+  await replayTrace(controller, trace);
+  return controller;
+}
+
+List<StructuredAnchor> _commandAnchors(TerminalController c) =>
+    c.anchors.where((a) => a.patternId == 'command').toList();
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('REPLAY #1042 — owner multi-line tool command (unjoinable seam)', () {
+    const firstLine = 'echo "=== LXC 109 status on pve ==="';
+
+    test('the anchor payload is the first command line, marked '
+        'maybeIncomplete (honest partial copy)', () async {
+      final controller = await _replay(
+          'claude_tool_result_multiline_cmd_55x32.byte-trace.json');
+      addTearDown(controller.dispose);
+
+      final cmds = _commandAnchors(controller);
+      expect(cmds, isNotEmpty,
+          reason: r'the `⎿  $ echo …` row is a strong-prompt command');
+      for (final a in cmds) {
+        expect(a.payload, firstLine,
+            reason: 'the seam onto the `ssh pve` band has no boundary '
+                'evidence — it must NOT join (a real newline separates the '
+                'lines; gluing corrupts the paste)');
+        expect(a.maybeIncomplete, isTrue,
+            reason: 'the deeper-indent successor was rejected as a '
+                'continuation — the anchor must say the copy may be '
+                'incomplete (#1042, the owner report)');
+      }
+    });
+  });
+
+  group(r'REPLAY #1042 — 07-02 `⎿  $ ` wrangler word-wrap (recall)', () {
+    test('the word-wrapped wrangler command joins FULLY, space reinserted, '
+        'unmarked', () async {
+      final controller =
+          await _replay('claude_tool_result_cmd_58x32.byte-trace.json');
+      addTearDown(controller.dispose);
+
+      final cmds = _commandAnchors(controller);
+      expect(cmds, isNotEmpty);
+      for (final a in cmds) {
+        expect(
+          a.payload,
+          'command -v wrangler && wrangler --version || echo '
+          '"wrangler: NOT on PATH"',
+          reason: 'the head row ends at col 56 (= cols-2, the TUI word-wrap '
+              'margin) and the continuation sits in the `⎿` band — the '
+              'in-block join must recover the whole command and reinsert '
+              'the space the wrap consumed',
+        );
+        expect(a.maybeIncomplete, isFalse,
+            reason: 'a blank row ends the block — nothing was left behind');
+      }
+    });
+  });
+}

--- a/native/test/ui/ghostty_gutter_command_test.dart
+++ b/native/test/ui/ghostty_gutter_command_test.dart
@@ -382,5 +382,99 @@ void main() {
       await tester.pump();
       expect(find.byKey(const Key('gutter-mark-5')), findsNothing);
     });
+
+    // #1042 — the maybeIncomplete honesty affordances: the chip renders an
+    // ellipsis-marked variant (same size), the copy toast says so, and the
+    // multi-match sheet carries a one-line note. No modals.
+    group('maybeIncomplete affordances (#1042)', () {
+      StructuredAnchor incompleteAnchor({List<int> rows = const [5]}) =>
+          StructuredAnchor(
+            patternId: kGhosttyCommandPatternId,
+            payload: _command,
+            maybeIncomplete: true,
+            ranges: [
+              for (final r in rows)
+                HighlightRange(
+                  startRow: r,
+                  startCol: 0,
+                  endRow: r,
+                  endCol: 20,
+                  payload: _command,
+                ),
+            ],
+          );
+
+      testWidgets('an incomplete command anchor renders the ellipsis chip '
+          'variant', (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([incompleteAnchor(rows: const [5])]);
+        await tester.pump();
+        final icon = tester.widget<Icon>(
+          find.descendant(
+            of: find.byKey(const Key('gutter-mark-5')),
+            matching: find.byType(Icon),
+          ),
+        );
+        expect(icon.icon, kGutterIncompleteIcon,
+            reason: 'the incomplete variant is the ellipsis-marked glyph');
+        expect(icon.icon, isNot(Icons.terminal));
+        expect(icon.size, GutterMarkStyle.normal.glyphSize,
+            reason: 'same size as the normal chip glyph');
+      });
+
+      testWidgets('tap the incomplete chip → copies the payload, toast reads '
+          '"Copied — may be incomplete"', (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([incompleteAnchor(rows: const [5])]);
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('gutter-mark-5')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(lastClipboard, _command,
+            reason: 'the copy itself is unchanged — the toast is the hedge');
+        expect(find.text('Copied — may be incomplete'), findsOneWidget);
+        await drainToast(tester);
+      });
+
+      testWidgets('a COMPLETE command anchor keeps the normal toast text',
+          (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([_commandAnchor(rows: const [5])]);
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('gutter-mark-5')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(lastClipboard, _command);
+        expect(find.textContaining('Copied:'), findsOneWidget);
+        expect(find.textContaining('may be incomplete'), findsNothing);
+        await drainToast(tester);
+      });
+
+      testWidgets('the multi-match sheet shows the one-line note and its '
+          '"Copy command" toast hedges too', (tester) async {
+        final controller = await pumpLayer(tester);
+        controller.setAnchors([
+          incompleteAnchor(rows: const [3]),
+          _urlAnchor(row: 3),
+        ]);
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('gutter-mark-3')));
+        await tester.pumpAndSettle();
+        expect(find.byKey(const Key('gutter-pattern-list')), findsOneWidget);
+        expect(find.text('Command — may be incomplete'), findsOneWidget,
+            reason: 'the sheet subtitle is the one-line note');
+
+        await tester.tap(find.byKey(const Key('gutter-item-0-copy')));
+        await tester.pumpAndSettle();
+        expect(lastClipboard, _command);
+        expect(find.text('Copied — may be incomplete'), findsOneWidget);
+        await drainToast(tester);
+      });
+    });
   });
 }

--- a/native/third_party/flterm/lib/src/foundation/structured_text.dart
+++ b/native/third_party/flterm/lib/src/foundation/structured_text.dart
@@ -129,6 +129,15 @@ final class TextPattern {
   /// their final occurrence.
   final int? rangeGroup;
 
+  /// Non-null iff this pattern is a COMMAND source ([TextPattern.command],
+  /// #998 B) — the scorer lexicon the factory captured. #1042 uses it two
+  /// ways: the scanner's IN-BLOCK continuation join re-runs the establishment
+  /// probe (strong prompt + scored body) on the accumulating logical line,
+  /// and only command matches are evaluated for [StructuredMatch.maybeIncomplete].
+  /// Null for every non-command pattern (URL/path/OSC-8/custom) — zero
+  /// behavior change there.
+  final Set<String>? commandLexicon;
+
   const TextPattern({
     required this.id,
     required this.regex,
@@ -138,6 +147,7 @@ final class TextPattern {
     this.isOsc8Source = false,
     this.tier = TextTier.span,
     this.rangeGroup,
+    this.commandLexicon,
   });
 
   /// The built-in URL pattern (#726/#764 moved in-fork, #767).
@@ -278,6 +288,9 @@ final class TextPattern {
       tier: TextTier.block,
       rangeGroup: 1,
       normalize: (raw) => _extractCommand(raw, lexiconSet),
+      // #1042: marks this pattern as the command source — enables the
+      // scanner's in-block continuation join + maybeIncomplete marking.
+      commandLexicon: lexiconSet,
     );
   }
 
@@ -569,6 +582,13 @@ final RegExp _kCommandPattern =
 /// one). Distinguishes the two score thresholds in [_extractCommand].
 final RegExp _kStrongPromptProbe = RegExp('^(?:$_kStrongPromptAlt)');
 
+/// Whether a row's head (read from its content start) is ANY prompt shape —
+/// strong or weak (#1042). A fresh prompt row is a SIBLING entry: it ends a
+/// command block for both the in-block continuation join and the
+/// maybeIncomplete marking (a successor prompt means the block legitimately
+/// finished, not that its wrap was lost).
+final RegExp _kAnyPromptProbe = RegExp('^(?:$_kStrongPromptAlt|$_kWeakPromptAlt)');
+
 /// A leading `VAR=value` shell assignment token (+1, counted once).
 final RegExp _kAssignmentToken = RegExp(r'^[A-Za-z_][A-Za-z0-9_]*=\S*$');
 
@@ -646,11 +666,23 @@ final class StructuredMatch {
   /// covered by both tiers. Defaults to [TextTier.span].
   final TextTier tier;
 
+  /// #1042: true when this COMMAND match's payload is LIKELY TRUNCATED — its
+  /// last row's successor was REJECTED as a wrap continuation while still
+  /// looking like block content (non-blank, not a fresh prompt, not a new
+  /// block) AND either the last row's content reaches the wrap boundary
+  /// (the #1007 corroborated-wrapCol / grid-edge machinery) or the successor
+  /// sits DEEPER than the block indent (the Claude-TUI continuation band —
+  /// the owner-trace shape). The join itself stays boundary-gated (precision
+  /// stance); this flag is the honesty valve the widget layer surfaces
+  /// ("Copied — may be incomplete"). Always false for non-command patterns.
+  final bool maybeIncomplete;
+
   const StructuredMatch({
     required this.patternId,
     required this.ranges,
     required this.payload,
     this.tier = TextTier.span,
+    this.maybeIncomplete = false,
   });
 
   /// Returns true if the cell at ABSOLUTE ([row], [col]) falls in any range.
@@ -691,17 +723,24 @@ final class StructuredAnchor {
   /// a soft-wrapped match spans (a single-row match has exactly one).
   final List<HighlightRange> ranges;
 
+  /// #1042: whether the underlying command match's payload is LIKELY
+  /// TRUNCATED (see [StructuredMatch.maybeIncomplete]) — the widget layer
+  /// renders the incomplete chip variant / hedged copy toast off this.
+  final bool maybeIncomplete;
+
   const StructuredAnchor({
     required this.patternId,
     required this.payload,
     required this.ranges,
+    this.maybeIncomplete = false,
   });
 
   /// Builds an anchor from a detected [StructuredMatch].
   StructuredAnchor.fromMatch(StructuredMatch match)
     : patternId = match.patternId,
       payload = match.payload,
-      ranges = match.ranges;
+      ranges = match.ranges,
+      maybeIncomplete = match.maybeIncomplete;
 
   /// Returns true if the cell at ABSOLUTE ([row], [col]) falls in any range.
   bool contains(int row, int col) {
@@ -830,7 +869,21 @@ class StructuredTextScanner {
 
     if (regexPatterns.isEmpty) return matches;
 
-    final lines = _assembleLines(reader, rows, cols);
+    // #1042: the wrap-column inference is shared by the line assembly's join
+    // gates AND the maybeIncomplete boundary test below, so it is computed
+    // once here. The command lexicon (non-null only when a TextPattern.command
+    // is registered) arms the in-block continuation join inside the assembly.
+    final (wrapCol, wrapColCount) = _inferWrapCol(reader, rows, cols);
+    Set<String>? commandLexicon;
+    for (final p in regexPatterns) {
+      if (p.commandLexicon != null) {
+        commandLexicon = p.commandLexicon;
+        break;
+      }
+    }
+
+    final lines = _assembleLines(
+        reader, rows, cols, wrapCol, wrapColCount, commandLexicon);
     for (final line in lines) {
       final text = line.text;
       if (text.isEmpty) continue;
@@ -892,12 +945,19 @@ class StructuredTextScanner {
             payload,
           );
           if (ranges.isEmpty) continue;
+          // #1042: a COMMAND match whose successor row was rejected as a
+          // continuation while still looking like block content is LIKELY
+          // TRUNCATED — mark it so the widget layer can say so.
+          final maybeIncomplete = pattern.commandLexicon != null &&
+              _commandMaybeIncomplete(
+                  reader, line, cols, wrapCol, wrapColCount);
           matches.add(
             StructuredMatch(
               patternId: pattern.id,
               ranges: ranges,
               payload: payload,
               tier: pattern.tier,
+              maybeIncomplete: maybeIncomplete,
             ),
           );
         }
@@ -997,16 +1057,23 @@ class StructuredTextScanner {
   /// AUTHORITATIVE [CellReader.rowWrap] flag (never guessed from width). A
   /// blank cell becomes a single space so column positions stay aligned and a
   /// URL never silently swallows a gap.
-  List<_LogicalLine> _assembleLines(CellReader reader, int rows, int cols) {
+  /// [wrapCol]/[wrapColCount] are [_inferWrapCol]'s result, hoisted to the
+  /// caller (#1042) so the maybeIncomplete boundary test shares the exact
+  /// inference the join gates use: the dominant content-end among long rows —
+  /// an app (Claude TUI, gh, a pager) often wraps NARROWER than the terminal
+  /// and PADS the rest of the row with blanks, so joining must key off where
+  /// wrapped rows ACTUALLY end, not the terminal edge. [commandLexicon]
+  /// (non-null iff a [TextPattern.command] is registered) arms the #1042
+  /// in-block continuation join.
+  List<_LogicalLine> _assembleLines(
+    CellReader reader,
+    int rows,
+    int cols,
+    int wrapCol,
+    int wrapColCount,
+    Set<String>? commandLexicon,
+  ) {
     final base = reader.baseAbsRow;
-    // Infer the app's WRAP COLUMN — the dominant content-end among long rows. An
-    // app (Claude TUI, gh, a pager) often wraps NARROWER than the terminal and
-    // PADS the rest of the row with blanks, so the terminal's last cell is empty
-    // even on a wrapped row (the device bug: a plain-text URL wrapping at the
-    // CLI's ~53-col content width in a 55-col terminal only bubbled/copied its
-    // first row). Joining must key off where wrapped rows ACTUALLY end, not the
-    // terminal edge.
-    final (wrapCol, wrapColCount) = _inferWrapCol(reader, rows, cols);
     final lines = <_LogicalLine>[];
     var r = 0;
     while (r < rows) {
@@ -1085,24 +1152,59 @@ class StructuredTextScanner {
           final content = reader.cellContent(r, c);
           glyphs.add(_Glyph(content.isEmpty ? ' ' : content, absRow, c));
         }
-        if (r < rows - 1 &&
-            _continuesOnto(reader, r, cols, wrapCol, wrapColCount, blockIndent,
-                hangIndent, hangHeadEnd)) {
-          final widthJoin = !reader.rowWrap(r);
-          // #998 B: a width-join whose continuation starts DEEPER than the
-          // block indent is the #996 hanging shape — record the hanging
-          // indent + the head row's content-end so subsequent rows of this
-          // block can continue at the same discipline (see _continuesOnto).
-          if (widthJoin && hangIndent < 0) {
-            final nextStart = _contentStart(reader, r + 1, cols);
-            if (nextStart > blockIndent) {
-              hangIndent = nextStart;
-              hangHeadEnd = _contentEnd(reader, r, cols);
-            }
+        if (r < rows - 1) {
+          var continues = _continuesOnto(reader, r, cols, wrapCol,
+              wrapColCount, blockIndent, hangIndent, hangHeadEnd);
+          // #1042: IN-BLOCK continuation join — an ESTABLISHED command block
+          // (the accumulated line already carries a STRONG prompt + scored
+          // body, the #998 B/#1013 machinery) whose head row reaches the wrap
+          // boundary continues onto a non-blank, non-prompt, non-new-block
+          // successor even without URL-token evidence. Evaluated only AFTER
+          // every pre-existing rule rejected, so URL/hang joins keep their
+          // exact behavior (and their mid-token spaceless gluing).
+          var commandJoin = false;
+          if (!continues && commandLexicon != null) {
+            commandJoin = _commandBlockContinues(reader, r, cols, wrapCol,
+                wrapColCount, glyphs, commandLexicon);
+            continues = commandJoin;
           }
-          viaWidthJoin = widthJoin;
-          r++;
-          continue;
+          if (continues) {
+            final widthJoin = !reader.rowWrap(r);
+            // #998 B: a width-join whose continuation starts DEEPER than the
+            // block indent is the #996 hanging shape — record the hanging
+            // indent + the head row's content-end so subsequent rows of this
+            // block can continue at the same discipline (see _continuesOnto).
+            if (widthJoin && hangIndent < 0) {
+              final nextStart = _contentStart(reader, r + 1, cols);
+              if (nextStart > blockIndent) {
+                hangIndent = nextStart;
+                hangHeadEnd = _contentEnd(reader, r, cols);
+              }
+            }
+            if (commandJoin) {
+              // #1042: a command seam whose head ends SHORT of the grid edge
+              // is a TUI WORD wrap — the breaking space was consumed by the
+              // wrap (the 07-02 wrangler trace: `|| echo` / `"wrangler: NOT
+              // on PATH"` with no space cell anywhere), so joining spaceless
+              // would corrupt the paste (`echo"wrangler…`). Reinsert ONE
+              // space, tagged to the head row's first padding cell so range
+              // mapping stays cell-true. A head ending EXACTLY at the grid
+              // edge is a mid-token hard break (every char preserved) and
+              // glues spaceless, like the URL joins. Residual accepted risk:
+              // a mid-token TUI break at a content width SHORT of the grid
+              // edge (no URL evidence, so no pre-#1042 rule claimed it) gains
+              // a wrong internal space — still strictly better than the
+              // silent first-row truncation it replaces, and the marking
+              // rules keep the copy honest.
+              final end = _contentEnd(reader, r, cols);
+              if (end < cols) {
+                glyphs.add(_Glyph(' ', absRow, end));
+              }
+            }
+            viaWidthJoin = widthJoin;
+            r++;
+            continue;
+          }
         }
         break;
       }
@@ -1271,6 +1373,111 @@ class StructuredTextScanner {
       return false;
     }
     return true;
+  }
+
+  /// #1042 in-block continuation: whether an ESTABLISHED command block whose
+  /// accumulated line is [glyphs] continues from local row [r] onto row [r]+1.
+  ///
+  /// Runs ONLY after every pre-existing join rule rejected the seam, and only
+  /// when a [TextPattern.command] is registered ([lexicon] non-null at the
+  /// caller). Bounded liberality (#1042): the block is already a
+  /// STRONG-prompt command with a scored body (re-probed on the accumulated
+  /// text — weak `$`/`❯` prompts never get the liberal join), the head row's
+  /// content REACHES the wrap boundary ([_reachesWrapBoundary] — the #1007
+  /// corroborated-wrapCol / grid-edge machinery, reused), and the successor
+  /// does not END the block: a blank row, a fresh prompt row (a sibling
+  /// entry), or a new-block start (bullet / fresh scheme) all stop it. The
+  /// successor's INDENT is deliberately unconstrained — a Claude-TUI
+  /// tool-result wraps its command into a deeper `⎿` band the same-margin
+  /// rule can never accept (the 07-02 wrangler trace), and the establishment
+  /// + boundary gates carry the precision instead.
+  bool _commandBlockContinues(
+    CellReader reader,
+    int r,
+    int cols,
+    int wrapCol,
+    int wrapColCount,
+    List<_Glyph> glyphs,
+    Set<String> lexicon,
+  ) {
+    if (glyphs.isEmpty) return false;
+    final end = _contentEnd(reader, r, cols);
+    if (!_reachesWrapBoundary(end, cols, wrapCol, wrapColCount)) return false;
+    final next = r + 1;
+    final nextStart = _contentStart(reader, next, cols);
+    if (nextStart >= cols) return false; // blank row: the block ended
+    if (_startsNewBlock(reader, next, cols, nextStart)) return false;
+    if (_isPromptRow(reader, next, cols, nextStart)) return false;
+    // Establishment LAST (the costliest gate): the accumulated line must
+    // already BE a strong-prompt command per the #998 B scorer.
+    final text = _LogicalLine(glyphs).text;
+    return _kStrongPromptProbe.hasMatch(text) &&
+        _extractCommand(text, lexicon) != null;
+  }
+
+  /// #1042: whether content ending at column [end] reaches the wrap boundary.
+  ///
+  /// Reuses the #1007 machinery: the inferred [wrapCol] is trusted when
+  /// CORROBORATED (>= 2 long rows end there) or itself at/near the grid edge,
+  /// and the reach test keeps the 1-col wide-char/pad slack. Independently,
+  /// content within 2 cols of the GRID edge reaches it — the fixed right
+  /// margin a TUI reserves (the #1007 doc's 53-in-55 Claude-TUI capture; the
+  /// 07-02 wrangler trace word-wraps at 56-in-58). Do NOT widen the 2-col
+  /// tolerance without a real captured trace.
+  bool _reachesWrapBoundary(int end, int cols, int wrapCol, int wrapColCount) {
+    if (wrapCol > 0 &&
+        (wrapColCount >= 2 || wrapCol >= cols - 2) &&
+        end >= wrapCol - 1) {
+      return true;
+    }
+    return end >= cols - 2;
+  }
+
+  /// #1042: whether local [row], read from its content start [from], begins
+  /// with ANY prompt shape (strong or weak — [_kAnyPromptProbe]). 40 head
+  /// chars cover the longest realistic `user@host:path$ ` prompt.
+  bool _isPromptRow(CellReader reader, int row, int cols, int from) =>
+      _kAnyPromptProbe.hasMatch(_rowHead(reader, row, cols, from, 40));
+
+  /// #1042: whether a COMMAND match on [line] is LIKELY TRUNCATED — the
+  /// honesty-valve signal behind [StructuredMatch.maybeIncomplete].
+  ///
+  /// True iff the line's last row has a successor that was REJECTED as a
+  /// continuation (it follows an assembled line, so every join rule already
+  /// declined it) while still looking like block content — non-blank, not a
+  /// fresh prompt row, not a new-block start — AND the evidence points at a
+  /// lost wrap:
+  ///   * the last row's content reaches the wrap boundary
+  ///     ([_reachesWrapBoundary]) — it filled up, yet nothing joined (e.g. a
+  ///     WEAK-prompt command, which never gets the #1042 in-block join); OR
+  ///   * the successor sits DEEPER than the block indent — the Claude-TUI
+  ///     continuation band (the owner trace: `  ⎿  $ echo …` whose
+  ///     genuinely multi-line command continues at the deeper `ssh pve` band
+  ///     that no boundary evidence may join).
+  /// Everything else stays silent: a blank row, a fresh prompt, a new block,
+  /// or a same-indent short row (a bash command followed by its output) are
+  /// legitimate block ends, and an absent successor (window edge) proves
+  /// nothing. Accepted hedge: a complete `⎿  $ cmd` whose OUTPUT paints in
+  /// the same deeper band reads as "MAY be incomplete" — a hedge glyph/toast,
+  /// never a modal, and strictly better than a silent partial copy.
+  bool _commandMaybeIncomplete(
+    CellReader reader,
+    _LogicalLine line,
+    int cols,
+    int wrapCol,
+    int wrapColCount,
+  ) {
+    if (line.glyphs.isEmpty) return false;
+    final lastLocal = line.glyphs.last.absRow - reader.baseAbsRow;
+    final next = lastLocal + 1;
+    if (next >= reader.rows) return false; // successor unknown → stay silent
+    final nextStart = _contentStart(reader, next, cols);
+    if (nextStart >= cols) return false; // blank row: legitimate end
+    if (_startsNewBlock(reader, next, cols, nextStart)) return false;
+    if (_isPromptRow(reader, next, cols, nextStart)) return false;
+    final end = _contentEnd(reader, lastLocal, cols);
+    if (_reachesWrapBoundary(end, cols, wrapCol, wrapColCount)) return true;
+    return nextStart > line.glyphs.first.col;
   }
 
   /// Whether local [row]'s LAST whitespace-delimited token looks like a split

--- a/native/third_party/flterm/test/foundation/structured_text_command_incomplete_1042_test.dart
+++ b/native/third_party/flterm/test/foundation/structured_text_command_incomplete_1042_test.dart
@@ -1,0 +1,268 @@
+// #1042 — command anchors at unjoinable wraps: bounded IN-BLOCK continuation
+// joins + the `maybeIncomplete` honesty marking.
+//
+// Owner device report (+134, trace 2026-07-11T02-32-14): a wrapped command
+// anchored only its FIRST row and the copy gave a partial command with NO
+// indication. Two-part fix, tested here at the scanner level:
+//
+//   * RECALL (bounded): within an ESTABLISHED command block (STRONG prompt +
+//     scored body — the #998 B/#1013 machinery), a head row whose content
+//     reaches the wrap boundary (the #1007 corroborated-wrapCol / grid-edge
+//     machinery, reused) continues onto the next row even without URL-token
+//     evidence — stopping at blank rows, fresh prompt rows, and new-block
+//     starts. A word-wrap seam (head ends SHORT of the grid edge — the TUI
+//     consumed the breaking space) reinserts ONE space; an exact grid-edge
+//     seam is a mid-token hard break and joins spaceless.
+//   * HONESTY: when a command anchor's successor row was REJECTED as a
+//     continuation while looking like block content (non-blank, not a prompt,
+//     not a new block) AND either the anchor's last row reaches the wrap
+//     boundary OR the successor sits DEEPER than the block indent (the
+//     Claude-TUI continuation band — the owner-trace shape), the match/anchor
+//     carries `maybeIncomplete: true`. Precision stance unchanged: the join
+//     still demands boundary evidence; the marking is the honesty valve.
+//
+// Shapes below are REAL corpus text (the owner trace + the 07-02 wrangler
+// trace), not synthetic prose. The #1013 controls live in
+// structured_text_command_test.dart and must stay green alongside.
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pure headless [CellReader] from per-row text + soft-wrap flags (same seam
+/// as structured_text_command_test.dart).
+class _FakeCellReader implements CellReader {
+  _FakeCellReader(
+    List<String> rowTexts, {
+    required this.cols,
+    List<bool>? wraps,
+  }) : _rows = [
+         for (final t in rowTexts)
+           List<String>.generate(
+             cols,
+             (c) => c < t.length ? t[c] : ' ',
+           ),
+       ],
+       _wraps = wraps ?? List<bool>.filled(rowTexts.length, false);
+
+  final List<List<String>> _rows;
+  final List<bool> _wraps;
+
+  @override
+  final int cols;
+
+  @override
+  final int baseAbsRow = 0;
+
+  @override
+  int get rows => _rows.length;
+
+  @override
+  String cellContent(int row, int col) {
+    final ch = _rows[row][col];
+    return ch == ' ' ? '' : ch;
+  }
+
+  @override
+  bool rowWrap(int row) => row >= 0 && row < _wraps.length && _wraps[row];
+
+  @override
+  String? hyperlinkAt(int row, int col) => null;
+}
+
+void main() {
+  const scanner = StructuredTextScanner();
+  final command = TextPattern.command();
+  final url = TextPattern.url();
+
+  List<StructuredMatch> commandsIn(
+    List<String> rows, {
+    required int cols,
+    List<bool>? wraps,
+  }) {
+    final reader = _FakeCellReader(rows, cols: cols, wraps: wraps);
+    return scanner
+        .scan(reader, [url, command])
+        .where((m) => m.patternId == 'command')
+        .toList();
+  }
+
+  group('in-block continuation join (#1042 recall)', () {
+    test('a word-wrapped tool-result command joins with the consumed space '
+        'reinserted (the 07-02 wrangler shape, head ends at cols-2)', () {
+      // Real 07-02 trace shape: 58-col grid, head row content ends at col 56
+      // (the TUI word-wrapped at its 2-col right margin, eating the space),
+      // continuation at the deeper `⎿` band indent. No URL token anywhere —
+      // the pre-#1042 joins all reject this seam.
+      const row0 =
+          r'  ⎿  $ command -v wrangler && wrangler --version || echo';
+      const row1 = '     "wrangler: NOT on PATH"';
+      expect(row0.length, 56, reason: 'head must end at cols-2 (58-col grid)');
+      final cmds = commandsIn([row0, row1, ''], cols: 58);
+      expect(cmds, hasLength(1));
+      expect(
+        cmds.single.payload,
+        'command -v wrangler && wrangler --version || echo '
+        '"wrangler: NOT on PATH"',
+        reason: 'the word-wrap seam must reinsert the space the TUI consumed',
+      );
+      expect(cmds.single.maybeIncomplete, isFalse,
+          reason: 'a blank row legitimately ends the block — fully joined');
+    });
+
+    test('a mid-token hard break AT the grid edge joins WITHOUT a space', () {
+      // Head fills the grid exactly (end == cols): a hard break preserves
+      // every char, so the halves glue back spaceless. Deeper-indent
+      // continuation so no pre-#1042 rule claims the seam first.
+      const row0 = r'⎿  $ echo /tmp/veryverylongpa';
+      const row1 = '     th.txt';
+      final cols = row0.length; // end == cols → hard break
+      final cmds = commandsIn([row0, row1, ''], cols: cols);
+      expect(cmds, hasLength(1));
+      expect(cmds.single.payload, 'echo /tmp/veryverylongpath.txt');
+      expect(cmds.single.maybeIncomplete, isFalse);
+    });
+
+    test('the join STOPS at a fresh prompt row (no evidence-free gluing)', () {
+      // Head reaches the grid edge, but the next row is a new gutter-prompt
+      // entry — a sibling command, not a continuation. The sibling sits at a
+      // DEEPER indent so no pre-#1042 rule claims the seam (the same-margin
+      // width join has its own, pre-existing semantics at the grid edge).
+      const row0 = r'⎿  $ echo aaaaaaaaaaaaaaa';
+      const row1 = '  56      ls -la /tmp';
+      final cols = row0.length;
+      final cmds = commandsIn([row0, row1], cols: cols);
+      // The gutter row anchors as its OWN sibling command; the echo payload
+      // must stay first-line-only and unmarked (a prompt successor is a
+      // legitimate block end).
+      final echo =
+          cmds.where((m) => m.payload == 'echo aaaaaaaaaaaaaaa').toList();
+      expect(echo, hasLength(1));
+      expect(echo.single.maybeIncomplete, isFalse,
+          reason: 'a fresh prompt successor is a legitimate block end');
+    });
+
+    test('a WEAK-prompt command never in-block joins (strong prompts only)',
+        () {
+      // Weak `$ ` prompt, lexicon+flag+operator (score 4) — detected, but the
+      // liberal in-block join is reserved for STRONG prompts; the deeper
+      // successor stays out of the payload.
+      const row0 = r'  $ ls -la /tmp/some/dir | grep foobarbazqu';
+      const row1 = '     ux.txt';
+      final cols = row0.length; // reaches the grid edge
+      final cmds = commandsIn([row0, row1, ''], cols: cols);
+      expect(cmds, hasLength(1));
+      expect(cmds.single.payload, 'ls -la /tmp/some/dir | grep foobarbazqu');
+      expect(cmds.single.maybeIncomplete, isTrue,
+          reason: 'the rejected boundary-reaching seam is exactly the '
+              'honesty-valve case');
+    });
+
+    test('prose behind a strong prompt gets NO in-block join (no established '
+        'command, no anchor)', () {
+      const row0 = r'dev@fd-dev:~$ yes that looks right to me and more xy';
+      const row1 = '     indented follow-up prose';
+      final cols = row0.length;
+      final cmds = commandsIn([row0, row1], cols: cols);
+      expect(cmds, isEmpty,
+          reason: 'body score < 2 → never established → never joined');
+    });
+  });
+
+  group('maybeIncomplete truth table (#1042 honesty)', () {
+    // The owner-trace shape: a strong `⎿  $ ` command whose successor is the
+    // TUI's DEEPER-indented continuation band, with no boundary evidence at
+    // the seam (a genuinely multi-line command — joining would corrupt).
+    const ownerRow0 = r'  ⎿  $ echo "=== LXC 109 status on pve ==="';
+    const ownerRow1 = r"     ssh pve 'pct status 109 2>&1; pct exec 109 --";
+    const ownerCmd = 'echo "=== LXC 109 status on pve ==="';
+
+    test('deeper-indent rejected successor → maybeIncomplete=true, payload '
+        'stays the first line (the owner trace shape)', () {
+      final cmds = commandsIn([ownerRow0, ownerRow1], cols: 55);
+      expect(cmds, hasLength(1));
+      expect(cmds.single.payload, ownerCmd,
+          reason: 'seam has no boundary evidence — must NOT join (a real '
+              'newline separates the lines; gluing corrupts the paste)');
+      expect(cmds.single.maybeIncomplete, isTrue);
+    });
+
+    test('blank successor → false (the block legitimately ended)', () {
+      final cmds = commandsIn([ownerRow0, '', ownerRow1], cols: 55);
+      expect(cmds, hasLength(1));
+      expect(cmds.single.maybeIncomplete, isFalse);
+    });
+
+    test('fresh prompt successor → false', () {
+      final cmds =
+          commandsIn([ownerRow0, r'dev@fd-dev:~$ git status'], cols: 55);
+      final echo =
+          cmds.where((m) => m.payload == ownerCmd).toList();
+      expect(echo, hasLength(1));
+      expect(echo.single.maybeIncomplete, isFalse);
+    });
+
+    test('new-block (bullet) successor → false', () {
+      final cmds = commandsIn([ownerRow0, '     - a bullet item'], cols: 55);
+      expect(cmds, hasLength(1));
+      expect(cmds.single.maybeIncomplete, isFalse);
+    });
+
+    test('same-indent short-row successor (a bash command followed by its '
+        'output) → false', () {
+      final cmds = commandsIn(
+        [r'dev@fd-dev:~$ ls -la /tmp', 'total 40'],
+        cols: 55,
+      );
+      expect(cmds, hasLength(1));
+      expect(cmds.single.maybeIncomplete, isFalse,
+          reason: 'no boundary reach + no deeper band → nothing suggests a '
+              'truncated wrap');
+    });
+
+    test('no successor row in the buffer → false (stay silent on unknowns)',
+        () {
+      final cmds = commandsIn([ownerRow0], cols: 55);
+      expect(cmds, hasLength(1));
+      expect(cmds.single.maybeIncomplete, isFalse);
+    });
+
+    test('a fully JOINED wrapped command (soft-wrap flag) → false', () {
+      const row0 = r'dev@fd-dev:~$ curl -fsSL https://agent-hub.tailbe5094.ts.n';
+      const row1 = 'et:8444/setup.sh | bash  -s reset';
+      final cmds = commandsIn(
+        [row0, row1, ''],
+        cols: row0.length,
+        wraps: [true, false, false],
+      );
+      expect(cmds, hasLength(1));
+      expect(cmds.single.maybeIncomplete, isFalse);
+    });
+  });
+
+  group('anchor plumbing', () {
+    test('StructuredAnchor.fromMatch carries maybeIncomplete', () {
+      final reader = _FakeCellReader([
+        r'  ⎿  $ echo "=== LXC 109 status on pve ==="',
+        r"     ssh pve 'pct status 109 2>&1; pct exec 109 --",
+      ], cols: 55);
+      final match = scanner
+          .scan(reader, [command])
+          .singleWhere((m) => m.patternId == 'command');
+      expect(match.maybeIncomplete, isTrue);
+      final anchor = StructuredAnchor.fromMatch(match);
+      expect(anchor.maybeIncomplete, isTrue);
+    });
+
+    test('non-command matches never carry the flag', () {
+      final reader = _FakeCellReader(
+        ['see https://example.com/x for details', 'and more prose'],
+        cols: 55,
+      );
+      final matches = scanner.scan(reader, [url]);
+      expect(matches, isNotEmpty);
+      for (final m in matches) {
+        expect(m.maybeIncomplete, isFalse);
+      }
+    });
+  });
+}


### PR DESCRIPTION
# fix(native): command anchors at unjoinable wraps — in-block joins + honest "may be incomplete" (#1042)

Owner +134 report (trace `2026-07-11T02-32-14`): a wrapped command anchored only its first row and the copy was silently partial.

## Join-rule delta (one sentence)
Within an ESTABLISHED command block (strong prompt + scored body, re-probed on the accumulating line), a head row that reaches the wrap boundary (#1007 corroborated-wrapCol / grid-edge machinery, reused) now continues onto a non-blank, non-prompt, non-new-block successor without URL-token evidence — evaluated only after every existing rule rejected the seam, with ONE space reinserted at word-wrap seams (head short of the grid edge; an exact grid-edge break glues spaceless).

## Honesty valve
`maybeIncomplete` on `StructuredMatch`/`StructuredAnchor`: fires when the anchor's successor row was rejected as a continuation while still looking like block content AND (the last row reaches the wrap boundary OR the successor sits DEEPER than the block indent — the Claude-TUI band, the owner-trace shape). App: ellipsis chip variant (`kGutterIncompleteIcon`, same size), toast **"Copied — may be incomplete"**, one-line note in the chip sheet. No modals. Precision stance unchanged: no join without boundary evidence — the marking is how it stays honest.

## Fixture outcome (the owner trace)
`claude_tool_result_multiline_cmd_55x32.byte-trace.json` (verbatim) is the **genuinely unjoinable** case: the `⎿  $ echo "=== LXC 109 status on pve ==="` head ends at col 43 in a 55-col grid (no boundary evidence) and a REAL newline separates it from the `ssh pve …` band (joining would paste `…==="ssh pve…`, corrupted — the TUI even elides the tail with `…`). Outcome: payload stays line 1, `maybeIncomplete=true` → chip + toast say so.

**Red→green recall bonus:** the EXISTING `claude_tool_result_cmd_58x32` fixture's wrangler command was itself truncated at `|| echo` (word-wrapped at col 56 = cols-2). It now joins FULLY — `command -v wrangler && wrangler --version || echo "wrangler: NOT on PATH"` — with the consumed space reinserted, unmarked (blank successor).

## Tests
- Fork unit: `structured_text_command_incomplete_1042_test.dart` — 14 tests: join cases (word-wrap space, grid-edge spaceless, stop at prompt, weak-prompt exclusion, prose control) + maybeIncomplete truth table (deeper band TRUE; blank/prompt/bullet/same-indent-short/no-successor/joined FALSE). Red baseline confirmed by stashing the impl.
- Replay (ffi, every-commit): `replay_command_truncation_1042_test.dart` — owner fixture + wrangler red→green. All #1013 fixtures/controls green (`replay_command_block_998_test.dart`).
- Widget: incomplete chip variant, both toast texts, sheet note + hedged sheet copy (in `ghostty_gutter_command_test.dart`).
- Emulator (`command_incomplete_1042_test.dart` via `native-connect-test.sh`): CASE A — real soft-wrapped 103-char command at a live test-sshd prompt → FULL copy, normal chip/toast; CASE B — the owner TUI band painted at the live prompt → first-line copy, ellipsis chip, hedged toast. Screenshots below.
- Gates: fork suite 862 green (foreground), `native-fast-gate.sh` 2074 green.

## Screenshots
- `test-results/emulator-shots/*-1042-full-chip_.png` — wrapped command, normal terminal chip
- `test-results/emulator-shots/*-1042-incomplete-chip_.png` — owner-shape band, ellipsis chip
- `test-results/emulator-shots/*-1042-incomplete-toast_.png` — "Copied — may be incomplete"

## Honest caveats
- The issue's literal marking signal (last row at/near the boundary) does NOT fire on the owner trace itself (head ends col 43/55); the deeper-band successor clause was added so the reported case marks. A complete `⎿  $ cmd` whose tool OUTPUT paints in the same deeper band would also read "MAY be incomplete" — a hedge glyph/toast, accepted and documented.
- Space reinsertion keys on head-end < grid edge; a no-URL mid-token TUI break at a content width short of the edge would gain a wrong internal space (documented in code; strictly better than the silent truncation it replaces).
- A plain-shell heredoc/PS2 continuation does NOT mark (bare `>` is excluded by design since #998; a heredoc head shows no wrap evidence) — the emulator's unjoinable case reproduces the owner's actual TUI shape instead.
- Pre-existing behavior discovered (not changed): the same-margin width join at the grid edge will join a gutter-prompt sibling row (#925-class residual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa