### PR TITLE
feat(native): SSH local port forwarding (ssh -L) — ad hoc on live sessions + profile-armed defaults (#1047)

### DIFF
--- a/docker/test-sshd/Dockerfile
+++ b/docker/test-sshd/Dockerfile
@@ -8,9 +8,15 @@ RUN apk add --no-cache openssh-server bash tmux \
  && chmod 700 /home/testuser/.ssh
 
 # Allow password auth (for the password credential test path)
+# AllowTcpForwarding=local (#1047): the ssh -L integration test needs the
+# server to accept direct-tcpip channels. `local` permits ONLY local
+# forwarding — remote (-R) stays blocked, matching the app's v1 scope.
+# NOTE: Alpine's stock sshd_config ships an UNCOMMENTED `AllowTcpForwarding no`
+# and sshd honours the FIRST occurrence — an appended line is dead config, so
+# replace the existing directive in place.
 RUN sed -i 's/^#PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config \
  && sed -i 's/^#PermitEmptyPasswords .*/PermitEmptyPasswords no/' /etc/ssh/sshd_config \
- && echo 'AllowTcpForwarding no' >> /etc/ssh/sshd_config \
+ && sed -i 's/^AllowTcpForwarding .*/AllowTcpForwarding local/' /etc/ssh/sshd_config \
  && echo 'X11Forwarding no' >> /etc/ssh/sshd_config
 
 COPY testuser_id_ed25519.pub /home/testuser/.ssh/authorized_keys

--- a/native/integration_test/port_forward_1047_test.dart
+++ b/native/integration_test/port_forward_1047_test.dart
@@ -1,0 +1,296 @@
+// On-emulator ssh -L port-forward integration (#1047).
+//
+// The REAL proof: the headless engine/host tests fake the direct-tcpip
+// channel, so only this test exercises dartssh2's `forwardLocal` over a live
+// SSH connection. It drives the real app on the emulator against test-sshd:
+//
+//   1. Connect (Save & connect → a saved profile exists for the star toggle).
+//   2. Seed a TCP marker server ON test-sshd through the live shell:
+//      a nohup'd busybox `nc -l -p 8088` loop serving PF_OK_1047 per connect
+//      (nohup so the loop survives the deliberate session drop in step 6).
+//   3. Session menu → Port forwards sheet → add 18088 → 127.0.0.1:8088.
+//   4. HONEST probe: the test driver runs IN the app process, so a dart:io
+//      Socket connect to 127.0.0.1:18088 goes through the app's loopback
+//      listener → direct-tcpip channel → test-sshd's nc → asserts the marker.
+//   5. Star the forward as a profile default (store write, end to end).
+//   6. Drop the connection SERVER-side (kill the session's sshd from the
+//      shell) → auto-reconnect → the forward RE-ARMS → probe again.
+//   7. Remove the forward → connection refused + empty table.
+//
+// Screenshot: after step 4 the test HOLDS the sheet on screen (~8s, logged
+// with PF_SHEET_HOLD markers) so an external `scripts/emu-shot.sh` captures
+// the sheet with an ACTIVE forward — screenshots ARE the review artifact.
+//
+// Network: scripts/native-connect-test.sh bridges emulator 127.0.0.1:2222 →
+// test-sshd:22. The forwarded target (127.0.0.1:8088) is test-sshd's OWN
+// loopback — reachable only through the tunnel, so a passing probe cannot be
+// a bridge artifact.
+
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/ssh/ssh_session.dart' show SshSessionState;
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+const _marker = 'PF_OK_1047';
+
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+Future<bool> _reachTerminal(WidgetTester tester) {
+  return _pumpUntil(
+    tester,
+    () => find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+  );
+}
+
+/// Open the session menu via the bottom bar (#782 idiom — see
+/// sftp_browse_smoke_test.dart for why the InkWell, not the icon Row).
+Future<void> _openSessionMenu(WidgetTester tester) async {
+  await tester.testTextInput.receiveAction(TextInputAction.done);
+  await tester.pump(const Duration(milliseconds: 200));
+  final trigger = find.byKey(const Key('session-bar-open-menu'));
+  await tester.ensureVisible(trigger);
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.tap(trigger, warnIfMissed: false);
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('session-menu-new')).evaluate().isNotEmpty,
+    maxSlices: 20,
+  );
+}
+
+/// Send [command] through the live PTY and wait for [sentinel] to echo back.
+Future<void> _shellRun(
+  WidgetTester tester,
+  SessionEntry entry, {
+  required String command,
+  required String sentinel,
+  int maxSlices = 40,
+}) async {
+  final out = <int>[];
+  final sub = entry.proxy.output.listen(out.addAll);
+  addTearDown(sub.cancel);
+  await tester.pump(const Duration(milliseconds: 200));
+  entry.proxy.sendInput(Uint8List.fromList(utf8.encode('$command\n')));
+  final ok = await _pumpUntil(
+    tester,
+    () => utf8.decode(out, allowMalformed: true).contains(sentinel),
+    maxSlices: maxSlices,
+  );
+  expect(ok, isTrue, reason: 'shell command never echoed sentinel $sentinel');
+}
+
+/// The honest probe: dial the FORWARDED local port from inside the app
+/// process and read everything until the far side closes.
+Future<String> _probeForwardedPort(int port) async {
+  final socket = await Socket.connect(
+    InternetAddress.loopbackIPv4,
+    port,
+    timeout: const Duration(seconds: 5),
+  );
+  final got = <int>[];
+  final done = Completer<void>();
+  socket.listen(
+    got.addAll,
+    onDone: () {
+      if (!done.isCompleted) done.complete();
+    },
+    onError: (Object _) {
+      if (!done.isCompleted) done.complete();
+    },
+  );
+  await done.future.timeout(
+    const Duration(seconds: 8),
+    onTimeout: () => socket.destroy(),
+  );
+  socket.destroy();
+  return utf8.decode(got, allowMalformed: true);
+}
+
+ForwardInfo? _forwardOf(SessionEntry entry, int localPort) {
+  for (final f in entry.proxy.forwards) {
+    if (f.localPort == localPort) return f;
+  }
+  return null;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'ssh -L: add via sheet → marker through tunnel; survives drop→reconnect; '
+    'remove → refused (#1047)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // 1) Connect. Save & connect persists a profile, so the star toggle
+      // (profile default) is exercisable later.
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      expect(await _reachTerminal(tester), isTrue,
+          reason: 'never reached the terminal screen');
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+
+      // 2) Marker server on test-sshd's loopback. nohup: the loop must
+      // survive the deliberate session drop in step 6.
+      await _shellRun(
+        tester,
+        entry!,
+        command:
+            "nohup sh -c 'while true; do echo $_marker | nc -l -p 8088; done' "
+            '>/dev/null 2>&1 & echo SRV_UP_1047',
+        sentinel: 'SRV_UP_1047',
+      );
+
+      // 3) Session menu → Port forwards sheet → add 18088 → 127.0.0.1:8088.
+      await _openSessionMenu(tester);
+      await tester.tap(find.byKey(const Key('session-menu-port-forwards')));
+      final sheetUp = await _pumpUntil(
+        tester,
+        () =>
+            find.byKey(const Key('port-forwards-sheet')).evaluate().isNotEmpty,
+        maxSlices: 20,
+      );
+      expect(sheetUp, isTrue, reason: 'Port forwards sheet never opened');
+
+      await tester.enterText(
+        find.byKey(const Key('forward-local-port')),
+        '18088',
+      );
+      await tester.enterText(
+        find.byKey(const Key('forward-remote-host')),
+        '127.0.0.1',
+      );
+      await tester.enterText(
+        find.byKey(const Key('forward-remote-port')),
+        '8088',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('forward-add-submit')));
+
+      final active = await _pumpUntil(
+        tester,
+        () => _forwardOf(entry, 18088)?.status == ForwardStatus.active,
+        maxSlices: 30,
+      );
+      expect(active, isTrue,
+          reason: 'forward 18088 never went ACTIVE '
+              '(table: ${entry.proxy.forwards.map((f) => '${f.localPort}:${f.status.name} ${f.error ?? ''}')})');
+      expect(find.byKey(const Key('forward-row-18088')), findsOneWidget);
+
+      // 4) The honest probe: through the app's loopback listener → tunnel →
+      // test-sshd's nc. The marker proves the direct-tcpip path end to end.
+      final body = await _probeForwardedPort(18088);
+      expect(body, contains(_marker),
+          reason: 'forwarded fetch did not return the marker');
+
+      // Screenshot hold: keep the sheet + ACTIVE row on screen for the
+      // external emu-shot (see file header).
+      debugPrint('PF_SHEET_HOLD_BEGIN');
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      debugPrint('PF_SHEET_HOLD_END');
+
+      // 5) Star it as a profile default (store write, end to end).
+      await tester.tap(find.byKey(const Key('forward-default-18088')));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 6) Drop the connection SERVER-side: kill this session's sshd. The
+      // controller auto-reconnects (softDisconnected → reconnecting →
+      // connected) and the host re-arms the retained forward config.
+      entry.proxy.sendInput(
+        Uint8List.fromList(utf8.encode('kill -9 \$PPID\n')),
+      );
+      final dropped = await _pumpUntil(
+        tester,
+        () => entry.proxy.data.state != SshSessionState.connected,
+        maxSlices: 30,
+      );
+      expect(dropped, isTrue, reason: 'server-side kill never dropped session');
+      // While dropped, the forward must NOT be active (died with the session).
+      final reconnected = await _pumpUntil(
+        tester,
+        () =>
+            entry.proxy.data.state == SshSessionState.connected &&
+            _forwardOf(entry, 18088)?.status == ForwardStatus.active,
+        maxSlices: 80,
+      );
+      expect(reconnected, isTrue,
+          reason: 'forward did not re-arm after auto-reconnect '
+              '(state=${entry.proxy.data.state.name}, '
+              'table: ${entry.proxy.forwards.map((f) => '${f.localPort}:${f.status.name}')})');
+
+      final bodyAfter = await _probeForwardedPort(18088);
+      expect(bodyAfter, contains(_marker),
+          reason: 'forward re-armed but the tunnel did not carry the marker');
+
+      // 7) Remove → refused + empty table. The sheet stayed open (modal
+      // route, unaffected by the reconnect underneath).
+      await tester.tap(find.byKey(const Key('forward-remove-18088')));
+      final removed = await _pumpUntil(
+        tester,
+        () => _forwardOf(entry, 18088) == null,
+        maxSlices: 20,
+      );
+      expect(removed, isTrue, reason: 'forward never left the table');
+      await tester.pump(const Duration(milliseconds: 500));
+      await expectLater(
+        Socket.connect(
+          InternetAddress.loopbackIPv4,
+          18088,
+          timeout: const Duration(seconds: 3),
+        ),
+        throwsA(isA<SocketException>()),
+      );
+    },
+  );
+}

--- a/native/lib/services/port_forwarder.dart
+++ b/native/lib/services/port_forwarder.dart
@@ -1,0 +1,160 @@
+// SSH LOCAL port-forward engine (ssh -L semantics, #1047).
+//
+// Task-isolate-side: forwards live beside the SSH client (the dart:io
+// ServerSocket must be owned where the `SSHClient` is — the foreground task
+// isolate, which the #1018/#1021 keepalive hold keeps alive). Each accepted
+// local connection opens a `direct-tcpip` channel to the remote target and
+// pipes bidirectionally until either side closes.
+//
+// The tunnel type is dartssh2's [SSHSocket] — exactly the interface
+// `SSHClient.forwardLocal` returns (`SSHForwardChannel implements SSHSocket`),
+// so production injects `client.forwardLocal` and tests inject an in-memory
+// fake without touching a real socket.
+//
+// SECURITY (.claude/rules/security.md): listeners bind 127.0.0.1 ONLY — the
+// forward is for THIS device (in-app + sibling apps via the shared loopback),
+// never an open relay on the LAN. No remote→local (-R) in v1.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dartssh2/dartssh2.dart' show SSHSocket;
+
+/// Opens the remote leg of one forwarded connection — production wraps
+/// `SSHClient.forwardLocal(remoteHost, remotePort)`; tests inject a fake.
+/// Throwing signals a channel-open refusal for THAT connection only.
+typedef ForwardTunnelOpener =
+    Future<SSHSocket> Function(String remoteHost, int remotePort);
+
+/// One forward's configuration: listen on 127.0.0.1:[localPort], tunnel each
+/// connection to [remoteHost]:[remotePort] as reachable FROM the SSH server.
+class PortForwardConfig {
+  const PortForwardConfig({
+    required this.localPort,
+    required this.remoteHost,
+    required this.remotePort,
+  });
+
+  /// The device-side listen port. 0 asks the OS for an ephemeral port (tests);
+  /// user-facing forwards always carry an explicit port.
+  final int localPort;
+  final String remoteHost;
+  final int remotePort;
+}
+
+/// A live ssh -L listener: one bound ServerSocket + the set of live pipes.
+///
+/// Lifecycle: [start] binds (throws [SocketException] on port-in-use — the
+/// caller surfaces that as the forward's error status); [close] tears down the
+/// listener AND every live pipe in both directions. A per-connection
+/// channel-open failure closes that connection only and reports through
+/// [onChannelError] — the listener keeps accepting, matching `ssh -L` (which
+/// logs "channel open failed" per attempt and stays up).
+class PortForwardListener {
+  PortForwardListener._(this.config, this._server, this._open, this.onChannelError) {
+    _server.listen(_handleAccept, onError: (_) {}, cancelOnError: false);
+  }
+
+  final PortForwardConfig config;
+  final ServerSocket _server;
+  final ForwardTunnelOpener _open;
+
+  /// Invoked with a short description each time a connection's direct-tcpip
+  /// channel open is refused (session down, remote refused, prohibited).
+  final void Function(String error)? onChannelError;
+
+  final Set<Socket> _liveSockets = {};
+  final Set<SSHSocket> _liveTunnels = {};
+  bool _closed = false;
+
+  /// The actually-bound port (== `config.localPort` unless it was 0).
+  int get boundPort => _server.port;
+
+  static Future<PortForwardListener> start({
+    required PortForwardConfig config,
+    required ForwardTunnelOpener openTunnel,
+    void Function(String error)? onChannelError,
+  }) async {
+    // SECURITY: loopback ONLY (.claude/rules/security.md) — never 0.0.0.0.
+    final server = await ServerSocket.bind(
+      InternetAddress.loopbackIPv4,
+      config.localPort,
+    );
+    return PortForwardListener._(config, server, openTunnel, onChannelError);
+  }
+
+  Future<void> _handleAccept(Socket socket) async {
+    if (_closed) {
+      socket.destroy();
+      return;
+    }
+    _liveSockets.add(socket);
+    final SSHSocket tunnel;
+    try {
+      tunnel = await _open(config.remoteHost, config.remotePort);
+    } catch (e) {
+      // Channel refused for THIS connection: close it, keep listening.
+      onChannelError?.call(
+        'channel to ${config.remoteHost}:${config.remotePort} failed: $e',
+      );
+      _liveSockets.remove(socket);
+      socket.destroy();
+      return;
+    }
+    if (_closed) {
+      // close() raced the channel open — tear the fresh tunnel down too.
+      _liveSockets.remove(socket);
+      socket.destroy();
+      tunnel.destroy();
+      return;
+    }
+    _liveTunnels.add(tunnel);
+
+    // remote → local: when the tunnel's read side ends (remote closed), flush
+    // what we have and drop the local socket.
+    unawaited(() async {
+      try {
+        await socket.addStream(tunnel.stream);
+        await socket.flush();
+      } catch (_) {
+        // Local socket gone mid-write — the other direction's teardown runs.
+      } finally {
+        _liveSockets.remove(socket);
+        socket.destroy();
+      }
+    }());
+
+    // local → remote: when the local socket's read side ends (app closed),
+    // close our end of the channel so the remote sees EOF.
+    unawaited(() async {
+      try {
+        await tunnel.sink.addStream(socket);
+      } catch (_) {
+        // Tunnel gone mid-write — the other direction's teardown runs.
+      } finally {
+        _liveTunnels.remove(tunnel);
+        try {
+          await tunnel.close();
+        } catch (_) {
+          /* already closed */
+        }
+      }
+    }());
+  }
+
+  /// Stop accepting AND tear down every live pipe (both directions). Safe to
+  /// call more than once.
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    await _server.close();
+    for (final s in _liveSockets.toList()) {
+      s.destroy();
+    }
+    _liveSockets.clear();
+    for (final t in _liveTunnels.toList()) {
+      t.destroy();
+    }
+    _liveTunnels.clear();
+  }
+}

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -16,6 +16,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show SocketException;
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -31,6 +32,7 @@ import '../ssh/ssh_session.dart';
 import '../ssh/ssh_shell.dart';
 import '../ssh/sftp_session.dart';
 import 'attention_signal_scanner.dart';
+import 'port_forwarder.dart';
 import 'session_attention_notification.dart';
 import 'session_messages.dart';
 import 'task_ssh_gateway.dart';
@@ -70,6 +72,13 @@ Future<SshShellTransport?> _defaultExecOpener(
 
 SshSessionController _defaultControllerFactory() => SshSessionController();
 
+/// Builds the per-session direct-tcpip tunnel opener for the ssh -L engine
+/// (#1047). Production resolves the session's live `SSHClient` at ACCEPT time
+/// (not arm time) so a forward armed early — or re-armed across a reconnect —
+/// always dials over the CURRENT client. Tests inject fakes.
+typedef HostForwardOpenerFactory = ForwardTunnelOpener Function(
+    String sessionId);
+
 /// #982: how long to wait for the `-CC` handshake (the `\x1bP1000p` DCS) after
 /// writing the entry command before declaring control mode FAILED and falling
 /// back to the scrape path. Nested tmux / a shell that never enters `-CC` never
@@ -87,6 +96,7 @@ class SessionHost {
     SftpSessionOpener? sftpOpener,
     HostShellOpener? shellOpener,
     HostExecOpener? execOpener,
+    HostForwardOpenerFactory? forwardOpenerFactory,
     this.snapshotInterval = const Duration(seconds: 2),
     this.resumeProbeTimeout = const Duration(seconds: 2),
     this.resumeStaleThreshold = const Duration(seconds: 20),
@@ -100,6 +110,7 @@ class SessionHost {
        _sftpOpener = sftpOpener,
        _shellOpener = shellOpener ?? _defaultShellOpener,
        _execOpener = execOpener ?? _defaultExecOpener,
+       _forwardOpenerFactory = forwardOpenerFactory,
        _attentionNotifier = attentionNotifier,
        _nowMs = nowMs ?? (() => DateTime.now().millisecondsSinceEpoch) {
     _commandSub = _gateway.incoming.listen(_dispatch);
@@ -147,6 +158,11 @@ class SessionHost {
   /// used when [tmuxControlMode] is ON: the tmux `-CC` invocation runs as the
   /// channel's exec command instead of being typed into an interactive shell.
   final HostExecOpener _execOpener;
+
+  /// Per-session direct-tcpip tunnel opener factory for ssh -L forwards
+  /// (#1047). Null in production → [_defaultForwardOpener] dials over the
+  /// session's live `SSHClient.forwardLocal`. Tests inject a fake.
+  final HostForwardOpenerFactory? _forwardOpenerFactory;
 
   /// How often a snapshot is pushed to the UI side. Tests use a short
   /// interval; production defaults to two seconds.
@@ -379,6 +395,13 @@ class SessionHost {
         _handleTmuxGesture(cmd);
       case SshTmuxScrollCommand():
         _handleTmuxScroll(cmd);
+      case SshForwardAddCommand():
+        _handleForwardAdd(cmd);
+      case SshForwardRemoveCommand():
+        _handleForwardRemove(cmd);
+      case SshForwardListCommand():
+        final s = _sessions[cmd.sessionId];
+        if (s != null) _emitForwardList(cmd.sessionId, s);
     }
   }
 
@@ -476,6 +499,161 @@ class SessionHost {
     } catch (_) {
       // Channel closed; reconnect re-syncs.
     }
+  }
+
+  // --- Local port forwarding, ssh -L (#1047) ---
+
+  /// Default tunnel opener: dial a direct-tcpip channel over the session's
+  /// LIVE `SSHClient` (resolved per accepted connection, so a reconnect's new
+  /// client is picked up automatically). Throws when the session has no client
+  /// — the engine reports it as a per-connection channel error and keeps
+  /// listening, mirroring `ssh -L`.
+  ForwardTunnelOpener _defaultForwardOpener(String sessionId) {
+    return (String remoteHost, int remotePort) async {
+      final client = _sessions[sessionId]?.controller.client;
+      if (client == null) {
+        throw StateError('session not connected');
+      }
+      return client.forwardLocal(remoteHost, remotePort);
+    };
+  }
+
+  /// Store/refresh the forward config keyed by localPort; arm immediately when
+  /// the session is already `connected` (ad hoc on a live session), otherwise
+  /// the `connected` transition arms it. Always replies with the table.
+  Future<void> _handleForwardAdd(SshForwardAddCommand cmd) async {
+    final hosted = _sessions[cmd.sessionId];
+    if (hosted == null) return;
+    final config = PortForwardConfig(
+      localPort: cmd.localPort,
+      remoteHost: cmd.remoteHost,
+      remotePort: cmd.remotePort,
+    );
+    // Re-add of an existing port: replace the config; drop a live listener so
+    // it re-arms at the (possibly new) target.
+    final prior = hosted.forwardListeners.remove(cmd.localPort);
+    if (prior != null) unawaited(prior.close());
+    hosted.forwardErrors.remove(cmd.localPort);
+    hosted.forwardConfigs[cmd.localPort] = config;
+    clifecycle(
+      'task.host',
+      'forward add ${cmd.localPort} → ${cmd.remoteHost}:${cmd.remotePort} '
+          '(state=${hosted.controller.data.state.name})',
+    );
+    if (hosted.controller.data.state == SshSessionState.connected) {
+      await _armForward(cmd.sessionId, hosted, config);
+    }
+    _emitForwardList(cmd.sessionId, hosted);
+  }
+
+  Future<void> _handleForwardRemove(SshForwardRemoveCommand cmd) async {
+    final hosted = _sessions[cmd.sessionId];
+    if (hosted == null) return;
+    hosted.forwardConfigs.remove(cmd.localPort);
+    hosted.forwardErrors.remove(cmd.localPort);
+    final listener = hosted.forwardListeners.remove(cmd.localPort);
+    if (listener != null) {
+      clifecycle('task.host', 'forward remove ${cmd.localPort}');
+      await listener.close();
+    }
+    _emitForwardList(cmd.sessionId, hosted);
+  }
+
+  /// Arm every configured-but-unbound forward. Called on each `connected`
+  /// transition (initial connect AND reconnect) — the re-arm contract.
+  Future<void> _armForwards(String sessionId, _HostedSession hosted) async {
+    for (final config in hosted.forwardConfigs.values.toList()) {
+      await _armForward(sessionId, hosted, config);
+    }
+    if (hosted.forwardConfigs.isNotEmpty) {
+      _emitForwardList(sessionId, hosted);
+    }
+  }
+
+  /// Bind one forward's loopback listener. A bind failure (port in use) is
+  /// recorded as the forward's error — never a session failure. Guards the
+  /// await: a teardown/drop/config-removal that raced the bind closes the
+  /// fresh listener instead of leaking it.
+  Future<void> _armForward(
+    String sessionId,
+    _HostedSession hosted,
+    PortForwardConfig config,
+  ) async {
+    if (hosted.forwardListeners.containsKey(config.localPort)) return;
+    final opener =
+        (_forwardOpenerFactory ?? _defaultForwardOpener)(sessionId);
+    try {
+      final listener = await PortForwardListener.start(
+        config: config,
+        openTunnel: opener,
+        onChannelError: (error) {
+          // Per-connection channel failure: the listener survives (ssh -L
+          // semantics); surface the message on the row + telemetry.
+          hosted.forwardErrors[config.localPort] = error;
+          clifecycle(
+            'task.host',
+            'forward ${config.localPort} channel error: $error',
+          );
+          _emitForwardList(sessionId, hosted);
+        },
+      );
+      // Raced by teardown / disconnect / remove while binding?
+      final stillWanted = _sessions[sessionId] == hosted &&
+          hosted.forwardConfigs.containsKey(config.localPort) &&
+          hosted.controller.data.state == SshSessionState.connected;
+      if (!stillWanted) {
+        await listener.close();
+        return;
+      }
+      hosted.forwardListeners[config.localPort] = listener;
+      hosted.forwardErrors.remove(config.localPort);
+      clifecycle(
+        'task.host',
+        'forward ${config.localPort} → '
+            '${config.remoteHost}:${config.remotePort} ACTIVE',
+      );
+    } on SocketException catch (e) {
+      hosted.forwardErrors[config.localPort] =
+          'Port ${config.localPort} is already in use (${e.osError?.message ?? e.message})';
+      clifecycle(
+        'task.host',
+        'forward ${config.localPort} bind FAILED: ${e.message}',
+      );
+    } catch (e) {
+      hosted.forwardErrors[config.localPort] = 'Forward failed: $e';
+    }
+  }
+
+  /// Close every live listener, KEEPING the configs so the next `connected`
+  /// re-arms them. Emits the table (rows fall back to `starting`).
+  void _dropForwards(String sessionId, _HostedSession hosted) {
+    if (hosted.forwardListeners.isEmpty) return;
+    for (final listener in hosted.forwardListeners.values.toList()) {
+      unawaited(listener.close());
+    }
+    hosted.forwardListeners.clear();
+    _emitForwardList(sessionId, hosted);
+  }
+
+  void _emitForwardList(String sessionId, _HostedSession hosted) {
+    if (_disposed) return;
+    final forwards = <ForwardInfo>[
+      for (final config in hosted.forwardConfigs.values)
+        ForwardInfo(
+          localPort: config.localPort,
+          remoteHost: config.remoteHost,
+          remotePort: config.remotePort,
+          status: hosted.forwardListeners.containsKey(config.localPort)
+              ? ForwardStatus.active
+              : (hosted.forwardErrors.containsKey(config.localPort)
+                    ? ForwardStatus.error
+                    : ForwardStatus.starting),
+          error: hosted.forwardErrors[config.localPort],
+        ),
+    ];
+    _gateway.send(
+      SshForwardListEvent(sessionId: sessionId, forwards: forwards).toJson(),
+    );
   }
 
   void _handleHostKeyDecision(SshHostKeyDecisionCommand cmd) {
@@ -701,6 +879,10 @@ class SessionHost {
       // shell whose output re-pipes to the terminal.
       if (data.state != SshSessionState.connected) {
         _dropShell(hosted);
+        // #1047: forwards die with the connection — close every listener
+        // synchronously (the config is RETAINED so re-entering `connected`
+        // re-arms it below; that is the reconnect re-arm contract).
+        _dropForwards(cmd.sessionId, hosted);
       }
       // Open the PTY shell the first time we reach `connected` (and re-open
       // after a reconnect, which re-enters `connected`). Without this the
@@ -713,6 +895,9 @@ class SessionHost {
         // happens before the remote ever produced a byte.
         hosted.connectedAtMs = _nowMs();
         unawaited(_ensureShell(cmd.sessionId, hosted));
+        // #1047: (re)arm every configured port forward now that the client is
+        // live — covers both a pre-connect forwardAdd and the reconnect re-arm.
+        unawaited(_armForwards(cmd.sessionId, hosted));
       }
     });
 
@@ -769,6 +954,18 @@ class SessionHost {
   Future<void> _teardown(String sessionId, _HostedSession hosted) async {
     await hosted.stateSub?.cancel();
     hosted.stateSub = null;
+    // #1047: a torn-down session takes its forwards (listeners AND config)
+    // with it — a later fresh connect re-arms from the profile defaults.
+    for (final listener in hosted.forwardListeners.values.toList()) {
+      try {
+        await listener.close();
+      } catch (_) {
+        /* ignore */
+      }
+    }
+    hosted.forwardListeners.clear();
+    hosted.forwardConfigs.clear();
+    hosted.forwardErrors.clear();
     await hosted.shellSub?.cancel();
     hosted.shellSub = null;
     hosted.tmuxChannel = null; // #909: drop the control-mode adapter on teardown.
@@ -2101,6 +2298,20 @@ class _HostedSession {
   /// Opened on the first list/download command, reused after, closed on
   /// teardown. Null until the first SFTP op.
   SftpSession? sftp;
+
+  /// #1047: DESIRED ssh -L forwards, keyed by localPort. Configs survive a
+  /// connection drop (the re-arm-on-reconnect contract) and die only with the
+  /// hosted session itself. Insertion-ordered so the UI list is stable.
+  final Map<int, PortForwardConfig> forwardConfigs = {};
+
+  /// #1047: LIVE loopback listeners, keyed by localPort. Strictly a subset of
+  /// [forwardConfigs]; emptied whenever the session leaves `connected`.
+  final Map<int, PortForwardListener> forwardListeners = {};
+
+  /// #1047: last bind/channel error per localPort — cleared on a successful
+  /// (re)bind, kept alongside an ACTIVE listener for per-connection channel
+  /// failures (the listener survives those, mirroring `ssh -L`).
+  final Map<int, String> forwardErrors = {};
 
   /// Live PTY shell channel, opened on first `connected`. Output is piped to
   /// the UI terminal via SshOutputEvent; input commands write here. Null until

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -108,6 +108,24 @@ enum SshTaskCommandKind {
   /// no `%output` for copy-mode scroll, so the client must capture it. A no-op
   /// unless control mode is ON. NEVER used by the scrape (flag-OFF) path.
   tmuxScroll,
+
+  // --- Local port forwarding, ssh -L (#1047) ---
+
+  /// UI → task: add (or update, keyed by localPort) a LOCAL port forward for
+  /// this session. The task stores the config on the hosted session and arms a
+  /// 127.0.0.1 listener the moment the session is `connected` (immediately for
+  /// a live session; on the `connected` transition otherwise — which also makes
+  /// reconnect re-arm "for free"). Replies with an [SshForwardListEvent].
+  forwardAdd,
+
+  /// UI → task: remove the forward listening on `localPort` — closes the
+  /// listener + every live pipe and forgets the config. Replies with an
+  /// [SshForwardListEvent].
+  forwardRemove,
+
+  /// UI → task: replay the session's current forward table as an
+  /// [SshForwardListEvent] (sheet-open hydration).
+  forwardList,
 }
 
 /// The kind of tmux window gesture an [SshTmuxGestureCommand] carries (#911).
@@ -182,6 +200,13 @@ enum SshTaskEventKind {
   /// so the UI-side ring — the one the bundle reads — actually contains them.
   /// Task-global, so [sessionId] is the empty sentinel (mirrors ready).
   lifecycle,
+
+  /// Task → UI: the session's CURRENT port-forward table (#1047) — the reply to
+  /// every forwardAdd/forwardRemove/forwardList AND pushed on any status change
+  /// (armed on connect, dropped on disconnect, bind/channel errors). One small
+  /// authoritative-list event instead of per-forward deltas keeps the UI free
+  /// of reconciliation state.
+  forwardList,
 
   /// Task → UI: one structured tmux control-mode (`-CC`) telemetry line (#906).
   /// The control-mode trace (`cmtrace` / `controlModeLog`) is written in the
@@ -363,6 +388,20 @@ sealed class SshTaskCommand {
           sessionId: sessionId,
           deltaLines: (json['deltaLines'] as int?) ?? 0,
         );
+      case SshTaskCommandKind.forwardAdd:
+        return SshForwardAddCommand(
+          sessionId: sessionId,
+          localPort: json['localPort'] as int,
+          remoteHost: json['remoteHost'] as String,
+          remotePort: json['remotePort'] as int,
+        );
+      case SshTaskCommandKind.forwardRemove:
+        return SshForwardRemoveCommand(
+          sessionId: sessionId,
+          localPort: json['localPort'] as int,
+        );
+      case SshTaskCommandKind.forwardList:
+        return SshForwardListCommand(sessionId: sessionId);
     }
   }
 }
@@ -840,6 +879,73 @@ class SshTmuxScrollCommand extends SshTaskCommand {
 }
 
 // ---------------------------------------------------------------------------
+// Port-forward commands (#1047)
+// ---------------------------------------------------------------------------
+
+/// UI → task: add/update the LOCAL forward listening on 127.0.0.1:[localPort],
+/// tunnelling each connection to [remoteHost]:[remotePort] via a direct-tcpip
+/// channel (ssh -L). Keyed by [localPort] — re-adding the same port replaces
+/// the target (idempotent, so profile-armed re-sends are safe). The task
+/// replies with an [SshForwardListEvent].
+class SshForwardAddCommand extends SshTaskCommand {
+  const SshForwardAddCommand({
+    required String sessionId,
+    required this.localPort,
+    required this.remoteHost,
+    required this.remotePort,
+  }) : super(sessionId);
+
+  final int localPort;
+  final String remoteHost;
+  final int remotePort;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.forwardAdd;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'localPort': localPort,
+    'remoteHost': remoteHost,
+    'remotePort': remotePort,
+  };
+}
+
+/// UI → task: remove the forward keyed by [localPort] — the task closes the
+/// listener + live pipes and forgets the config, then replies with an
+/// [SshForwardListEvent]. A no-op for an unknown port (still replies).
+class SshForwardRemoveCommand extends SshTaskCommand {
+  const SshForwardRemoveCommand({
+    required String sessionId,
+    required this.localPort,
+  }) : super(sessionId);
+
+  final int localPort;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.forwardRemove;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'localPort': localPort,
+  };
+}
+
+/// UI → task: replay the session's current forward table (sheet hydration).
+class SshForwardListCommand extends SshTaskCommand {
+  const SshForwardListCommand({required String sessionId}) : super(sessionId);
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.forwardList;
+
+  @override
+  Map<String, dynamic> toJson() => {'kind': kind.name, 'sessionId': sessionId};
+}
+
+// ---------------------------------------------------------------------------
 // Events (task → UI)
 // ---------------------------------------------------------------------------
 
@@ -961,10 +1067,79 @@ sealed class SshTaskEvent {
         );
       case SshTaskEventKind.lifecycle:
         return SshLifecycleEvent(line: json['line'] as String);
+      case SshTaskEventKind.forwardList:
+        return SshForwardListEvent(
+          sessionId: sessionId,
+          forwards: (json['forwards'] as List)
+              .map(
+                (f) =>
+                    ForwardInfo.fromJson(Map<String, dynamic>.from(f as Map)),
+              )
+              .toList(),
+        );
       case SshTaskEventKind.controlModeTrace:
         return SshControlModeTraceEvent(line: json['line'] as String);
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Port-forward status (#1047)
+// ---------------------------------------------------------------------------
+
+/// Lifecycle status of one forward as reported by the task side (#1047).
+enum ForwardStatus {
+  /// Config held, listener not bound yet — the session isn't `connected`
+  /// (pre-connect add, or dropped with the session awaiting re-arm).
+  starting,
+
+  /// Listener bound on 127.0.0.1 and accepting. [ForwardInfo.error] may still
+  /// carry the LAST per-connection channel failure (ssh -L keeps listening).
+  active,
+
+  /// The listener could not bind (port in use) — [ForwardInfo.error] says why.
+  error,
+}
+
+/// One forward's wire-serializable status row (#1047). Kept small: it crosses
+/// the isolate IPC on every table change.
+class ForwardInfo {
+  const ForwardInfo({
+    required this.localPort,
+    required this.remoteHost,
+    required this.remotePort,
+    required this.status,
+    this.error,
+  });
+
+  final int localPort;
+  final String remoteHost;
+  final int remotePort;
+  final ForwardStatus status;
+
+  /// Bind failure (status == error) or the most recent per-connection channel
+  /// failure (status may still be active — the listener survives).
+  final String? error;
+
+  Map<String, dynamic> toJson() => {
+    'localPort': localPort,
+    'remoteHost': remoteHost,
+    'remotePort': remotePort,
+    'status': status.name,
+    if (error != null) 'error': error,
+  };
+
+  factory ForwardInfo.fromJson(Map<String, dynamic> json) => ForwardInfo(
+    localPort: json['localPort'] as int,
+    remoteHost: json['remoteHost'] as String,
+    remotePort: json['remotePort'] as int,
+    // Unknown status (future schema) degrades to starting — never a crash.
+    status: ForwardStatus.values.firstWhere(
+      (s) => s.name == json['status'],
+      orElse: () => ForwardStatus.starting,
+    ),
+    error: json['error'] as String?,
+  );
 }
 
 class SshStateEvent extends SshTaskEvent {
@@ -1218,6 +1393,32 @@ class SshControlModeTraceEvent extends SshTaskEvent {
     'kind': kind.name,
     'sessionId': sessionId,
     'line': line,
+  };
+}
+
+/// Task → UI: the session's current forward table (#1047). Authoritative list
+/// (not a delta) so the UI just replaces its cached copy. Emitted in reply to
+/// every forward command and pushed on any status change.
+///
+/// [SYNC] single-codebase wire contract; the round-trip suite in
+/// `forward_messages_test.dart` is the sync check — keep this event, the host
+/// emitter (SessionHost._emitForwardList) and the proxy recorder in step.
+class SshForwardListEvent extends SshTaskEvent {
+  const SshForwardListEvent({
+    required String sessionId,
+    required this.forwards,
+  }) : super(sessionId);
+
+  final List<ForwardInfo> forwards;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.forwardList;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'forwards': forwards.map((f) => f.toJson()).toList(),
   };
 }
 

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -70,6 +70,12 @@ class SshSessionProxy {
   final StreamController<SshTaskEvent> _sftpCtrl =
       StreamController<SshTaskEvent>.broadcast();
 
+  /// Port-forward table updates (#1047). Each event is the AUTHORITATIVE
+  /// current list; [forwards] caches the latest so late subscribers (the
+  /// session-menu badge, a re-opened sheet) render without a round-trip.
+  final StreamController<List<ForwardInfo>> _forwardCtrl =
+      StreamController<List<ForwardInfo>>.broadcast();
+
   SshSessionData _data = const SshSessionData();
   ProxySnapshot _snapshot = const ProxySnapshot(state: SshSessionState.idle);
   StreamSubscription<Map<String, dynamic>>? _eventSub;
@@ -121,6 +127,15 @@ class SshSessionProxy {
   /// [SftpDownloadChunkEvent], [SftpDownloadDoneEvent], [SftpErrorEvent].
   /// The file browser filters by request id.
   Stream<SshTaskEvent> get sftpEvents => _sftpCtrl.stream;
+
+  /// Port-forward table stream (#1047): the authoritative list on every
+  /// change. Pair with [forwards] as `initialData` for late subscribers.
+  Stream<List<ForwardInfo>> get forwardEvents => _forwardCtrl.stream;
+
+  /// Latest forward table received from the task side (#1047). Empty until
+  /// the first [SshForwardListEvent].
+  List<ForwardInfo> get forwards => _forwards;
+  List<ForwardInfo> _forwards = const [];
 
   /// Latest snapshot received from the task side. Used by the audit screen
   /// and by `rebind()` to redraw without waiting for the next emit.
@@ -402,6 +417,46 @@ class SshSessionProxy {
     );
   }
 
+  /// Add (or update — keyed by [localPort]) an ssh -L port forward (#1047):
+  /// listen on 127.0.0.1:[localPort] on the device, tunnel each connection to
+  /// [remoteHost]:[remotePort] via a direct-tcpip channel. Idempotent, so
+  /// re-sending profile defaults on (re)connect is safe. Status arrives on
+  /// [forwardEvents].
+  void forwardAdd({
+    required int localPort,
+    String remoteHost = '127.0.0.1',
+    required int remotePort,
+  }) {
+    if (_disposed) return;
+    gateway.send(
+      SshForwardAddCommand(
+        sessionId: sessionId,
+        localPort: localPort,
+        remoteHost: remoteHost,
+        remotePort: remotePort,
+      ).toJson(),
+    );
+  }
+
+  /// Remove the forward keyed by [localPort] (#1047) — the task closes the
+  /// listener + live pipes. The updated table arrives on [forwardEvents].
+  void forwardRemove(int localPort) {
+    if (_disposed) return;
+    gateway.send(
+      SshForwardRemoveCommand(
+        sessionId: sessionId,
+        localPort: localPort,
+      ).toJson(),
+    );
+  }
+
+  /// Ask the task to replay the current forward table (#1047) — sheet-open
+  /// hydration. The reply arrives on [forwardEvents] (and updates [forwards]).
+  void forwardList() {
+    if (_disposed) return;
+    gateway.send(SshForwardListCommand(sessionId: sessionId).toJson());
+  }
+
   /// Send a PTY resize to the remote.
   ///
   /// #848 — NO-OP GUARD: a resize whose (cols, rows) are IDENTICAL to the last
@@ -459,6 +514,7 @@ class SshSessionProxy {
     if (!_outputCtrl.isClosed) await _outputCtrl.close();
     if (!_shellReadyCtrl.isClosed) await _shellReadyCtrl.close();
     if (!_sftpCtrl.isClosed) await _sftpCtrl.close();
+    if (!_forwardCtrl.isClosed) await _forwardCtrl.close();
   }
 
   void _handleEvent(Map<String, dynamic> payload) {
@@ -535,6 +591,11 @@ class SshSessionProxy {
         // recorded it into the control-mode ring before _incoming; a per-session
         // proxy has nothing to do — handle it for switch exhaustiveness only.
         break;
+      case SshForwardListEvent():
+        // Port-forward table (#1047): cache the authoritative list for late
+        // subscribers (menu badge) and fan out to the sheet.
+        _forwards = event.forwards;
+        if (!_forwardCtrl.isClosed) _forwardCtrl.add(event.forwards);
       case SftpListingEvent():
       case SftpDownloadChunkEvent():
       case SftpDownloadDoneEvent():

--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -401,6 +401,17 @@ class SessionsNotifier extends Notifier<SessionsState> {
         ),
         title: entry.title,
       );
+      // #1047: re-arm the profile's default port forwards. When the foreground
+      // isolate was torn down (last-session drop) the fresh SessionHost has no
+      // forward config, so the reconnect must re-send it. Idempotent when the
+      // hosted session survived (keyed by localPort).
+      for (final fwd in match.forwards) {
+        entry.proxy.forwardAdd(
+          localPort: fwd.localPort,
+          remoteHost: fwd.remoteHost,
+          remotePort: fwd.remotePort,
+        );
+      }
     } catch (_) {
       // Best-effort: degrade to the bare held-params reconnect.
       entry.proxy.reconnect();

--- a/native/lib/storage/profiles_store.dart
+++ b/native/lib/storage/profiles_store.dart
@@ -21,6 +21,59 @@ import '../diagnostics/connect_trace.dart';
 import 'secrets_store.dart';
 import 'vault.dart';
 
+/// One profile-default LOCAL port forward (ssh -L, #1047): listen on
+/// 127.0.0.1:[localPort] on the device, tunnel to [remoteHost]:[remotePort]
+/// as reachable from the SSH server. Armed automatically on (re)connect.
+/// Identity within a profile is [localPort] (one listener per port).
+class ProfileForward {
+  const ProfileForward({
+    required this.localPort,
+    required this.remoteHost,
+    required this.remotePort,
+  });
+
+  final int localPort;
+  final String remoteHost;
+  final int remotePort;
+
+  Map<String, dynamic> toJson() => {
+    'localPort': localPort,
+    'remoteHost': remoteHost,
+    'remotePort': remotePort,
+  };
+
+  /// Validating decode: null for anything unusable (corrupt-resilience per
+  /// .claude/rules — a bad entry is dropped, never a crash). An absent/empty
+  /// remoteHost defaults to 127.0.0.1 (the ssh -L default target).
+  static ProfileForward? fromJson(Map<String, dynamic> json) {
+    final lp = _coercePort(json['localPort']);
+    final rp = _coercePort(json['remotePort']);
+    if (lp == null || rp == null) return null;
+    final hostRaw = json['remoteHost'];
+    final host = (hostRaw is String && hostRaw.trim().isNotEmpty)
+        ? hostRaw.trim()
+        : '127.0.0.1';
+    return ProfileForward(localPort: lp, remoteHost: host, remotePort: rp);
+  }
+
+  static int? _coercePort(Object? raw) {
+    final int v;
+    if (raw is int) {
+      v = raw;
+    } else if (raw is double) {
+      v = raw.toInt();
+    } else if (raw is String) {
+      final parsed = int.tryParse(raw);
+      if (parsed == null) return null;
+      v = parsed;
+    } else {
+      return null;
+    }
+    if (v < 1 || v > 65535) return null;
+    return v;
+  }
+}
+
 /// Persisted profile shape. Connection metadata + optional visual identity +
 /// optional vault references. Equality is by (host, port, username) — the
 /// natural identity used for dedupe everywhere else in the app.
@@ -39,6 +92,7 @@ class SavedProfile {
     this.keyVaultId,
     this.initialCommand,
     this.defaultPath = '',
+    this.forwards = const [],
   });
 
   final String title;
@@ -93,6 +147,12 @@ class SavedProfile {
   /// .claude/rules code-style), so legacy profiles keep their current behaviour.
   final String defaultPath;
 
+  /// Profile-default LOCAL port forwards (ssh -L, #1047), armed on every
+  /// (re)connect of a session matching this profile. Empty for legacy
+  /// profiles (absent field reads back as [] via [_coerceForwards] — the
+  /// schema migration, no key bump per .claude/rules code-style).
+  final List<ProfileForward> forwards;
+
   /// Identity key for dedupe / lookup. Matches the PWA's behavior of treating
   /// (host:port:username) as the unique constraint.
   String get identityKey => '$host:$port:$username';
@@ -138,6 +198,21 @@ class SavedProfile {
     return null;
   }
 
+  /// Validate a raw stored forwards list (#1047). Non-list / absent → [];
+  /// corrupt entries inside the list are dropped individually (per
+  /// [ProfileForward.fromJson]). This IS the schema migration for the
+  /// absent-field case — no key bump.
+  static List<ProfileForward> _coerceForwards(Object? raw) {
+    if (raw is! List) return const [];
+    final out = <ProfileForward>[];
+    for (final entry in raw) {
+      if (entry is! Map) continue;
+      final fwd = ProfileForward.fromJson(Map<String, dynamic>.from(entry));
+      if (fwd != null) out.add(fwd);
+    }
+    return out;
+  }
+
   /// Validate a raw stored default path (#891). Returns the trimmed string when
   /// it's a non-empty String; anything else (null, absent on an OLD profile,
   /// non-String) yields '' so legacy profiles + corrupt values fall back to the
@@ -168,6 +243,10 @@ class SavedProfile {
     // #891: omit when empty so old profiles + default-empty ones stay byte-for-
     // byte identical (absent field is the migration signal, not a key bump).
     if (defaultPath.isNotEmpty) out['defaultPath'] = defaultPath;
+    // #1047: same omit-when-empty policy for the default forwards.
+    if (forwards.isNotEmpty) {
+      out['forwards'] = forwards.map((f) => f.toJson()).toList();
+    }
     return out;
   }
 
@@ -234,6 +313,7 @@ class SavedProfile {
     }
 
     final String defaultPath = _coerceDefaultPath(json['defaultPath']);
+    final List<ProfileForward> forwards = _coerceForwards(json['forwards']);
 
     return SavedProfile(
       title: title,
@@ -249,6 +329,7 @@ class SavedProfile {
       keyVaultId: keyVaultId,
       initialCommand: initialCommand,
       defaultPath: defaultPath,
+      forwards: forwards,
     );
   }
 
@@ -260,6 +341,7 @@ class SavedProfile {
     String? fontFamily,
     String? theme,
     String? defaultPath,
+    List<ProfileForward>? forwards,
   }) {
     return SavedProfile(
       title: title ?? this.title,
@@ -275,6 +357,7 @@ class SavedProfile {
       keyVaultId: keyVaultId ?? this.keyVaultId,
       initialCommand: initialCommand,
       defaultPath: defaultPath ?? this.defaultPath,
+      forwards: forwards ?? this.forwards,
     );
   }
 
@@ -562,6 +645,7 @@ class ProfilesStore {
             keyVaultId: profile.keyVaultId,
             initialCommand: profile.initialCommand,
             defaultPath: profile.defaultPath,
+            forwards: profile.forwards,
           );
           updated++;
           continue;
@@ -709,6 +793,26 @@ class ProfilesStore {
     final idx = list.indexWhere((p) => p.identityKey == identityKey);
     if (idx < 0) return false;
     list[idx] = list[idx].copyWith(theme: themeKey);
+    await save(list);
+    return true;
+  }
+
+  /// Persist the profile-default port forwards (#1047) onto the profile
+  /// matching [identityKey] (`host:port:username`). The sheet's per-forward
+  /// "profile default" toggle calls this with the full desired list (an empty
+  /// list clears them).
+  ///
+  /// NO-OP when no saved profile matches — an ad-hoc connect must NOT be
+  /// materialized as a saved profile just because the user armed a forward
+  /// (mirrors [setFontSize]/[setTheme]). Returns true iff a profile updated.
+  Future<bool> setForwards(
+    String identityKey,
+    List<ProfileForward> forwards,
+  ) async {
+    final list = await load();
+    final idx = list.indexWhere((p) => p.identityKey == identityKey);
+    if (idx < 0) return false;
+    list[idx] = list[idx].copyWith(forwards: forwards);
     await save(list);
     return true;
   }

--- a/native/lib/ui/connect_form.dart
+++ b/native/lib/ui/connect_form.dart
@@ -233,6 +233,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
     double? fontSize,
     String? fontFamily,
     String? colorHex,
+    List<ProfileForward> forwards = const [],
   }) async {
     // Captured before the async gap so we can pop a pushed "New session" route
     // after dispatching connect without touching `context` post-await.
@@ -329,6 +330,17 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       // `SshConnectCommand.controlMode`. Default OFF → scrape path unchanged.
       ref.read(tmuxControlModeProvider);
       await entry.proxy.connect(params);
+      // #1047: arm the profile's default port forwards. Sent AFTER connect on
+      // the same ordered gateway, so the task-side hosted session exists when
+      // forwardAdd lands; the listeners bind on the `connected` transition.
+      // Idempotent (keyed by localPort) — a dedup re-connect just refreshes.
+      for (final fwd in forwards) {
+        entry.proxy.forwardAdd(
+          localPort: fwd.localPort,
+          remoteHost: fwd.remoteHost,
+          remotePort: fwd.remotePort,
+        );
+      }
       // Once we've proven network reachability, fire-and-forget a crash upload
       // sweep. Tailscale being down at boot is the common case.
       unawaited(CrashReporter.uploadPending());
@@ -458,6 +470,7 @@ class _ConnectFormState extends ConsumerState<ConnectForm> {
       fontSize: profile.fontSize,
       fontFamily: profile.fontFamily,
       colorHex: profile.color,
+      forwards: profile.forwards,
     );
   }
 

--- a/native/lib/ui/port_forwards_sheet.dart
+++ b/native/lib/ui/port_forwards_sheet.dart
@@ -1,0 +1,388 @@
+// Port forwards sheet (#1047) — session menu → "Port forwards".
+//
+// Lists the ACTIVE session's ssh -L forwards with live per-forward status
+// (starting / active / error), an add form (local port, remote host, remote
+// port), per-forward remove, and a per-forward "profile default" star that
+// persists the forward onto the session's saved profile so it re-arms on
+// every (re)connect. Monochrome Material glyphs only
+// (feedback_monochrome_icons_no_emoji); every control is a ≥44px target.
+//
+// Presented via showModalBottomSheet on the app Navigator (the session-menu
+// overlay closes FIRST — its barrier sits above pushed routes, #664 idiom).
+//
+// Security (.claude/rules/security.md): forwards bind 127.0.0.1 ONLY; the
+// sheet states that so the surface is honest about scope. No -R in v1.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../services/session_messages.dart';
+import '../state/sessions.dart';
+import '../storage/profiles_store.dart';
+
+/// Open the Port forwards sheet for [entry] on [navigatorContext] (the app
+/// Navigator's context — NOT the session-menu overlay's, which must already
+/// be closed, #664).
+Future<void> showPortForwardsSheet(
+  BuildContext navigatorContext, {
+  required SessionEntry entry,
+  required ProfilesStore store,
+}) {
+  return showModalBottomSheet<void>(
+    context: navigatorContext,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (_) => PortForwardsSheet(entry: entry, store: store),
+  );
+}
+
+class PortForwardsSheet extends StatefulWidget {
+  const PortForwardsSheet({
+    super.key,
+    required this.entry,
+    required this.store,
+  });
+
+  final SessionEntry entry;
+  final ProfilesStore store;
+
+  @override
+  State<PortForwardsSheet> createState() => _PortForwardsSheetState();
+}
+
+class _PortForwardsSheetState extends State<PortForwardsSheet> {
+  late List<ForwardInfo> _forwards;
+  StreamSubscription<List<ForwardInfo>>? _sub;
+
+  /// localPorts marked as profile defaults for this session's profile. Null
+  /// while loading OR when the session has no saved profile (ad-hoc) — then
+  /// the star column is hidden (we never materialize a profile, #640 idiom).
+  Set<int>? _defaultPorts;
+  bool _hasProfile = false;
+
+  final _localPortCtrl = TextEditingController();
+  final _remoteHostCtrl = TextEditingController(text: '127.0.0.1');
+  final _remotePortCtrl = TextEditingController();
+  String? _formError;
+
+  @override
+  void initState() {
+    super.initState();
+    _forwards = widget.entry.proxy.forwards;
+    _sub = widget.entry.proxy.forwardEvents.listen((list) {
+      if (!mounted) return;
+      setState(() => _forwards = list);
+    });
+    // Hydrate: the task replays the authoritative table.
+    widget.entry.proxy.forwardList();
+    unawaited(_loadDefaults());
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    _localPortCtrl.dispose();
+    _remoteHostCtrl.dispose();
+    _remotePortCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadDefaults() async {
+    final profiles = await widget.store.load();
+    if (!mounted) return;
+    for (final p in profiles) {
+      if (p.identityKey == widget.entry.profileKey) {
+        setState(() {
+          _hasProfile = true;
+          _defaultPorts = p.forwards.map((f) => f.localPort).toSet();
+        });
+        return;
+      }
+    }
+    setState(() {
+      _hasProfile = false;
+      _defaultPorts = <int>{};
+    });
+  }
+
+  /// Toggle "arm on connect" for [info]'s localPort on the saved profile.
+  Future<void> _toggleDefault(ForwardInfo info) async {
+    final ports = _defaultPorts;
+    if (!_hasProfile || ports == null) return;
+    final next = <int>{...ports};
+    final adding = next.add(info.localPort);
+    if (!adding) next.remove(info.localPort);
+    // Rebuild the profile list from the CURRENT session table (source of
+    // truth for targets) filtered to the marked ports.
+    final list = <ProfileForward>[
+      for (final f in _forwards)
+        if (next.contains(f.localPort))
+          ProfileForward(
+            localPort: f.localPort,
+            remoteHost: f.remoteHost,
+            remotePort: f.remotePort,
+          ),
+    ];
+    await widget.store.setForwards(widget.entry.profileKey, list);
+    if (!mounted) return;
+    setState(() => _defaultPorts = next);
+  }
+
+  /// When a forward is removed from the live session, also drop a matching
+  /// profile default — a removed forward that silently re-arms on the next
+  /// connect would read as "remove didn't work".
+  Future<void> _remove(ForwardInfo info) async {
+    widget.entry.proxy.forwardRemove(info.localPort);
+    final ports = _defaultPorts;
+    if (_hasProfile && ports != null && ports.contains(info.localPort)) {
+      final next = <int>{...ports}..remove(info.localPort);
+      final list = <ProfileForward>[
+        for (final f in _forwards)
+          if (f.localPort != info.localPort && next.contains(f.localPort))
+            ProfileForward(
+              localPort: f.localPort,
+              remoteHost: f.remoteHost,
+              remotePort: f.remotePort,
+            ),
+      ];
+      await widget.store.setForwards(widget.entry.profileKey, list);
+      if (!mounted) return;
+      setState(() => _defaultPorts = next);
+    }
+  }
+
+  void _submitAdd() {
+    final localPort = int.tryParse(_localPortCtrl.text.trim());
+    final remotePort = int.tryParse(_remotePortCtrl.text.trim());
+    final remoteHostRaw = _remoteHostCtrl.text.trim();
+    final remoteHost = remoteHostRaw.isEmpty ? '127.0.0.1' : remoteHostRaw;
+    if (localPort == null || localPort < 1 || localPort > 65535) {
+      setState(() => _formError = 'Local port must be 1–65535');
+      return;
+    }
+    if (remotePort == null || remotePort < 1 || remotePort > 65535) {
+      setState(() => _formError = 'Remote port must be 1–65535');
+      return;
+    }
+    setState(() => _formError = null);
+    widget.entry.proxy.forwardAdd(
+      localPort: localPort,
+      remoteHost: remoteHost,
+      remotePort: remotePort,
+    );
+    _localPortCtrl.clear();
+    _remotePortCtrl.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // Float above the soft keyboard so the add form stays reachable.
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(bottom: bottomInset),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.7,
+          ),
+          child: Column(
+            key: const Key('port-forwards-sheet'),
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 4, 20, 2),
+                child: Text('Port forwards', style: theme.textTheme.titleSmall),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+                child: Text(
+                  // Honest scope: loopback-only listeners (rules/security.md).
+                  'Listens on 127.0.0.1 on this device; tunnels to the host '
+                  'over SSH.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+              if (_forwards.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+                  child: Text(
+                    'No forwards yet.',
+                    key: const Key('port-forwards-empty'),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                )
+              else
+                Flexible(
+                  child: ListView(
+                    shrinkWrap: true,
+                    children: [
+                      for (final f in _forwards) _forwardRow(theme, f),
+                    ],
+                  ),
+                ),
+              const Divider(height: 1),
+              _addForm(theme),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _forwardRow(ThemeData theme, ForwardInfo f) {
+    final (IconData glyph, Color color, String label) = switch (f.status) {
+      ForwardStatus.active => (
+        Icons.check_circle,
+        theme.colorScheme.primary,
+        'Active',
+      ),
+      ForwardStatus.starting => (
+        Icons.pending_outlined,
+        theme.colorScheme.onSurfaceVariant,
+        'Waiting for connection',
+      ),
+      ForwardStatus.error => (
+        Icons.error_outline,
+        theme.colorScheme.error,
+        'Error',
+      ),
+    };
+    final isDefault = _defaultPorts?.contains(f.localPort) ?? false;
+    final subtitle = f.error ?? label;
+    return ListTile(
+      key: Key('forward-row-${f.localPort}'),
+      dense: true,
+      leading: Icon(glyph, size: 20, color: color),
+      title: Text(
+        '${f.localPort}  →  ${f.remoteHost}:${f.remotePort}',
+        style: theme.textTheme.bodyMedium,
+      ),
+      subtitle: Text(
+        subtitle,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: f.status == ForwardStatus.error
+              ? theme.colorScheme.error
+              : theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // "Arm on connect" profile-default star. Hidden for ad-hoc sessions
+          // with no saved profile (never materialize one).
+          if (_hasProfile)
+            IconButton(
+              key: Key('forward-default-${f.localPort}'),
+              tooltip: isDefault
+                  ? 'Profile default (arms on connect)'
+                  : 'Save as profile default',
+              visualDensity: VisualDensity.compact,
+              icon: Icon(
+                isDefault ? Icons.star : Icons.star_border,
+                color: isDefault ? theme.colorScheme.primary : null,
+              ),
+              onPressed: () => unawaited(_toggleDefault(f)),
+            ),
+          IconButton(
+            key: Key('forward-remove-${f.localPort}'),
+            tooltip: 'Remove forward',
+            visualDensity: VisualDensity.compact,
+            icon: const Icon(Icons.close),
+            onPressed: () => unawaited(_remove(f)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _addForm(ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              SizedBox(
+                width: 88,
+                child: TextField(
+                  key: const Key('forward-local-port'),
+                  controller: _localPortCtrl,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  decoration: const InputDecoration(
+                    labelText: 'Local',
+                    hintText: '18088',
+                    isDense: true,
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Icon(
+                  Icons.arrow_forward,
+                  size: 16,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              Expanded(
+                child: TextField(
+                  key: const Key('forward-remote-host'),
+                  controller: _remoteHostCtrl,
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  decoration: const InputDecoration(
+                    labelText: 'Remote host',
+                    isDense: true,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              SizedBox(
+                width: 88,
+                child: TextField(
+                  key: const Key('forward-remote-port'),
+                  controller: _remotePortCtrl,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  decoration: const InputDecoration(
+                    labelText: 'Remote',
+                    hintText: '8088',
+                    isDense: true,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (_formError != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Text(
+                _formError!,
+                key: const Key('forward-form-error'),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ),
+          const SizedBox(height: 8),
+          FilledButton.icon(
+            key: const Key('forward-add-submit'),
+            onPressed: _submitAdd,
+            icon: const Icon(Icons.add, size: 18),
+            label: const Text('Add forward'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -25,6 +25,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../main.dart' show openConnectHome;
+import '../services/session_messages.dart' show ForwardInfo, ForwardStatus;
 import '../ssh/ssh_session.dart';
 import '../state/detection_providers.dart';
 import '../state/favorites_providers.dart';
@@ -35,6 +36,7 @@ import '../storage/profiles_store.dart' show ProfilesStore;
 import 'detection_lab_screen.dart';
 import 'favorites_menu_sheet.dart';
 import 'file_browser_screen.dart';
+import 'port_forwards_sheet.dart';
 import 'session_state_dot.dart';
 
 /// Opens the session menu as a NON-MODAL overlay anchored to the bottom, above
@@ -537,6 +539,23 @@ class _SessionControlsRow extends ConsumerWidget {
               },
             ),
           ),
+          // 3a. Port forwards (#1047) — opens the ssh -L sheet for the ACTIVE
+          // session. The glyph carries a count badge while any forward is
+          // ACTIVE (cheap: the proxy caches the latest table). Same #664
+          // overlay idiom as the pickers: capture the app navigator + the
+          // entry/store, close the menu, THEN show the sheet.
+          _ForwardsButton(
+            entry: sessions.active,
+            enabled: hasActive,
+            onOpen: (entry) {
+              final navContext = Navigator.of(context).context;
+              final store = ref.read(profilesStoreProvider);
+              onClose();
+              unawaited(
+                showPortForwardsSheet(navContext, entry: entry, store: store),
+              );
+            },
+          ),
           // Files moved to a PER-ROW affordance (#649): each session row now
           // carries its own `session-menu-files-${id}` icon next to its X.
           // 3b. Link/path DETECTION toggle (#955/#888) — GLOBAL. Its glyph is a
@@ -720,6 +739,71 @@ class _StepButton extends StatelessWidget {
       behavior: HitTestBehavior.deferToChild,
       onLongPress: enabled ? onLongPress : null,
       child: Semantics(label: tooltip, child: button),
+    );
+  }
+}
+
+/// Port-forwards control (#1047): a ~44px monochrome icon that opens the ssh
+/// -L sheet for the ACTIVE session, wearing a small count badge while any
+/// forward is ACTIVE. Reactive via the proxy's forward stream (initialData =
+/// the proxy's cached table, so a re-opened menu shows the count immediately).
+class _ForwardsButton extends StatelessWidget {
+  const _ForwardsButton({
+    required this.entry,
+    required this.enabled,
+    required this.onOpen,
+  });
+
+  final SessionEntry? entry;
+  final bool enabled;
+  final void Function(SessionEntry entry) onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final e = entry;
+    if (e == null) {
+      return IconButton(
+        key: const Key('session-menu-port-forwards'),
+        tooltip: 'Port forwards',
+        iconSize: 20,
+        constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+        padding: EdgeInsets.zero,
+        visualDensity: VisualDensity.compact,
+        icon: const Icon(Icons.settings_ethernet),
+        onPressed: null,
+      );
+    }
+    return StreamBuilder<List<ForwardInfo>>(
+      stream: e.proxy.forwardEvents,
+      initialData: e.proxy.forwards,
+      builder: (context, snapshot) {
+        final forwards = snapshot.data ?? const <ForwardInfo>[];
+        final activeCount =
+            forwards.where((f) => f.status == ForwardStatus.active).length;
+        final glyph = Icon(
+          Icons.settings_ethernet,
+          color: activeCount > 0 ? theme.colorScheme.primary : null,
+        );
+        return IconButton(
+          key: const Key('session-menu-port-forwards'),
+          tooltip: activeCount > 0
+              ? 'Port forwards ($activeCount active)'
+              : 'Port forwards',
+          iconSize: 20,
+          constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+          padding: EdgeInsets.zero,
+          visualDensity: VisualDensity.compact,
+          icon: activeCount > 0
+              ? Badge.count(
+                  key: const Key('session-menu-port-forwards-badge'),
+                  count: activeCount,
+                  child: glyph,
+                )
+              : glyph,
+          onPressed: enabled ? () => onOpen(e) : null,
+        );
+      },
     );
   }
 }

--- a/native/test/services/forward_host_test.dart
+++ b/native/test/services/forward_host_test.dart
@@ -1,0 +1,349 @@
+// SessionHost port-forward routing tests (#1047).
+//
+// Exercises the task-side forward lifecycle end to end over the real IPC pair
+// (InMemoryGatewayPair) with a REAL loopback ServerSocket and a fake tunnel
+// opener injected via the host's `forwardOpenerFactory` seam — no real SSH.
+// Covers the state-transition contract (per rules: test TRANSITIONS):
+//   - forwardAdd before `connected` stores config (status starting, no bind)
+//   - `connected` transition ARMS the listener (status active, bytes pipe)
+//   - leaving `connected` drops the listener; re-entering RE-ARMS it (the
+//     reconnect re-arm the issue requires)
+//   - forwardRemove closes the listener → connection refused + empty list
+//   - port-in-use bind failure surfaces as status error with a message
+//
+// Pattern lifted from reconnect_shell_revive_test.dart (drivable controller +
+// silent-socket sentinel client).
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+
+class _SilentSocket implements SSHSocket {
+  final _outbound = StreamController<List<int>>();
+  final _doneCompleter = Completer<void>();
+
+  @override
+  Stream<Uint8List> get stream => const Stream<Uint8List>.empty();
+
+  @override
+  StreamSink<List<int>> get sink => _outbound.sink;
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() async {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+    await _outbound.close();
+    return done;
+  }
+
+  @override
+  void destroy() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+}
+
+class _DrivableController extends SshSessionController {
+  // The socketOpener never resolves: a real `connect('h':22)` would otherwise
+  // fail DNS and drive connected → failed underneath the test's driven states.
+  _DrivableController(this._client)
+      : super(
+          socketOpener: (host, port, {timeout}) {
+            return Future.delayed(const Duration(days: 1), () {
+              throw Exception('socketOpener not used in forward tests');
+            });
+          },
+        );
+
+  final SSHClient _client;
+
+  @override
+  SSHClient? get client => _client;
+}
+
+/// Echo tunnel — same as port_forwarder_test's, kept local for isolation.
+class _EchoTunnel implements SSHSocket {
+  final _out = StreamController<Uint8List>();
+  final _in = StreamController<List<int>>();
+  final _done = Completer<void>();
+
+  _EchoTunnel() {
+    _in.stream.listen(
+      (data) {
+        if (!_out.isClosed) {
+          _out.add(data is Uint8List ? data : Uint8List.fromList(data));
+        }
+      },
+      onDone: () {
+        if (!_out.isClosed) _out.close();
+      },
+    );
+  }
+
+  @override
+  Stream<Uint8List> get stream => _out.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _in.sink;
+
+  @override
+  Future<void> get done => _done.future;
+
+  @override
+  Future<void> close() async {
+    if (!_in.isClosed) await _in.close();
+    if (!_done.isCompleted) _done.complete();
+  }
+
+  @override
+  void destroy() {
+    _in.close();
+    if (!_out.isClosed) _out.close();
+    if (!_done.isCompleted) _done.complete();
+  }
+}
+
+const _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+Future<void> _settle() =>
+    Future<void>.delayed(const Duration(milliseconds: 40));
+
+Future<Uint8List> _roundTrip(int port, List<int> payload) async {
+  final socket = await Socket.connect(InternetAddress.loopbackIPv4, port);
+  socket.add(payload);
+  await socket.flush();
+  final got = <int>[];
+  final completer = Completer<Uint8List>();
+  late StreamSubscription<Uint8List> sub;
+  sub = socket.listen(
+    (chunk) {
+      got.addAll(chunk);
+      if (got.length >= payload.length) {
+        completer.complete(Uint8List.fromList(got));
+        sub.cancel();
+        socket.destroy();
+      }
+    },
+    onDone: () {
+      if (!completer.isCompleted) completer.complete(Uint8List.fromList(got));
+      socket.destroy();
+    },
+  );
+  return completer.future.timeout(const Duration(seconds: 5));
+}
+
+/// Pick a free loopback port by binding an ephemeral socket and releasing it.
+Future<int> _freePort() async {
+  final s = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = s.port;
+  await s.close();
+  return port;
+}
+
+typedef _Ctx = ({
+  SessionHost host,
+  SshSessionProxy proxy,
+  InMemoryGatewayPair pair,
+  _DrivableController Function() controllerOf,
+  List<List<ForwardInfo>> lists,
+});
+
+Future<_Ctx> _setUp(String sid) async {
+  final socket = _SilentSocket();
+  final sentinelClient = SSHClient(socket, username: 'u');
+  late _DrivableController controller;
+  _DrivableController factory() {
+    controller = _DrivableController(sentinelClient);
+    return controller;
+  }
+
+  final pair = InMemoryGatewayPair();
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: factory,
+    forwardOpenerFactory: (sessionId) =>
+        (remoteHost, remotePort) async => _EchoTunnel(),
+    snapshotInterval: const Duration(hours: 1),
+  );
+  final proxy = SshSessionProxy(sessionId: sid, gateway: pair.uiSide);
+
+  final lists = <List<ForwardInfo>>[];
+  proxy.forwardEvents.listen(lists.add);
+
+  addTearDown(() async {
+    await proxy.dispose();
+    await host.dispose();
+    await pair.dispose();
+    try {
+      sentinelClient.close();
+    } catch (_) {}
+    socket.destroy();
+  });
+
+  proxy.connect(_params);
+  await _settle();
+  return (
+    host: host,
+    proxy: proxy,
+    pair: pair,
+    controllerOf: () => controller,
+    lists: lists,
+  );
+}
+
+void main() {
+  test('forwardAdd before connected: config stored, arms on connected',
+      () async {
+    final ctx = await _setUp('sid-fwd-arm');
+    final port = await _freePort();
+
+    // Add while still idle (auth never completes on the silent socket).
+    ctx.proxy.forwardAdd(
+      localPort: port,
+      remoteHost: '127.0.0.1',
+      remotePort: 8088,
+    );
+    await _settle();
+
+    expect(ctx.lists, isNotEmpty, reason: 'add must emit a forward list');
+    expect(ctx.lists.last.single.status, ForwardStatus.starting,
+        reason: 'not connected yet — nothing may bind');
+    // Not listening yet.
+    expect(
+      () => Socket.connect(
+        InternetAddress.loopbackIPv4,
+        port,
+        timeout: const Duration(seconds: 2),
+      ),
+      throwsA(isA<SocketException>()),
+    );
+
+    // Connected transition arms the listener.
+    ctx.controllerOf().debugSetConnectedForTest(_params);
+    await _settle();
+    expect(ctx.lists.last.single.status, ForwardStatus.active);
+
+    final echoed = await _roundTrip(port, [10, 20, 30]);
+    expect(echoed, [10, 20, 30], reason: 'bytes must pipe through the tunnel');
+  });
+
+  test('leaving connected drops the listener; reconnect RE-ARMS it', () async {
+    final ctx = await _setUp('sid-fwd-rearm');
+    final port = await _freePort();
+
+    ctx.controllerOf().debugSetConnectedForTest(_params);
+    await _settle();
+    ctx.proxy.forwardAdd(
+      localPort: port,
+      remoteHost: '127.0.0.1',
+      remotePort: 8088,
+    );
+    await _settle();
+    expect(ctx.lists.last.single.status, ForwardStatus.active);
+    await _roundTrip(port, [1]);
+
+    // Drop: the session leaves connected → listener must die with it.
+    await ctx.controllerOf().disconnect();
+    await _settle();
+    expect(ctx.lists.last.single.status, ForwardStatus.starting,
+        reason: 'forward dies with the session (config retained)');
+    expect(
+      () => Socket.connect(
+        InternetAddress.loopbackIPv4,
+        port,
+        timeout: const Duration(seconds: 2),
+      ),
+      throwsA(isA<SocketException>()),
+    );
+
+    // Reconnect: re-entering connected re-arms the retained config.
+    ctx.controllerOf().debugSetConnectedForTest(_params);
+    await _settle();
+    expect(ctx.lists.last.single.status, ForwardStatus.active,
+        reason: 'profile/ad-hoc forwards re-arm on reconnect');
+    final echoed = await _roundTrip(port, [7, 8]);
+    expect(echoed, [7, 8]);
+  });
+
+  test('forwardRemove closes the listener → refused + empty list', () async {
+    final ctx = await _setUp('sid-fwd-rm');
+    final port = await _freePort();
+
+    ctx.controllerOf().debugSetConnectedForTest(_params);
+    await _settle();
+    ctx.proxy.forwardAdd(
+      localPort: port,
+      remoteHost: '127.0.0.1',
+      remotePort: 8088,
+    );
+    await _settle();
+    await _roundTrip(port, [1, 2]);
+
+    ctx.proxy.forwardRemove(port);
+    await _settle();
+    expect(ctx.lists.last, isEmpty);
+    expect(
+      () => Socket.connect(
+        InternetAddress.loopbackIPv4,
+        port,
+        timeout: const Duration(seconds: 2),
+      ),
+      throwsA(isA<SocketException>()),
+    );
+  });
+
+  test('port-in-use surfaces as status error with a message', () async {
+    final ctx = await _setUp('sid-fwd-inuse');
+    final squatter = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(squatter.close);
+
+    ctx.controllerOf().debugSetConnectedForTest(_params);
+    await _settle();
+    ctx.proxy.forwardAdd(
+      localPort: squatter.port,
+      remoteHost: '127.0.0.1',
+      remotePort: 8088,
+    );
+    await _settle();
+
+    final info = ctx.lists.last.single;
+    expect(info.status, ForwardStatus.error);
+    expect(info.error, isNotNull);
+    expect(info.error, contains('${squatter.port}'));
+  });
+
+  test('forwardList replays the current table on demand', () async {
+    final ctx = await _setUp('sid-fwd-list');
+    final port = await _freePort();
+    ctx.proxy.forwardAdd(
+      localPort: port,
+      remoteHost: 'db.internal',
+      remotePort: 5432,
+    );
+    await _settle();
+    ctx.lists.clear();
+
+    ctx.proxy.forwardList();
+    await _settle();
+    expect(ctx.lists, hasLength(1));
+    final info = ctx.lists.single.single;
+    expect(info.localPort, port);
+    expect(info.remoteHost, 'db.internal');
+    expect(info.remotePort, 5432);
+  });
+}

--- a/native/test/services/forward_messages_test.dart
+++ b/native/test/services/forward_messages_test.dart
@@ -1,0 +1,110 @@
+// Wire-contract round-trip tests for the port-forward IPC envelopes (#1047).
+//
+// Mirrors task_ipc_test.dart: every forward command and the forward-list
+// status event must round-trip through toJson/fromJson without losing
+// information — the task-side host and UI-side proxy both rely on it.
+// [SYNC] single-codebase wire contract (both isolates are session_messages.dart);
+// this round-trip suite is the sync check.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_messages.dart';
+
+void main() {
+  group('forward command round-trips (#1047)', () {
+    test('SshForwardAddCommand preserves all fields', () {
+      const cmd = SshForwardAddCommand(
+        sessionId: 'h:22:u:1',
+        localPort: 18088,
+        remoteHost: '127.0.0.1',
+        remotePort: 8088,
+      );
+      final restored = SshTaskCommand.fromJson(cmd.toJson());
+      expect(restored, isA<SshForwardAddCommand>());
+      restored as SshForwardAddCommand;
+      expect(restored.kind, SshTaskCommandKind.forwardAdd);
+      expect(restored.sessionId, 'h:22:u:1');
+      expect(restored.localPort, 18088);
+      expect(restored.remoteHost, '127.0.0.1');
+      expect(restored.remotePort, 8088);
+    });
+
+    test('SshForwardRemoveCommand round-trips', () {
+      const cmd = SshForwardRemoveCommand(
+        sessionId: 'h:22:u:1',
+        localPort: 18088,
+      );
+      final restored = SshTaskCommand.fromJson(cmd.toJson());
+      expect(restored, isA<SshForwardRemoveCommand>());
+      restored as SshForwardRemoveCommand;
+      expect(restored.kind, SshTaskCommandKind.forwardRemove);
+      expect(restored.localPort, 18088);
+    });
+
+    test('SshForwardListCommand round-trips', () {
+      const cmd = SshForwardListCommand(sessionId: 'h:22:u:1');
+      final restored = SshTaskCommand.fromJson(cmd.toJson());
+      expect(restored, isA<SshForwardListCommand>());
+      expect(restored.kind, SshTaskCommandKind.forwardList);
+      expect(restored.sessionId, 'h:22:u:1');
+    });
+  });
+
+  group('forward event round-trips (#1047)', () {
+    test('SshForwardListEvent preserves per-forward status + error', () {
+      const event = SshForwardListEvent(
+        sessionId: 'h:22:u:1',
+        forwards: [
+          ForwardInfo(
+            localPort: 18088,
+            remoteHost: '127.0.0.1',
+            remotePort: 8088,
+            status: ForwardStatus.active,
+          ),
+          ForwardInfo(
+            localPort: 2000,
+            remoteHost: 'db.internal',
+            remotePort: 5432,
+            status: ForwardStatus.error,
+            error: 'Port 2000 is already in use',
+          ),
+        ],
+      );
+      final restored = SshTaskEvent.fromJson(event.toJson());
+      expect(restored, isA<SshForwardListEvent>());
+      restored as SshForwardListEvent;
+      expect(restored.kind, SshTaskEventKind.forwardList);
+      expect(restored.sessionId, 'h:22:u:1');
+      expect(restored.forwards.length, 2);
+      final a = restored.forwards[0];
+      expect(a.localPort, 18088);
+      expect(a.remoteHost, '127.0.0.1');
+      expect(a.remotePort, 8088);
+      expect(a.status, ForwardStatus.active);
+      expect(a.error, isNull);
+      final b = restored.forwards[1];
+      expect(b.localPort, 2000);
+      expect(b.remoteHost, 'db.internal');
+      expect(b.remotePort, 5432);
+      expect(b.status, ForwardStatus.error);
+      expect(b.error, 'Port 2000 is already in use');
+    });
+
+    test('SshForwardListEvent round-trips empty list', () {
+      const event = SshForwardListEvent(sessionId: 'sid', forwards: []);
+      final restored =
+          SshTaskEvent.fromJson(event.toJson()) as SshForwardListEvent;
+      expect(restored.forwards, isEmpty);
+    });
+
+    test('ForwardInfo tolerates an unknown status string (forward compat)', () {
+      final restored = ForwardInfo.fromJson(const {
+        'localPort': 1,
+        'remoteHost': 'h',
+        'remotePort': 2,
+        'status': 'someFutureStatus',
+      });
+      // Unknown status degrades to starting (never a crash).
+      expect(restored.status, ForwardStatus.starting);
+    });
+  });
+}

--- a/native/test/services/port_forwarder_test.dart
+++ b/native/test/services/port_forwarder_test.dart
@@ -1,0 +1,205 @@
+// Port-forward engine tests (#1047).
+//
+// Exercises the task-side ssh -L listener in isolation: a real dart:io
+// ServerSocket on 127.0.0.1 with a FAKE tunnel opener standing in for the
+// dartssh2 direct-tcpip channel (`SSHClient.forwardLocal` returns an
+// `SSHSocket`; the fake implements the same interface). Covers:
+//   - accept → bidirectional pipe (echo round-trip)
+//   - close → subsequent connects refused + live pipes torn down
+//   - port-in-use bind failure surfaces as a SocketException
+//   - channel-open refusal closes the accepted socket, keeps listening
+//     (ssh -L semantics), and reports via onChannelError
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart' show SSHSocket;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/port_forwarder.dart';
+
+/// A fake direct-tcpip tunnel that ECHOES everything written to its sink back
+/// out of its stream — so a local socket round-trip proves both pipe
+/// directions work.
+class _EchoTunnel implements SSHSocket {
+  final _out = StreamController<Uint8List>();
+  final _in = StreamController<List<int>>();
+  final _done = Completer<void>();
+  bool closed = false;
+
+  _EchoTunnel() {
+    _in.stream.listen(
+      (data) {
+        if (!_out.isClosed) {
+          _out.add(data is Uint8List ? data : Uint8List.fromList(data));
+        }
+      },
+      onDone: () {
+        // Remote side sees our half-close: end the read stream too.
+        if (!_out.isClosed) _out.close();
+      },
+    );
+  }
+
+  @override
+  Stream<Uint8List> get stream => _out.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _in.sink;
+
+  @override
+  Future<void> get done => _done.future;
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    if (!_in.isClosed) await _in.close();
+    if (!_done.isCompleted) _done.complete();
+  }
+
+  @override
+  void destroy() {
+    closed = true;
+    _in.close();
+    if (!_out.isClosed) _out.close();
+    if (!_done.isCompleted) _done.complete();
+  }
+}
+
+Future<Uint8List> _roundTrip(int port, List<int> payload) async {
+  final socket = await Socket.connect(InternetAddress.loopbackIPv4, port);
+  socket.add(payload);
+  await socket.flush();
+  final got = <int>[];
+  final completer = Completer<Uint8List>();
+  late StreamSubscription<Uint8List> sub;
+  sub = socket.listen(
+    (chunk) {
+      got.addAll(chunk);
+      if (got.length >= payload.length) {
+        completer.complete(Uint8List.fromList(got));
+        sub.cancel();
+        socket.destroy();
+      }
+    },
+    onDone: () {
+      if (!completer.isCompleted) {
+        completer.complete(Uint8List.fromList(got));
+      }
+      socket.destroy();
+    },
+  );
+  return completer.future.timeout(const Duration(seconds: 5));
+}
+
+void main() {
+  test('accept → bidirectional pipe: bytes echo through the tunnel', () async {
+    final tunnels = <_EchoTunnel>[];
+    final listener = await PortForwardListener.start(
+      config: const PortForwardConfig(
+        localPort: 0, // ephemeral for the test; prod uses the user's port
+        remoteHost: '127.0.0.1',
+        remotePort: 8088,
+      ),
+      openTunnel: (host, port) async {
+        expect(host, '127.0.0.1');
+        expect(port, 8088);
+        final t = _EchoTunnel();
+        tunnels.add(t);
+        return t;
+      },
+    );
+    addTearDown(listener.close);
+
+    final payload = List<int>.generate(64, (i) => i);
+    final echoed = await _roundTrip(listener.boundPort, payload);
+    expect(echoed, payload);
+    expect(tunnels.length, 1);
+  });
+
+  test('close → subsequent connects are refused + tunnels torn down', () async {
+    final tunnels = <_EchoTunnel>[];
+    final listener = await PortForwardListener.start(
+      config: const PortForwardConfig(
+        localPort: 0,
+        remoteHost: '127.0.0.1',
+        remotePort: 8088,
+      ),
+      openTunnel: (host, port) async {
+        final t = _EchoTunnel();
+        tunnels.add(t);
+        return t;
+      },
+    );
+    final port = listener.boundPort;
+    // Prove it was live first (also creates a live tunnel to tear down).
+    await _roundTrip(port, [1, 2, 3]);
+
+    await listener.close();
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(
+      () => Socket.connect(
+        InternetAddress.loopbackIPv4,
+        port,
+        timeout: const Duration(seconds: 2),
+      ),
+      throwsA(isA<SocketException>()),
+    );
+    expect(
+      tunnels.every((t) => t.closed),
+      isTrue,
+      reason: 'live tunnels must be torn down with the listener',
+    );
+  });
+
+  test('port-in-use bind failure throws SocketException', () async {
+    final squatter = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(squatter.close);
+    expect(
+      () => PortForwardListener.start(
+        config: PortForwardConfig(
+          localPort: squatter.port,
+          remoteHost: '127.0.0.1',
+          remotePort: 8088,
+        ),
+        openTunnel: (_, _) async => _EchoTunnel(),
+      ),
+      throwsA(isA<SocketException>()),
+    );
+  });
+
+  test(
+    'channel-open refusal closes THAT socket, keeps listening, reports error',
+    () async {
+      final errors = <String>[];
+      var attempts = 0;
+      final listener = await PortForwardListener.start(
+        config: const PortForwardConfig(
+          localPort: 0,
+          remoteHost: '127.0.0.1',
+          remotePort: 8088,
+        ),
+        openTunnel: (host, port) async {
+          attempts += 1;
+          if (attempts == 1) {
+            throw Exception('channel open failed: administratively prohibited');
+          }
+          return _EchoTunnel();
+        },
+        onChannelError: errors.add,
+      );
+      addTearDown(listener.close);
+
+      // First connection: tunnel refused → socket ends with no data.
+      final refused = await _roundTrip(listener.boundPort, [9, 9, 9]);
+      expect(refused, isEmpty, reason: 'refused channel must not echo bytes');
+      expect(errors, isNotEmpty);
+      expect(errors.first, contains('administratively prohibited'));
+
+      // Listener survives (ssh -L keeps listening): the next connect pipes.
+      final ok = await _roundTrip(listener.boundPort, [4, 5, 6]);
+      expect(ok, [4, 5, 6]);
+    },
+  );
+}

--- a/native/test/storage/profile_forwards_test.dart
+++ b/native/test/storage/profile_forwards_test.dart
@@ -1,0 +1,172 @@
+// Per-profile default port forwards — persistence round-trip (#1047).
+//
+// Mirrors profile_default_path_test.dart: the `forwards` field follows the
+// schema-in-value conventions (absent field on an OLD profile reads back as
+// [], corrupt entries are dropped, no key bump), and `setForwards` upserts the
+// list onto the matching identity without materializing ad-hoc profiles.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ProfileForward json (#1047)', () {
+    test('round-trips all fields', () {
+      const fwd = ProfileForward(
+        localPort: 18088,
+        remoteHost: 'db.internal',
+        remotePort: 5432,
+      );
+      final restored = ProfileForward.fromJson(fwd.toJson());
+      expect(restored, isNotNull);
+      expect(restored!.localPort, 18088);
+      expect(restored.remoteHost, 'db.internal');
+      expect(restored.remotePort, 5432);
+    });
+
+    test('invalid ports / missing fields yield null (corrupt resilience)', () {
+      expect(ProfileForward.fromJson(const {}), isNull);
+      expect(
+        ProfileForward.fromJson(const {
+          'localPort': 0,
+          'remoteHost': 'h',
+          'remotePort': 80,
+        }),
+        isNull,
+      );
+      expect(
+        ProfileForward.fromJson(const {
+          'localPort': 80,
+          'remoteHost': 'h',
+          'remotePort': 700000,
+        }),
+        isNull,
+      );
+    });
+
+    test('empty remoteHost defaults to 127.0.0.1', () {
+      final restored = ProfileForward.fromJson(const {
+        'localPort': 18088,
+        'remotePort': 8088,
+      });
+      expect(restored, isNotNull);
+      expect(restored!.remoteHost, '127.0.0.1');
+    });
+  });
+
+  group('SavedProfile.forwards (#1047)', () {
+    test('absent field reads back as empty list (legacy profile)', () {
+      final p = SavedProfile.fromJson(const {
+        'title': 't',
+        'host': 'h',
+        'port': 22,
+        'username': 'u',
+      });
+      expect(p.forwards, isEmpty);
+    });
+
+    test('round-trips through toJson/fromJson', () {
+      final p = SavedProfile(
+        title: 't',
+        host: 'h',
+        port: 22,
+        username: 'u',
+        forwards: const [
+          ProfileForward(
+            localPort: 18088,
+            remoteHost: '127.0.0.1',
+            remotePort: 8088,
+          ),
+        ],
+      );
+      final restored = SavedProfile.fromJson(p.toJson());
+      expect(restored.forwards, hasLength(1));
+      expect(restored.forwards.single.localPort, 18088);
+      expect(restored.forwards.single.remotePort, 8088);
+    });
+
+    test('empty forwards is OMITTED from json (legacy byte-stability)', () {
+      final p = SavedProfile(title: 't', host: 'h', port: 22, username: 'u');
+      expect(p.toJson().containsKey('forwards'), isFalse);
+    });
+
+    test('corrupt entries inside the list are dropped, valid ones kept', () {
+      final p = SavedProfile.fromJson(const {
+        'title': 't',
+        'host': 'h',
+        'port': 22,
+        'username': 'u',
+        'forwards': [
+          {'localPort': 18088, 'remoteHost': 'x', 'remotePort': 8088},
+          'garbage',
+          {'localPort': -1, 'remoteHost': 'x', 'remotePort': 8088},
+        ],
+      });
+      expect(p.forwards, hasLength(1));
+      expect(p.forwards.single.localPort, 18088);
+    });
+  });
+
+  group('ProfilesStore.setForwards (#1047)', () {
+    test('persists onto the matching identity, survives reload', () async {
+      SharedPreferences.setMockInitialValues({
+        profilesPrefsKey: jsonEncode([
+          {'title': 'box', 'host': 'h', 'port': 22, 'username': 'u'},
+        ]),
+      });
+      final store = ProfilesStore();
+      final ok = await store.setForwards('h:22:u', const [
+        ProfileForward(
+          localPort: 18088,
+          remoteHost: '127.0.0.1',
+          remotePort: 8088,
+        ),
+      ]);
+      expect(ok, isTrue);
+
+      final reloaded = await ProfilesStore().load();
+      expect(reloaded.single.forwards, hasLength(1));
+      expect(reloaded.single.forwards.single.localPort, 18088);
+    });
+
+    test('NO-OP (returns false) for an unknown identity — never materializes',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final store = ProfilesStore();
+      final ok = await store.setForwards('nope:22:u', const [
+        ProfileForward(
+          localPort: 1,
+          remoteHost: 'h',
+          remotePort: 2,
+        ),
+      ]);
+      expect(ok, isFalse);
+      expect(await store.load(), isEmpty);
+    });
+
+    test('setting an empty list clears persisted forwards', () async {
+      SharedPreferences.setMockInitialValues({
+        profilesPrefsKey: jsonEncode([
+          {
+            'title': 'box',
+            'host': 'h',
+            'port': 22,
+            'username': 'u',
+            'forwards': [
+              {'localPort': 18088, 'remoteHost': 'x', 'remotePort': 8088},
+            ],
+          },
+        ]),
+      });
+      final store = ProfilesStore();
+      final ok = await store.setForwards('h:22:u', const []);
+      expect(ok, isTrue);
+      final reloaded = await ProfilesStore().load();
+      expect(reloaded.single.forwards, isEmpty);
+    });
+  });
+}

--- a/scripts/native-connect-test.sh
+++ b/scripts/native-connect-test.sh
@@ -56,7 +56,10 @@ TEST_FILE="${1:-integration_test/connect_smoke_test.dart}"
 NATIVE_DIR="${REPO_ROOT}/native"
 PROXY_PID_FILE="${MOBISSH_TMPDIR}/connect-test-socat.pid"
 PROXY2_PID_FILE="${MOBISSH_TMPDIR}/connect-test-socat2.pid"
-SSHD_HOST="test-sshd"
+# Overridable (#1047): when several per-worktree fixture containers share the
+# `test-sshd` network alias, Docker DNS round-robins among them — pin a
+# specific container name here for a deterministic target.
+SSHD_HOST="${SSHD_HOST:-test-sshd}"
 SSHD_PORT="22"
 BRIDGE_PORT="2222"
 BRIDGE_PORT2="${BRIDGE_PORT2:-}"


### PR DESCRIPTION
Implements #1047 — SSH LOCAL port forwarding (`ssh -L` semantics): ad hoc on live sessions + profile-armed defaults.

## Spike verdict: dartssh2 2.17.1 (pinned, NOT bumped)

The pinned version fully supports client-side local forwarding:
- `SSHClient.forwardLocal(String remoteHost, int remotePort, {localHost, localPort})` (ssh_client.dart:370) opens a `direct-tcpip` channel (`_openForwardLocalChannel`, :1260 — `SSH_Message_Channel_Open.directTcpip`).
- Returns `SSHForwardChannel implements SSHSocket` — `stream` / `sink` / `close()` / `destroy()` / `done`, exactly the pipe interface needed.
- A refused channel open surfaces as a thrown error from `_waitChannelOpen` — handled per-connection.

**Verdict: no upgrade needed. Ad hoc forwarding shipped (not connect-time-only).**

## Design

- **Engine** (`native/lib/services/port_forwarder.dart`, task isolate): `PortForwardListener` binds a dart:io `ServerSocket` on **127.0.0.1 ONLY** (comment cites `.claude/rules/security.md`; no `-R` in v1), each accept opens a direct-tcpip tunnel via an injected `ForwardTunnelOpener` (prod: `client.forwardLocal`, resolved at ACCEPT time so a reconnect's new client is picked up) and pipes bidirectionally with mutual teardown. A per-connection channel refusal closes that socket, keeps listening, and reports the error — `ssh -L` semantics.
- **Lifecycle**: forward CONFIG lives on the hosted session keyed by localPort; listeners arm on every `connected` transition and drop synchronously on leaving it → **forwards die with the connection and re-arm on reconnect automatically** (task-side, no UI round-trip). Session teardown clears config too.
- **IPC** (`session_messages.dart`): `forwardAdd` / `forwardRemove` / `forwardList` commands + ONE authoritative `forwardList` status event (`[{localPort, remoteHost, remotePort, status: starting|active|error, error?}]`) — no delta reconciliation in the UI. `[SYNC]` round-trip suite in `forward_messages_test.dart`.
- **Profile defaults**: `SavedProfile.forwards` (schema-in-value: absent → `[]`, corrupt entries dropped, omit-when-empty; no key bump) + `ProfilesStore.setForwards` (NO-OP for ad-hoc identities — never materializes a profile). Armed by re-sending idempotent `forwardAdd`s right after `connect` (ordered gateway ⇒ hosted session exists) in `connect_form._connectWithParams` AND `sessions._reviveFromProfile` (covers the torn-down-isolate revive).
- **UI**: session menu grows a `settings_ethernet` control (44px, count badge while any forward is ACTIVE) → **Port forwards** modal sheet: live status rows, add form (local port / remote host default 127.0.0.1 / remote port), remove, per-forward ★ "profile default". Removing a forward also un-defaults it (a removed forward silently re-arming would read as "remove didn't work").

## Test-fixture change (flagged)

`docker/test-sshd/Dockerfile`: `AllowTcpForwarding no` → **`local`** (direct-tcpip only; `-R` stays blocked). Two gotchas found and fixed:
- Alpine ships an UNCOMMENTED `AllowTcpForwarding no` and sshd honours the FIRST directive — the fixture's old appended line was dead config; the new value is a sed replace-in-place.
- Stale per-worktree fixture containers share the `test-sshd` DNS alias round-robin; `native-connect-test.sh`'s `SSHD_HOST` is now env-overridable so a run can pin a specific container. **Stale fixtures built before this PR will refuse forwards** — recreate them (`scripts/test-sshd-up.sh` after image removal, or `docker compose up -d --build --force-recreate`) before running the integration suite.

## Tests

- `test/services/port_forwarder_test.dart` — engine: accept→bidirectional echo pipe, close→refused + tunnel teardown, port-in-use `SocketException`, channel refusal keeps listening + reports.
- `test/services/forward_messages_test.dart` — IPC round-trips (incl. unknown-status forward-compat).
- `test/services/forward_host_test.dart` — host transitions over the real `InMemoryGatewayPair` with REAL loopback sockets + fake tunnels: pre-connect add stays `starting` (no bind), `connected` arms (bytes pipe), drop kills the listener (refused) with config retained, reconnect RE-ARMS, remove→refused+empty, port-in-use → `error` row with message.
- `test/storage/profile_forwards_test.dart` — store round-trip, corrupt resilience, setForwards upsert/clear/no-materialize.
- `integration_test/port_forward_1047_test.dart` (on-emulator, the proof): real connect to test-sshd; nohup'd `nc -l -p 8088` marker loop seeded through the live shell; forward 18088→127.0.0.1:8088 added via the REAL sheet; **honest probe** — the driver runs in the app process, so a dart:io `Socket` connect to 127.0.0.1:18088 traverses listener→direct-tcpip→nc and asserts the marker; ★ profile default; server-side `kill -9 $PPID` drops the session → auto-reconnect → forward re-arms → marker again; remove → refused. Includes a screenshot hold of the sheet with the ACTIVE row.

**Results**: `scripts/native-fast-gate.sh` PASSED (analyze + 2099 unit tests). On-emulator integration PASSED end-to-end (`All tests passed!` — full sequence: sheet add → marker through the tunnel → star → server-side sshd kill → auto-reconnect re-arm → marker again → remove → refused).

**Screenshot** (local artifact): `test-results/emulator-shots/20260711T172015+0000-pf-sheet-active-1047_.png` — the sheet mid drop→reconnect: the starred `18088 → 127.0.0.1:8088` row RETAINED with "Waiting for connection" under the "Disconnected — reconnecting…" banner (the re-arm story in one frame; the active state is asserted by the test itself: marker fetched through the tunnel before AND after the drop).

## Session-state adjacency (#589)

Connect/reconnect arming touches the session lifecycle — the forward arm/drop hooks live exactly on the `connected` transition edges in `SessionHost`. The emulator integration test above ran as the required proof; `scripts/native-fast-gate.sh` (analyze + full unit suite, 2099 tests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa