### PR TITLE
chore(infra): guaranteed teardown for agent test-sshd fixtures + emulator idle-stop (#1049)

### DIFF
--- a/scripts/ci-reap.sh
+++ b/scripts/ci-reap.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# scripts/ci-reap.sh — belt-and-braces sweeper for orphaned test infrastructure (#1049).
+#
+# Operator directive (agent-hub msg 64, 2026-07-11): agent-*-test-sshd-1 fixtures
+# aged 3-12 days plus a 5-day idle emulator swap-thrashed the PVE host (load 190).
+# Primary teardown is the EXIT traps in the spawning scripts (see
+# scripts/lib/testsshd-fixture.sh for the mechanism map); this sweep catches what
+# traps cannot: kill -9, worktree deleted mid-run, and test-sshd-up.sh fixtures
+# that intentionally outlive one script call (multi-test agent runs).
+#
+# Actions per sweep:
+#   1. REMOVE agent-*-test-sshd-1 containers older than CI_REAP_MAX_AGE_HOURS
+#      (default 6). Age = the container's docker Created timestamp. The age
+#      guard is what protects ACTIVE agents' fixtures — anything younger than
+#      the threshold is never touched.
+#   2. STOP (never remove) the mobissh-emulator container when idle longer than
+#      CI_REAP_EMU_IDLE_HOURS (default 12). Idle = age of the last-used marker
+#      (${MOBISSH_TMPDIR}/emulator-last-used) that emu-container-ctl.sh touches
+#      on every ensure/up/restart/wipe. A missing marker is touched NOW (starts
+#      the clock) — never an instant stop. `emu-container-ctl.sh ensure` re-boots
+#      a stopped emulator on demand (~2min).
+#   3. NEVER touches fd-dev, mobissh-prod, mobissh-feedback, or the canonical
+#      mobissh-test-sshd-1 fixture: strict ^agent-*-test-sshd-1$ name pattern
+#      PLUS an explicit protected-name list.
+#
+# Wire-in: called opportunistically (non-fatal) from emulator-ctl.sh ensure and
+# emu-container-ctl.sh ensure. `install-cron` adds an hourly entry when a cron
+# daemon exists — fd-dev has none today, so the ensure wire-in is the active
+# cadence.
+#
+# Usage: scripts/ci-reap.sh [run|install-cron]
+# Env:
+#   CI_REAP_MAX_AGE_HOURS   fixture age threshold in hours, fractional ok (default 6)
+#   CI_REAP_EMU_IDLE_HOURS  emulator idle threshold in hours, fractional ok (default 12)
+#   CI_REAP_NAME_PREFIX     fixture container-name prefix to consider (default
+#                           "agent-"; live verification scopes this to its own
+#                           throwaway projects so parallel agents are untouched)
+#   CI_REAP_DRY_RUN         1 = log intended actions without executing (default 0)
+set -euo pipefail
+
+MOBISSH_TMPDIR="${MOBISSH_TMPDIR:-/tmp/mobissh}"
+MOBISSH_LOGDIR="${MOBISSH_LOGDIR:-/tmp/mobissh/logs}"
+mkdir -p "$MOBISSH_TMPDIR" "$MOBISSH_LOGDIR"
+LOGFILE="${MOBISSH_LOGDIR}/ci-reap.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+CI_REAP_MAX_AGE_HOURS="${CI_REAP_MAX_AGE_HOURS:-6}"
+CI_REAP_EMU_IDLE_HOURS="${CI_REAP_EMU_IDLE_HOURS:-12}"
+CI_REAP_NAME_PREFIX="${CI_REAP_NAME_PREFIX:-agent-}"
+CI_REAP_DRY_RUN="${CI_REAP_DRY_RUN:-0}"
+EMU_CONTAINER="mobissh-emulator"
+EMU_MARKER="${MOBISSH_TMPDIR}/emulator-last-used"
+
+log() { echo "> [$(date +%Y%m%dT%H%M%S%z)] ci-reap: $*"; }
+err() { echo "! [$(date +%Y%m%dT%H%M%S%z)] ci-reap: $*" >&2; }
+
+hours_to_secs() { awk -v h="$1" 'BEGIN{printf "%.0f", h*3600}'; }
+
+is_protected() {
+  local name="$1"
+  case "$name" in
+    fd-dev|mobissh-prod|mobissh-feedback|mobissh-test-sshd-1|"$EMU_CONTAINER") return 0 ;;
+  esac
+  # This dev container itself (hostname is its container id/name).
+  [[ "$name" == "$(hostname)" ]]
+}
+
+reap_fixtures() {
+  local max_age_s now names name created_s age_s
+  max_age_s="$(hours_to_secs "$CI_REAP_MAX_AGE_HOURS")"
+  now="$(date +%s)"
+  names="$(docker ps -a --format '{{.Names}}')"
+  local matched=0
+  for name in $names; do
+    case "$name" in
+      "${CI_REAP_NAME_PREFIX}"*-test-sshd-1) ;;
+      *) continue ;;
+    esac
+    if is_protected "$name"; then
+      log "SKIP protected: $name"
+      continue
+    fi
+    matched=$((matched + 1))
+    # Container may vanish between `docker ps` and `inspect` (trap teardown
+    # racing the sweep) — skip instead of aborting the whole sweep.
+    if ! created_s="$(date -d "$(docker inspect -f '{{.Created}}' "$name")" +%s)"; then
+      log "SKIP $name (inspect failed — likely torn down concurrently)"
+      continue
+    fi
+    age_s=$(( now - created_s ))
+    if (( age_s > max_age_s )); then
+      if [[ "$CI_REAP_DRY_RUN" == "1" ]]; then
+        log "DRY RUN: would remove $name (age ${age_s}s > ${max_age_s}s)"
+      else
+        log "removing orphaned fixture $name (age ${age_s}s > ${max_age_s}s)"
+        if ! docker rm -f "$name"; then
+          err "failed to remove $name"
+        fi
+      fi
+    else
+      log "keeping $name (age ${age_s}s <= ${max_age_s}s)"
+    fi
+  done
+  log "fixture sweep done (${matched} candidate(s), prefix '${CI_REAP_NAME_PREFIX}', threshold ${CI_REAP_MAX_AGE_HOURS}h)"
+}
+
+reap_emulator() {
+  local idle_max_s now marker_s idle_s
+  if ! docker ps --format '{{.Names}}' | grep -qx "$EMU_CONTAINER"; then
+    log "emulator: $EMU_CONTAINER not running — nothing to do"
+    return 0
+  fi
+  if [[ ! -f "$EMU_MARKER" ]]; then
+    # No marker (fresh fd-dev, or pre-#1049): start the idle clock now instead
+    # of guessing — never an instant stop.
+    date +%Y%m%dT%H%M%S%z > "$EMU_MARKER"
+    log "emulator: no last-used marker — created $EMU_MARKER (idle clock starts now)"
+    return 0
+  fi
+  idle_max_s="$(hours_to_secs "$CI_REAP_EMU_IDLE_HOURS")"
+  now="$(date +%s)"
+  marker_s="$(stat -c %Y "$EMU_MARKER")"
+  idle_s=$(( now - marker_s ))
+  if (( idle_s > idle_max_s )); then
+    if [[ "$CI_REAP_DRY_RUN" == "1" ]]; then
+      log "DRY RUN: would stop $EMU_CONTAINER (idle ${idle_s}s > ${idle_max_s}s)"
+    else
+      log "stopping idle $EMU_CONTAINER (idle ${idle_s}s > ${idle_max_s}s; ensure re-boots on demand)"
+      if ! docker stop "$EMU_CONTAINER"; then
+        err "failed to stop $EMU_CONTAINER"
+      fi
+    fi
+  else
+    log "emulator: active (idle ${idle_s}s <= ${idle_max_s}s)"
+  fi
+}
+
+cmd_run() {
+  reap_fixtures
+  reap_emulator
+}
+
+cmd_install_cron() {
+  if ! command -v crontab >/dev/null 2>&1; then
+    err "no crontab binary on this host (fd-dev runs no cron daemon) — install-cron unavailable"
+    err "active cadence is the ci-reap wire-in from emulator-ctl.sh / emu-container-ctl.sh ensure"
+    return 1
+  fi
+  # Cron entry must reference the MAIN repo, not a deletable worktree.
+  # shellcheck source=lib/repo-guard.sh
+  source "$(dirname "$0")/lib/repo-guard.sh"
+  local current=""
+  if out="$(crontab -l 2>/dev/null)"; then current="$out"; fi
+  # grep exception: zero remaining entries is a valid state.
+  strip_ci_reap() { grep -v 'ci-reap' || true; }
+  # The redirect inside the CRON LINE stops cron from mailing every sweep; the
+  # script already tees its own output to $LOGFILE.
+  { printf '%s\n' "$current" | strip_ci_reap
+    printf '23 * * * * %s/scripts/ci-reap.sh run >/dev/null 2>&1\n' "$REPO_ROOT"
+  } | crontab -
+  log "installed hourly cron entry: 23 * * * * ${REPO_ROOT}/scripts/ci-reap.sh run"
+}
+
+case "${1:-run}" in
+  run)          cmd_run ;;
+  install-cron) cmd_install_cron ;;
+  *)
+    echo "Usage: scripts/ci-reap.sh [run|install-cron]"
+    exit 2
+    ;;
+esac

--- a/scripts/desktop-smoke.sh
+++ b/scripts/desktop-smoke.sh
@@ -47,9 +47,17 @@ mkdir -p "$FRAMES_DIR"
 log() { echo "> $*"; }
 err() { echo "! $*" >&2; }
 
+# Per-worktree fixture teardown (#1049): if THIS run spawns test-sshd (step 2),
+# down it on exit. Pre-existing fixtures are left alone (ci-reap.sh sweeps).
+source "${REPO_ROOT}/scripts/lib/testsshd-fixture.sh"
+SPAWNED_SSHD_PROJECT=""
+
 XVFB_PID=""
 WATCHER_PID=""
 cleanup() {
+  if [[ -n "$SPAWNED_SSHD_PROJECT" ]]; then
+    testsshd_fixture_down "$SPAWNED_SSHD_PROJECT" "${REPO_ROOT}/docker-compose.test.yml"
+  fi
   if [[ -n "$WATCHER_PID" ]] && kill -0 "$WATCHER_PID" 2>/dev/null; then
     kill "$WATCHER_PID" 2>/dev/null || true
   fi
@@ -76,12 +84,15 @@ else
 fi
 
 # 2. test-sshd reachable (bring it up + join the mobissh network if needed).
+#    Spawner owns teardown (#1049): a fixture spawned here is downed on exit.
 if ! getent hosts "$SMOKE_HOST" >/dev/null 2>&1; then
-  log "$SMOKE_HOST not resolvable — running test-sshd-up.sh"
+  log "$SMOKE_HOST not resolvable — running test-sshd-up.sh (teardown on exit)"
   if ! "${REPO_ROOT}/scripts/test-sshd-up.sh"; then
     err "test-sshd-up failed — cannot reach $SMOKE_HOST"
     exit 2
   fi
+  # test-sshd-up.sh composes up from REPO_ROOT — that dirname is the project.
+  SPAWNED_SSHD_PROJECT="$(cd "$REPO_ROOT" && testsshd_compose_project)"
 fi
 log "$SMOKE_HOST resolves OK"
 

--- a/scripts/emu-container-ctl.sh
+++ b/scripts/emu-container-ctl.sh
@@ -14,6 +14,14 @@
 #   status   print container + guest boot state (exit 0 booted, 1 not).
 #   logs     tail the emulator container log.
 #
+# IDLE-STOP POLICY (#1049, operator directive 2026-07-11): the emulator is no
+# longer always-on. A 5-day idle mobissh-emulator (2.8GB) swap-thrashed the PVE
+# host, so scripts/ci-reap.sh STOPS the container after CI_REAP_EMU_IDLE_HOURS
+# (12h) without use. Every ensure/up/restart/wipe touches the last-used marker
+# (${MOBISSH_TMPDIR}/emulator-last-used); `ensure` re-boots a stopped emulator
+# on demand (~2min cost) — callers already go through ensure, so idle-stop is
+# transparent apart from that boot wait.
+#
 # Env: EMU_BOOT_TIMEOUT (default 300s), EMU_GPU / EMU_MEMORY_MB / EMU_CORES pass
 #      through to the container (see docker-compose.emulator.yml).
 set -euo pipefail
@@ -28,10 +36,24 @@ exec > >(tee -a "$LOGFILE") 2>&1
 COMPOSE_FILE="docker-compose.emulator.yml"
 CONTAINER="mobissh-emulator"
 EMU_BOOT_TIMEOUT="${EMU_BOOT_TIMEOUT:-300}"
+EMU_MARKER="${MOBISSH_TMPDIR}/emulator-last-used"
 
 log() { echo "> [$(date +%Y%m%dT%H%M%S%z)] $*"; }
 err() { echo "! [$(date +%Y%m%dT%H%M%S%z)] $*" >&2; }
 ok()  { echo "+ [$(date +%Y%m%dT%H%M%S%z)] $*"; }
+
+# Last-used marker read by scripts/ci-reap.sh for the idle-stop policy (#1049).
+touch_last_used() {
+  date +%Y%m%dT%H%M%S%z > "$EMU_MARKER"
+}
+
+# Opportunistic orphan sweep (#1049) — cheap; the marker is touched FIRST so
+# this emulator reads as active. Non-fatal: a reap failure must not block ensure.
+opportunistic_reap() {
+  if ! scripts/ci-reap.sh run; then
+    err "ci-reap sweep failed (non-fatal)"
+  fi
+}
 
 is_running() {
   docker ps --filter "name=${CONTAINER}" --format '{{.Names}}' 2>/dev/null | grep -q "^${CONTAINER}$"
@@ -71,12 +93,15 @@ wait_boot() {
 
 cmd_up() {
   ensure_network
+  touch_last_used
   log "docker compose up -d (${CONTAINER})"
   docker compose -f "$COMPOSE_FILE" up -d --build
   wait_boot
 }
 
 cmd_ensure() {
+  touch_last_used
+  opportunistic_reap
   if is_running && guest_booted; then
     ok "${CONTAINER} already up + booted."
     return 0
@@ -91,6 +116,7 @@ cmd_ensure() {
 
 cmd_restart() {
   ensure_network
+  touch_last_used
   log "recreating ${CONTAINER} (fresh -read-only overlay = clean /data)"
   docker compose -f "$COMPOSE_FILE" up -d --build --force-recreate
   wait_boot
@@ -98,6 +124,7 @@ cmd_restart() {
 
 cmd_wipe() {
   ensure_network
+  touch_last_used
   log "wipe: full down + up recreate of ${CONTAINER}"
   docker compose -f "$COMPOSE_FILE" down || true
   docker compose -f "$COMPOSE_FILE" up -d --build --force-recreate

--- a/scripts/emulator-ctl.sh
+++ b/scripts/emulator-ctl.sh
@@ -25,6 +25,13 @@
 # Env: EMU_CORES (default 0-2), EMU_MEMORY_MB (default 4096), AVD (default
 #      MobiSSH_Pixel7), EMU_WIPE (default 0; 1 → boot with -wipe-data and drop
 #      -read-only so the reset persists to the userdata qcow2).
+#
+# IDLE-STOP POLICY (#1049, operator directive 2026-07-11): "always-on" no longer
+# means "runs for days unused" — an idle emulator + orphaned agent-*-test-sshd-1
+# fixtures swap-thrashed the PVE host. `ensure` runs scripts/ci-reap.sh
+# opportunistically (sweeps stale fixtures; stops the mobissh-emulator CONTAINER
+# after 12h idle — this legacy in-fd-dev process variant is not auto-stopped,
+# only the container is). Re-boot on demand via ensure costs ~2min.
 set -euo pipefail
 
 export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-/opt/android-sdk}"
@@ -116,6 +123,10 @@ boot() {
 cmd="${1:-ensure}"
 case "$cmd" in
   ensure)
+    # Opportunistic orphan sweep (#1049) — non-fatal, must not block the boot.
+    if ! "$(dirname "$0")/ci-reap.sh" run; then
+      err "ci-reap sweep failed (non-fatal)"
+    fi
     dev="$(live_device)"
     if is_booted "$dev"; then
       log "reusing live emulator: $dev (no reboot)"

--- a/scripts/lib/testsshd-fixture.sh
+++ b/scripts/lib/testsshd-fixture.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# scripts/lib/testsshd-fixture.sh — shared helpers for per-worktree test-sshd
+# fixture teardown (#1049).
+#
+# Background: `docker compose -f docker-compose.test.yml up` derives its project
+# name from the CWD's basename. Run from the main checkout that is `mobissh`
+# (container `mobissh-test-sshd-1`, the canonical long-lived fixture). Run from
+# an agent worktree (`.claude/worktrees/agent-<id>/`) it is `agent-<id>`
+# (container `agent-<id>-test-sshd-1`) — and those orphaned for days after a
+# worktree was deleted, which thrashed the PVE host (operator directive,
+# agent-hub msg 64). The spawning script must guarantee teardown on exit.
+#
+# Source this from any script that composes up docker-compose.test.yml:
+#   source "$(dirname "$0")/lib/testsshd-fixture.sh"
+#
+# Provides:
+#   testsshd_compose_project — echo the compose project name docker compose
+#                              would derive from $PWD
+#   testsshd_fixture_down P  — `docker compose -p P down` the fixture, but ONLY
+#                              for agent-* projects; refuses (no-op, exit 0) for
+#                              anything else so the canonical fixture is safe
+#
+# Teardown mechanism map (#1049) — every spawn path is covered by ONE of:
+#   EXIT trap (this lib): run-appium-tests.sh, run-emulator-tests.sh,
+#     desktop-smoke.sh + native-connect-test.sh (teardown-if-spawned), and —
+#     transitively — tests/emulator/sshd-fixture.js, whose compose-up lands in
+#     the same project as its mandated wrappers (run-appium/run-emulator).
+#   Age sweep (scripts/ci-reap.sh): test-sshd-up.sh fixtures, which
+#     INTENTIONALLY outlive one script call (multi-test agent runs). The docker
+#     Created timestamp is the age marker; the sweeper removes agent-* fixtures
+#     older than CI_REAP_MAX_AGE_HOURS (default 6h).
+
+# Echo the project name `docker compose` derives from $PWD: lowercased basename
+# with characters outside [a-z0-9_-] removed and leading separators trimmed.
+testsshd_compose_project() {
+  basename "$PWD" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9_-]//g' -e 's/^[_-]*//'
+}
+
+# Down a per-worktree fixture project. Guarded: acts only on agent-* projects.
+# Usage: testsshd_fixture_down <project> [compose-file]
+testsshd_fixture_down() {
+  local proj="${1:-}"
+  local compose_file="${2:-docker-compose.test.yml}"
+  case "$proj" in
+    agent-*) ;;
+    *)
+      # Not a per-worktree fixture (e.g. canonical `mobissh` project) — leave it.
+      return 0
+      ;;
+  esac
+  echo "> testsshd-fixture: docker compose -p $proj down (#1049 teardown)"
+  if ! docker compose -f "$compose_file" -p "$proj" down --remove-orphans; then
+    # Compose file may be gone (worktree deleted mid-run) — remove the container directly.
+    echo "! testsshd-fixture: compose down failed, falling back to docker rm -f ${proj}-test-sshd-1" >&2
+    if ! docker rm -f "${proj}-test-sshd-1"; then
+      echo "! testsshd-fixture: could not remove ${proj}-test-sshd-1 (ci-reap.sh will sweep it)" >&2
+      return 1
+    fi
+  fi
+}

--- a/scripts/native-connect-test.sh
+++ b/scripts/native-connect-test.sh
@@ -75,7 +75,17 @@ EMU_ADBD_ENDPOINT="${EMU_ADBD_ENDPOINT:-${EMU_CONTAINER_NAME}:5556}"
 log() { echo "> $*"; }
 err() { echo "! $*" >&2; }
 
+# Per-worktree fixture teardown (#1049): if THIS run spawns the test-sshd
+# fixture (step 2 below), it downs it on exit — including failure paths. A
+# fixture that was already up (canonical, or deliberately persistent via
+# test-sshd-up.sh) is not ours to tear down; scripts/ci-reap.sh sweeps those.
+source "${REPO_ROOT}/scripts/lib/testsshd-fixture.sh"
+SPAWNED_SSHD_PROJECT=""
+
 cleanup() {
+  if [[ -n "$SPAWNED_SSHD_PROJECT" ]]; then
+    testsshd_fixture_down "$SPAWNED_SSHD_PROJECT" "${REPO_ROOT}/docker-compose.test.yml"
+  fi
   # Tear down the socat proxy + adb reverse so repeated runs don't stack.
   if [[ -f "$PROXY_PID_FILE" ]]; then
     local pid
@@ -163,11 +173,21 @@ else
 fi
 log "device: $DEVICE"
 
-# 2. Verify test-sshd reachable from this container.
+# 2. Verify test-sshd reachable from this container; spawn it if missing.
+#    Spawner owns teardown (#1049): the EXIT trap downs the fixture we spawn
+#    here, so an agent run can never strand an agent-<id>-test-sshd-1 orphan.
 if ! getent hosts "$SSHD_HOST" >/dev/null 2>&1; then
-  err "$SSHD_HOST not resolvable — is the mobissh docker network joined + test-sshd up?"
-  err "try: docker compose -f docker-compose.test.yml up -d"
-  exit 2
+  log "$SSHD_HOST not resolvable — running test-sshd-up.sh (teardown on exit)"
+  if ! "${REPO_ROOT}/scripts/test-sshd-up.sh"; then
+    err "test-sshd-up failed — cannot reach $SSHD_HOST"
+    exit 2
+  fi
+  # test-sshd-up.sh composes up from REPO_ROOT — that dirname is the project.
+  SPAWNED_SSHD_PROJECT="$(cd "$REPO_ROOT" && testsshd_compose_project)"
+  if ! getent hosts "$SSHD_HOST" >/dev/null 2>&1; then
+    err "$SSHD_HOST still not resolvable after test-sshd-up.sh"
+    exit 2
+  fi
 fi
 log "$SSHD_HOST resolves OK"
 

--- a/scripts/run-appium-tests.sh
+++ b/scripts/run-appium-tests.sh
@@ -96,6 +96,13 @@ PORT=$MOBISSH_PORT scripts/server-ctl.sh ensure
 # Ensure shared Docker network exists (external: true in compose requires pre-creation)
 docker network create mobissh 2>/dev/null || true
 docker compose -f docker-compose.test.yml up -d test-sshd 2>&1
+# Per-worktree fixture teardown (#1049): run from an agent worktree, the compose
+# project above (and any re-up by tests' sshd-fixture.js — same project) is
+# agent-<id>; down it when this run exits, INCLUDING failure paths. From the
+# main checkout the project is `mobissh` and fixture_down is a guarded no-op.
+source scripts/lib/testsshd-fixture.sh
+FIXTURE_PROJECT="$(testsshd_compose_project)"
+trap 'testsshd_fixture_down "$FIXTURE_PROJECT"' EXIT
 # Join shared network so we can reach test-sshd via DNS
 docker network connect mobissh "$(hostname)" 2>/dev/null || true
 wait_for_port test-sshd 22 "test-sshd" 20

--- a/scripts/run-emulator-tests.sh
+++ b/scripts/run-emulator-tests.sh
@@ -62,6 +62,13 @@ PORT=$MOBISSH_PORT bash scripts/server-ctl.sh ensure
 log "Ensuring Docker test-sshd..."
 docker network create mobissh 2>/dev/null || true
 docker compose -f docker-compose.test.yml up -d test-sshd 2>&1 | grep -v '^$' || true
+# Per-worktree fixture teardown (#1049): run from an agent worktree, the compose
+# project above (and any re-up by tests' sshd-fixture.js — same project) is
+# agent-<id>; down it when this run exits, INCLUDING failure paths. From the
+# main checkout the project is `mobissh` and fixture_down is a guarded no-op.
+source scripts/lib/testsshd-fixture.sh
+FIXTURE_PROJECT="$(testsshd_compose_project)"
+trap 'testsshd_fixture_down "$FIXTURE_PROJECT"' EXIT
 # Join shared network so we can reach test-sshd via DNS
 docker network connect mobissh "$(hostname)" 2>/dev/null || true
 wait_for_port test-sshd 22 "test-sshd" 20

--- a/scripts/test-sshd-up.sh
+++ b/scripts/test-sshd-up.sh
@@ -5,6 +5,14 @@
 #
 # Needed after a host/process restart (the container + network join die with it).
 # Mirrors what tests/emulator/sshd-fixture.js does, for manual/orchestrator use.
+#
+# TEARDOWN (#1049): run from an AGENT WORKTREE, compose names the fixture
+# agent-<worktree-id>-test-sshd-1. That fixture intentionally OUTLIVES this
+# script call (multi-test agent runs re-use it), so there is no EXIT trap here;
+# instead scripts/ci-reap.sh removes agent-* fixtures older than
+# CI_REAP_MAX_AGE_HOURS (6h) using the container's docker Created timestamp as
+# the age marker. Run scripts (native-connect-test.sh, desktop-smoke.sh) that
+# call this on-demand DO tear down what they spawned, on exit.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tests/emulator/sshd-fixture.js
+++ b/tests/emulator/sshd-fixture.js
@@ -3,6 +3,14 @@
  *
  * Docker test-sshd lifecycle helper. Starts the Alpine+OpenSSH container
  * from docker-compose.test.yml and waits for SSH to be ready.
+ *
+ * TEARDOWN (#1049): the compose project (and thus the container name) derives
+ * from process.cwd() — in an agent worktree that is agent-<id>-test-sshd-1.
+ * This helper does NOT tear down (parallel Playwright workers share the
+ * fixture). The mandated wrappers (scripts/run-appium-tests.sh,
+ * scripts/run-emulator-tests.sh) down the same compose project via EXIT trap;
+ * direct playwright invocations are backstopped by scripts/ci-reap.sh (6h age
+ * sweep).
  */
 
 const { execSync } = require('child_process');


### PR DESCRIPTION
Closes #1049.

Operator directive (agent-hub msg 64, 2026-07-11): agent-`*`-test-sshd-1 fixtures aged 3-12 days plus a 5-day idle emulator swap-thrashed the PVE host. Every fixture spawn path now has a documented, guaranteed teardown mechanism.

## Spawn-path survey (what actually creates `agent-<id>-test-sshd-1`)
The compose project name derives from the CWD basename, so any `docker compose -f docker-compose.test.yml up` from an agent worktree creates the per-worktree fixture. Actual spawn paths and their mechanism:

| Spawn path | Mechanism |
|---|---|
| `run-appium-tests.sh`, `run-emulator-tests.sh` (direct compose up) | EXIT trap downs the compose project |
| `tests/emulator/sshd-fixture.js` (compose up from `process.cwd()`) | same project as its mandated wrappers above → covered by their trap; direct playwright runs → sweeper |
| `native-connect-test.sh`, `desktop-smoke.sh` (via `test-sshd-up.sh` when test-sshd unresolvable) | spawn-if-missing + teardown-if-spawned in existing cleanup trap (incl. failure paths) |
| `test-sshd-up.sh` standalone (multi-test agent runs — fixture intentionally outlives one call) | ci-reap.sh age sweep; docker `Created` timestamp is the age marker |
| `cc-*-setup.sh` | spawn NOTHING (they mutate the running test-sshd over ssh) — no trap needed; issue's assumption corrected |

Teardown is guarded: `testsshd_fixture_down` (new `scripts/lib/testsshd-fixture.sh`) only ever downs `agent-*` compose projects — the canonical `mobissh-test-sshd-1` can never be downed by a trap — with a `docker rm -f` fallback for the deleted-worktree case.

## Sweeper: `scripts/ci-reap.sh`
- Removes `agent-*-test-sshd-1` older than `CI_REAP_MAX_AGE_HOURS` (6). The age guard is what protects active parallel agents' fixtures.
- Stops (never removes) `mobissh-emulator` idle > `CI_REAP_EMU_IDLE_HOURS` (12). Idle = mtime of `${MOBISSH_TMPDIR}/emulator-last-used`, touched by `emu-container-ctl.sh` on every ensure/up/restart/wipe. Missing marker → touched now (starts the clock), never an instant stop.
- Never touches fd-dev / mobissh-prod / mobissh-feedback / mobissh-test-sshd-1: strict `agent-*-test-sshd-1` name pattern PLUS explicit protected list.
- Wired opportunistically (non-fatal) into `emulator-ctl.sh ensure` and `emu-container-ctl.sh ensure`. `CI_REAP_DRY_RUN=1` and `CI_REAP_NAME_PREFIX` allow safe verification.
- Idle-stop policy documented in both emulator script headers (ensure re-boots on demand, ~2min).

## Live verification (transcript excerpts)
Scoped so the PARALLEL agent's fixture (`agent-a21ce083522118114-test-sshd-1`) and the running emulator were never touched: `CI_REAP_NAME_PREFIX` scoping, dry-run for the emulator decision, and private compose networks so throwaways never joined the shared `test-sshd` DNS alias pool (#1047 round-robin).

TEST A — old removed, fresh kept (threshold 0.02h=72s, prefix `agent-test-reap`):
```
before reap:
agent-test-reap-fresh-test-sshd-1 1 second ago Up Less than a second (health: starting)
agent-test-reap-old-test-sshd-1 About a minute ago Up About a minute (healthy)
agent-a21ce083522118114-test-sshd-1 About an hour ago Up About an hour (healthy)
> ci-reap: keeping agent-test-reap-fresh-test-sshd-1 (age 1s <= 72s)
> ci-reap: removing orphaned fixture agent-test-reap-old-test-sshd-1 (age 81s > 72s)
after reap:
agent-test-reap-fresh-test-sshd-1 1 second ago Up Less than a second (health: starting)
agent-a21ce083522118114-test-sshd-1 About an hour ago Up About an hour (healthy)
TEST A: parallel agent's fixture untouched (still present)
```

TEST B — production defaults keep young fixtures (dry run):
```
> ci-reap: keeping agent-test-reap-fresh-test-sshd-1 (age 1s <= 21600s)
> ci-reap: keeping agent-a21ce083522118114-test-sshd-1 (age 4187s <= 21600s)
```

TEST C — emulator idle decision (dry-run, scratch marker; real emulator untouched):
```
13h-old marker: > ci-reap: DRY RUN: would stop mobissh-emulator (idle 46800s > 43200s)
fresh marker:   > ci-reap: emulator: active (idle 0s <= 43200s)
```

TEST D — EXIT-trap teardown on FORCED non-zero exit (exact wrapper sequence, own worktree project):
```
driver: fixture up for project agent-a65eace91ea4b5cb1:
agent-a65eace91ea4b5cb1-test-sshd-1 Up Less than a second (health: starting)
driver: forcing FAILURE exit 1 (trap must still tear down)
> testsshd-fixture: docker compose -p agent-a65eace91ea4b5cb1 down (#1049 teardown)
 Container agent-a65eace91ea4b5cb1-test-sshd-1 Removed
fixture agent-a65eace91ea4b5cb1-test-sshd-1 is GONE after failing run
```

TEST E — canonical-project guard: `testsshd_fixture_down mobissh` is a no-op (returns 0, no docker action).

Post-run `docker ps -a --filter name=test-sshd` shows only the parallel agent's fixture; all verification networks removed; `mobissh-emulator` still Up.

Gate: `scripts/native-fast-gate.sh` PASSED in foreground (analyze clean, 2079 tests).
`bash -n` clean on all 9 touched shell scripts.

## Honest caveats
- fd-dev has NO cron daemon (`crontab` binary absent), so `ci-reap.sh install-cron` reports that and exits 1 (verified). The active sweep cadence is the wire-in to both emulator `ensure` paths — every emulator use sweeps. If the emulator goes unused for days AND no ensure runs, nothing sweeps; installing cron/tini-based scheduling in the fd-dev image would close that gap (operator-side).
- The emulator idle STOP was verified in dry-run only (a parallel agent was actively using `mobissh-emulator`); the decision path (marker age → stop) is exercised, the `docker stop` itself is not.
- `shellcheck` is not installed in fd-dev; only `bash -n` ran.
- The legacy in-fd-dev emulator PROCESS (`emulator-ctl.sh`) is not auto-stopped — only the `mobissh-emulator` container is; documented in the header.
- `emulator-maintain.sh` was left untouched (issue offered it as an alternative home; a dedicated `ci-reap.sh` keeps reaping independent of AVD-health logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa