### PR TITLE
fix(native): re-tune detection wash alphas for behind-glyphs regime (#1053)

### DIFF
--- a/native/lib/ui/ghostty_terminal_decorators.dart
+++ b/native/lib/ui/ghostty_terminal_decorators.dart
@@ -124,25 +124,30 @@ bool ghosttyPathRequiresVerification(String payload) {
 }
 
 /// #1000 wash alphas — the wash is a translucent background FILL (no stroke),
-/// tuned per terminal-BACKGROUND luminance: a dark terminal needs less pigment
-/// for the wash to register than a light one (where ambient screen brightness
-/// washes out faint tints). Detected < verified by a clearly-visible margin at
-/// phone density, and every value stays inside the readable band (glyphs
-/// legible in the wash; the wash still distinct from flterm's ~0x33-alpha
-/// native selection fill). #1045: the glyphs now paint OVER the wash, so
-/// "legible" is by construction — the band still governs how loud the wash
-/// itself reads.
-const double kGhosttyBubbleDetectedWashAlphaOnDark = 0.26;
+/// tuned per terminal-BACKGROUND luminance. #1053 (P0 regression): these were
+/// tuned LOW for the OLD over-glyphs regime, where any higher value dimmed the
+/// text. Since #1045 the glyphs paint OVER the wash (full brightness by
+/// construction), so the fill composites UNDER the text over the near-black
+/// terminal cell background — at 0.26 the green was near-invisible against
+/// black. The behind-glyphs regime WANTS a much stronger fill: a louder wash no
+/// longer costs glyph contrast, so the alphas are re-tuned UP until the
+/// highlight obviously reads on both dark AND light terminals. Detected stays a
+/// clear-but-secondary fill; verified is clearly stronger (detected < verified
+/// by a visible margin). The Detection Lab intensity band still multiplies
+/// these via `resolveStyle`, clamped to [0,1] — at the top of the band a
+/// verified wash saturates to opaque, which is fine now that glyphs are on top.
+const double kGhosttyBubbleDetectedWashAlphaOnDark = 0.55;
 
-/// Detected wash alpha over a LIGHT terminal background (#1000).
-const double kGhosttyBubbleDetectedWashAlphaOnLight = 0.32;
+/// Detected wash alpha over a LIGHT terminal background (#1000, re-tuned #1053).
+const double kGhosttyBubbleDetectedWashAlphaOnLight = 0.48;
 
 /// VERIFIED wash alpha over a dark terminal background (#990 shade, #1000
-/// wash language): a detected file path confirmed to exist on the host.
-const double kGhosttyBubbleVerifiedWashAlphaOnDark = 0.42;
+/// wash language, re-tuned #1053): a detected file path confirmed to exist on
+/// the host.
+const double kGhosttyBubbleVerifiedWashAlphaOnDark = 0.78;
 
-/// Verified wash alpha over a LIGHT terminal background (#1000).
-const double kGhosttyBubbleVerifiedWashAlphaOnLight = 0.50;
+/// Verified wash alpha over a LIGHT terminal background (#1000, re-tuned #1053).
+const double kGhosttyBubbleVerifiedWashAlphaOnLight = 0.66;
 
 /// The wash colour (#1000): the SAME opaque hue as the gutter chip —
 /// `GutterMarkStyle.chipColor` forces the accent's alpha to 1.0, mirrored here

--- a/native/test/ui/detection_style_resolver_test.dart
+++ b/native/test/ui/detection_style_resolver_test.dart
@@ -199,10 +199,14 @@ void main() {
         const DetectionPatternStyle(activeIntensity: 100.0),
         brightness: Brightness.light,
       ).resolveStyle('path', verified: true);
+      // #1053: with the behind-glyphs verified base raised, base × maxIntensity
+      // exceeds 1.0, so the alpha saturates at the [0,1] ceiling (the multiplier
+      // is still clamped to the band first — both clamps engage).
       expect(
         resolvedHigh.washColor.a,
         closeTo(
-          kGhosttyBubbleVerifiedWashAlphaOnLight * kDetectionIntensityMax,
+          (kGhosttyBubbleVerifiedWashAlphaOnLight * kDetectionIntensityMax)
+              .clamp(0.0, 1.0),
           0.01,
         ),
       );

--- a/native/test/ui/ghostty_wash_alpha_1053_test.dart
+++ b/native/test/ui/ghostty_wash_alpha_1053_test.dart
@@ -1,0 +1,123 @@
+// #1053 (P0 regression) — the behind-glyphs wash must be OBVIOUSLY visible.
+// Since #1045 the fill composites UNDER full-brightness glyphs over a near-black
+// terminal cell background, so the old over-glyphs alphas (0.26/0.42) were
+// near-invisible. These assert the re-tuned alphas clear a visibility floor on
+// BOTH themes, keep detected < verified with a clear margin, and that the
+// Detection Lab intensity multiplier still composes on top of the new bases.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/storage/detection_styles_store.dart';
+import 'package:mobissh/ui/detection_style_resolver.dart';
+import 'package:mobissh/ui/ghostty_terminal_decorators.dart';
+
+/// The alpha below which a translucent green wash over a near-black terminal
+/// background reads as "near-invisible" (the +136/#1045 regression state).
+const double _kVisibilityFloor = 0.45;
+
+/// The minimum margin verified must keep above detected so the two states stay
+/// visually distinct at phone density.
+const double _kMinSeparation = 0.10;
+
+void main() {
+  group('#1053 behind-glyphs wash alphas clear the visibility floor', () {
+    test('every wash alpha is at or above the visibility floor (both themes)',
+        () {
+      expect(kGhosttyBubbleDetectedWashAlphaOnDark,
+          greaterThanOrEqualTo(_kVisibilityFloor));
+      expect(kGhosttyBubbleDetectedWashAlphaOnLight,
+          greaterThanOrEqualTo(_kVisibilityFloor));
+      expect(kGhosttyBubbleVerifiedWashAlphaOnDark,
+          greaterThanOrEqualTo(_kVisibilityFloor));
+      expect(kGhosttyBubbleVerifiedWashAlphaOnLight,
+          greaterThanOrEqualTo(_kVisibilityFloor));
+    });
+
+    test('detected stays clearly below verified on both themes', () {
+      expect(
+        kGhosttyBubbleVerifiedWashAlphaOnDark -
+            kGhosttyBubbleDetectedWashAlphaOnDark,
+        greaterThanOrEqualTo(_kMinSeparation),
+      );
+      expect(
+        kGhosttyBubbleVerifiedWashAlphaOnLight -
+            kGhosttyBubbleDetectedWashAlphaOnLight,
+        greaterThanOrEqualTo(_kMinSeparation),
+      );
+    });
+
+    test('all alphas stay within a sane [floor, 1.0] range', () {
+      for (final a in [
+        kGhosttyBubbleDetectedWashAlphaOnDark,
+        kGhosttyBubbleDetectedWashAlphaOnLight,
+        kGhosttyBubbleVerifiedWashAlphaOnDark,
+        kGhosttyBubbleVerifiedWashAlphaOnLight,
+      ]) {
+        expect(a, lessThanOrEqualTo(1.0));
+        expect(a, greaterThanOrEqualTo(_kVisibilityFloor));
+      }
+    });
+  });
+
+  group('#1053 ghosttyBubbleWashColor carries the re-tuned alphas', () {
+    const accent = Color(0xFF5B9BD5);
+
+    test('the composed wash alpha matches the re-tuned constant per state', () {
+      expect(
+        ghosttyBubbleWashColor(accent,
+                verified: false, backgroundBrightness: Brightness.dark)
+            .a,
+        closeTo(kGhosttyBubbleDetectedWashAlphaOnDark, 1e-9),
+      );
+      expect(
+        ghosttyBubbleWashColor(accent,
+                verified: true, backgroundBrightness: Brightness.dark)
+            .a,
+        closeTo(kGhosttyBubbleVerifiedWashAlphaOnDark, 1e-9),
+      );
+      expect(
+        ghosttyBubbleWashColor(accent,
+                verified: false, backgroundBrightness: Brightness.light)
+            .a,
+        closeTo(kGhosttyBubbleDetectedWashAlphaOnLight, 1e-9),
+      );
+      expect(
+        ghosttyBubbleWashColor(accent,
+                verified: true, backgroundBrightness: Brightness.light)
+            .a,
+        closeTo(kGhosttyBubbleVerifiedWashAlphaOnLight, 1e-9),
+      );
+    });
+  });
+
+  group('#1053 the Detection Lab intensity band still multiplies the new base',
+      () {
+    const accent = Color(0xFF5B9BD5);
+
+    test('a mid-band multiplier scales the raised detected base', () {
+      const resolver = DetectionStyleResolver(
+        styles: DetectionStyles.empty,
+        accent: accent,
+        backgroundBrightness: Brightness.dark,
+      );
+      final base = resolver.resolveStyle('url', verified: false).washColor.a;
+      // Empty store → base is the shipped constant, unmultiplied.
+      expect(base, closeTo(kGhosttyBubbleDetectedWashAlphaOnDark, 1e-9));
+
+      final scaled = DetectionStyleResolver(
+        styles: const DetectionStyles({
+          'path': DetectionPatternStyle(inactiveIntensity: 1.2),
+        }),
+        accent: accent,
+        backgroundBrightness: Brightness.dark,
+      ).resolveStyle('path', verified: false).washColor.a;
+      expect(
+        scaled,
+        closeTo(
+          (kGhosttyBubbleDetectedWashAlphaOnDark * 1.2).clamp(0.0, 1.0),
+          0.01,
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## #1053 (P0 regression) — detection wash invisible behind glyphs

Fixes #1053. The +136 change (#1045) correctly moved the wash BEHIND the glyphs
(text is no longer dimmed), but the four wash-alpha constants were still the LOW
values tuned for the OLD over-glyphs overlay. Behind glyphs the fill composites
UNDER the text over a near-black terminal cell background, so 0.26 green was
near-invisible — the owner's "background bubble highlight is now just invisible."

This is a **tuning** fix, not structural — the behind-glyphs approach (#1045) is
kept intact. No paint-order / RenderState change (guardrail
`reference_paint_root_985`); only color constants moved.

### Final alphas (`ghostty_terminal_decorators.dart`)

| constant | old (over-glyphs) | new (behind-glyphs) |
|---|---|---|
| detected wash — dark | 0.26 | **0.55** |
| detected wash — light | 0.32 | **0.48** |
| verified wash — dark | 0.42 | **0.78** |
| verified wash — light | 0.50 | **0.66** |

detected stays a clear-but-secondary fill; verified is clearly stronger. The
Detection Lab intensity band still multiplies these via `resolveStyle`, clamped
to `[0,1]` — at the top of the band a verified wash now saturates to opaque,
which is fine now that glyphs paint on top. All four values clear a 0.45
visibility floor on both themes.

### Verification

- **Fast gate green** (`native-fast-gate.sh`): analyze + 2084 unit/widget tests.
- **New `ghostty_wash_alpha_1053_test.dart`**: every alpha ≥ 0.45 floor (both
  themes), detected < verified by a clear margin, and the intensity multiplier
  still composes on the raised base.
- **Updated resolver clamp test**: verified × maxIntensity now exceeds 1.0, so
  the test asserts the `[0,1]` ceiling engages (both clamps).
- **Emulator (dark theme)**: a 4-row wrapped `https://example.com/bbb…` URL and
  a verified `/etc/motd` path render an **OBVIOUS** green highlight behind
  full-brightness legible glyphs — a dramatic improvement over the near-invisible
  +136 state.

Before → after (local emulator shots, dark theme):

- After (fix): `test-results/emulator-shots/20260711T184112+0000-wash1053-a_.png`
  — bold, clearly-readable green wash behind full-contrast glyphs.

The on-emulator integration test (`url_bubble_wrap_988_test.dart`) rendered the
wash correctly (`WASH_HOLD_1045 wash visible, rows=4`) but then "did not
complete" in its later tap/scroll phase because a **parallel agent's test
relaunched the app on the shared emulator** mid-run (a follow-up frame caught the
app splash screen). That failure is environmental contention, not this change —
the wash render + detection are proven by the captured frame.

### Scope

Files: `ghostty_terminal_decorators.dart` (constants + comment),
`ghostty_wash_alpha_1053_test.dart` (new), `detection_style_resolver_test.dart`
(clamp assertion). No edits to `ghostty_terminal_view.dart`,
`structured_text.dart`, `terminal_controller*.dart`, or `port_forwards_sheet.dart`
(parallel agents own those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa