### PR TITLE
feat(native): port-forward sheet live effect preview (8888 → hostname:8250) + direction semantics (#1054)

### DIFF
--- a/native/integration_test/port_forward_preview_1054_test.dart
+++ b/native/integration_test/port_forward_preview_1054_test.dart
@@ -1,0 +1,160 @@
+// On-emulator: port-forward sheet live preview + direction semantics (#1054).
+//
+// UI-only refinement over #1047. Drives the real app on the emulator: connect,
+// open the Port forwards sheet, type 8888 / hostname / 8250, and assert the
+// add-form effect line reads `8888  →  hostname:8250` with a plain-language
+// direction sentence naming the session host. Then Add and assert the list row
+// renders the same compact mapping. The sheet is HELD on screen (~8s) at each
+// checkpoint so an external `scripts/emu-shot.sh` captures the review artifact.
+
+@Tags(['integration'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/sessions.dart';
+
+import 'support/connect_helpers.dart';
+
+const _slice = Duration(milliseconds: 500);
+
+Future<bool> _pumpUntil(
+  WidgetTester tester,
+  bool Function() test, {
+  int maxSlices = 80,
+}) async {
+  for (var i = 0; i < maxSlices; i++) {
+    await tester.pump(_slice);
+    final trust = find.text('Trust + connect');
+    if (trust.evaluate().isNotEmpty) {
+      await tester.tap(trust.first);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    if (test()) return true;
+  }
+  return false;
+}
+
+Future<void> _openSessionMenu(WidgetTester tester) async {
+  await tester.testTextInput.receiveAction(TextInputAction.done);
+  await tester.pump(const Duration(milliseconds: 200));
+  final trigger = find.byKey(const Key('session-bar-open-menu'));
+  await tester.ensureVisible(trigger);
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.tap(trigger, warnIfMissed: false);
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('session-menu-new')).evaluate().isNotEmpty,
+    maxSlices: 20,
+  );
+}
+
+String _previewText(WidgetTester tester) {
+  return tester.widget<Text>(find.byKey(const Key('forward-preview'))).data!;
+}
+
+String _semanticsText(WidgetTester tester) {
+  return tester
+      .widget<Text>(find.byKey(const Key('forward-preview-semantics')))
+      .data!;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'port-forward sheet shows live 8888 → hostname:8250 preview + semantics (#1054)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+      final reached = await _pumpUntil(
+        tester,
+        () =>
+            find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty,
+      );
+      expect(reached, isTrue, reason: 'never reached the terminal screen');
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+
+      // Open the Port forwards sheet.
+      await _openSessionMenu(tester);
+      await tester.tap(find.byKey(const Key('session-menu-port-forwards')));
+      final sheetUp = await _pumpUntil(
+        tester,
+        () =>
+            find.byKey(const Key('port-forwards-sheet')).evaluate().isNotEmpty,
+        maxSlices: 20,
+      );
+      expect(sheetUp, isTrue, reason: 'Port forwards sheet never opened');
+
+      // Type the owner's example endpoints; the preview updates live.
+      await tester.enterText(
+        find.byKey(const Key('forward-local-port')),
+        '8888',
+      );
+      await tester.enterText(
+        find.byKey(const Key('forward-remote-host')),
+        'hostname',
+      );
+      await tester.enterText(
+        find.byKey(const Key('forward-remote-port')),
+        '8250',
+      );
+      await tester.pump();
+
+      expect(_previewText(tester), '8888  →  hostname:8250');
+      final semantics = _semanticsText(tester);
+      expect(semantics, contains('127.0.0.1:8888'));
+      expect(semantics, contains('hostname:8250'));
+      expect(semantics, contains(entry!.host),
+          reason: 'semantics line must name the session host');
+
+      // Screenshot hold #1: the add form WITH the live preview.
+      debugPrint('PF_PREVIEW_HOLD_BEGIN');
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      debugPrint('PF_PREVIEW_HOLD_END');
+
+      // Add it → the list row renders the same compact mapping.
+      await tester.tap(find.byKey(const Key('forward-add-submit')));
+      final rowUp = await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('forward-row-8888')).evaluate().isNotEmpty,
+        maxSlices: 30,
+      );
+      expect(rowUp, isTrue, reason: 'forward row never rendered');
+      expect(find.text('8888  →  hostname:8250'), findsOneWidget);
+
+      // Screenshot hold #2: the list row mapping.
+      debugPrint('PF_ROW_HOLD_BEGIN');
+      for (var i = 0; i < 16; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      debugPrint('PF_ROW_HOLD_END');
+    },
+  );
+}

--- a/native/lib/ui/port_forwards_sheet.dart
+++ b/native/lib/ui/port_forwards_sheet.dart
@@ -48,6 +48,38 @@ class PortForwardsSheet extends StatefulWidget {
   final SessionEntry entry;
   final ProfilesStore store;
 
+  /// Default remote host shown when the field is blank — a bare `-L
+  /// localPort:remotePort` binds the SSH server's own loopback (#1054).
+  static const String defaultRemoteHost = '127.0.0.1';
+
+  /// The concrete effect line for the add form: `localPort → remoteHost:remotePort`.
+  /// Empty ports render as a `·` placeholder so the shape is always visible;
+  /// a blank remote host shows the resolved default (127.0.0.1).
+  static String previewMapping(
+    String localPort,
+    String remoteHost,
+    String remotePort,
+  ) {
+    final l = localPort.trim().isEmpty ? '·' : localPort.trim();
+    final h = remoteHost.trim().isEmpty ? defaultRemoteHost : remoteHost.trim();
+    final r = remotePort.trim().isEmpty ? '·' : remotePort.trim();
+    return '$l  →  $h:$r';
+  }
+
+  /// Plain-language direction so `ssh -L` can't be misread: what reaches what,
+  /// through which host ([sessionHost]).
+  static String previewSemantics(
+    String localPort,
+    String remoteHost,
+    String remotePort,
+    String sessionHost,
+  ) {
+    final l = localPort.trim().isEmpty ? '·' : localPort.trim();
+    final h = remoteHost.trim().isEmpty ? defaultRemoteHost : remoteHost.trim();
+    final r = remotePort.trim().isEmpty ? '·' : remotePort.trim();
+    return 'Apps on this phone at 127.0.0.1:$l reach $h:$r through $sessionHost.';
+  }
+
   @override
   State<PortForwardsSheet> createState() => _PortForwardsSheetState();
 }
@@ -75,9 +107,19 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
       if (!mounted) return;
       setState(() => _forwards = list);
     });
+    // Live effect preview (#1054): rebuild the `L → host:R` line as the user
+    // types so the concrete mapping + direction stay in front of them.
+    _localPortCtrl.addListener(_onFieldChanged);
+    _remoteHostCtrl.addListener(_onFieldChanged);
+    _remotePortCtrl.addListener(_onFieldChanged);
     // Hydrate: the task replays the authoritative table.
     widget.entry.proxy.forwardList();
     unawaited(_loadDefaults());
+  }
+
+  void _onFieldChanged() {
+    if (!mounted) return;
+    setState(() {});
   }
 
   @override
@@ -260,8 +302,10 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
       dense: true,
       leading: Icon(glyph, size: 20, color: color),
       title: Text(
+        // Compact `L → host:R` mapping (#1054) — same shape as the add-form
+        // preview so a saved forward reads identically to its preview.
         '${f.localPort}  →  ${f.remoteHost}:${f.remotePort}',
-        style: theme.textTheme.bodyMedium,
+        style: theme.textTheme.bodyMedium?.copyWith(fontFamily: 'monospace'),
       ),
       subtitle: Text(
         subtitle,
@@ -304,12 +348,56 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
   }
 
   Widget _addForm(ThemeData theme) {
+    final mapping = PortForwardsSheet.previewMapping(
+      _localPortCtrl.text,
+      _remoteHostCtrl.text,
+      _remotePortCtrl.text,
+    );
+    final semantics = PortForwardsSheet.previewSemantics(
+      _localPortCtrl.text,
+      _remoteHostCtrl.text,
+      _remotePortCtrl.text,
+      widget.entry.host,
+    );
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
         children: [
+          // Live effect preview (#1054): the concrete mapping, big + monospace,
+          // so the direction and endpoints are unambiguous before Add.
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  mapping,
+                  key: const Key('forward-preview'),
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontFamily: 'monospace',
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  semantics,
+                  key: const Key('forward-preview-semantics'),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
           Row(
             children: [
               SizedBox(
@@ -321,7 +409,8 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   decoration: const InputDecoration(
                     labelText: 'Local',
-                    hintText: '18088',
+                    hintText: '8888',
+                    helperText: 'phone',
                     isDense: true,
                   ),
                 ),
@@ -342,6 +431,8 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
                   autocorrect: false,
                   decoration: const InputDecoration(
                     labelText: 'Remote host',
+                    hintText: 'hostname',
+                    helperText: 'resolved from the SSH server',
                     isDense: true,
                   ),
                 ),
@@ -356,7 +447,8 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   decoration: const InputDecoration(
                     labelText: 'Remote',
-                    hintText: '8088',
+                    hintText: '8250',
+                    helperText: 'on server',
                     isDense: true,
                   ),
                 ),

--- a/native/test/ui/port_forwards_sheet_preview_1054_test.dart
+++ b/native/test/ui/port_forwards_sheet_preview_1054_test.dart
@@ -1,0 +1,157 @@
+// Port-forward sheet live preview + direction semantics (#1054).
+//
+// The refinement over #1047 is UI-only: an add-form effect line that reads
+// `localPort → remoteHost:remotePort` live as the fields change, a
+// plain-language semantics line naming the session host, and list rows that
+// render the same compact mapping. These tests drive the real widget over an
+// in-memory gateway pair (no live SSH) and seed the forward table by pushing a
+// SshForwardListEvent from the task side.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xterm/xterm.dart';
+
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/port_forwards_sheet.dart';
+
+const _sessionId = 'ra-server:22:me:1';
+const _sessionHost = 'ra-server';
+
+class _Harness {
+  _Harness()
+      : pair = InMemoryGatewayPair(),
+        store = ProfilesStore() {
+    proxy = SshSessionProxy(sessionId: _sessionId, gateway: pair.uiSide);
+    entry = SessionEntry(
+      id: _sessionId,
+      host: _sessionHost,
+      port: 22,
+      username: 'me',
+      proxy: proxy,
+      terminal: Terminal(maxLines: 200),
+    );
+  }
+
+  final InMemoryGatewayPair pair;
+  final ProfilesStore store;
+  late final SshSessionProxy proxy;
+  late final SessionEntry entry;
+
+  /// Push an authoritative forward table from the task side → proxy → sheet.
+  void pushForwards(List<ForwardInfo> forwards) {
+    pair.taskSide.send(
+      SshForwardListEvent(sessionId: _sessionId, forwards: forwards).toJson(),
+    );
+  }
+}
+
+Future<void> _pumpSheet(WidgetTester tester, _Harness h) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: PortForwardsSheet(entry: h.entry, store: h.store),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+String _text(WidgetTester tester, Key key) {
+  return tester.widget<Text>(find.byKey(key)).data!;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('previewMapping: blank remote host resolves to 127.0.0.1', () {
+    expect(
+      PortForwardsSheet.previewMapping('8888', '', '8250'),
+      '8888  →  127.0.0.1:8250',
+    );
+    expect(
+      PortForwardsSheet.previewMapping('8888', 'hostname', '8250'),
+      '8888  →  hostname:8250',
+    );
+  });
+
+  test('previewSemantics threads the session host + endpoints', () {
+    final line =
+        PortForwardsSheet.previewSemantics('8888', 'hostname', '8250', 'ra-server');
+    expect(line, contains('127.0.0.1:8888'));
+    expect(line, contains('hostname:8250'));
+    expect(line, contains('ra-server'));
+  });
+
+  testWidgets('preview + semantics update live as fields change', (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    await _pumpSheet(tester, h);
+
+    // Blank form: default remote host is shown, ports are placeholders.
+    expect(
+      _text(tester, const Key('forward-preview')),
+      contains('127.0.0.1'),
+    );
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '8888');
+    await tester.pump();
+    // Blank remote host still resolves to the default in the live preview.
+    expect(
+      _text(tester, const Key('forward-preview')),
+      '8888  →  127.0.0.1:·',
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('forward-remote-host')),
+      'hostname',
+    );
+    await tester.enterText(
+      find.byKey(const Key('forward-remote-port')),
+      '8250',
+    );
+    await tester.pump();
+
+    expect(
+      _text(tester, const Key('forward-preview')),
+      '8888  →  hostname:8250',
+    );
+
+    final semantics = _text(tester, const Key('forward-preview-semantics'));
+    expect(semantics, contains('127.0.0.1:8888'));
+    expect(semantics, contains('hostname:8250'));
+    // The session host is threaded read-only into the direction sentence.
+    expect(semantics, contains(_sessionHost));
+  });
+
+  testWidgets('list row renders the compact L → host:R mapping', (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    await _pumpSheet(tester, h);
+
+    h.pushForwards(const [
+      ForwardInfo(
+        localPort: 8888,
+        remoteHost: 'hostname',
+        remotePort: 8250,
+        status: ForwardStatus.active,
+      ),
+    ]);
+    // Two broadcast hops (gateway → proxy → sheet); let the event loop turn.
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.pump();
+
+    expect(find.byKey(const Key('forward-row-8888')), findsOneWidget);
+    expect(find.text('8888  →  hostname:8250'), findsOneWidget);
+    // Status label is present alongside the mapping.
+    expect(find.text('Active'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

Refines the #1047 port-forward sheet so the concrete mapping and `ssh -L`
direction are unambiguous. UI-only — no engine/IPC/store change (the model
already carries localPort/remoteHost/remotePort; the session host comes from
`entry.host`, already available).

Closes #1054.

## Changes (native/lib/ui/port_forwards_sheet.dart)

- **Add-form live PREVIEW**: big monospace `localPort → remoteHost:remotePort`,
  updating live as the fields change (controller listeners → setState). Blank
  remote host resolves to the default `127.0.0.1`; empty ports show a `·`
  placeholder so the shape is always visible.
- **Plain-language semantics** under the preview, naming the session host:
  "Apps on this phone at 127.0.0.1:&lt;L&gt; reach &lt;host&gt;:&lt;R&gt; through
  &lt;sessionHost&gt;." — so the `-L` direction can't be misread.
- **List rows** keep the compact `L → host:R` mapping (now monospace to match
  the preview) alongside active/waiting/error status.
- **Field hints** clarify LOCAL = phone, REMOTE host = resolved from the SSH
  server; example hints updated to the owner's 8888 / hostname / 8250.

The preview/semantics logic is exposed as pure static helpers
(`PortForwardsSheet.previewMapping` / `previewSemantics`) for direct testing.

## Tests

- **Widget** `native/test/ui/port_forwards_sheet_preview_1054_test.dart`:
  preview updates live as fields change; blank remote host shows 127.0.0.1;
  list row renders `8888 → hostname:8250`; semantics line threads the session
  host. (4 tests, green.)
- **Emulator** `native/integration_test/port_forward_preview_1054_test.dart`:
  connect → open sheet → type 8888 / hostname / 8250 → assert preview reads
  `8888  →  hostname:8250` + semantics names the session host → Add → assert the
  list row mapping. PASSED on the mobissh-emulator (screenshot below).
- `scripts/native-fast-gate.sh`: analyze clean, full unit/widget suite green
  (2083 tests).

## Screenshot

Port forwards sheet on-device — list row `8888 → hostname:8250 Active`, the
preview box, the direction sentence, and the labeled Local/Remote-host/Remote
fields:
`test-results/emulator-shots/20260711T184641+0000-pf-preview-form-1054_.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa