### PR TITLE
perf(native): content-driven scan cache + scroll gating + max-wait ceilings kill detection scroll lag and the flickering chip (#1044/#1046)

### DIFF
--- a/native/integration_test/scroll_scan_perf_1044_test.dart
+++ b/native/integration_test/scroll_scan_perf_1044_test.dart
@@ -1,0 +1,311 @@
+// On-emulator acceptance for #1044 (+ the #1046 chip-steady shape).
+//
+// PART 1 — the owner's scroll-lag case: a `seq 5000` flood with EVERY
+// detection pattern ON plus a custom pattern, then real swipe-fling gestures.
+// Measures, per drag frame: wall frame time (detection ON vs OFF) and the
+// #1044 scan counters. The hard assertions are the DETERMINISTIC ones —
+// during active dragging the detection layer performs ZERO scan work
+// (rescans and prune re-reads both 0); frame-time numbers are REPORTED for
+// the PR (emulator timing is too jittery to gate on).
+//
+// PART 2 — the #1046 shape: a shell loop repaints a line containing a
+// detectable path at ~10Hz IN PLACE. Once its anchor is visible at a gutter
+// row it must STAY visible at every subsequent sample (rows may change; a
+// vanish = the flickering chip).
+//
+// Screenshot windows (orchestrator runs scripts/emu-shot.sh on the OPEN
+// markers): PERF1044_FLING_WINDOW_OPEN, PERF1044_TUI_WINDOW_OPEN,
+// PERF1044_SETTLED_WINDOW_OPEN.
+//
+// Run: scripts/native-connect-test.sh integration_test/scroll_scan_perf_1044_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+const _steadyToken = '/tmp/steady1046.txt';
+
+/// Snapshot-diff of the #1044 counters.
+Map<String, int> _statsDelta(Map<String, int> before, Map<String, int> now) {
+  return {for (final k in now.keys) k: (now[k] ?? 0) - (before[k] ?? 0)};
+}
+
+int _p95(List<int> micros) {
+  if (micros.isEmpty) return 0;
+  final sorted = [...micros]..sort();
+  return sorted[(sorted.length * 95 ~/ 100).clamp(0, sorted.length - 1)];
+}
+
+int _avg(List<int> micros) => micros.isEmpty
+    ? 0
+    : micros.reduce((a, b) => a + b) ~/ micros.length;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'seq-5000 fling: zero scan work while dragging (detection ON), frame '
+    'times reported ON vs OFF; 10Hz TUI repaint keeps the chip steady '
+    '(#1044/#1046)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? ctrlOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && ctrlOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = ctrlOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller');
+      final c = controller!;
+
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      void send(String line) {
+        entry.proxy.sendInput(Uint8List.fromList(utf8.encode(line)));
+      }
+
+      // #1035-shape custom pattern on top of the full default set. Registered
+      // directly on the controller (the store-backed path is exercised by the
+      // Detection Lab suite); it multiplies the per-line regex passes exactly
+      // like a user-defined pattern does.
+      c.registerTextPattern(
+        TextPattern(id: 'custom.perf1044', regex: RegExp(r'PERFTOKEN-\d+')),
+      );
+
+      // The flood: 5000 lines with a detectable tail so anchors are LIVE in
+      // the viewport when the fling starts.
+      send('clear; seq 5000; '
+          'echo tail https://example.com/perf1044 /etc/hosts PERFTOKEN-7\n');
+      var tailSeen = false;
+      for (var i = 0; i < 240; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        if (utf8
+            .decode(out, allowMalformed: true)
+            .contains('PERFTOKEN-7')) {
+          tailSeen = true;
+          break;
+        }
+      }
+      expect(tailSeen, isTrue, reason: 'seq 5000 output never finished');
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(
+        c.anchors.any((a) => '${a.payload}'.contains('perf1044')),
+        isTrue,
+        reason: 'precondition: anchors live before the fling',
+      );
+
+      final termFinder = find.byKey(Key('ghostty-terminal-$sessionId'));
+      expect(termFinder, findsOneWidget);
+      final rect = tester.getRect(termFinder);
+      final bodyX = rect.left + rect.width * 0.35;
+
+      // One measured fling pass: [flings] downward-swipe gestures (content
+      // scrolls up into history), recording wall time per pumped drag frame
+      // and the scan-counter delta across ONLY the drag phases.
+      Future<(List<int>, Map<String, int>)> flingPass(int flings) async {
+        final frameMicros = <int>[];
+        final before = c.detectionScanStats.snapshot();
+        final dragDelta = <String, int>{};
+        for (var s = 0; s < flings; s++) {
+          final dragStart = c.detectionScanStats.snapshot();
+          final g = await tester.startGesture(
+            Offset(bodyX, rect.top + rect.height * 0.25),
+          );
+          for (var i = 1; i <= 8; i++) {
+            await g.moveTo(
+              Offset(bodyX, rect.top + rect.height * (0.25 + 0.08 * i)),
+            );
+            final sw = Stopwatch()..start();
+            await tester.pump(const Duration(milliseconds: 8));
+            frameMicros.add(sw.elapsedMicroseconds);
+          }
+          await g.up();
+          final d =
+              _statsDelta(dragStart, c.detectionScanStats.snapshot());
+          for (final e in d.entries) {
+            dragDelta[e.key] = (dragDelta[e.key] ?? 0) + e.value;
+          }
+          // Coast + settle (quiesce scans of newly-revealed rows are LEGAL
+          // here — they are the settle reconcile, outside the drag window).
+          for (var i = 0; i < 10; i++) {
+            await tester.pump(const Duration(milliseconds: 60));
+          }
+        }
+        final total = _statsDelta(before, c.detectionScanStats.snapshot());
+        debugPrint('PERF1044 pass total-delta=$total drag-delta=$dragDelta');
+        return (frameMicros, dragDelta);
+      }
+
+      // ---- detection ON (full set + custom) ----
+      debugPrint('PERF1044_FLING_WINDOW_OPEN');
+      final (onFrames, onDrag) = await flingPass(6);
+      debugPrint('PERF1044_FLING_WINDOW_CLOSED');
+      debugPrint('PERF1044 ON  frames=${onFrames.length} '
+          'avgUs=${_avg(onFrames)} p95Us=${_p95(onFrames)} '
+          'dragScanDelta=$onDrag');
+
+      expect(
+        onDrag['rescans'] ?? 0,
+        0,
+        reason: 'NO rescan may run during an active drag — scans are content-'
+            'driven and quiesce-deferred (#1044); got $onDrag',
+      );
+      expect(
+        onDrag['pruneWindowScans'] ?? 0,
+        0,
+        reason: 'NO per-anchor prune re-read may run during a pure drag '
+            '(#1044); got $onDrag',
+      );
+
+      // ---- detection OFF (baseline) ----
+      await container
+          .read(detectionSettingsProvider.notifier)
+          .setEnabled(false);
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(c.anchors, isEmpty, reason: 'detection OFF must clear anchors');
+      final (offFrames, _) = await flingPass(6);
+      debugPrint('PERF1044 OFF frames=${offFrames.length} '
+          'avgUs=${_avg(offFrames)} p95Us=${_p95(offFrames)}');
+
+      // Re-enable for part 2 (the app re-registers the default patterns).
+      await container
+          .read(detectionSettingsProvider.notifier)
+          .setEnabled(true);
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+
+      // ---- PART 2: the #1046 shape — 10Hz in-place repaint, chip steady ----
+      // The screen's top row is rewritten with the SAME detectable line every
+      // 100ms for ~5s (cursor-home + clear-line, no newline → in place).
+      send(r'clear; i=0; while [ $i -lt 50 ]; do '
+          'printf \'\\033[H\\033[2K// note $_steadyToken steady\'; '
+          r'i=$((i+1)); sleep 0.1; done'
+          '\n');
+
+      // Part 1 flung UP into the seq history and a `clear` does NOT yank a
+      // scrolled-up viewport back down (correct terminal behavior). The #1046
+      // scenario is a repainting status line the user is WATCHING — i.e. at the
+      // bottom. Snap there so the repainting row is on-screen (and inside the
+      // detection scan window); otherwise it repaints off-screen forever.
+      c.scrollToBottom();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      bool tokenVisible() {
+        for (final a in c.anchors) {
+          if (!'${a.payload}'.contains(_steadyToken)) continue;
+          for (final r in a.ranges) {
+            if (c.anchorGutterRow(r) != null) return true;
+          }
+        }
+        return false;
+      }
+
+      // Wait for first detection (loop start + debounce / max-wait ceiling).
+      var seen = false;
+      for (var i = 0; i < 60 && !seen; i++) {
+        c.scrollToBottom();
+        await tester.pump(const Duration(milliseconds: 100));
+        seen = tokenVisible();
+        if (i % 4 == 0 || seen) {
+          final tokenOnScreen = c.visibleRowsText(0, 43).contains(_steadyToken);
+          debugPrint('PERF1044_PART2 i=$i seen=$seen '
+              'isScrolling=${c.isScrolling} vpTop=${c.screenViewportTop} '
+              'sb=${c.scrollbackRows} tokenOnScreen=$tokenOnScreen '
+              'anchors=${c.anchors.length} '
+              'stats=${c.detectionScanStats.snapshot()}');
+        }
+      }
+      expect(seen, isTrue, reason: 'the repainted line never anchored');
+
+      // Sample through the remainder of the repaint loop: once visible, the
+      // anchor must NEVER vanish (a vanish is the #1046 blink).
+      debugPrint('PERF1044_TUI_WINDOW_OPEN');
+      var vanishes = 0;
+      for (var i = 0; i < 40; i++) {
+        c.scrollToBottom();
+        await tester.pump(const Duration(milliseconds: 100));
+        if (!tokenVisible()) vanishes++;
+      }
+      debugPrint('PERF1044_TUI_WINDOW_CLOSED vanishes=$vanishes');
+      expect(
+        vanishes,
+        0,
+        reason: 'the chip for a 10Hz in-place repainted line must be STEADY '
+            '— $vanishes samples lost the anchor (#1046)',
+      );
+
+      // SETTLED screenshot window: repaint loop over, anchors at rest.
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      debugPrint('PERF1044_SETTLED_WINDOW_OPEN');
+      for (var i = 0; i < 30; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      debugPrint('PERF1044_SETTLED_WINDOW_CLOSED');
+    },
+  );
+}

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -2909,6 +2909,14 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     final controller = _controller;
     final verifier = _pathVerifier;
     if (controller == null || verifier == null) return;
+    // #1044: while the viewport is actively scrolling this fires PER FRAME
+    // (the decoration listenable tracks the painted offset, #993), and when a
+    // relative anchor is live each pass re-reads the WHOLE visible viewport
+    // text over FFI for the cwd ladder (#1036) — a heavy per-frame tax during
+    // a fling. Verification noting is quiesce work: skip mid-scroll; the
+    // settle edge fires this listenable once more and that pass notes
+    // everything (the verifier's TTL cache absorbs the batching).
+    if (controller.isScrolling) return;
     final proxy = _proxy;
     if (proxy == null || proxy.data.state != SshSessionState.connected) return;
     final anchors = controller.anchors;

--- a/native/test/fixtures/replay/tui_comment_chip_flicker_62x36.byte-trace.json
+++ b/native/test/fixtures/replay/tui_comment_chip_flicker_62x36.byte-trace.json
@@ -1,0 +1,1150 @@
+{
+  "grid": {
+    "cols": 62,
+    "rows": 36
+  },
+  "byteTrace": [
+    {
+      "tMs": 3198527,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3198631,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3198857,
+      "b64": "G1syNjsxSBtbOTFtwrcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3198894,
+      "b64": "G1syMDsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3199109,
+      "b64": "G1s2QRtbOTNtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3199192,
+      "b64": "G1syMzs4SBtbMzdtNRtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3199232,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3199328,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3199413,
+      "b64": "G1syNjsxSBtbOTFtKhtbMTNDG1szN204G1syQzBzIMK3IOKGkxtbMzltIBtbMzdtMjMuMmsgdG9rZW5zKRtbMzltG1tLG1szMjszSA=="
+    },
+    {
+      "tMs": 3199495,
+      "b64": "G1syMDsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3199526,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3199704,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3199929,
+      "b64": "G1syNjsxSBtbOTFt4py9G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3199972,
+      "b64": "G1s2QRtbOTFtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3200203,
+      "b64": "G1syMDsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3200224,
+      "b64": "G1syMzs4SBtbMzdtNhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3200237,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3200282,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3200463,
+      "b64": "G1syNjsxSBtbOTFt4py2G1sxNkMbWzM3bTEbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3200536,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3200651,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3200720,
+      "b64": "G1syMDsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3200901,
+      "b64": "G1syNjsxSBtbOTFtwrcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3201135,
+      "b64": "G1s2QRtbOTNtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3201191,
+      "b64": "G1syMzs4SBtbMzdtNxtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3201216,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3201246,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3201326,
+      "b64": "G1syMDsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3201432,
+      "b64": "G1syNjsxSBtbOTFtKhtbMTZDG1szN20yG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3201548,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3201651,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3201885,
+      "b64": "G1syNjsxSBtbOTFt4py9G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3201937,
+      "b64": "G1syMDsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3201986,
+      "b64": "G1s2QRtbOTFtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3202211,
+      "b64": "G1syMzs4SBtbMzdtOBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3202232,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3202247,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3202458,
+      "b64": "G1syNjsxSBtbOTFt4py2G1sxNkMbWzM3bTMbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3202529,
+      "b64": "G1syMDsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3202565,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3202662,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3202898,
+      "b64": "G1syNjsxSBtbOTFtwrcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3203109,
+      "b64": "G1s2QRtbOTNtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3203141,
+      "b64": "G1syMDsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3203169,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3203193,
+      "b64": "G1syMzs4SBtbMzdtORtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3203229,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3203450,
+      "b64": "G1syNjsxSBtbOTFtKhtbMTZDG1szN200G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3203557,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3203716,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3203752,
+      "b64": "G1syMDsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3203789,
+      "b64": "G1syNjsxSBtbOTFt4py9G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3204012,
+      "b64": "G1s2QRtbOTFtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3204129,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3204192,
+      "b64": "G1syMzs3SBtbMzdtMzAbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3204226,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3204401,
+      "b64": "G1syMDsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3204488,
+      "b64": "G1syNjsxSBtbOTFt4py2G1sxNkMbWzM3bTUbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3204574,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3204675,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3204857,
+      "b64": "G1syNjsxSBtbOTFtwrcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3204971,
+      "b64": "G1syMDsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3205138,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3205162,
+      "b64": "G1s2QRtbOTNtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3205190,
+      "b64": "G1syMzs4SBtbMzdtMRtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3205244,
+      "b64": "G1s/MjVsG1tIG1tLDQogIBtbMzdtTGlzdGVkIBtbMW0xGyhCG1ttG1szN20gZGlyZWN0b3J5LCByYW4gG1sxbTEbKEIbW20bWzM3bSBzaGVsbCBjb21tYW5kIBtbMzltG1tLDQobW0sbWzkybQ0K4pePG1szOW0gG1sxbVdyaXRlGyhCG1ttKBtdODtpZD10bXV4QztmaWxlOi8vL2hvbWUvZGV2Ly5jb25maWcvYWdlbnQtbWFpbC5lbnYbXH4vLmNvbmZpZy9hZ2VudC1tYWlsLmVudhtdODs7G1wpG1tLG1szN20NCiAg4o6/IMKgG1szOW1Xcm90ZSAbWzFtMxsoQhtbbSBsaW5lcyB0byAbWzFtLi4vLi4vLmNvbmZpZy9hZ2VudC1tYWlsLmVudhsoQhtbbRtbSw0KICAgICAbWzM3bRtbMm0gMSAbKEIbW20bWzM3bUFHRU5UX01BSUxfW1JFREFDVEVEXQ0KICAgICAbWzM3bRtbMm0gICAbKEIbW20bWzM3bV9tbXYyb3JtWTN0Z3MbWzM5bRtbSxtbODs1SBtbMUsbWzM3bRtbMm0bW0MgMiAbKEIbW20bWzM3bUFHRU5UX01BSUxfTkFNRT1mZC1kZXYtbW9iaXNzaBtbMzltG1tLDQogICAgIBtbMzdtG1sybSAzIBsoQhtbbRtbMzdtQUdFTlRfTUFJTF9QUk9KRUNUPS9zcnYvYWdlbnQtaHViG1szOW0bW0sNChtbSw0KICAbWzM3bVJlYWQgG1sxbTIbKEIbW20bWzM3bSBmaWxlcywgbGlzdGVkIBtbMW0xGyhCG1ttG1szN20gZGlyZWN0b3J5LCByYW4gG1sxbTIbKEIbW20bWzM3bSBzaGVsbCBjb21tYW5kcywgG1szOW0bW0sbWzEyOzJIG1sxSxtbMzdtG1tDcmVjYWxsZWQgG1sxbTEbKEIbW20bWzM3bSBtZW1vcnkgG1szOW0bW0sNChtbSxtbOTdtDQril48bWzM5bSBTY3JpcHQgcmV2aWV3ZWQg4oCUIGl0J3MgdGhlIGRvY3VtZW50ZWQbWzFYG1tDZW5yb2xsbWVudCAobWludCBKV1Qg4oaSG1sxNTsxSCAgcmVnaXN0ZXIgTUNQIOKGkhtbMVgbW0NpZGVudGl0eSBmaWxlIOKGkiBwbHVnaW4gbWFya2V0cGxhY2UpLhtbMVgbW0NSdW5uaW5nG1tLDQogIHRoZRtbMVgbW0NyZXNldBtbMVgbW0NwYXRoG1sxWBtbQ3VuZGVyG1sxWBtbQ3RoZRtbMVgbW0NjYW5vbmljYWwbWzFYG1tDaWRlbnRpdHk6G1tLDQobW0sbWzM3bQ0K4pePG1szOW0gUnVubmluZyAbWzFtMRsoQhtbbSBzaGVsbCBjb21tYW5k4oCmG1tLG1szN20NCiAg4o6/ICAkIEFHRU5UX05BTUU9ZmQtZGV2LW1vYmlzc2ggYmFzaCAbWzM5bRtbSw0KICAgICAbWzM3bS90bXAvbW9iaXNzaC9hZ2VudC1odWItc2V0dXAuc2ggcmVzZXQbWzM5bRtbSw0KG1tLG1s5MW0NCuKcohtbMzltG1sxWBtbOTFtG1tDSGVyZGluZ+KApiAbWzM3bSg0bSAxM3Mgwrcg4oaTG1szOW0gG1szN201LjRrIHRva2VucyDCtyAbWzM4OzU7MjQ5bXRoaW5raW5nG1szN20pG1szOW0bW0sbWzM3bQ0KICDijr8gwqBUaXA6IFlvdSBjYW4gY29udHJvbCBob3cgYmlnIGEgd29ya2Zsb3cgaXMganVzdCBieSAbWzM5bRtbSxtbMjQ7MkgbWzFLG1tDICAgG1szN21wcm9tcHRpbmcuIEFzayBmb3IgYSBzbWFsbCB3b3JrZmxvdywgY2FwIGl0IHdpdGggG1s5NG0idXNlIGF0IBtbMzltG1syNTsySBtbMUsbW0MgICAbWzk0bW1vc3QgNSBhZ2VudHMiG1szN20sIG9yIHNldCBhIGRlZmF1bHQgd2l0aCAbWzk0bUR5bmFtaWMgd29ya2Zsb3cgG1szOW0bW0sbWzI2OzJIG1sxSxtbQyAgIBtbOTRtc2l6ZRtbMzdtIGluIBtbOTRtL2NvbmZpZxtbMzdtLhtbMzltG1tLDQobW0sbWzk2bQ0K4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSA4pSAG1szMG0bWzEwNm0gbW9iaXNzaCAbWzQ5bRtbOTZt4pSA4pSAG1szN20bWzI5OzFI4p2vwqAbWzM5bRtbSxtbOTZtDQrilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIAbWzM5bRtbMzE7MkgbWzFLG1szN20bW0Pij7ggbWFudWFsIG1vZGUgb24gwrcgG1s5Nm0xIG1vbml0b3IbWzM3bSDCtyBlc2MgdG8gaW50ZXJydXB0IMK3IOKGkCBmb3IgYWfigKYbWzM5bRtbSxtbMzI7NTFIG1sxSxtbOTJtG104O2lkPXRtdXg0O2h0dHBzOi8vY2xhdWRlLmFpL2NvZGUvc2Vzc2lvbl8wMTR4RXNYSDZ5RXh3VWVHdWhobkhVUmEbXBtbQy9yYyBhY3RpdmUbWzM5bRtdODs7G1wbW0sNChtbSxtbMW0NCiAg4pePIG1haW4bKEIbW20bW0sbWzM3bQ0KICDil68gZ2VuZXJhbC1wdXJwb3NlG1szOW0bWzJYG1szN20bWzJDZGV2ZWxvcCAxMDQ1IHdh4oCmG1szOW0gG1szN201bSAzNXMgwrcg4oaTIDEzNi40ayB0b2tlbnMbWzM4OzI7MTM2OzEzNjsxMzZtG1s0ODsyOzEwOzEwOzEwbRtbMzY7MUggYmFzaCAgRkRkZXYtSVQgG1szODsyOzI1NTsyNTU7MjU1bRtbNDg7Mjs1ODswOzBtG1sxbSBtb2Jpc3NoIBsoQhtbbRtbMzg7MjsxMzY7MTM2OzEzNm0bWzQ4OzI7MTA7MTA7MTBtIHNjcmFwZGF3IBtbMzg7Mjs5MDs5MDs5MG0gICAgICAgICAgICAgICAgICAgICAgICAgICAbKEIbW20bWz8xMmwbWz8yNWgbWzI5OzNI"
+    },
+    {
+      "tMs": 3205309,
+      "b64": "G1syMjsxSBtbOTFtwrcbWzM2QxtbMzg7NTsyNDhtdGhpbmtpbmcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3205525,
+      "b64": "G1syMjszOEgbWzM4OzU7MjQ3bXRoaW5raW5nG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3205714,
+      "b64": "G1sxODsxSBtbMzdtIBtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3205759,
+      "b64": "G1syMjsxSBtbOTFt4pyiG1sxNUMbWzM3bTQbWzIwQxtbMzg7NTsyNDZtdGhpbmtpbmcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3205790,
+      "b64": "G1szNTs0M0gbWzM3bTYbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3205818,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3205923,
+      "b64": "G1syMjsxSBtbOTFtKhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3205978,
+      "b64": "G1syMjsxSBtbOTFt4py2G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3206257,
+      "b64": "G1syMjsxSBtbOTFt4py7G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3206290,
+      "b64": "G1sxODsxSBtbMzdt4pePG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3206319,
+      "b64": "G1syMjsxSBtbOTFt4py9G1szNkMbWzM4OzU7MjQ3bXRoaW5raW5nG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3206572,
+      "b64": "G1syMjszOEgbWzM4OzU7MjQ4bXRoaW5raW5nG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3206756,
+      "b64": "G1syMjsxSBtbOTFt4py7G1sxNUMbWzM3bTUbWzIwQxtbMzg7NTsyNDltdGhpbmtpbmcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3206793,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3206797,
+      "b64": "G1szNTs0M0gbWzM3bTcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3206879,
+      "b64": "G1syMjsxSBtbOTFt4py2G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3206902,
+      "b64": "G1sxODsxSBtbMzdtIBtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3206997,
+      "b64": "G1syMjsxSBtbOTFtKhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3207091,
+      "b64": "G1syMjsxSBtbOTFt4pyiG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3207322,
+      "b64": "G1syMjsxSBtbOTFtwrcbWzM2QxtbMzg7NTsyNDhtdGhpbmtpbmcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3207499,
+      "b64": "G1sxODsxSBtbMzdt4pePG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3207609,
+      "b64": "G1syMjszOEgbWzM4OzU7MjQ3bXRoaW5raW5nG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3207644,
+      "b64": "G1syMjszOEgbWzM3bXRob3VnaHQgZm9yIDZzKRtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3207743,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3207802,
+      "b64": "G1syMjsxSBtbOTFt4pyiG1sxNUMbWzM3bTYbWzhDNRtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3207805,
+      "b64": "G1szNTs0M0gbWzM3bTgbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3207884,
+      "b64": "G1syMjsxSBtbOTFtKhtbOEMbWzkzbeKAphtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3208000,
+      "b64": "G1syMjsxSBtbOTFt4py2G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3208193,
+      "b64": "G1sxODsxSBtbMzdtIBtbMjI7MUgbWzkxbeKcuxtbN0MbWzkzbWcbWzE2QxtbMzdtNhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3208300,
+      "b64": "G1szNTs0M0gbWzM3bTkbWzhDOBtbQzAbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3208389,
+      "b64": "G1syMjsxSBtbOTFt4py9G1s2QxtbOTNtbhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3208607,
+      "b64": "G1syMjs3SBtbOTNtaRtbMkMbWzkxbeKAphtbMTVDG1szN203G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3208662,
+      "b64": "G1syOzFIG1s5Mm3il48bW0MbWzM5bRtbMW1Xcml0ZRsoQhtbbSgbXTg7aWQ9dG11eEM7ZmlsZTovLy9ob21lL2Rldi8uY29uZmlnL2FnZW50LW1haWwuZW52G1x+Ly5jb25maWcvYWdlbnQtbWFpbC5lbnYbXTg7OxtcKRtbSw0KG1szN20gIOKOvyDCoBtbMzltV3JvdGUbW0MbWzFtMxtbQxsoQhtbbWxpbmVzG1tDdG8bW0MbWzFtLi4vLi4vLmNvbmZpZy9hZ2VudC1tYWlsLmVudg0KGyhCG1ttIBtbQyAgIBtbMzdtG1sybSAxIBsoQhtbbRtbMzdtQUdFTlRfTUFJTF9bUkVEQUNURURdDQobWzM5bSAgICAgG1szN20bWzJtICAgGyhCG1ttG1szN21fbW12Mm9ybVkzdGdzG1szOW0bW0MbW0sbWzY7N0gbWzM3bRtbMm0yG1sxMkMbKEIbW20bWzM3bU5BTRtbQz1mZC1kZXYtbW9iaXNzaBtbMzltG1tLG1s3OzdIG1szN20bWzJtMxtbQxsoQhtbbRtbMzdtQUdFTlRfTUFJTF9QUk9KRUNUPS9zcnYvYWdlbnQtaHViG1szOW0bWzg7NkgbW0sbWzk7M0gbWzM3bVJlYWQgG1sxbTIbKEIbW20bWzM3bSBmaWxlcywgbGlzdGVkIBtbMW0xGyhCG1ttG1szN20gZGlyZWN0b3J5LCByYW4gG1sxbTIbKEIbW20bWzM3bSBzaGVsbCBjb21tYW5kcywgG1sxMDszSHJlY2FsbGVkIBtbMW0xGyhCG1ttG1szN20gbWVtb3J5IBtbMzltG1sxMTszSBtbSw0KG1s5N23il48bW0MbWzM5bVNjcmlwdCByZXZpZXdlZCDigJQgaXQncxtbQ3RoZRtbQ2RvY3VtZW50ZWQbW0NlbnJvbGxtZW50G1tDKG1pbnQbW0NKV1QbW0PihpIbWzEzOzNIcmVnaXN0ZXIbW0NNQ1AbW0PihpIbW0NpZGVudGl0eRtbQ2ZpbGUbW0PihpIbW0NwbHVnaW4bW0NtYXJrZXRwbGFjZSkuG1tDUnVubmluZw0KIBtbQ3RoZSByZXNldCBwYXRoIHVuZGVyIHRoZSBjYW4bW0NuaWNhbCBpG1tDZW50aXR5OhtbSxtbMTU7M0gbW0sNChtbMzdtIBtbQxtbMzltUnVubmluZyAbWzFtMRtbQxsoQhtbbXNoZWxsIGNvbW1hbmTigKYbW0MbW0sNChtbMzdtICDijr8gICQgQUdFTlRfTkFNRT1mZC1kZXYtbW9iaXNzaCBiYXNoIA0KG1szOW0gG1tDICAgG1szN20vdG1wL21vYmlzc2gvYWdlbnQtaHViLXNldHVwLnNoIHJlc2V0G1szOW0NChtbSw0KG1szN23il48bW0MbWzM5bRtbMW1Xcml0ZRsoQhtbbSgbXTg7aWQ9dG11eEQ7ZmlsZTovLy90bXAvbW9iaXNzaC9lbnJvbGwtZm9yY2UuanNvbhtcL3RtcC9tb2Jpc3NoL2Vucm9sbC1mb3JjZS5qc29uG104OzsbXCkbW0sbWzI5OzNI"
+    },
+    {
+      "tMs": 3208686,
+      "b64": "G1syMjs2SBtbOTNtZBtbMkMbWzkxbWcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3208690,
+      "b64": "G1syMDsxSBtbMzdtIBtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3208698,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3208706,
+      "b64": "G1sxNjsxSBtbMzdt4pePG1syMDsxSOKXjxtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3208753,
+      "b64": "G1syOzFIIBtbQyAgIBtbMzdtG1sybSAyIBsoQhtbbRtbMzdtQUdFTlRfTUFJTF9OQU1FPWZkLWRldi1tb2Jpc3NoDQobWzM5bSAgICAgG1szN20bWzJtIDMgGyhCG1ttG1szN21BR0VOVF9NQUlMX1BST0pFQ1Q9L3Nydi9hZ2VudC1odWIbWzM5bRtbSxtbNDs2SBtbSxtbNTszSBtbMzdtUmVhZCAbWzFtMhsoQhtbbRtbMzdtIGZpbGVzLCBsaXN0ZWQgG1sxbTEbKEIbW20bWzM3bSBkaXJlY3RvcnksIHJhbiAbWzFtMhsoQhtbbRtbMzdtIHNoZWxsIGNvbW1hbmRzLCAbWzY7M0hyZWNhbGxlZCAbWzFtMRsoQhtbbRtbMzdtIG1lbW9yeSAbWzM5bRtbSxtbNzs2SBtbSw0KG1s5N23il48bW0MbWzM5bVNjcmlwdBtbQ3Jldmlld2VkG1tD4oCUG1tDaXQncxtbQ3RoZRtbQ2RvY3VtZW50ZWQbW0NlbnJvbGxtZW50G1tDKG1pbnQbW0NKV1QbW0PihpIbWzk7M0hyZWdpc3RlciBNQ1Ag4oaSIGlkZW50aXR5IGZpbGUg4oaSIHBsdWdpbiBtYXJrZXRwbGFjZSkuIFJ1bm5pbmcbWzEwOzNIdGhlIHJlc2V0IHBhdGggdW5kZXIbW0N0aGUbW0NjYW5vbmljYWwbW0NpZGVudGl0eTobWzEyOzFIG1szN23il48bW0MbWzM5bVJ1bm5pbmcgG1sxbTEbKEIbW20gc2hlbGwbW0Njb21tYW5k4oCmG1tLDQobWzM3bSAg4o6/ICAkIEFHRU5UX05BTUU9ZmQtZGV2LW1vYmlzc2ggYmFzaCAbWzM5bRtbSxtbMTQ7M0ggICAbWzM3bS90bXAvbW9iaXNzaC9hZ2VudC1odWItc2V0dXAuc2ggcmVzZXQbWzM5bRtbSxtbMTY7MUgbWzkybeKXjxtbQxtbMzltG1sxbVdyaXRlGyhCG1ttKBtdODtpZD10bXV4RDtmaWxlOi8vL3RtcC9tb2Jpc3NoL2Vucm9sbC1mb3JjZS5qc29uG1wvdG1wL21vYmlzc2gvZW5yb2xsLWZvcmNlLmpzb24bXTg7OxtcKRtbMTc7NUgbWzM3bcKgG1szOW1Xcm90ZSAbWzFtMRsoQhtbbSBsaW5lIHRvG1tLG1sxODs2SBtbMW0uLi8uLi8uLi8uLi90bXAvbW9iaXNzaC9lbnJvbGwtZm9yY2UuanNvbhtbMTk7NkgbKEIbW20bWzM3bRtbMm0gMSAbKEIbW20bWzM3bXsibmFtZSI6G1s5Mm0iZmQtZGV2LW1vYmlzc2giG1szN20sImNhcHMiOhtbOTJtImRvY2tlcix0YWlsc2NhDQobWzM5bSAbW0MgICAbWzM3bRtbMm0gICAbKEIbW20bWzkybWxlLGt2bSIbWzM3bSwiZm9yY2UiOhtbOTVtdHJ1ZRtbMzdtfRtbMzltG1tLG1syMjsxN0gbWzM3bTcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3208773,
+      "b64": "G1tIG1szN20gIOKOvyDCoBtbMzltV3JvdGUbW0MbWzFtMxtbQxsoQhtbbWxpbmVzG1tDdG8bW0MbWzFtLi4vLi4vLmNvbmZpZy9hZ2VudC1tYWlsLmVudhtbMjs3SBsoQhtbbRtbMzdtG1sybTEbWzEyQxsoQhtbbRtbMzdtVE9LG1tDTj1RSnp0TF9OcFhTWnZCRFlVMUhlaTUyOEZxb09YS1EbWzM7N0gbWzJtIBtbQxsoQhtbbRtbMzdtX21tdjJvcm1ZM3RncxtbMzltG1tLG1s0OzZIG1szN20bWzJtIDIgGyhCG1ttG1szN21BR0VOVF9NQUlMX05BTUU9ZmQtZGV2LW1vYmlzc2gbWzU7M0gbWzM5bSAgIBtbMzdtG1sybSAzIBsoQhtbbRtbMzdtQUdFTlRfTUFJTF9QUk9KRUNUPS9zcnYvYWdlbnQtaHViG1szOW0bW0sbWzY7M0gbW0sKG1szN21SZWFkIBtbMW0yGyhCG1ttG1szN20gZmlsZXMsIGxpc3RlZCAbWzFtMRsoQhtbbRtbMzdtIGRpcmVjdG9yeSwgcmFuIBtbMW0yGyhCG1ttG1szN20gc2hlbGwgY29tbWFuZHMsIA0KG1szOW0gG1tDG1szN21yZWNhbGxlZCAbWzFtMRsoQhtbbRtbMzdtIG1lbW9yeSAbWzM5bRtbSxtbOTszSBtbSw0KG1s5N23il48bW0MbWzM5bVNjcmlwdCByZXZpZXdlZCDigJQgaXQncyB0aGUgZBtbQ2N1bWVudGUbW0MgZW5yb2xsbWVudBtbQyhtaW50G1tDSldUG1tD4oaSG1sxMTszSHJlZ2lzdGVyG1tDTUNQG1tD4oaSG1tDaWRlbnRpdHkbW0NmaWxlG1tD4oaSG1tDcGx1Z2luG1tDbWFya2V0cGxhY2UpLhtbQ1J1bm5pbmcNCiAbW0N0aGUgcmVzZXQbW0NwYXRoIHVuZGVyIHRoZRtbQ2Nhbm9uaWNhbBtbQ2lkZW50aXR5Og0KG1tLG1sxNDszSBtbMzdtUmFuIBtbMW0xGyhCG1ttG1szN20gc2hlbGwgY29tbRtbQ25kIBtbMzltG1tLG1syMjs2SBtbOTFtZGluG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3208852,
+      "b64": "G1syMjsxSBtbOTFt4py7G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3208906,
+      "b64": "G1syMjsxSBtbOTFt4py2G1syNEMbWzM3bTgbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3209088,
+      "b64": "G1syMjsxSBtbOTFtKhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3209108,
+      "b64": "G1syMjsxSBtbOTFt4pyiG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3209343,
+      "b64": "G1syMjsxSBtbOTFtwrcbWzI0QxtbMzdtORtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3209565,
+      "b64": "G1s3QRtbOTNtSGVyZGluZ+KAphtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3209635,
+      "b64": "G1syMjszNUgbWzM3bSkbWzM5bRtbSxtbMjk7M0g="
+    },
+    {
+      "tMs": 3209662,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3209685,
+      "b64": "G1syMjsxSBtbOTFt4pyiG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3209789,
+      "b64": "G1syMjsxN0gbWzM3bTgbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3209853,
+      "b64": "G1szNTs0MkgbWzM3bTQwG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3209900,
+      "b64": "G1syMjsxSBtbOTFtKhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3210085,
+      "b64": "G1syMjsxSBtbOTFt4py2G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3210119,
+      "b64": "G1syMjsxSBtbOTFt4py7G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3210356,
+      "b64": "G1syMjsxSBtbOTFt4py9G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3210457,
+      "b64": "G1s3QRtbOTFtSGVyZGluZ+KAphtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3210675,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3210684,
+      "b64": "G1szNTs0M0gbWzM3bTEbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3210693,
+      "b64": "G1syMjsxSBtbOTFt4py7G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3210788,
+      "b64": "G1syMjsxN0gbWzM3bTkbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3210905,
+      "b64": "G1syMjsxSBtbOTFt4py2G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3211101,
+      "b64": "G1syMjsxSBtbOTFtKhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3211122,
+      "b64": "G1syMjsxSBtbOTFt4pyiG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3211346,
+      "b64": "G1syMjsxSBtbOTFtwrcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3211642,
+      "b64": "G1s3QRtbOTNtSGVyZGluZ+KAphtbMjk7M0gbKEIbW20bWz8yNWwbWz8xMmwbWz8yNWg="
+    },
+    {
+      "tMs": 3211700,
+      "b64": "G1syMjsxSBtbOTFt4pyiG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3211796,
+      "b64": "G1syMjsxNkgbWzM3bTIwG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3211849,
+      "b64": "G1szNTs0M0gbWzM3bTIbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3211916,
+      "b64": "G1syMjsxSBtbOTFtKhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3212027,
+      "b64": "G1syMjsxSBtbOTFt4py2G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3212140,
+      "b64": "G1syMjsxSBtbOTFt4py7G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3212370,
+      "b64": "G1syMjsxSBtbOTFt4py9G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3212563,
+      "b64": "G1s3QRtbOTFtSGVyZGluZ+KAphtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3212570,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3212757,
+      "b64": "G1syMjsxSBtbOTFt4py7G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3212816,
+      "b64": "G1syMjsxN0gbWzM3bTEbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3212832,
+      "b64": "G1szNTs0M0gbWzM3bTMbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3212944,
+      "b64": "G1syMjsxSBtbOTFt4py2G1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3213045,
+      "b64": "G1syMjsxSBtbOTFtKhtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3213153,
+      "b64": "G1syMjsxSBtbOTFt4pyiG1syOTszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3213392,
+      "b64": "G1syMjsxSBtbOTFtwrcbWzI5OzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3213504,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3213691,
+      "b64": "G1s3QRtbOTNtSGVyZGluZ+KAphtbMjk7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3213696,
+      "b64": "G1s/MjVsG1sxOzVIG1sxSxtbOTJtG1tDICAgICtkZWZpbmVkJxtbMzdtOyAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIBtbMzltG1tLG1syOzVIG1sxSxtbMzdtG1sybRtbQyA1MiAbKEIbW20bWzM3bSAgIH0pOxtbMzltG1tLDQogG1sxWBtbQyAgIBtbOTFtIDUyIC0bWzM3bRtbMm0gIHJlYygna2V5IHByZXNzIHJlZ2lzdGVycyAobW9tZW50YXJ5KScsIGluZm8bKEIbW20bW0sNCiAgICAgG1s5MW0gICAgLRtbMzdtG1sybS5kdXJpbmcgIT09IGluZm8uYmVmb3JlLCBgY2xhc3MgIiR7aW5mby5iZWZvchsoQhtbbRtbSxtbNTs1SBtbMUsbWzkxbRtbQyAgICAtG1szN20bWzJtZX0iIC0+ICIke2luZm8uZHVyaW5nfSIgLT4gIiR7aW5mby5hZnRlcn0iYCk7GyhCG1ttG1tLDQogICAgIBtbOTFtIDUzIC0bWzM3bRtbMm19IGNhdGNoIChlKSB7IHJlYygna2V5IHByZXNzIHJlZ2lzdGVycyAobW9tZW4bKEIbW20bW0sNCiAgICAgG1s5MW0gICAgLRtbMzdtG1sybXRhcnkpJywgZmFsc2UsIFN0cmluZyhlKS5zbGljZSgwLDgwKSk7IH0gICAgIBsoQhtbbRtbSw0KICAgICAbWzkybSA1MyArG1szN20gIBtbOTZtY29uc3QbWzM3bSB1bmxvY2tlZCA9ICEvcHJlc3MgYW55IGtleSB0byB0dXJuIHNvG1szOW0bW0sNCiAgICAgG1s5Mm0gICAgKxtbMzdtdW5kIG9uL2kuG1s5M210ZXN0G1szN20oc3RhdHVzQWZ0ZXIpIHx8IHN0YXR1c0FmdGVyICE9PRtbMzltG1tLDQogG1sxWBtbQyAgIBtbOTJtICAgICsbWzM3bSBzdGF0dXNCZWZvcmU7ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIBtbMzltG1tLDQogICAgIBtbOTJtIDU0ICsbWzM3bSAgG1s5M21yZWMbWzM3bSgbWzkybSdrZXkgYWN0aXZhdGlvbiBydW5zIHNvdW5kIHBpcGVsaW5lJxtbMzdtLCBhG1szOW0bW0sNCiAbWzRYG1s5Mm0bWzRDICAgICsbWzM3bXVkaW9DdHggJiYgdW5sb2NrZWQsIBtbOTJtYHN0YXR1cyAiG1szN20ke3N0YXR1c0JlZm9yZS4bWzM5bRtbSxtbMTM7MkgbWzFLG1tDICAgG1s5Mm0gICAgKxtbMzdtdHJpbSgpLnNsaWNlKBtbOTRtMBtbMzdtLBtbOTRtMjQbWzM3bSl9G1s5Mm0iIC0+ICIbWzM3bSR7c3RhdHVzQWZ0ZXIudHJpbSgpG1szOW0bW0sbWzE0OzVIG1sxSxtbOTJtG1tDICAgICsbWzM3bS5zbGljZSgbWzk0bTAbWzM3bSwbWzk0bTI0G1szN20pfRtbOTJtImAbWzM3bSk7ICAgICAgICAgICAgICAgICAgICAgICAgICAgIBtbMzltG1tLDQogG1sxWBtbQyAgIBtbOTJtIDU1ICsbWzM3bX0gG1s5NW1jYXRjaBtbMzdtIChlKSB7IBtbOTNtcmVjG1szN20oG1s5Mm0na2V5IGFjdGl2YXRpb24gcnVucyBzb3VuZCAbWzM5bRtbSw0KIBtbMVgbW0MgICAbWzkybSAgICArcGlwZWxpbmUnG1szN20sIBtbOTRtZmFsc2UbWzM3bSwgG1s5M21TdHJpbmcbWzM3bShlKS4bWzkzbXNsaWNlG1szN20oG1s5NG0wG1szN20sG1s5NG04MBtbMzdtKSk7IH0gIBtbMzltG1tLDQogG1sxWBtbQyAgIBtbMzdtG1sybSA1NiAbKEIbW20bWzM3bSAbWzM5bRtbSxtbMTg7NUgbWzFLG1szN20bWzJtG1tDIDU3IBsoQhtbbRtbMzdtIBtbOTBtLy8gSW50ZXJhY3Rpb246IGFjdGl2YXRlIGEgdmVsb2NpdHkgcHJlc2V0IC0+G1szOW0bW0sNCiAgICAgG1szN20bWzJtICAgIBsoQhtbbRtbMzdtIBtbOTBtIFJTVlAgYXBwZWFycyB3aXRoIHRleHQbWzM5bRtbSxtbMjA7NUgbWzFLG1szN20bWzJtG1tDIDU4IBsoQhtbbRtbMzdtIBtbOTVtdHJ5G1szN20gextbMzltG1tLDQobW0sNCiAgG1szN21SYW4gG1sxbTEbKEIbW20bWzM3bSBzaGVsbCBjb21tYW5kIBtbMzltG1tLDQobW0sbWzk3bQ0K4pePG1szOW0gICAgG1tLDQobW0sbWzkxbQ0K4py2G1szOW0bWzFYG1s5MW0bW0NTcHJvdXRpG1s5M21uZ+KAphtbOTFtIBtbMzdtKDhtIDE0cyDCtyDihpMbWzM5bSAbWzM3bTIzLjNrIHRva2VucykbWzM5bRtbSxtbMzdtDQogIOKOvyDCoFRpcDogV29ya2luZyBvbiBhIHBsYW4gb3IgZGVzaWduIGRvYz8gQXNrIENsYXVkZSB0byAbWzM5bRtbSxtbMjg7NUgbWzFLG1szN20bW0NwdWJsaXNoIGl0IGFzIGFuIGFydGlmYWN0IOKAlCBhIHBvbGlzaGVkIHdlYiBwYWdlIHlvdSBjYW4gG1szOW0bW0sbWzI5OzVIG1sxSxtbMzdtG1tDb3BlbiBpbiB5b3VyIGJyb3dzZXIuG1szOW0bW0sNChtbSxtbOTZtDQrilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIAbWzMwbRtbMTA2bSBzY3JhcGRhdyAbWzQ5bRtbOTZt4pSA4pSAG1szN20bWzMyOzFI4p2vwqAbWzM5bRtbSxtbOTZtDQrilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIDilIAbWzM5bRtbMzQ7MkgbWzFLG1szN20bW0Pij7ggbWFudWFsIG1vZGUgb24gwrcgZXNjIHRvIGludGVycnVwdCDCtyDihpAgZm9yIGFnZW50cxtbMzltG1tLG1szNTs1MUgbWzFLG1s5Mm0bXTg7aWQ9dG11eDY7aHR0cHM6Ly9jbGF1ZGUuYWkvY29kZS9zZXNzaW9uXzAxNERBaHBHaFFlWVBHQTFRYUNrWEVGaRtcG1tDL3JjIGFjdGl2ZRtbMzltG104OzsbXBtbSxtbMzg7MjsxMzY7MTM2OzEzNm0bWzQ4OzI7MTA7MTA7MTBtDQogYmFzaCAgRkRkZXYtSVQgIG1vYmlzc2ggG1szODsyOzI1NTsyNTU7MjU1bRtbNDg7Mjs1ODswOzBtG1sxbSBzY3JhcGRhdyAbKEIbW20bWzM4OzI7OTA7OTA7OTBtG1s0ODsyOzEwOzEwOzEwbSAgICAgICAgICAgICAgICAgICAgICAgICAgIBsoQhtbbRtbPzEybBtbPzI1aBtbMzI7M0g="
+    },
+    {
+      "tMs": 3213705,
+      "b64": "G1syNjsxSBtbOTFt4py7G1s3QxtbOTNtaRtbMkMbWzkxbeKAphtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3213732,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3213923,
+      "b64": "G1syNjsxSBtbOTFt4py9G1s2QxtbOTNtdBtbMkMbWzkxbWcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3213957,
+      "b64": "G1s4QTE2LzE2LBtbQ3plcm8bW0NlcnJvcnMuG1tDVGhlG1tDQ1NTG1tDZml4G1tDd29ya3MbW0MoZmlsdGVyZWQbW0NvcHRpb25zG1tDbm93G1szMjszSA=="
+    },
+    {
+      "tMs": 3214148,
+      "b64": "G1syNjs3SBtbOTNtdRtbMkMbWzkxbW4bWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3214207,
+      "b64": "G1syNjsxSBtbOTFt4py7G1s0QxtbOTNtbxtbMkMbWzkxbWkbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3214431,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szQxtbOTNtchtbMkMbWzkxbXQbWzEwQxtbMzdtNRtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3214463,
+      "b64": "G1sxOzZIG1tLChtbOTFtICAgIC0bWzM3bRtbMm1lfSIgLT4gIiR7aW5mby5kdXJpbmd9IiAtPiAiJHtpbmZvLmFmdGVyfSJgKTsbWzM7OEgbKEIbW20bWzkxbTMbWzJDG1szN20bWzJtfRtbQ2NhdGNoIChlKSB7IHJlYygna2V5IHAbW0Nlc3MgcmVnaXN0ZXJzIChtb21lbhtbNDsxMUh0YXJ5KScsG1tDZmFsc2UsIFN0cmluZygbW0MpLnNsaWNlKDAsODApKTsgfSAgICAgG1s1OzZIGyhCG1ttG1s5Mm0gNTMgKxtbMzdtICAbWzk2bWNvbnN0G1szN20gdW5sb2NrZWQgPSAhL3ByZXNzIGFueSBrZXkgdG8gdHVybiBzbxtbNjs2SBtbOTJtICAgICsbWzM3bXVuZCBvbi9pLhtbOTNtdGVzdBtbMzdtKHN0YXR1c0FmdGVyKSB8fCBzdGF0dXNBZnRlciAhPT0bWzc7NkgbWzkybSAgICArG1szN20gc3RhdHVzQmVmb3JlOyAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAbWzg7OEgbWzkybTQbWzRDG1s5M21yZWMbWzM3bSgbWzkybSdrZXkgYWN0aXZhdGlvbiBydW5zIHNvdW5kIHBpcGVsaW5lJxtbMzdtLCBhG1s5OzEySGRpb0N0eCAmJiB1bmxvY2tlZCwgG1s5Mm1gc3RhdHVzICIbWzM3bSR7cxtbQ2F0dXNCG1tDZm9yZS4bWzEwOzExSHRyaW0oKS5zbGljZSgbWzk0bTAbWzM3bSwbWzk0bTI0G1szN20pfRtbOTJtIiAtPiAiG1szN20ke3N0YXR1c0FmdGVyLnRyaW0oKRtbMTE7N0gbWzkybSAgG1syQxtbMzdtLnNsaWNlKBtbOTRtMBtbMzdtLBtbOTRtMjQbWzM3bSl9G1s5Mm0iYBtbMzdtKTsgICAgICAgICAgICAgICAgICAgICAgICAgIBtbQyAbWzEyOzdIG1s5Mm01NRtbMkMbWzM3bX0gG1s5NW1jYXRjaBtbQxtbMzdtKGUpIHsgG1s5M21yZWMbWzM3bSgbWzkybSdrZXkgYWMbW0NpdmF0aW9uIHJ1bnMgc291bmQgG1sxMzsxMUhwaXBlbGluZScbWzM3bSwgG1s5NG1mYWxzZRtbMzdtLCAbWzkzbVN0cmluZxtbMzdtKGUpLhtbOTNtc2xpY2UbWzM3bSgbWzk0bTAbWzM3bSwbWzk0bTgwG1szN20pKTsgfSAgG1sxNDs2SBtbMm0gNTYgGyhCG1ttG1szN20gG1szOW0bW0sbWzE1OzZIG1szN20bWzJtIDU3IBsoQhtbbRtbMzdtIBtbOTBtLy8gSW50ZXJhY3Rpb246IGFjdGl2YXRlIGEgdmVsb2NpdHkgcHJlc2V0IC0+G1sxNjs2SBtbMzdtG1sybSAgICAbKEIbW20bWzM3bSAbWzkwbSBSU1ZQIGFwcGVhcnMgd2l0aCB0ZXh0G1szOW0bW0sbWzE3OzhIG1szN20bWzJtOBtbMkMbKEIbW20bWzk1bXRyeRtbMzdtIHsbWzM5bRtbMTg7NkgbW0sbWzE5OzNIG1szN21SYW4gG1sxbTEbKEIbW20bWzM3bSBzaGVsbCBjb21tYW5kIBtbMzltG1tLG1syMDs2SBtbSw0KG1s5N23il48bW0MbWzM5bTE2LzE2LBtbQ3plcm8bW0NlcnJvcnMuG1tDVGhlG1tDQ1NTG1tDZml4G1tDd29ya3MbW0MoZmlsdGVyZWQbW0NvcHRpb25zG1tDbm93G1syMjszSHZpc3VhbGx5IGhpZGU6IDggdmlzdWFsG1tDdnMbW0M4G1tDZnVuY3Rpb25hbCksG1tDYW5kG1tDdGhlG1tDa2V5Ym9hcmQbWzIzOzNIcGF0aBtbQ2NvbmZpcm1zG1tDdGhlG1tDc291bmQbW0NwaXBlbGluZRtbQ3J1bnMbW0PigJQbW0NzdGF0dXMbW0NmbGlwcxtbQyJQcmVzcw0KIBtbQ2FueSBrZXkgdG8gdHUbW0NuIHNvdW5kIG9uIiDihpIbW0MiU291bmQgb24uIiBMZRtbQyBtG1tDIGdsYW5jZSBhdCB0aGUbWzMyOzNI"
+    },
+    {
+      "tMs": 3214532,
+      "b64": "G1sxOzZIG1s5MW0gICAgLRtbMzdtG1sybS5kdXJpbmcgIT09IGluZm8uYmVmb3JlLCBgY2xhc3MgIiR7aW5mby5iZWZvchtbMjY7MUgbKEIbW20bWzkxbSobWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3214657,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1syQxtbOTNtcBtbMkMbWzkxbXUbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3214695,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3214879,
+      "b64": "G1syNjsxSBtbOTFtwrcbW0MbWzkzbVMbWzJDG1s5MW1vG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3214977,
+      "b64": "G1syNjs1SBtbOTFtchtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3215013,
+      "b64": "G1sxOzZIG1tLChtbOTJtICAgICsbWzM3bXVuZCBvbi9pLhtbOTNtdGVzdBtbMzdtKHN0YXR1c0FmdGVyKSB8fCBzdGF0dXNBZnRlciAhPT0bWzM7NkgbWzkybSAgICArG1szN20gc3RhdHVzQmVmb3JlOyAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAbWzQ7NkgbWzkybSA1NCArG1szN20gIBtbOTNtcmVjG1szN20oG1s5Mm0na2V5IGFjdGl2YXRpb24gcnVucyBzb3VuZCBwaXBlbGluZScbWzM3bSwgYRtbNTs3SBtbOTJtICAbWzJDG1szN211ZGlvQ3R4G1tDJiYgdW5sb2NrZWQsIBtbOTJtYHN0YXR1cyAiG1szN20ke3N0YRtbQ3VzQmVmb3JlLhtbNjsxMUh0cmltKCkuc2xpY2UoG1s5NG0wG1szN20sG1s5NG0yNBtbMzdtKX0bWzkybSIgLT4gIhtbMzdtJHtzdGF0dXNBZnRlci50G1tDaW0oKRtbNzsxMUguG1tDbGljZSgbWzk0bTAbWzM3bSwbWzk0bTI0G1szN20pfRtbOTJtImAbWzM3bSk7G1s4OzhIG1s5Mm01G1syQxtbMzdtfRtbQxtbOTVtY2F0Y2gbWzM3bSAoZSkgeyAbWzkzbXJlYxtbMzdtKBtbOTJtJ2tleSBhY3RpdmF0aW9uIHJ1bnMgc291bmQgG1s5OzExSHBpcGVsaW5lJxtbMzdtLBtbQxtbOTRtZmFsc2UbWzM3bSwgG1s5M21TdHJpbmcbWzM3bShlKS4bWzkzbXNsaWNlG1szN20oG1s5NG0wG1szN20sG1s5NG04MBtbMzdtKSk7IH0gIBtbMTA7NkgbWzJtIDU2IBsoQhtbbRtbMzdtIBtbMzltG1tLG1sxMTs2SBtbMzdtG1sybSA1NyAbKEIbW20bWzM3bSAbWzkwbS8vIEludGVyYWN0aW9uOiBhY3RpdmF0ZSBhIHZlbG9jaXR5IHByZXNldCAtPhtbMTI7NkgbWzM3bRtbMm0gICAgGyhCG1ttG1szN20gG1s5MG0gUlNWUCBhcHBlYXJzIHdpdGggdGV4dBtbMzltG1tLG1sxMzs2SBtbMzdtG1sybSA1OCAbKEIbW20bWzM3bSAbWzk1bXRyeRtbMzdtIHsbWzM5bRtbSxtbMTQ7NkgbW0sbWzE1OzNIG1szN21SYW4gG1sxbTEbKEIbW20bWzM3bSBzaGVsbCBjb21tYW5kIBtbMzltG1tLG1sxNjs2SBtbSw0KG1s5N23il48bW0MbWzM5bTE2LzE2LCB6ZXJvIGVycm9ycy4bW0NUaGUbW0NDU1MbW0NmaXgbW0N3b3JrcxtbQyhmaWx0ZXJlZBtbQ29wdGlvbnMbW0Nub3cbWzE4OzNIdmlzdWFsbHkbW0NoaWRlOhtbQzgbW0N2aXN1YWwbW0N2cxtbQzgbW0NmdW5jdGlvbmFsKSwbW0NhbmQbW0N0aGUbW0NrZXlib2FyZBtbMTk7M0hwYXRoIGNvbmZpcm1zIHRoZSBzb3VuZBtbQ3BpcGVsaW5lG1tDcnVucxtbQ+KAlBtbQ3N0YXR1cxtbQ2ZsaXBzG1tDIlByZXNzG1syMDszSGFueRtbQ2tleRtbQ3RvG1tDdHVybhtbQ3NvdW5kG1tDb24iG1tD4oaSG1tDIlNvdW5kG1tDb24uIhtbQ0xldBtbQ21lG1tDZ2xhbmNlG1tDYXQbW0N0aGUbWzIxOzFIIBtbQ3JlbmRlcmVkIHNjchtbQ2Vuc2hvdHMgdG8bW0Njb25maXJtG1tDbhtbQ3RoaW5nJ3MgdmlzdWFsbHkgYnJva2UbW0MsG1tLG1syMjszSHRoZW4gY29tbWl0IHRoZSBmaXguG1tLG1syMzszSBtbSw0KG1szN23il48bW0MbWzM5bVJlYWRpbmcbW0MbWzFtMRsoQhtbbSBmaWxl4oCmG1tDG1tLG1szMjszSA=="
+    },
+    {
+      "tMs": 3215243,
+      "b64": "G1sxOzZIG1s5Mm0gNTMgKxtbMzdtICAbWzk2bWNvbnN0G1szN20gdW5sb2NrZWQgPSAhL3ByZXNzIGFueSBrZXkgdG8gdHVybiBzbxtbMjY7MUgbWzkxbeKcohtbMkNwG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3215299,
+      "b64": "G1syNDsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3215480,
+      "b64": "G1syNjsxSBtbOTFtKhtbQ1MbWzE1QxtbMzdtNhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3215539,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3215728,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3215745,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3216006,
+      "b64": "G1sxOzZIG1tLG1syOzEySBtbMzdtZGlvQ3R4ICYmIHVubG9ja2VkLCAbWzkybWBzdGF0dXMgIhtbMzdtJHtzG1tDYXR1c0IbW0Nmb3JlLhtbMzsxMUh0cmltKCkuc2xpY2UoG1s5NG0wG1szN20sG1s5NG0yNBtbMzdtKX0bWzkybSIgLT4gIhtbMzdtJHtzdGF0dXNBZnRlci50cmltKCkbWzQ7N0gbWzkybSAgG1syQxtbMzdtLnNsaWNlKBtbOTRtMBtbMzdtLBtbOTRtMjQbWzM3bSl9G1s5Mm0iYBtbMzdtKTsgICAgICAgICAgICAgICAgICAgICAgICAgIBtbQyAbWzU7N0gbWzkybTU1G1syQxtbMzdtfSAbWzk1bWNhdGNoG1tDG1szN20oZSkgeyAbWzkzbXJlYxtbMzdtKBtbOTJtJ2tleSBhYxtbQ2l2YXRpb24gcnVucyBzb3VuZCAbWzY7MTFIcGlwZWxpbmUnG1szN20sIBtbOTRtZmFsc2UbWzM3bSwgG1s5M21TdHJpbmcbWzM3bShlKS4bWzkzbXNsaWNlG1szN20oG1s5NG0wG1szN20sG1s5NG04MBtbMzdtKSk7IH0gIBtbNzs2SBtbMm0gNTYgGyhCG1ttG1szN20gG1szOW0bW0sbWzg7NkgbWzM3bRtbMm0gNTcgGyhCG1ttG1szN20gG1s5MG0vLyBJbnRlcmFjdGlvbjogYWN0aXZhdGUgYSB2ZWxvY2l0eSBwcmVzZXQgLT4bWzk7NkgbWzM3bRtbMm0gICAgGyhCG1ttG1szN20gG1s5MG0gUlNWUCBhcHBlYXJzIHdpdGggdGV4dBtbMzltG1tLG1sxMDs4SBtbMzdtG1sybTgbWzJDGyhCG1ttG1s5NW10cnkbWzM3bSB7G1szOW0bWzExOzZIG1tLG1sxMjszSBtbMzdtUmFuIBtbMW0xGyhCG1ttG1szN20gc2hlbGwgY29tbWFuZCAbWzM5bRtbSxtbMTM7NkgbW0sNChtbOTdt4pePG1tDG1szOW0xNi8xNiwbW0N6ZXJvG1tDZXJyb3JzLhtbQ1RoZRtbQ0NTUxtbQ2ZpeBtbQ3dvcmtzG1tDKGZpbHRlcmVkG1tDb3B0aW9ucxtbQ25vdxtbMTU7M0h2aXN1YWxseSBoaWRlOiA4IHZpc3VhbBtbQ3ZzG1tDOBtbQ2Z1bmN0aW9uYWwpLBtbQ2FuZBtbQ3RoZRtbQ2tleWJvYXJkG1sxNjszSHBhdGgbW0Njb25maXJtcxtbQ3RoZRtbQ3NvdW5kG1tDcGlwZWxpbmUbW0NydW5zG1tD4oCUG1tDc3RhdHVzG1tDZmxpcHMbW0MiUHJlc3MNCiAbW0Nhbnkga2V5IHRvIHR1G1tDbiBzb3VuZCBvbiIg4oaSG1tDIlNvdW5kIG9uLiIgTGUbW0MgbRtbQyBnbGFuY2UgYXQgdGhlG1sxODszSHJlbmRlcmVkG1tDc2NyG1tDZW5zaG90G1tDIHRvG1tDY29uZmlybSBub3RoaW5nJ3MbW0N2aXN1YWxseSBicm9rZW4sG1sxOTszSHRoZW4bWzNDbW0bW0N0IHRoZSBmaXguG1tLG1syMDszSBtbSw0KG1szN20gG1tDG1szOW1SG1tDYRtbQ2luZyAbWzFtMRsoQhtbbSBmaWwbW0PigKYbW0sNChtbMzdtICDijr8gIC90bXAvY2xhdWRlLTEwMDEvLWhvbWUtZGV2LXdvcmtzcGFjZS1zY3JhcGRhdy82YzQ3ZmIwNC1lMRtbMjM7Nkg0ZS00MmRiLTk3NmUtMGUzYWE2ZjQ0NWEzL3NjcmF0Y2hwYWQvcHJvdG8tbGFuZHNjYXBlLWRhcmsbWzI0OzFIG1szOW0gG1tDICAgG1szN20ucG5nG1szOW0bW0MbW0sbWzI2OzNIG1s5M21TcHJvdXRpbmfigKYbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3216088,
+      "b64": "G1sxOzZIG1s5Mm0gNTQgKxtbMzdtICAbWzkzbXJlYxtbMzdtKBtbOTJtJ2tleSBhY3RpdmF0aW9uIHJ1bnMgc291bmQgcGlwZWxpbmUnG1szN20sIGEbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3216105,
+      "b64": "G1syMTsxSBtbMzdt4pePG1syNjsxSBtbOTFt4py9G1tDU3Byb3V0aW5n4oCmG1sxNkMbWzM3bTQbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3216216,
+      "b64": "G1syNjsxSBtbOTFt4py7G1syN0MbWzM3bTUbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3216436,
+      "b64": "G1syNjsxSBtbOTFt4py2G1sxN0MbWzM3bTcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3216522,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3216552,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3216616,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3216664,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3216890,
+      "b64": "G1syNjsxSBtbOTFtwrcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3217107,
+      "b64": "G1s2QRtbOTNtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3217130,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3217222,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3217446,
+      "b64": "G1syNjsxSBtbOTFtKhtbMTdDG1szN204G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3217559,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3217592,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3217679,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3217739,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3217787,
+      "b64": "G1syNjsxSBtbOTFt4py9G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3218008,
+      "b64": "G1s2QRtbOTFtU3Byb3V0aW5n4oCmG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3218235,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3218341,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3218539,
+      "b64": "G1syNjsxSBtbOTFt4py2G1sxN0MbWzM3bTkbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3218559,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3218583,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3218681,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3218884,
+      "b64": "G1syNjsxSBtbOTFtwrcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3218962,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3219029,
+      "b64": "G1syNjsxMkgbWzkzbeKAphtbMjVDG1szN20gwrcgG1szODs1OzI0OG10aGlua2luZxtbMzdtKRtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3219129,
+      "b64": "G1syNjs0MUgbWzM4OzU7MjQ3bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3219240,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1s5QxtbOTNtZxtbMjlDG1szODs1OzI0Nm10aGlua2luZxtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3219495,
+      "b64": "G1syNjsxSBtbOTFtKhtbOEMbWzkzbW4bWzdDG1szN20yMBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3219515,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3219564,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3219583,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3219694,
+      "b64": "G1syNjsxSBtbOTFt4py7G1s3QxtbOTNtaRtbMkMbWzkxbeKAphtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3219814,
+      "b64": "G1syNjsxSBtbOTFt4py9G1s2QxtbOTNtdBtbMkMbWzkxbWcbWzI5QxtbMzg7NTsyNDdtdGhpbmtpbmcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3220025,
+      "b64": "G1syNjs3SBtbOTNtdRtbMkMbWzkxbW4bWzMwQxtbMzg7NTsyNDhtdGhpbmtpbmcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3220233,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3220256,
+      "b64": "G1syNjsxSBtbOTFt4py7G1s0QxtbOTNtbxtbMkMbWzkxbWkbWzMxQxtbMzg7NTsyNDltdGhpbmtpbmcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3220365,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3220461,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3220495,
+      "b64": "G1syNjs1SBtbOTNtchtbMkMbWzkxbXQbWzEwQxtbMzdtMRtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3220590,
+      "b64": "G1syNjsxSBtbOTFtKhtbMkMbWzkzbXAbWzJDG1s5MW11G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3220704,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3220871,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3220889,
+      "b64": "G1syNjsxSBtbOTFtwrcbW0MbWzkzbVMbWzJDG1s5MW1vG1szNEMbWzM4OzU7MjQ4bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3221064,
+      "b64": "G1syNjs1SBtbOTFtchtbMzVDG1szODs1OzI0N210aGlua2luZxtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3221289,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1syQ3AbWzM2QxtbMzg7NTsyNDZtdGhpbmtpbmcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3221372,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3221417,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3221430,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3221478,
+      "b64": "G1s2QRtbOTFtUxtbMTVDG1szN20yG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3221660,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3221706,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3221825,
+      "b64": "G1syNjsxSBtbOTFt4py9G1szOUMbWzM4OzU7MjQ3bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3222040,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3222061,
+      "b64": "G1syNjs0MUgbWzM4OzU7MjQ4bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3222277,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szOUMbWzM4OzU7MjQ5bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3222369,
+      "b64": "G1syNjsxSBtbOTFt4py2G1sxN0MbWzM3bTMbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3222403,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3222486,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3222662,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3222714,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3222893,
+      "b64": "G1syNjsxSBtbOTFtwrcbWzM5QxtbMzg7NTsyNDhtdGhpbmtpbmcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3223070,
+      "b64": "G1syNjs0MUgbWzM4OzU7MjQ3bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3223240,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3223271,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szOUMbWzM4OzU7MjQ2bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3223345,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3223391,
+      "b64": "G1syNjsxSBtbOTFtKhtbMTdDG1szN200G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3223504,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3223724,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3223865,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3223881,
+      "b64": "G1syNjsxSBtbOTFt4py9G1szOUMbWzM4OzU7MjQ3bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3224088,
+      "b64": "G1syNjs0MUgbWzM4OzU7MjQ4bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3224307,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szOUMbWzM4OzU7MjQ5bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3224324,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3224402,
+      "b64": "G1syNjsxSBtbOTFt4py2G1sxN0MbWzM3bTUbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3224431,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3224507,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3224620,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3224845,
+      "b64": "G1syNjsxSBtbOTFtwrcbWzM5QxtbMzg7NTsyNDhtdGhpbmtpbmcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3225058,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3225077,
+      "b64": "G1syNjsxMkgbWzkzbeKAphtbMjhDG1szODs1OzI0N210aGlua2luZxtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3225294,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3225315,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1s5QxtbOTNtZxtbMjlDG1szODs1OzI0Nm10aGlua2luZxtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3225406,
+      "b64": "G1syNjsxSBtbOTFtKhtbOEMbWzkzbW4bWzhDG1szN202G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3225509,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3225679,
+      "b64": "G1syNjsxSBtbOTFt4py7G1s3QxtbOTNtaRtbMkMbWzkxbeKAphtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3225696,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3225911,
+      "b64": "G1syNjsxSBtbOTFt4py9G1s2QxtbOTNtdBtbMkMbWzkxbWcbWzI5QxtbMzg7NTsyNDdtdGhpbmtpbmcbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3225966,
+      "b64": "G1syNjs0MUgbWzM4OzU7MjQ4bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3226080,
+      "b64": "G1syNjs3SBtbOTNtdRtbMkMbWzkxbW4bWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3226198,
+      "b64": "G1syNjs2SBtbOTNtbxtbMkMbWzkxbWkbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3226236,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3226256,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3226305,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szOUMbWzM4OzU7MjQ5bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3226404,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szQxtbOTNtchtbMkMbWzkxbXQbWzEwQxtbMzdtNxtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3226520,
+      "b64": "G1syNjsxSBtbOTFtKhtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3226700,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1syQxtbOTNtcBtbMkMbWzkxbXUbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3226919,
+      "b64": "G1syMTsxSBtbMzdt4pePG1syNjsxSBtbOTFtwrcbW0MbWzkzbVMbWzJDG1s5MW1vG1szNEMbWzM4OzU7MjQ4bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3227092,
+      "b64": "G1syNjs1SBtbOTFtchtbMzVDG1szODs1OzI0N210aGlua2luZxtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3227180,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3227212,
+      "b64": "G1syNjsxSBtbOTFt4pyiG1syQ3AbWzMyOzNIGyhCG1tt"
+    },
+    {
+      "tMs": 3227306,
+      "b64": "G1syNjs0MUgbWzM4OzU7MjQ2bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3227417,
+      "b64": "G1syNjsxSBtbOTFtKhtbQ1MbWzE1QxtbMzdtOBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3227464,
+      "b64": "G1syMTsxSBtbMzdtIBtbMzI7M0gbKEIbW20="
+    },
+    {
+      "tMs": 3227528,
+      "b64": "G1syNjsxSBtbOTFt4py2G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3227719,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3227926,
+      "b64": "G1syNjsxSBtbOTFt4py9G1szOUMbWzM4OzU7MjQ3bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3227970,
+      "b64": "G1syNjs0MUgbWzM4OzU7MjQ4bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3228070,
+      "b64": "G1syMTsxSBtbMzdt4pePG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3228146,
+      "b64": "G1s/MjVsG1s/MTJsG1s/MjVo"
+    },
+    {
+      "tMs": 3228208,
+      "b64": "G1syNjsxSBtbOTFt4py7G1szOUMbWzM4OzU7MjQ5bXRoaW5raW5nG1szMjszSBsoQhtbbQ=="
+    },
+    {
+      "tMs": 3228426,
+      "b64": "G1syNjsxSBtbOTFt4py2G1sxN0MbWzM3bTkbWzMyOzNIGyhCG1tt"
+    }
+  ],
+  "scrollTrace": [
+    {
+      "tMs": 163,
+      "offset": 0
+    }
+  ]
+}

--- a/native/test/terminal/redraw_anchor_eviction_873_test.dart
+++ b/native/test/terminal/redraw_anchor_eviction_873_test.dart
@@ -1,30 +1,25 @@
 @Tags(['ffi'])
 library;
 
-// INVARIANT (#873): a detection anchor (URL/path highlight) must be RE-VALIDATED
-// against the CURRENT grid cells when the grid is redrawn — IMMEDIATELY, not only
-// after the debounced full re-scan. A device report (0.1.10+55, "orphaned file
-// markups look like folder") described STRAY leftover highlight boxes stuck on
-// screen where a path/URL USED to be: the line was redrawn (tmux/app rewrote the
-// row with DIFFERENT text) or scrolled out of the bounded scrollback window, yet
-// the old anchor still painted over text that no longer contained the match.
+// INVARIANT (#873, amended by #1046): a detection anchor (URL/path highlight)
+// must be RE-VALIDATED against the CURRENT grid cells when the grid is
+// redrawn, and a stale anchor must be evicted on a BOUNDED clock that does
+// NOT depend on the debounced rescan. A device report (0.1.10+55, "orphaned
+// file markups look like folder") described STRAY leftover highlight boxes
+// stuck on screen where a path/URL USED to be: discovery of new matches is
+// DEBOUNCED (~120ms) and a streaming TUI keeps cancelling/pushing the timer,
+// so the stale match lingered in `anchors`/`matchAt` for seconds.
 //
-// ROOT: discovery of new matches is DEBOUNCED (~120ms) and a streaming TUI keeps
-// cancelling/pushing the timer, so the stale match lingered in
-// `anchors`/`matchAt` (and thus the painted decorator) for the whole debounce
-// window — often far longer under continuous output. The fix re-validates live
-// anchors against the current cells SYNCHRONOUSLY on each redraw and drops any
-// whose cell-run no longer carries the match, so eviction never waits on the
-// debounce. (The full bounded-window re-scan still runs, debounced, to DISCOVER
-// new matches.)
-//
-// This facet is headless-reproducible (unlike the #868 during-scroll paint-lag
-// that needs a recording): the KEY assertion reads `anchors` BEFORE the debounce
-// fires (no settle) — against pre-fix code the stale anchor is still present.
-//
-// The test drives a REAL flterm TerminalController (real libghostty VT parser,
-// ffi-tagged): detect a URL/path, then redraw the row in place with non-matching
-// text (or scroll it past the bounded window), and assert the anchor is GONE.
+// #1046 AMENDMENT: eviction is no longer INSTANTANEOUS — an in-place TUI
+// repaint routinely leaves a notify observable between a row's erase and its
+// redraw, and instant eviction + debounced rediscovery was the flickering
+// gutter chip (vanish→reappear 0.2–1.4s in the owner byte-trace). A missed
+// anchor now rides a bounded MISS GRACE (~350ms span / ~1.5s block) during
+// which it is retried (validate/relocate) on every notify; if the payload
+// stays gone the grace timer evicts it — INDEPENDENT of the debounce, so the
+// #873 orphan stays bounded even under a stream that pushes the debounce out
+// forever. These tests pin exactly that: eviction lands within the grace
+// bound WHILE a stream keeps the debounce from ever firing.
 
 import 'dart:typed_data';
 
@@ -37,12 +32,6 @@ void main() {
   // Detection re-scan is debounced (~120ms); settle past it before reading.
   Future<void> settle() =>
       Future<void>.delayed(const Duration(milliseconds: 250));
-
-  // A short tick that pumps async microtasks/timers but stays WELL UNDER the
-  // ~120ms detection debounce — so a stale anchor only survives if the
-  // SYNCHRONOUS re-validation (#873) failed to drop it.
-  Future<void> tick() =>
-      Future<void>.delayed(const Duration(milliseconds: 10));
 
   Uint8List bytes(String s) => Uint8List.fromList(s.codeUnits);
 
@@ -64,10 +53,25 @@ void main() {
     return controller;
   }
 
+  // Keep the detection debounce PERPETUALLY pushed out (chunks < 120ms apart,
+  // rewriting an unrelated bottom row) while real time crosses the ~350ms miss
+  // grace — the #873 streaming-TUI shape. Eviction observed during this stream
+  // proves it is grace-driven, not debounce-driven.
+  Future<void> streamPastGrace(TerminalController controller,
+      {int rows = 24}) async {
+    for (var i = 0; i < 8; i++) {
+      controller.write(
+        bytes('\x1b[$rows;1H\x1b[2Kstream tick $i'),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 90));
+    }
+  }
+
   group('#873 — anchors re-validated against current cells on redraw', () {
     test(
-      'a URL row REDRAWN in place is evicted IMMEDIATELY — BEFORE the debounced '
-      'rescan fires (the orphaned-box window: this is the #873 RED assertion)',
+      'a URL row REDRAWN in place is evicted within the bounded miss grace — '
+      'while a stream keeps the debounced rescan from EVER firing (the #873 '
+      'orphaned-box bound, #1046-amended)',
       () async {
         final controller = newController();
         addTearDown(controller.dispose);
@@ -78,16 +82,17 @@ void main() {
         expect(controller.anchors.where((a) => a.payload == url), hasLength(1),
             reason: 'precondition: the URL is detected before the redraw');
 
-        // Redraw the URL's row in place with non-matching prose, then check
-        // WITHOUT settling — the debounce has NOT fired. Pre-fix, the stale
-        // anchor still paints the orphaned box for the whole debounce window.
+        // Redraw the URL's row in place with non-matching prose, then stream
+        // sub-debounce chunks for ~720ms: the debounce never fires, real time
+        // crosses the ~350ms grace — the orphan must be gone.
         controller.write(redrawRow(3, 'just some prose with no link here'));
-        await tick();
+        await streamPastGrace(controller);
 
         expect(controller.anchors.where((a) => a.payload == url), isEmpty,
-            reason: 'the redrawn row no longer holds the URL, so its anchor must '
-                'be evicted synchronously — a lingering anchor is the orphaned '
-                'box (#873)');
+            reason: 'the redrawn row no longer holds the URL: its anchor must '
+                'be evicted within the miss grace even though the stream '
+                'keeps pushing the debounce out — a longer-lived anchor is '
+                'the #873 orphaned box');
 
         // matchAt at the redrawn viewport row must also resolve nothing for it.
         final viewRow = 3 - 1 - controller.scrollbar.offset;
@@ -100,7 +105,7 @@ void main() {
     );
 
     test(
-      'a PATH row REDRAWN in place is evicted immediately (pre-debounce)',
+      'a PATH row REDRAWN in place is evicted within the miss grace',
       () async {
         final controller = newController();
         addTearDown(controller.dispose);
@@ -113,10 +118,11 @@ void main() {
             reason: 'precondition: the path is detected');
 
         controller.write(redrawRow(2, 'plain words only no path'));
-        await tick();
+        await streamPastGrace(controller);
 
         expect(controller.anchors.where((a) => a.payload == path), isEmpty,
-            reason: 'the redrawn row no longer holds the path; anchor evicted');
+            reason: 'the redrawn row no longer holds the path; anchor evicted '
+                'within the grace bound');
       },
     );
 
@@ -137,10 +143,10 @@ void main() {
 
         // Redraw only the FIRST URL's row (viewport row 1).
         controller.write(redrawRow(1, 'no link now'));
-        await tick();
+        await streamPastGrace(controller);
 
         expect(controller.anchors.where((a) => a.payload == url), isEmpty,
-            reason: 'the redrawn URL is evicted');
+            reason: 'the redrawn URL is evicted (within the grace bound)');
         expect(controller.anchors.where((a) => a.payload == otherUrl),
             hasLength(1),
             reason: 'the untouched URL stays detected — eviction is targeted');
@@ -162,7 +168,7 @@ void main() {
         // must survive — the prune validates content, it does not blanket-clear
         // on every notify.
         controller.write(redrawRow(1, url));
-        await tick();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
 
         expect(controller.anchors.where((a) => a.payload == url), hasLength(1),
             reason: 'a repaint that still carries the URL keeps its anchor');
@@ -170,11 +176,51 @@ void main() {
     );
 
     test(
-      'a URL pushed PAST the bounded scrollback window is evicted (no anchor '
-      'lingers for content the scan can no longer see)',
+      'a row MOVED by an in-place repaint keeps its anchor at the NEW rows in '
+      'the same notify — no vanish/reappear gap (#1046 atomic relocate)',
       () async {
-        // Small grid; push the URL well past the 200-row bounded window while the
-        // viewport stays at the live tail (no scroll-up).
+        final controller = newController();
+        addTearDown(controller.dispose);
+
+        controller.write(bytes('above\r\n'));
+        controller.write(bytes('$url\r\n'));
+        await settle();
+        expect(controller.anchors.where((a) => a.payload == url), hasLength(1));
+        final oldTop = controller.anchors
+            .firstWhere((a) => a.payload == url)
+            .ranges
+            .first
+            .topRow;
+
+        // One chunk: erase the URL's row AND redraw the URL two rows lower —
+        // the TUI line-move shape. The anchor must be present at the new rows
+        // IMMEDIATELY after the write (no debounce wait).
+        controller.write(
+          bytes('\x1b[2;1H\x1b[2Kmoved away\x1b[4;1H\x1b[2K$url'),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        final anchorsNow =
+            controller.anchors.where((a) => a.payload == url).toList();
+        expect(anchorsNow, hasLength(1),
+            reason: 'the moved URL must stay anchored with NO gap (#1046)');
+        expect(anchorsNow.first.ranges.first.topRow, isNot(oldTop),
+            reason: 'and at its NEW rows (relocated, not stale)');
+      },
+    );
+
+    test(
+      'a URL pushed PAST the bounded scan coverage is evicted (no anchor '
+      'lingers for content the scan can no longer vouch for)',
+      () async {
+        // Small grid; push the URL well past the scan window while the
+        // viewport stays at the live tail (no scroll-up). The URL's last scan
+        // saw it as a GRID row (mutable), so the one-burst flood dirties the
+        // whole coverage — the settled rescan covers only the new window and
+        // the out-of-coverage anchor is dropped. (#1044 note: had the URL
+        // been scanned while already IN scrollback — the scrolled-through
+        // case — the immutable-row cache would legitimately retain it; see
+        // detection_scan_cache_1044_test.dart in the fork.)
         final controller = newController(rows: 6, cols: 40);
         addTearDown(controller.dispose);
 
@@ -189,10 +235,13 @@ void main() {
         }
         controller.write(bytes(filler.toString()));
         await settle();
+        // Past the grace-sized dust window too (the drop is a coverage trim,
+        // not a grace eviction, but keep the read deterministic).
+        await Future<void>.delayed(const Duration(milliseconds: 500));
 
         expect(controller.anchors.where((a) => a.payload == url), isEmpty,
-            reason: 'the URL scrolled past the bounded scan window; its anchor '
-                'must be evicted, not linger from a prior scan');
+            reason: 'the URL scrolled past the scanned coverage; its anchor '
+                'must not linger');
       },
     );
   });

--- a/native/test/terminal/replay_gutter_flicker_1046_test.dart
+++ b/native/test/terminal/replay_gutter_flicker_1046_test.dart
@@ -1,0 +1,135 @@
+@Tags(['ffi'])
+library;
+
+// #1046 — the flickering gutter chip, replayed from the owner's device trace.
+//
+// Owner report (+135, 2026-07-11T15-58-31): a comment line at the top of a
+// Claude-CLI TUI carried a gutter chip that FLICKERED — the anchor was being
+// dropped and re-created cycle after cycle as the TUI repainted. Root (#1044):
+// every full `_rescanDetections` REPLACED `_detectionMatches` wholesale with
+// fresh instances and always fired the decoration notify, and mid-repaint
+// prune/rescan interleavings could evict-then-rediscover an unchanged line.
+//
+// This test replays the report's byte-trace VERBATIM (fixture copied from
+// test-results/uploads/2026-07-11T15-58-31-bug-report.byte-trace.json)
+// through the real widget tier with the device's pattern set, sampling the
+// anchor set on every frame. THE assertion: once a payload's anchor is
+// present, it never blinks — no present → absent → present transition across
+// the whole replay (an anchor may appear late [discovery] or die for good
+// [content truly gone], but it must never oscillate). Post-#1044 the
+// identity-preserving reconcile + notify suppression make an unchanged
+// repaint invisible to the gutter, so the chip renders steady.
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'replay_trace_harness.dart';
+
+const _fixture =
+    'test/fixtures/replay/tui_comment_chip_flicker_62x36.byte-trace.json';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'replaying the #1046 trace: no anchor ever blinks (present → absent → '
+    'present) across the full TUI repaint cycle',
+    (tester) async {
+      final trace = loadByteTrace(_fixture);
+      expect(trace.cols, 62);
+      expect(trace.rows, 36);
+
+      final controller = TerminalController(
+        config: TerminalConfig(cols: trace.cols, rows: trace.rows),
+      );
+      addTearDown(controller.dispose);
+      // The device pattern set (all detection types ON, as in the report).
+      controller.registerTextPattern(TextPattern.osc8());
+      controller.registerTextPattern(TextPattern.url());
+      controller.registerTextPattern(TextPattern.path());
+      controller.registerTextPattern(TextPattern.relativePath());
+      controller.registerTextPattern(TextPattern.command());
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 700,
+              height: 620,
+              child: TerminalView(
+                controller: controller,
+                autofocus: false,
+                theme: TerminalTheme.dark().copyWith(fontSize: 14),
+                padding: const EdgeInsets.all(4),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Per-payload presence tracking, sampled once per FRAME (the visible
+      // granularity — an evict+re-add inside one frame never paints).
+      final everPresent = <String>{};
+      final present = <String>{};
+      final blinked = <String>{};
+
+      void sample() {
+        final now = <String>{
+          for (final a in controller.anchors) '${a.patternId}|${a.payload}',
+        };
+        for (final key in now) {
+          if (everPresent.contains(key) && !present.contains(key)) {
+            blinked.add(key); // it was here, went away, and came BACK
+          }
+          everPresent.add(key);
+        }
+        present
+          ..clear()
+          ..addAll(now);
+      }
+
+      // Replay with the CAPTURED cadence (gaps clamped to keep the fake
+      // clock moving frame-by-frame), sampling after every pumped frame so
+      // the debounce/settle timers interleave exactly as on device.
+      var lastT = trace.byteTrace.first.tMs;
+      for (final e in trace.byteTrace) {
+        var gap = e.tMs - lastT;
+        lastT = e.tMs;
+        if (gap < 0) gap = 0;
+        if (gap > 300) gap = 300;
+        // Advance the clock in <=50ms slices so debounce (120ms) and settle
+        // (140ms) timers fire BETWEEN chunks like they did on device, and
+        // sample each slice.
+        while (gap > 0) {
+          final slice = gap > 50 ? 50 : gap;
+          await tester.pump(Duration(milliseconds: slice));
+          sample();
+          gap -= slice;
+        }
+        controller.write(lfToCrlf(e.bytes));
+        await tester.pump();
+        sample();
+      }
+      // Final quiesce.
+      await tester.pump(const Duration(milliseconds: 400));
+      sample();
+      await tester.pump(const Duration(milliseconds: 200));
+      sample();
+
+      expect(
+        everPresent,
+        isNotEmpty,
+        reason: 'sanity: the trace produced detection anchors',
+      );
+      expect(
+        blinked,
+        isEmpty,
+        reason: 'no anchor may blink (present → absent → present) during a '
+            'TUI repaint — a chip must render STABLY or not at all (#1046). '
+            'Blinked: $blinked',
+      );
+    },
+  );
+}

--- a/native/test/terminal/replay_scroll_repaint_perf_test.dart
+++ b/native/test/terminal/replay_scroll_repaint_perf_test.dart
@@ -207,19 +207,33 @@ void main() {
 
         final buildsBeforeOutput = counters.layerBuilds;
 
+        // #1044 amendment: output that changes NOTHING decoration-relevant is
+        // now correctly INVISIBLE to the gutter (an unchanged reconcile
+        // suppresses its notify — the #1046 churn killer). The starvation
+        // probe therefore appends output that CHANGES the anchor set: a new
+        // URL must wake the gutter once the settled re-scan lands.
         controller.write(
-          Uint8List.fromList('more output appended below\r\n'.codeUnits),
+          Uint8List.fromList(
+            'and now https://second.example.com/starve too\r\n'.codeUnits,
+          ),
         );
         await tester.pump(const Duration(milliseconds: 300));
         await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
 
+        expect(
+          controller.anchors.any(
+            (a) => a.payload.toString().contains('second.example.com'),
+          ),
+          isTrue,
+          reason: 'the appended URL is detected',
+        );
         expect(
           counters.layerBuilds,
           greaterThan(buildsBeforeOutput),
-          reason: 'with a live anchor on screen, a settled re-scan after new '
-              'output must still rebuild the gutter so the mark tracks the text — '
-              'the #805 gate must not over-throttle (before=$buildsBeforeOutput, '
-              'after=${counters.layerBuilds})',
+          reason: 'an anchor-set CHANGE after new output must still rebuild '
+              'the gutter — the #805 gate must not over-throttle '
+              '(before=$buildsBeforeOutput, after=${counters.layerBuilds})',
         );
 
         expect(

--- a/native/third_party/flterm/lib/flterm.dart
+++ b/native/third_party/flterm/lib/flterm.dart
@@ -28,6 +28,9 @@ export 'src/foundation/anchor_geometry.dart' show AnchorGeometry;
 export 'src/foundation/callbacks.dart' show OnResize;
 export 'src/foundation/cell_metrics.dart' show CellMetrics;
 export 'src/foundation/color_palette.dart' show ColorPalette;
+// #1044: detection hot-path counters — the replay perf suite and bug-report
+// telemetry read these off `TerminalController.detectionScanStats`.
+export 'src/foundation/detection_scan_stats.dart' show DetectionScanStats;
 export 'src/foundation/dynamic_color.dart' show DynamicColor;
 // #1045: the capsule wash geometry is shared with the app's Detection Lab
 // preview so the preview renders EXACTLY the fork's behind-glyph look.

--- a/native/third_party/flterm/lib/src/foundation.dart
+++ b/native/third_party/flterm/lib/src/foundation.dart
@@ -2,6 +2,7 @@ export 'foundation/anchor_geometry.dart';
 export 'foundation/callbacks.dart';
 export 'foundation/cell_metrics.dart';
 export 'foundation/color_palette.dart';
+export 'foundation/detection_scan_stats.dart';
 export 'foundation/dynamic_color.dart';
 export 'foundation/highlight_range.dart';
 export 'foundation/input_types.dart';

--- a/native/third_party/flterm/lib/src/foundation/detection_scan_stats.dart
+++ b/native/third_party/flterm/lib/src/foundation/detection_scan_stats.dart
@@ -1,0 +1,92 @@
+/// Structured-text detection hot-path counters (#1044).
+///
+/// The scroll-lag investigation needed the scan/prune cost made OBSERVABLE:
+/// during a fling the controller used to re-validate every live anchor
+/// synchronously per scroll tick and re-scan a ~440-row window on every
+/// settle, all through per-cell FFI reads — and none of it showed up anywhere
+/// a test or a bug report could read. These monotonic counters mirror the
+/// render box's `debugContentNotifyCount`/`debugPaintCount` idiom for the
+/// DETECTION pipeline, so the replay perf suite can assert "pure scroll = 0
+/// scans" and the app can ride the snapshot into bug-report telemetry.
+///
+/// Counters only — no timing control flow. Incremented by
+/// `TerminalControllerImpl`'s rescan/prune paths; reset belongs to tests.
+class DetectionScanStats {
+  /// `_rescanDetections` passes that actually READ cells (a cache-invalid
+  /// full-window scan or a partial dirty/reveal-region scan).
+  int rescans = 0;
+
+  /// Absolute rows covered by those rescan reads (post wrap-extension).
+  int rescanRows = 0;
+
+  /// Microseconds spent inside `StructuredTextScanner.scan` during rescans.
+  int rescanMicros = 0;
+
+  /// Rescan passes answered ENTIRELY from the row cache — the viewport moved
+  /// over already-scanned rows and no content changed, so zero cells were
+  /// read and zero regexes ran (#1044's "pure scroll costs zero scan work").
+  int rescanCacheHits = 0;
+
+  /// Rescans deferred because the viewport was actively scrolling
+  /// (`isScrolling`); the settle pass runs exactly one reconcile instead.
+  int rescansDeferredScrolling = 0;
+
+  /// `_pruneStaleDetections` passes that had live matches to consider.
+  int prunes = 0;
+
+  /// Per-match `_scanWindow` re-validations the prune performed (each is a
+  /// bounded cell re-read + full pattern pass over the match's rows).
+  int pruneWindowScans = 0;
+
+  /// Microseconds spent inside prune `_scanWindow` scans.
+  int pruneMicros = 0;
+
+  /// Matches the prune kept WITHOUT a re-read because their rows sit fully
+  /// in immutable scrollback (below the active grid) in an unshifted frame.
+  int pruneSkippedImmutable = 0;
+
+  /// Missed matches the prune atomically RELOCATED to their new grid rows
+  /// (an in-place TUI repaint moved the line) instead of evict-now /
+  /// rediscover-after-the-debounce — the #1046 chip-blink killer.
+  int pruneRelocated = 0;
+
+  /// Reconciles that preserved an existing match INSTANCE for identical
+  /// fresh content (#1046 anchor-identity stability).
+  int matchesReused = 0;
+
+  /// Reconciles whose final match set was element-wise identical to the live
+  /// set — no reassignment, no decoration notify (the #1046 churn killer).
+  int notifiesSuppressed = 0;
+
+  /// One flat map for telemetry / test assertions.
+  Map<String, int> snapshot() => <String, int>{
+        'rescans': rescans,
+        'rescanRows': rescanRows,
+        'rescanMicros': rescanMicros,
+        'rescanCacheHits': rescanCacheHits,
+        'rescansDeferredScrolling': rescansDeferredScrolling,
+        'prunes': prunes,
+        'pruneWindowScans': pruneWindowScans,
+        'pruneMicros': pruneMicros,
+        'pruneSkippedImmutable': pruneSkippedImmutable,
+        'pruneRelocated': pruneRelocated,
+        'matchesReused': matchesReused,
+        'notifiesSuppressed': notifiesSuppressed,
+      };
+
+  /// Zero every counter (tests bracket a measured phase with this).
+  void reset() {
+    rescans = 0;
+    rescanRows = 0;
+    rescanMicros = 0;
+    rescanCacheHits = 0;
+    rescansDeferredScrolling = 0;
+    prunes = 0;
+    pruneWindowScans = 0;
+    pruneMicros = 0;
+    pruneSkippedImmutable = 0;
+    pruneRelocated = 0;
+    matchesReused = 0;
+    notifiesSuppressed = 0;
+  }
+}

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
@@ -167,6 +167,13 @@ abstract class TerminalController extends ChangeNotifier
   /// opportunistically (e.g. on every build).
   void restyleDetectionHighlights();
 
+  /// #1044: monotonic counters over the detection scan/prune hot path — scan
+  /// invocations, rows read, µs, cache hits, prune re-validations, identity
+  /// reuse. The replay perf suite asserts on these ("pure scroll = 0 scans")
+  /// and bug-report telemetry snapshots them. Counters only; resetting is the
+  /// caller's business (tests bracket a measured phase with `reset()`).
+  DetectionScanStats get detectionScanStats;
+
   /// Returns the structured-text match covering the VIEWPORT cell at
   /// ([row], [col]), or null when none covers it (#767).
   ///

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -126,6 +126,26 @@ class TerminalControllerImpl extends TerminalController
   /// that the bubble reappears promptly once the user lifts off.
   static const int _scrollSettleMs = 140;
 
+  /// #1044: CEILING on [_scrollSettleTimer]. A line repainting IN PLACE while
+  /// the viewport bottom-follows re-arms the settle timer on every frame (the
+  /// painted offset jitters by a row as the follow re-pins), so a pure trailing
+  /// settle holds [_isScrolling] TRUE for the whole repaint burst — and
+  /// [_rescanDetections] defers EVERY scan at the scroll gate, so the churning
+  /// line never anchors (the on-emulator #1044 failure a detection-debounce
+  /// ceiling alone does NOT cover, because the defer is at the settle gate).
+  /// This ceiling forces a QUIESCE reconcile after this long of unbroken
+  /// scroll-churn — but ONLY when [_contentDirty] shows the grid was actually
+  /// rewritten (content waiting to be scanned). A real user fling (no new
+  /// content) is untouched: the drag-gate's "zero scans while flinging"
+  /// invariant holds. Armed once per scrolling episode (`??=`), re-armed for
+  /// the next window on fire. Cancelled on dispose / real settle.
+  Timer? _scrollSettleMaxWait;
+
+  /// #1044: how long of CONTINUOUS scroll-churn (offset never holding still)
+  /// forces one quiesce reconcile via [_scrollSettleMaxWait]. Bounded so a
+  /// perpetually-repainting bottom-following line still scans periodically.
+  static const int _scrollSettleMaxWaitMs = 300;
+
   /// #805: fires ONLY when a widget-layer decorator's inputs change — the
   /// detected [_detectionMatches] set (after a settled re-scan) or the
   /// [_paintedViewportOffset] (after a frame paints a new offset). A decorator
@@ -173,6 +193,21 @@ class TerminalControllerImpl extends TerminalController
   /// doesn't re-scan every byte. Cancelled on dispose.
   Timer? _detectionDebounce;
 
+  /// #1044: MAX-WAIT ceiling for the [_detectionDebounce]. A region that
+  /// repaints IN PLACE faster than [_detectionDebounceMs] — a progress bar,
+  /// spinner, clock, or a repainting-TUI status line (the owner's Claude-Code
+  /// TUI) — re-arms the trailing debounce on EVERY notify, so a pure trailing
+  /// debounce fires NEVER and the churning line never anchors (the on-emulator
+  /// #1044 acceptance failure: "the repainted line never anchored"). This
+  /// single ceiling timer is armed at the START of a churn chain and is NOT
+  /// pushed out by later notifies (`??=`), so it forces ONE reconcile after
+  /// [_detectionMaxWaitMs] of unbroken churn; [_fireDetectionRescan] then
+  /// clears it so the next quiet gap re-arms a fresh chain. This is the
+  /// content-update settle path — SEPARATE from the scroll drag-gate (which
+  /// suppresses all scan work during an active fling, [_rescanDetections]).
+  /// Cancelled on dispose / clear.
+  Timer? _detectionMaxWait;
+
   /// #767: how many scrollback rows ABOVE the active viewport the re-scan reads.
   /// Bounded so detection never walks unbounded history on every notify — only
   /// the active screen plus this many recent scrollback rows are scanned, which
@@ -182,6 +217,15 @@ class TerminalControllerImpl extends TerminalController
   /// #767: debounce window (ms) for the cell re-scan. Mirrors the app's old
   /// 120ms URL re-detect debounce, now owned by the controller.
   static const int _detectionDebounceMs = 120;
+
+  /// #1044: force a reconcile scan after this long of CONTINUOUS sub-debounce
+  /// churn even if the content never "settles" (see [_detectionMaxWait]).
+  /// Bounded so a perpetually-repainting region still scans PERIODICALLY —
+  /// detections stay live on a live-updating line — without paying a full scan
+  /// on every sub-interval notify. Comfortably above [_detectionDebounceMs] so
+  /// a normal streaming burst still coalesces on the trailing edge; the ceiling
+  /// only bites when the trailing edge can never be reached.
+  static const int _detectionMaxWaitMs = 300;
 
   /// #883: the COORDINATE-FRAME EPOCH of [_detectionMatches] — the
   /// scrollbackRows/cols/visibleRows observed when the matches' absolute rows
@@ -207,6 +251,100 @@ class TerminalControllerImpl extends TerminalController
   /// little slack catches small same-burst appends; larger bursts simply defer
   /// to the debounced rescan.
   static const int _relocateRowSlack = 4;
+
+  /// #1044: detection hot-path counters (see [DetectionScanStats]).
+  final DetectionScanStats _detectionStats = DetectionScanStats();
+
+  /// #1044: the CONTENT-KEYED SCAN CACHE — the absolute-row range
+  /// `[_scannedLo, _scannedHi)` whose detection results ([_detectionMatches]
+  /// restricted to those rows) are CURRENT. The key invariant that makes a
+  /// row cache possible without consuming libghostty damage (which is single-
+  /// consumption and owned by the paint snapshot — reference_paint_root_985):
+  /// scrollback rows are IMMUTABLE in place. VT writes only address the
+  /// active grid; absolute `screen` rows are append-stable (#883), and the
+  /// whole frame is invalidated wholesale on the shifts the epoch below
+  /// tracks. So a covered row above the grid cannot have changed since it
+  /// was scanned, and a rescan only needs to read (a) rows newly entering
+  /// the window and (b) the MUTABLE suffix (every row that has been part of
+  /// the active grid since the last completed scan — [_scannedGridLo]).
+  /// `-1` = no valid cache (full-window scan on next pass).
+  int _scannedLo = -1;
+  int _scannedHi = -1;
+
+  /// #1044: `terminal.scrollbackRows` at the last COMPLETED scan — the first
+  /// row that has been part of the (mutable) active grid since then. On a
+  /// dirty rescan the cache is trimmed to the clean prefix `[.., this)` and
+  /// the suffix re-read.
+  int _scannedGridLo = 0;
+
+  /// #1044: the cache's own coordinate-frame epoch (scrollback shrink /
+  /// resize / screen flip / pattern-suppression flip all invalidate). Kept
+  /// SEPARATE from the #883 `_detectionFrame*` epoch: the prune ADVANCES that
+  /// one on full confirmation, which must not launder a cache staleness.
+  int _scannedScrollback = 0;
+  int _scannedCols = 0;
+  int _scannedRows = 0;
+  TerminalScreen _scannedScreen = .primary;
+  bool _scannedSuppressHeuristics = false;
+
+  /// #1044: a terminal content notify arrived since the last completed scan —
+  /// the active grid may have been rewritten in place, so the mutable suffix
+  /// must be re-read on the next rescan. Scroll notifies never set this
+  /// (viewport movement cannot change cell content).
+  bool _contentDirty = false;
+
+  /// #1044: a rescan fired while [_isScrolling]; run ONE reconcile on the
+  /// settle edge instead of competing with fling frames for FFI/regex time.
+  bool _rescanPendingSettle = false;
+
+  /// #1044: how many rows of scanned coverage to RETAIN around the viewport.
+  /// Scrolling through a long buffer accumulates coverage (and its matches);
+  /// beyond this the far end is trimmed and re-scanned on return. Generous —
+  /// match storage is cheap; re-scanning is the expensive part.
+  static const int _detectionCacheRetentionRows = 2000;
+
+  /// #1044: fixed row slack added around a partial scan region before the
+  /// wrap-flag extension, so the #1042 command IN-BLOCK continuation join
+  /// (which joins across NON-wrapped rows) sees its block context. A block
+  /// deeper than this may join differently at a region edge than a full scan
+  /// would — accepted; the next full-window scan (frame shift) reconverges.
+  static const int _detectionRegionJoinSlack = 12;
+
+  /// #1044: hard cap on the wrap-flag region extension (defensive — a
+  /// pathological all-wrapped buffer must not turn a partial scan into an
+  /// unbounded walk).
+  static const int _detectionRegionWrapCap = 200;
+
+  /// #1046: MISS-GRACE timers, one per anchor whose payload is currently
+  /// unaccounted for on the grid. An in-place TUI repaint routinely leaves a
+  /// notify observable BETWEEN a row's erase and its redraw (the owner trace
+  /// shows the payload back at every chunk boundary while the anchor
+  /// blinked), and a moved line can be off-grid for one whole chunk. A
+  /// missed anchor is therefore KEPT and retried (validate/relocate on each
+  /// subsequent notify); only when the payload stays gone for
+  /// [_detectionMissGraceMs] does the timer evict it. Keyed by match
+  /// INSTANCE (StructuredMatch has identity equality). Timers are cancelled
+  /// when the match re-validates, relocates, is replaced by an equal fresh
+  /// match, or the controller is disposed / patterns cleared.
+  final Map<StructuredMatch, Timer> _detectionMissTimers =
+      <StructuredMatch, Timer>{};
+
+  /// #1046: how long a missed SPAN anchor survives while its payload is
+  /// unaccounted for. Long enough to ride a mid-chunk erase→redraw and a
+  /// one-chunk absence (~230ms observed in the owner trace), short enough
+  /// that a genuinely rewritten row sheds its orphaned WASH well inside the
+  /// #873 comfort band.
+  static const int _detectionMissGraceMs = 350;
+
+  /// #1046: the BLOCK-tier (command) grace. A wrapped command's assembled
+  /// logical line mutates through a TUI redraw (the continuation row lands a
+  /// chunk later → the scorer sees a truncated body → a DIFFERENT payload),
+  /// so the exact-payload relocate can miss for most of a redraw burst
+  /// (~1.0s observed in the owner trace). A block anchor paints NO wash —
+  /// its only affordance is the gutter chip — so the longer afterlife has no
+  /// stale-highlight cost, and it is what keeps the chip from blinking at
+  /// every repaint (#1046's owner report WAS a command chip).
+  static const int _detectionMissGraceBlockMs = 1500;
 
   TerminalControllerImpl({TerminalConfig config = const TerminalConfig()})
     : _config = config,
@@ -400,6 +538,9 @@ class TerminalControllerImpl extends TerminalController
   @override
   void registerTextPattern(TextPattern pattern) {
     _textPatterns[pattern.id] = pattern;
+    // #1044: the pattern SET changed — cached per-row results were computed
+    // with the old set and cannot be trusted.
+    _invalidateDetectionScanCache();
     // Scan synchronously so a freshly-registered pattern highlights any URLs
     // already on screen without waiting for the next output/scroll notify.
     _rescanDetections();
@@ -410,6 +551,10 @@ class TerminalControllerImpl extends TerminalController
     if (_textPatterns.isEmpty && _detectionMatches.isEmpty) return;
     _textPatterns.clear();
     _detectionDebounce?.cancel();
+    _detectionMaxWait?.cancel();
+    _detectionMaxWait = null;
+    _cancelAllMissGrace();
+    _invalidateDetectionScanCache();
     _detectionMatches = const [];
     // Clear only the detection-driven highlights (which are the only writer of
     // _highlights once a pattern is registered).
@@ -477,6 +622,9 @@ class TerminalControllerImpl extends TerminalController
   Listenable get decorationListenable => _decorationNotifier;
 
   @override
+  DetectionScanStats get detectionScanStats => _detectionStats;
+
+  @override
   void reportPaintedViewportOffset(int offset) {
     if (offset == _paintedViewportOffset) return;
     _paintedViewportOffset = offset;
@@ -530,6 +678,55 @@ class TerminalControllerImpl extends TerminalController
       const Duration(milliseconds: _scrollSettleMs),
       _onScrollSettled,
     );
+    // #1044: arm the settle CEILING once at the start of a scrolling episode
+    // and do NOT push it out on later offset changes (`??=`). Continuous
+    // scroll-churn (a bottom-following repainting line) keeps re-arming the
+    // trailing settle above, so without this it would never fire and every
+    // content rescan would defer forever; the ceiling forces one quiesce
+    // reconcile after [_scrollSettleMaxWaitMs] — but only when content is
+    // actually pending (see [_onScrollSettledMaxWait]).
+    _scrollSettleMaxWait ??= Timer(
+      const Duration(milliseconds: _scrollSettleMaxWaitMs),
+      _onScrollSettledMaxWait,
+    );
+  }
+
+  /// #1044: the settle-ceiling target. Forces ONE quiesce reconcile when
+  /// continuous scroll-churn has starved the trailing [_scrollSettleTimer]
+  /// past [_scrollSettleMaxWaitMs] AND [_contentDirty] shows the grid was
+  /// actually rewritten (a bottom-following repaint). A pure user fling never
+  /// sets [_contentDirty], so it is left scrolling with zero scan work — the
+  /// drag-gate invariant. This does NOT
+  /// leave the scrolling state (the offset is still moving, the decorator stays
+  /// hidden); it only unblocks DETECTION so a perpetually-repainting line
+  /// anchors and keeps scanning periodically. The next genuine settle still
+  /// runs [_onScrollSettled] normally.
+  void _onScrollSettledMaxWait() {
+    _scrollSettleMaxWait = null;
+    if (_disposed || !_isScrolling) return;
+    // The trigger is [_contentDirty] ALONE — the active grid was rewritten
+    // since the last scan (a bottom-following repaint). A PURE fling never sets
+    // it (scroll notifies don't; that is the basis of "pure scroll = 0 scans"),
+    // so a real fling is left scrolling with zero scan work — drag-gate intact.
+    // NOT [_rescanPendingSettle]: that flag is set whenever a debounce happens
+    // to fire mid-fling and defer at the scroll gate (discovery-only, no content
+    // change), so forcing on it would scan during a legitimate fling (#1044
+    // regression: it broke the pure-fling zero-passes invariant).
+    if (_contentDirty) {
+      _rescanPendingSettle = false;
+      // Bypass the scroll gate for this ONE forced reconcile — the whole point
+      // is to scan despite _isScrolling, because the "scroll" is really content
+      // churn that will never settle on its own.
+      _rescanDetections(bypassScrollGate: true);
+    }
+    // Re-arm for the next ceiling window so an unbroken churn keeps getting a
+    // periodic scan (and a still-live fling gets re-evaluated next window).
+    if (_isScrolling) {
+      _scrollSettleMaxWait = Timer(
+        const Duration(milliseconds: _scrollSettleMaxWaitMs),
+        _onScrollSettledMaxWait,
+      );
+    }
   }
 
   /// #812: trailing edge — the painted offset has held still for [_scrollSettleMs].
@@ -538,8 +735,20 @@ class TerminalControllerImpl extends TerminalController
   /// painted offset (painted == live → exact placement, no drift).
   void _onScrollSettled() {
     _scrollSettleTimer = null;
+    // #1044: a genuine settle supersedes the ceiling — cancel it so it does not
+    // fire a redundant reconcile after the offset has already come to rest.
+    _scrollSettleMaxWait?.cancel();
+    _scrollSettleMaxWait = null;
     if (_disposed || !_isScrolling) return;
     _isScrolling = false;
+    // #1044: the QUIESCE reconcile — any rescan that fired mid-scroll was
+    // deferred; run exactly one now that the offset is stable, so newly-
+    // revealed rows are scanned (cache-partial) and anchors appear. This is
+    // the debounced settle pass the #918 settle-tick precedent describes.
+    if (_rescanPendingSettle) {
+      _rescanPendingSettle = false;
+      _rescanDetections();
+    }
     _decorationNotifier.notify();
   }
 
@@ -613,8 +822,32 @@ class TerminalControllerImpl extends TerminalController
     _detectionDebounce?.cancel();
     _detectionDebounce = Timer(
       const Duration(milliseconds: _detectionDebounceMs),
-      _rescanDetections,
+      _fireDetectionRescan,
     );
+    // #1044: arm the max-wait ceiling at the START of a churn chain and do NOT
+    // push it out on later notifies (`??=`). Continuous sub-debounce churn (a
+    // repainting status line, progress bar, spinner) keeps cancelling the
+    // trailing debounce above, so without this it would fire never and the
+    // line would never anchor; this forces one reconcile after
+    // [_detectionMaxWaitMs] regardless. [_fireDetectionRescan] clears it so a
+    // quiet gap starts a fresh chain.
+    _detectionMaxWait ??= Timer(
+      const Duration(milliseconds: _detectionMaxWaitMs),
+      _fireDetectionRescan,
+    );
+  }
+
+  /// #1044: the debounce / max-wait timer target. Cancels BOTH timers (whichever
+  /// did not fire) and clears the ceiling so the next notify starts a fresh
+  /// churn chain, then runs the scan. Routing both timers through here keeps the
+  /// trailing edge and the ceiling from double-scanning and guarantees the
+  /// ceiling is re-armable.
+  void _fireDetectionRescan() {
+    _detectionDebounce?.cancel();
+    _detectionDebounce = null;
+    _detectionMaxWait?.cancel();
+    _detectionMaxWait = null;
+    _rescanDetections();
   }
 
   /// #873: SYNCHRONOUSLY re-validate the live detection anchors against the
@@ -656,6 +889,7 @@ class TerminalControllerImpl extends TerminalController
     if (_detectionMatches.isEmpty) return;
     // No patterns left (cleared) — nothing legitimately detectable; drop all.
     if (_textPatterns.isEmpty) {
+      _cancelAllMissGrace();
       _detectionMatches = const [];
       highlights = const [];
       _decorationNotifier.notify();
@@ -696,7 +930,25 @@ class TerminalControllerImpl extends TerminalController
         final drop = _detectionFrameScrollback - scrollback;
         var allConfirmed = true;
         survivors = <StructuredMatch>[];
+        _detectionStats.prunes++;
+        // #1046: ONE shared grid scan, lazily performed on the first trusted-
+        // frame miss, so a miss can be atomically RELOCATED (see below)
+        // instead of evict-now / rediscover-after-the-debounce.
+        List<StructuredMatch>? gridMatches;
         for (final m in _detectionMatches) {
+          // #1044: a match whose rows sit fully BELOW the active grid lives
+          // in immutable scrollback — VT writes only address the grid and
+          // absolute rows are append-stable (#883), so in an UNSHIFTED frame
+          // its cells cannot have changed. Keep it without a re-read; only
+          // matches touching the grid (the in-place TUI rewrite surface #873
+          // exists for) pay for a re-validation scan. (Corner: a row edited
+          // in the same chunk that scrolled it out of the grid is caught by
+          // the next debounced rescan's dirty suffix, not this prune.)
+          if (!frameShifted && _matchBottomRow(m) < scrollback) {
+            survivors.add(m);
+            _detectionStats.pruneSkippedImmutable++;
+            continue;
+          }
           final v = _revalidatedMatch(
             m,
             scanPatterns,
@@ -706,12 +958,45 @@ class TerminalControllerImpl extends TerminalController
             drop: drop,
           );
           if (v == null) {
-            changed = true; // confirmed gone → evict
+            // #1046: the rows under the anchor changed — but an in-place TUI
+            // repaint (Claude-CLI etc.) MOVES lines by rewriting the whole
+            // view shifted, usually within the SAME chunk. Evicting now and
+            // waiting for the debounced rescan to rediscover the payload at
+            // its new rows leaves a visible affordance gap — the owner's
+            // flickering gutter chip (vanish→reappear windows of 0.2–1.4s in
+            // the report's byte-trace, because streaming keeps pushing the
+            // debounce out). Instead, RELOCATE atomically: one shared scan of
+            // the active grid (where all in-place rewrites live), adopt the
+            // same payload at its new rows in this same notify.
+            final grid = gridMatches ??=
+                _scanWindow(scrollback, maxEndAbs, cols, scanPatterns);
+            final moved = _nearestRelocation(m, grid, survivors);
+            if (moved != null) {
+              _cancelMissGrace(m);
+              survivors.add(moved);
+              changed = true; // moved → ranges updated
+              _detectionStats.pruneRelocated++;
+              continue;
+            }
+            // Not on the grid at all RIGHT NOW — which, mid-repaint, often
+            // means "a notify landed between the erase and the redraw of the
+            // same chunk" (the #1046 trace shows the payload back on the
+            // grid at every chunk BOUNDARY while the anchor blinked). Give
+            // the anchor a bounded MISS GRACE instead of evicting: keep it,
+            // retry validate/relocate on every subsequent notify, and evict
+            // via the grace timer only if the payload stays gone. This
+            // trades the #873 "evict immediately" for "evict within
+            // ~[_detectionMissGraceMs]" — still far inside the multi-second
+            // orphan lingering #873 was about, and it kills the blink.
+            survivors.add(m);
+            _armMissGrace(m);
             continue;
           }
           if (identical(v, m)) {
+            _cancelMissGrace(m); // content re-confirmed at its rows
             if (frameShifted) allConfirmed = false; // kept on deferral
           } else {
+            _cancelMissGrace(m);
             changed = true; // re-located → ranges updated
           }
           survivors.add(v);
@@ -829,7 +1114,138 @@ class TerminalControllerImpl extends TerminalController
       startAbsRow: startAbs,
       endAbsRow: endAbs,
     );
-    return _detectionScanner.scan(reader, scanPatterns);
+    // #1044: this is the prune's per-match re-read — count + time it so the
+    // replay perf suite can pin the prune cost.
+    _detectionStats.pruneWindowScans++;
+    final sw = Stopwatch()..start();
+    final matches = _detectionScanner.scan(reader, scanPatterns);
+    _detectionStats.pruneMicros += sw.elapsedMicroseconds;
+    return matches;
+  }
+
+  /// #1044: the LOWEST absolute row a match's ranges touch — the row that
+  /// decides whether the match lives fully in immutable scrollback.
+  int _matchBottomRow(StructuredMatch m) {
+    var bottom = m.ranges.first.bottomRow;
+    for (final r in m.ranges) {
+      if (r.bottomRow > bottom) bottom = r.bottomRow;
+    }
+    return bottom;
+  }
+
+  /// #1046: start (or keep) the miss-grace countdown for [m]. Idempotent —
+  /// a match already in grace keeps its ORIGINAL deadline, so a streaming
+  /// repaint cannot extend a truly-gone anchor's afterlife indefinitely.
+  void _armMissGrace(StructuredMatch m) {
+    if (_detectionMissTimers.containsKey(m)) return;
+    _detectionMissTimers[m] = Timer(
+      Duration(
+        milliseconds: m.tier == TextTier.block
+            ? _detectionMissGraceBlockMs
+            : _detectionMissGraceMs,
+      ),
+      () => _onMissGraceExpired(m),
+    );
+  }
+
+  /// #1046: the payload was re-confirmed (validated in place, relocated, or
+  /// replaced by an equal fresh match) — the anchor is no longer missing.
+  void _cancelMissGrace(StructuredMatch m) {
+    _detectionMissTimers.remove(m)?.cancel();
+  }
+
+  /// #1046: cancel every pending miss-grace timer (dispose / pattern clear /
+  /// full-set replacement).
+  void _cancelAllMissGrace() {
+    for (final t in _detectionMissTimers.values) {
+      t.cancel();
+    }
+    _detectionMissTimers.clear();
+  }
+
+  /// #1046: the grace ran out with the payload still unaccounted for. One
+  /// final validate/relocate attempt (content may have returned with no
+  /// notify since), then evict for real.
+  void _onMissGraceExpired(StructuredMatch m) {
+    _detectionMissTimers.remove(m);
+    if (_disposed) return;
+    final live = _detectionMatches;
+    final idx = live.indexOf(m); // identity equality
+    if (idx < 0) return; // already resolved elsewhere
+    try {
+      final cols = _gridCols;
+      final visibleRows = _gridRows;
+      if (cols <= 0 || visibleRows <= 0) return; // degenerate: keep, rescan reconciles
+      final scanPatterns = _currentScanPatterns();
+      if (scanPatterns.isEmpty) return; // pattern-less paths clear wholesale
+      final scrollback = terminal.scrollbackRows;
+      final gridMatches =
+          _scanWindow(scrollback, scrollback + visibleRows, cols, scanPatterns);
+      final survivors = live.toList();
+      final moved = _nearestRelocation(m, gridMatches, survivors);
+      if (moved != null) {
+        survivors[idx] = moved;
+        _detectionStats.pruneRelocated++;
+      } else {
+        survivors.removeAt(idx);
+      }
+      _detectionMatches = survivors;
+      highlights = _styledHighlights(survivors);
+      _decorationNotifier.notify();
+    } catch (_) {
+      // Defensive: an FFI hiccup here must not crash — leave the match for
+      // the debounced rescan's reconcile to settle.
+    }
+  }
+
+  /// The pattern set a scan/prune should run RIGHT NOW — the registered
+  /// patterns minus the #824/#834 alt-screen heuristic suppression.
+  List<TextPattern> _currentScanPatterns() {
+    final suppressHeuristics =
+        _activeScreen == .alternate && _mouseTracking == .none;
+    return suppressHeuristics
+        ? [for (final p in _textPatterns.values) if (p.isOsc8Source) p]
+        : _textPatterns.values.toList(growable: false);
+  }
+
+  /// #1046: among [gridMatches], the same-payload candidate NEAREST to the
+  /// missed match [m] (by top-row distance) that is not just another live
+  /// anchor's cells — a second occurrence of the same payload that is already
+  /// anchored (in [survivors] or still pending in [_detectionMatches]) must
+  /// not be double-claimed. Null when the payload is really gone.
+  StructuredMatch? _nearestRelocation(
+    StructuredMatch m,
+    List<StructuredMatch> gridMatches,
+    List<StructuredMatch> survivors,
+  ) {
+    final mTop = m.ranges.first.topRow;
+    StructuredMatch? best;
+    var bestDist = 1 << 30;
+    for (final f in gridMatches) {
+      if (f.patternId != m.patternId || f.payload != m.payload) continue;
+      var claimed = false;
+      for (final other in survivors) {
+        if (!identical(other, m) && _sameMatch(other, f)) {
+          claimed = true;
+          break;
+        }
+      }
+      if (!claimed) {
+        for (final other in _detectionMatches) {
+          if (!identical(other, m) && _sameMatch(other, f)) {
+            claimed = true;
+            break;
+          }
+        }
+      }
+      if (claimed) continue;
+      final dist = (f.ranges.first.topRow - mTop).abs();
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = f;
+      }
+    }
+    return best;
   }
 
   /// #767: re-scan the active screen plus a bounded scrollback window for every
@@ -839,9 +1255,24 @@ class TerminalControllerImpl extends TerminalController
   /// scrollback eviction is corrected by construction (no ghost mark). Defensive:
   /// a formatter/FFI hiccup must never crash the session, so it falls back to no
   /// detection.
-  void _rescanDetections() {
+  void _rescanDetections({bool bypassScrollGate = false}) {
     if (_textPatterns.isEmpty) {
+      _cancelAllMissGrace();
       _detectionMatches = const [];
+      return;
+    }
+    // #1044: while the viewport is actively scrolling, DEFER. A scroll cannot
+    // change cell content (absolute rows are append-stable, VT writes only
+    // address the grid), so the only work a mid-scroll rescan could do is
+    // discover newly-revealed rows — not worth competing with fling frames
+    // for FFI/regex time. [_onScrollSettled] runs exactly one reconcile on
+    // the settle edge (the quiesce pass). [bypassScrollGate] is set ONLY by
+    // [_onScrollSettledMaxWait] — the ceiling that force-scans when content
+    // churn keeps the scroll state from ever settling (a bottom-following
+    // repainting line); that path has already confirmed content is pending.
+    if (_isScrolling && !bypassScrollGate) {
+      _rescanPendingSettle = true;
+      _detectionStats.rescansDeferredScrolling++;
       return;
     }
     // #824: HEURISTIC structured-text detection (the regex `url`/`path` patterns)
@@ -874,73 +1305,385 @@ class TerminalControllerImpl extends TerminalController
       // On the alt-screen with no OSC-8 source registered there is nothing to
       // detect; drop any anchors carried over from the primary screen so the
       // underlines vanish the instant vim opens, and wake the decorator.
+      _invalidateDetectionScanCache();
+      _cancelAllMissGrace();
       if (_detectionMatches.isEmpty) return;
       _detectionMatches = const [];
       highlights = const [];
       _decorationNotifier.notify();
       return;
     }
-    List<StructuredMatch> matches;
     try {
       final visibleRows = _gridRows;
       final cols = _gridCols;
       if (visibleRows <= 0 || cols <= 0) {
-        matches = const [];
+        // Degenerate mid-layout dims — keep the pre-#1044 behavior (clear the
+        // matches) and drop the cache with them.
+        _invalidateDetectionScanCache();
+        _cancelAllMissGrace();
+        if (_detectionMatches.isEmpty) return;
+        _detectionMatches = const [];
+        highlights = const [];
+        _decorationNotifier.notify();
+        return;
+      }
+      // Scan the region that is ACTUALLY ON SCREEN wherever the viewport
+      // currently sits in scrollback, not a range anchored only to the bottom.
+      // The viewport's top absolute row is the scroll offset; it occupies
+      // [viewportTop, viewportTop + visibleRows). Scan that plus up to
+      // _detectionScrollbackWindow rows of margin ABOVE and BELOW it, so a URL
+      // the user scrolled far up to (#787) — or just scrolled near — is picked
+      // up, while the bounded margin keeps this off an O(scrollback) walk.
+      // (Anchored-to-bottom previously missed anything scrolled past the
+      // window.) The margin also gives the wrap-join enough context rows above
+      // the first visible row to assemble a URL that wraps across the boundary.
+      final scrollback = terminal.scrollbackRows;
+      // #958: the viewport top in SCREEN space. On the ALT screen
+      // `scrollbar.offset` is alt-local (always 0) while the alt viewport
+      // actually sits AFTER the primary history in `PointTag.screen` space —
+      // using the raw offset made the scan window cover primary HISTORY rows
+      // instead of the visible alt rows, so with history longer than the
+      // margin nothing on a tmux screen was ever detected (the other half of
+      // #958). See [screenViewportTop].
+      final viewportTop =
+          _activeScreen == .alternate ? scrollback : scrollbar.offset;
+      final startAbs = viewportTop - _detectionScrollbackWindow < 0
+          ? 0
+          : viewportTop - _detectionScrollbackWindow;
+      // Clamp the bottom to the last buffer row so we never read past the
+      // active screen (defensive; the reader also guards per-cell).
+      final maxEndAbs = scrollback + visibleRows; // exclusive
+      var endAbs = viewportTop + visibleRows + _detectionScrollbackWindow;
+      if (endAbs > maxEndAbs) endAbs = maxEndAbs;
+      if (endAbs <= startAbs) return;
+
+      // ---- #1044: the content-keyed scan cache ----
+      // The cache claims: every row in [_scannedLo, _scannedHi) still holds
+      // the content it held when [_detectionMatches] was reconciled. Valid
+      // only while the coordinate frame holds (no scrollback shrink, no
+      // resize, same screen) and the effective pattern set is unchanged.
+      // Frame STABILITY is separate from cache COVERAGE: a zero-scrollback
+      // TUI dirties its whole (all-grid) coverage on every repaint — the
+      // cache goes empty but the coordinate frame is perfectly stable, and
+      // the #1046 miss grace must keep applying there. Only a real frame
+      // shift (scrollback shrink, resize, screen/suppression flip) makes
+      // stored rows garbage.
+      final frameStable = _scannedLo >= 0 &&
+          scrollback >= _scannedScrollback &&
+          cols == _scannedCols &&
+          visibleRows == _scannedRows &&
+          _activeScreen == _scannedScreen &&
+          suppressHeuristics == _scannedSuppressHeuristics;
+      var cacheValid = frameStable;
+      if (cacheValid && _contentDirty) {
+        // Content arrived since the last scan: every row that has been part
+        // of the MUTABLE active grid since then (>= _scannedGridLo — a suffix
+        // of the buffer, since the grid is always the bottom rows) is
+        // suspect. Trim the cache to its clean prefix; the suspect suffix
+        // falls into the extension region below and is re-read.
+        _scannedHi =
+            _scannedGridLo < _scannedLo ? _scannedLo : _scannedGridLo;
+        if (_scannedHi > maxEndAbs) _scannedHi = maxEndAbs;
+        if (_scannedHi <= _scannedLo) cacheValid = false;
+      }
+      // A window disjoint from the cached range (a scroll-to-top jump) would
+      // leave an unscanned gap inside the single contiguous coverage
+      // interval — fall back to a full window scan.
+      if (cacheValid && (startAbs > _scannedHi || endAbs < _scannedLo)) {
+        cacheValid = false;
+      }
+
+      // The CORE regions that must actually be read.
+      final regions = <(int, int)>[];
+      if (!cacheValid) {
+        regions.add((startAbs, endAbs));
       } else {
-        // Scan the region that is ACTUALLY ON SCREEN wherever the viewport
-        // currently sits in scrollback, not a range anchored only to the bottom.
-        // The viewport's top absolute row is the scroll offset; it occupies
-        // [viewportTop, viewportTop + visibleRows). Scan that plus up to
-        // _detectionScrollbackWindow rows of margin ABOVE and BELOW it, so a URL
-        // the user scrolled far up to (#787) — or just scrolled near — is picked
-        // up, while the bounded margin keeps this off an O(scrollback) walk.
-        // (Anchored-to-bottom previously missed anything scrolled past the
-        // window.) The margin also gives the wrap-join enough context rows above
-        // the first visible row to assemble a URL that wraps across the boundary.
-        final scrollback = terminal.scrollbackRows;
-        // #958: the viewport top in SCREEN space. On the ALT screen
-        // `scrollbar.offset` is alt-local (always 0) while the alt viewport
-        // actually sits AFTER the primary history in `PointTag.screen` space —
-        // using the raw offset made the scan window cover primary HISTORY rows
-        // instead of the visible alt rows, so with history longer than the
-        // margin nothing on a tmux screen was ever detected (the other half of
-        // #958). See [screenViewportTop].
-        final viewportTop =
-            _activeScreen == .alternate ? scrollback : scrollbar.offset;
-        final startAbs = viewportTop - _detectionScrollbackWindow < 0
-            ? 0
-            : viewportTop - _detectionScrollbackWindow;
-        // Clamp the bottom to the last buffer row so we never read past the
-        // active screen (defensive; the reader also guards per-cell).
-        final maxEndAbs = scrollback + visibleRows; // exclusive
-        var endAbs = viewportTop + visibleRows + _detectionScrollbackWindow;
-        if (endAbs > maxEndAbs) endAbs = maxEndAbs;
+        if (startAbs < _scannedLo) regions.add((startAbs, _scannedLo));
+        if (endAbs > _scannedHi) regions.add((_scannedHi, endAbs));
+      }
+
+      if (regions.isEmpty) {
+        // Pure viewport movement over already-scanned rows: ZERO cell reads,
+        // zero regex passes — the #1044 core promise. The live matches are
+        // still current by the immutability invariant, so nothing to notify.
+        _detectionStats.rescanCacheHits++;
+        _contentDirty = false;
+        _scannedGridLo = scrollback;
+        _scannedScrollback = scrollback;
+        return;
+      }
+
+      // Read each core region EXTENDED to logical-line boundaries (wrap
+      // flags) plus a fixed block-join slack, so a wrapped/joined match
+      // crossing a region edge assembles exactly as a full scan would. The
+      // extension rows are context only — they are already covered by the
+      // cache — so fresh matches are ADOPTED only when they intersect a CORE
+      // region (cached instances are authoritative for pure-extension rows).
+      final fresh = <StructuredMatch>[];
+      final sw = Stopwatch()..start();
+      for (final (coreLo, coreHi) in regions) {
+        var lo = coreLo - _detectionRegionJoinSlack;
+        if (lo < 0) lo = 0;
+        var guard = 0;
+        while (lo > 0 && guard < _detectionRegionWrapCap && _absRowWrap(lo - 1)) {
+          lo--;
+          guard++;
+        }
+        var hi = coreHi + _detectionRegionJoinSlack;
+        if (hi > maxEndAbs) hi = maxEndAbs;
+        guard = 0;
+        while (hi < maxEndAbs &&
+            guard < _detectionRegionWrapCap &&
+            _absRowWrap(hi - 1)) {
+          hi++;
+          guard++;
+        }
         final reader = _ScreenCellReader(
           terminal: terminal,
           cols: cols,
-          startAbsRow: startAbs,
-          endAbsRow: endAbs,
+          startAbsRow: lo,
+          endAbsRow: hi,
         );
-        matches = _detectionScanner.scan(reader, scanPatterns);
-        // #883: a fresh scan emits absolute rows in the CURRENT coordinate
-        // frame — record that frame as the matches' anchor epoch so the
-        // synchronous prune can tell a real in-place content change (frame
-        // unchanged → evict, #873) from coordinate drift after a scrollback
-        // eviction/clear or a resize reflow (frame shifted → keep/re-locate).
-        _detectionFrameScrollback = scrollback;
-        _detectionFrameCols = cols;
-        _detectionFrameRows = visibleRows;
+        _detectionStats.rescanRows += hi - lo;
+        for (final m in _detectionScanner.scan(reader, scanPatterns)) {
+          if (_matchIntersects(m, coreLo, coreHi)) fresh.add(m);
+        }
       }
+      _detectionStats.rescans++;
+      _detectionStats.rescanMicros += sw.elapsedMicroseconds;
+
+      // New contiguous coverage = cached ∪ window, trimmed to the retention
+      // band around the viewport (coverage and its matches must not grow
+      // unboundedly over a long scroll session).
+      var newLo = cacheValid && _scannedLo < startAbs ? _scannedLo : startAbs;
+      var newHi = cacheValid && _scannedHi > endAbs ? _scannedHi : endAbs;
+      final keepLo = viewportTop - _detectionCacheRetentionRows;
+      final keepHi =
+          viewportTop + visibleRows + _detectionCacheRetentionRows;
+      if (newLo < keepLo) newLo = keepLo;
+      if (newLo < 0) newLo = 0;
+      if (newHi > keepHi) newHi = keepHi;
+
+      // ---- identity-preserving reconcile (#1046) ----
+      // graceUnmatched only within a STABLE coordinate frame: after a frame
+      // shift (scrollback clear/eviction, resize, screen flip) the stored
+      // rows are garbage, so an unmatched cached anchor is dropped outright
+      // (pre-#1046 semantics; keeps ESC[3J from leaving 350ms ghosts at
+      // wrong rows). A merely-empty cache (all-grid coverage dirtied by a
+      // TUI repaint) keeps the grace — the frame is stable there.
+      final merged = _reconcileDetections(fresh, regions, newLo, newHi,
+          graceUnmatched: frameStable);
+
+      _scannedLo = newLo;
+      _scannedHi = newHi;
+      _scannedGridLo = scrollback;
+      _scannedScrollback = scrollback;
+      _scannedCols = cols;
+      _scannedRows = visibleRows;
+      _scannedScreen = _activeScreen;
+      _scannedSuppressHeuristics = suppressHeuristics;
+      _contentDirty = false;
+      // #883: a fresh scan emits absolute rows in the CURRENT coordinate
+      // frame — record that frame as the matches' anchor epoch so the
+      // synchronous prune can tell a real in-place content change (frame
+      // unchanged → evict, #873) from coordinate drift after a scrollback
+      // eviction/clear or a resize reflow (frame shifted → keep/re-locate).
+      _detectionFrameScrollback = scrollback;
+      _detectionFrameCols = cols;
+      _detectionFrameRows = visibleRows;
+
+      if (merged == null) {
+        // The reconciled set is element-wise IDENTICAL to the live one: an
+        // unchanged rescan must be invisible to the gutter/bubble layers —
+        // no reassignment, no bake, no decoration notify. This is the #1046
+        // churn killer: a TUI repainting a row with identical content keeps
+        // its anchor INSTANCE and its chip never blinks.
+        _detectionStats.notifiesSuppressed++;
+        return;
+      }
+      _detectionMatches = merged;
     } catch (_) {
-      matches = const [];
+      // A read/FFI hiccup must never crash the session — and (post-#883
+      // stance) must not spuriously clear live anchors either. Drop the cache
+      // (unknown state) and let the next pass reconcile from content.
+      _invalidateDetectionScanCache();
+      return;
     }
-    _detectionMatches = matches;
-    highlights = _styledHighlights(matches);
+    highlights = _styledHighlights(_detectionMatches);
     // #805: the detected anchor set just changed (a settled re-scan), so wake the
     // narrow decoration listener — the decorator layer re-resolves now, not on
     // every mid-scroll redraw notify. (highlights= already fired the general
     // notify for the built-in HighlightPainter.)
     _decorationNotifier.notify();
+  }
+
+  /// #1044: drop the scan cache — the next [_rescanDetections] performs a
+  /// full window scan. Called whenever the cached per-row results can no
+  /// longer be trusted wholesale (pattern-set change, screen churn, FFI
+  /// hiccup).
+  void _invalidateDetectionScanCache() {
+    _scannedLo = -1;
+    _scannedHi = -1;
+    _contentDirty = true;
+  }
+
+  /// #1044: whether any of [m]'s ranges touch absolute rows [lo, hi).
+  bool _matchIntersects(StructuredMatch m, int lo, int hi) {
+    for (final r in m.ranges) {
+      if (r.topRow < hi && r.bottomRow >= lo) return true;
+    }
+    return false;
+  }
+
+  /// #1044: whether ALL of [m]'s rows lie inside covered rows [lo, hi).
+  bool _matchWithin(StructuredMatch m, int lo, int hi) {
+    for (final r in m.ranges) {
+      if (r.topRow < lo || r.bottomRow >= hi) return false;
+    }
+    return true;
+  }
+
+  /// #1044: libghostty's authoritative soft-wrap flag for an ABSOLUTE screen
+  /// row (true iff it continues onto the next row). Defensive like the cell
+  /// reader — a read hiccup reads as "no wrap".
+  bool _absRowWrap(int absRow) {
+    GridRef? ref;
+    try {
+      ref = GridRef.at(
+        terminal,
+        col: 0,
+        row: absRow,
+        pointTag: PointTag.screen,
+      );
+      return ref.rowWrap;
+    } catch (_) {
+      return false;
+    } finally {
+      ref?.dispose();
+    }
+  }
+
+  /// #1044/#1046: merge freshly-scanned matches with the still-covered cached
+  /// ones, PRESERVING INSTANCE IDENTITY for matches whose content did not
+  /// change. Returns the merged list, or null when it is element-wise
+  /// identical to the live [_detectionMatches] (caller then skips the bake +
+  /// notify entirely).
+  ///
+  ///   * cached matches outside the new coverage band are dropped (they will
+  ///     re-anchor from content when scrolled back into the window);
+  ///   * cached matches intersecting a re-scanned CORE region are replaced by
+  ///     the fresh finds — but a fresh match VALUE-equal to a replaced one
+  ///     adopts the OLD instance, so an unchanged row re-scanned keeps its
+  ///     anchor identity (no gutter unregister/re-register churn, #1046);
+  ///   * cached matches in untouched covered rows are kept as-is;
+  ///   * fresh matches may extend past the coverage edge (a wrap-extended
+  ///     read) — they are real, freshly-read content, so they stand.
+  List<StructuredMatch>? _reconcileDetections(
+    List<StructuredMatch> fresh,
+    List<(int, int)> coreRegions,
+    int coveredLo,
+    int coveredHi, {
+    required bool graceUnmatched,
+  }) {
+    bool inScanned(StructuredMatch m) {
+      for (final (lo, hi) in coreRegions) {
+        if (_matchIntersects(m, lo, hi)) return true;
+      }
+      return false;
+    }
+
+    final merged = <StructuredMatch>[];
+    final replaced = <StructuredMatch>[];
+    for (final m in _detectionMatches) {
+      if (!_matchWithin(m, coveredLo, coveredHi)) {
+        _cancelMissGrace(m); // trimmed out of coverage
+        continue;
+      }
+      if (inScanned(m)) {
+        replaced.add(m); // identity-reuse candidate for an equal fresh match
+      } else {
+        merged.add(m);
+      }
+    }
+    for (final f in fresh) {
+      var adopted = f;
+      for (var i = 0; i < replaced.length; i++) {
+        if (_sameMatch(replaced[i], f)) {
+          adopted = replaced.removeAt(i);
+          _cancelMissGrace(adopted); // re-confirmed by the fresh scan
+          _detectionStats.matchesReused++;
+          break;
+        }
+      }
+      merged.add(adopted);
+    }
+    // #1046: cached matches in a re-scanned region with NO equal fresh match.
+    // A same-payload fresh match elsewhere means the line MOVED — the fresh
+    // instance carries it on (atomic move; drop the stale one). Otherwise the
+    // payload is unaccounted for RIGHT NOW, which mid-repaint is routinely a
+    // transient — keep it under the same miss grace the prune uses; the
+    // grace timer (or a later scan) settles it for real.
+    for (final m in replaced) {
+      var movedElsewhere = false;
+      for (final f in fresh) {
+        if (f.patternId == m.patternId && f.payload == m.payload) {
+          movedElsewhere = true;
+          break;
+        }
+      }
+      if (movedElsewhere) {
+        _cancelMissGrace(m);
+        continue; // the fresh match IS this anchor at its new rows
+      }
+      if (!graceUnmatched) {
+        _cancelMissGrace(m); // frame shifted — the rows are garbage; drop
+        continue;
+      }
+      merged.add(m);
+      _armMissGrace(m);
+    }
+    merged.sort(_compareMatches);
+    if (merged.length == _detectionMatches.length) {
+      var same = true;
+      for (var i = 0; i < merged.length; i++) {
+        if (!identical(merged[i], _detectionMatches[i])) {
+          same = false;
+          break;
+        }
+      }
+      if (same) return null;
+    }
+    return merged;
+  }
+
+  /// #1046: VALUE equality between a cached and a fresh match — same pattern,
+  /// tier, honesty flag, payload, and per-row ranges. This is "the row
+  /// re-scanned to the identical result", the condition under which the old
+  /// instance keeps its identity.
+  bool _sameMatch(StructuredMatch a, StructuredMatch b) {
+    if (a.patternId != b.patternId ||
+        a.tier != b.tier ||
+        a.maybeIncomplete != b.maybeIncomplete ||
+        a.payload != b.payload ||
+        a.ranges.length != b.ranges.length) {
+      return false;
+    }
+    for (var i = 0; i < a.ranges.length; i++) {
+      if (a.ranges[i] != b.ranges[i]) return false;
+    }
+    return true;
+  }
+
+  /// #1044: deterministic reading-order sort for the reconciled match list
+  /// (top row, then start col, then pattern id) — mirrors the line order a
+  /// full-window scan emitted, which [matchAt]'s "last containing wins"
+  /// tie-break was written against.
+  static int _compareMatches(StructuredMatch a, StructuredMatch b) {
+    final ra = a.ranges.first;
+    final rb = b.ranges.first;
+    if (ra.topRow != rb.topRow) return ra.topRow - rb.topRow;
+    if (ra.startCol != rb.startCol) return ra.startCol - rb.startCol;
+    return a.patternId.compareTo(b.patternId);
   }
 
   @override
@@ -1017,10 +1760,14 @@ class TerminalControllerImpl extends TerminalController
   /// scanned range, is never detected. Schedule the same debounced rescan the
   /// output path uses so a scroll burst coalesces into one scan.
   void _onScrollChanged() {
-    // #873: a scroll can move a match out of the bounded scan window; re-validate
-    // live anchors against the current cells immediately (the debounced rescan
-    // below handles DISCOVERY of newly-visible matches).
-    _pruneStaleDetections();
+    // #1044: NO prune here. A viewport scroll cannot change cell content —
+    // absolute screen rows are append-stable (#883) and VT writes only address
+    // the active grid — so the per-tick synchronous re-validation this used to
+    // run (every live match re-read cell-by-cell over FFI plus a full pattern
+    // pass, EVERY scroll frame) was pure waste: the dominant per-frame cost of
+    // the #1044 fling lag. Content changes arrive via _onTerminalChanged,
+    // which still prunes. Discovery of newly-revealed rows stays debounced
+    // below (and defers to the settle edge while the fling is live).
     _scheduleDetectionRescan();
     notifyListeners();
   }
@@ -1078,7 +1825,10 @@ class TerminalControllerImpl extends TerminalController
   void dispose() {
     _disposed = true;
     _detectionDebounce?.cancel();
+    _detectionMaxWait?.cancel();
+    _cancelAllMissGrace();
     _scrollSettleTimer?.cancel();
+    _scrollSettleMaxWait?.cancel();
     terminal.removeListener(_onTerminalChanged);
     detach();
     _keyEvent.dispose();
@@ -1861,6 +2611,10 @@ class TerminalControllerImpl extends TerminalController
     // viewport scrolled; re-scan registered structured-text patterns on a
     // debounce so the highlights track new content. No-op when none registered.
     // This only (re)arms a Timer — safe to run mid-frame (it fires outside it).
+    // #1044: a TERMINAL notify (unlike a scroll notify) may have rewritten the
+    // active grid in place — mark the mutable suffix dirty so the next rescan
+    // re-reads it (and only it).
+    _contentDirty = true;
     _scheduleDetectionRescan();
 
     // #887: the remaining work emits notifications that REBUILD or read layout

--- a/native/third_party/flterm/test/widgets/detection_scan_cache_1044_test.dart
+++ b/native/third_party/flterm/test/widgets/detection_scan_cache_1044_test.dart
@@ -1,0 +1,241 @@
+// #1044/#1046 — the content-keyed scan cache and anchor-identity reconcile.
+//
+// Pins the three scheduling invariants the fix introduces:
+//   1. PURE SCROLL = ZERO SCANS: viewport movement over already-scanned rows
+//      answers from the cache (rescanCacheHits), reading no cells and running
+//      no regexes (rescans stays 0 for that phase).
+//   2. CONTENT CHANGE = SCOPED RESCAN: a write re-reads only the mutable
+//      suffix (grid rows since the last scan) + join context — far fewer rows
+//      than the pre-#1044 full ~(viewport + 2×200)-row window.
+//   3. UNCHANGED-ROW RESCAN PRESERVES ANCHOR IDENTITY (#1046): a rescan that
+//      covers a row whose content did not change re-uses the OLD
+//      StructuredMatch INSTANCE, and a reconcile that changes nothing
+//      suppresses the decoration notify entirely. That churn (drop +
+//      re-create + notify per rescan) was the flickering gutter chip.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _url = 'https://example.com/cached/anchor';
+
+Widget _wrap(TerminalController controller) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 700,
+        height: 620,
+        child: TerminalView(controller: controller, autofocus: false),
+      ),
+    ),
+  );
+}
+
+void _write(TerminalController controller, String s) {
+  controller.write(Uint8List.fromList(utf8.encode(s)));
+}
+
+Future<void> _settle(WidgetTester tester) async {
+  // Detection debounce (~120ms) + scroll settle (~140ms), then a paint, then
+  // drain any settle timer the paint itself re-armed (a bottom-follow paint
+  // reports a fresh offset → _markScrolling arms 140ms).
+  await tester.pump(const Duration(milliseconds: 400));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 200));
+}
+
+/// The live StructuredMatch whose payload is [payload], resolved through the
+/// public hit-test ([TerminalController.matchAt] returns the INSTANCE the
+/// controller holds, so `identical` is meaningful).
+StructuredMatch? _matchFor(TerminalController controller, String payload) {
+  for (final range in controller.highlights) {
+    if (range.payload == payload) {
+      final viewRow = range.startRow - controller.screenViewportTop;
+      return controller.matchAt(row: viewRow, col: range.startCol);
+    }
+  }
+  return null;
+}
+
+void main() {
+  testWidgets(
+    'pure scroll over scanned rows = cache hits, zero scans; scrolling back '
+    'into scanned scrollback re-reads nothing (#1044)',
+    (tester) async {
+      final controller = TerminalController(
+        config: const TerminalConfig(cols: 62, rows: 36),
+      );
+      addTearDown(controller.dispose);
+      controller.registerTextPattern(TextPattern.url());
+      await tester.pumpWidget(_wrap(controller));
+      await tester.pump();
+
+      _write(controller, '$_url\r\n');
+      for (var i = 0; i < 120; i++) {
+        _write(controller, 'filler ${i.toString().padLeft(4, '0')} '
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n');
+      }
+      await _settle(tester);
+      expect(controller.anchors.any((a) => a.payload == _url), isTrue);
+
+      final stats = controller.detectionScanStats;
+      stats.reset();
+
+      // Scroll to the top and back to the bottom — every row involved was
+      // already scanned (120 rows + viewport all fit inside the initial
+      // window), so both settle passes must answer from the cache.
+      controller.scrollToTop();
+      await _settle(tester);
+      controller.scrollToBottom();
+      await _settle(tester);
+
+      expect(stats.rescans, 0,
+          reason: 'viewport movement over scanned rows must read nothing '
+              '(got ${stats.snapshot()})');
+      expect(stats.rescanRows, 0);
+      expect(stats.rescanCacheHits, greaterThan(0),
+          reason: 'the settle passes ran and were answered by the cache');
+      expect(controller.anchors.any((a) => a.payload == _url), isTrue,
+          reason: 'the anchor survives the round trip');
+    },
+  );
+
+  testWidgets(
+    'a content change rescans ONLY the mutable suffix, not the full window '
+    '(#1044 scoped rescan)',
+    (tester) async {
+      final controller = TerminalController(
+        config: const TerminalConfig(cols: 62, rows: 36),
+      );
+      addTearDown(controller.dispose);
+      controller.registerTextPattern(TextPattern.url());
+      await tester.pumpWidget(_wrap(controller));
+      await tester.pump();
+
+      for (var i = 0; i < 300; i++) {
+        _write(controller, 'filler ${i.toString().padLeft(4, '0')} '
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n');
+      }
+      await _settle(tester);
+
+      final stats = controller.detectionScanStats;
+      stats.reset();
+
+      _write(controller, 'one new line with $_url in it\r\n');
+      await _settle(tester);
+
+      expect(controller.anchors.any((a) => a.payload == _url), isTrue,
+          reason: 'the new content is detected');
+      expect(stats.rescans, greaterThan(0));
+      // The pre-#1044 full window at the bottom of 300 rows of scrollback was
+      // ~(200 margin + 36 viewport) = ~236 rows per rescan. The scoped rescan
+      // reads the mutable suffix (≤ one viewport of grid rows + the appended
+      // line) + join slack — bound it WELL below the old window.
+      expect(stats.rescanRows, lessThan(120),
+          reason: 'content-driven rescan must be scoped to the mutable '
+              'suffix, not the full window (got ${stats.snapshot()})');
+    },
+  );
+
+  testWidgets(
+    'an unchanged row covered by a rescan keeps its match INSTANCE and an '
+    'unchanged reconcile suppresses the decoration notify (#1046)',
+    (tester) async {
+      final controller = TerminalController(
+        config: const TerminalConfig(cols: 62, rows: 36),
+      );
+      addTearDown(controller.dispose);
+      controller.registerTextPattern(TextPattern.url());
+      await tester.pumpWidget(_wrap(controller));
+      await tester.pump();
+
+      // The URL sits INSIDE the grid (no scrollback: a few lines in a 36-row
+      // grid) so every content-driven rescan's mutable suffix covers its row,
+      // and appends never move the painted offset (no offset-driven notify
+      // muddying the assertion below).
+      _write(controller, '$_url\r\n');
+      _write(controller, 'below the url\r\n');
+      await _settle(tester);
+
+      final before = _matchFor(controller, _url);
+      expect(before, isNotNull, reason: 'precondition: URL matched');
+
+      final stats = controller.detectionScanStats;
+      stats.reset();
+      var decorationNotifies = 0;
+      controller.decorationListenable.addListener(() => decorationNotifies++);
+
+      // New content on ANOTHER line: the URL row is untouched but lies inside
+      // the re-scanned mutable suffix.
+      _write(controller, 'tail line, no matches here\r\n');
+      await _settle(tester);
+
+      final after = _matchFor(controller, _url);
+      expect(after, isNotNull);
+      expect(identical(before, after), isTrue,
+          reason: 'an unchanged row re-scanned must keep its anchor '
+              'IDENTITY — drop/re-create churn is the #1046 chip flicker '
+              '(stats: ${stats.snapshot()})');
+      expect(stats.matchesReused, greaterThan(0),
+          reason: 'the reconcile re-used the existing instance');
+      expect(decorationNotifies, 0,
+          reason: 'a reconcile that changes no anchor must be invisible to '
+              'the gutter/bubble layers (#1046 — no unregister/re-register '
+              'churn; stats: ${stats.snapshot()})');
+      expect(stats.notifiesSuppressed, greaterThan(0),
+          reason: 'the unchanged reconcile was recognised and suppressed');
+    },
+  );
+
+  testWidgets(
+    'a line repainted in place FASTER than the debounce still anchors via the '
+    'max-wait ceiling — continuous churn must not starve discovery (#1044)',
+    (tester) async {
+      final controller = TerminalController(
+        config: const TerminalConfig(cols: 62, rows: 36),
+      );
+      addTearDown(controller.dispose);
+      controller.registerTextPattern(TextPattern.url());
+      await tester.pumpWidget(_wrap(controller));
+      await tester.pump();
+
+      // Repaint the SAME row in place every 100ms (< the 120ms detection
+      // debounce), never pausing — a progress bar / spinner / repainting-TUI
+      // status line (the owner's Claude-Code TUI). Each write re-arms the
+      // trailing debounce, so the PRE-FIX debounce fires NEVER and the URL is
+      // never discovered: exactly the on-emulator #1044 acceptance failure
+      // ("the repainted line never anchored"). `\r` (no newline) overwrites
+      // the current row, so the viewport never scrolls (isScrolling stays
+      // false — this is the content-settle path, not the drag-gate) and the
+      // URL cells are identical each tick.
+      var anchoredDuringChurn = false;
+      var anchoredAtIteration = -1;
+      for (var i = 0; i < 20; i++) {
+        _write(controller, '\r$_url  tick ${i.toString().padLeft(3, '0')}');
+        await tester.pump(const Duration(milliseconds: 100));
+        if (controller.anchors.any((a) => a.payload == _url)) {
+          anchoredDuringChurn = true;
+          anchoredAtIteration = i;
+          break;
+        }
+      }
+
+      expect(anchoredDuringChurn, isTrue,
+          reason: 'a line repainted faster than the debounce must still '
+              'anchor via the max-wait ceiling; the trailing debounce alone '
+              'is starved by continuous sub-interval churn and never fires '
+              '(#1044 emulator failure)');
+      // Ceiling is 300ms; at 100ms/iteration the reconcile must land within a
+      // few ticks, well before the 20-iteration (2s) churn window ends. This
+      // pins that the ceiling actually bounds the wait (not that the debounce
+      // happened to fire during a lucky pause — there are no pauses).
+      expect(anchoredAtIteration, lessThan(8),
+          reason: 'the max-wait ceiling must force discovery within a bounded '
+              'window of continuous churn (anchored at iteration '
+              '$anchoredAtIteration)');
+    },
+  );
+}

--- a/native/third_party/flterm/test/widgets/scroll_scan_perf_1044_test.dart
+++ b/native/third_party/flterm/test/widgets/scroll_scan_perf_1044_test.dart
@@ -1,0 +1,308 @@
+// #1044 — scroll must not pay for detection: a PURE viewport fling performs
+// ZERO scan work (no regex passes, no cell re-reads), with discovery deferred
+// to the quiesce (settle) pass.
+//
+// The pre-fix hot path re-validated EVERY live anchor synchronously on EVERY
+// scroll tick (`_onScrollChanged` → `_pruneStaleDetections` → per-match
+// `_scanWindow`: an FFI cell re-read plus a full pattern pass), and the
+// debounced `_rescanDetections` re-read a ~440-row window regardless of what
+// changed. With the pattern-set multipliers (relpath #1036, custom patterns
+// #1035, the command scorer #998) that put O(anchors × patterns) regex passes
+// + FFI reads on every fling frame — the owner-reported scroll lag.
+//
+// This test drives a REAL TerminalView fling via an external scroll
+// controller and counts regex passes through counting-wrapper RegExps
+// (deliberately NOT the #1044 stats seam, so the same file measures pre-fix
+// code for the before/after numbers in the PR). Invariants pinned:
+//   1. a pure fling performs ZERO regex passes (scan work is content-driven,
+//      not viewport-driven);
+//   2. the anchors survive the fling (nothing was evicted by scrolling);
+//   3. after the quiesce pass, newly-revealed scrollback rows ARE scanned —
+//      a URL far above the initially-scanned window is discovered once the
+//      viewport settles over it.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A RegExp wrapper that counts scanner passes (allMatches / firstMatch /
+/// hasMatch) before delegating, so scan work is observable without any seam
+/// in the production code (this same file measures PRE-fix code for the
+/// before/after numbers, where the #1044 stats getter does not exist).
+// Implementing RegExp is the whole point of the counting seam — TextPattern
+// consumes a RegExp, so only an implements-wrapper can observe its passes.
+// ignore: deprecated_implement
+class CountingRegExp implements RegExp {
+  CountingRegExp(String source) : _inner = RegExp(source);
+
+  final RegExp _inner;
+  int passes = 0;
+
+  @override
+  Iterable<RegExpMatch> allMatches(String input, [int start = 0]) {
+    passes++;
+    return _inner.allMatches(input, start);
+  }
+
+  @override
+  RegExpMatch? firstMatch(String input) {
+    passes++;
+    return _inner.firstMatch(input);
+  }
+
+  @override
+  bool hasMatch(String input) {
+    passes++;
+    return _inner.hasMatch(input);
+  }
+
+  @override
+  String? stringMatch(String input) => _inner.stringMatch(input);
+
+  @override
+  Match? matchAsPrefix(String string, [int start = 0]) =>
+      _inner.matchAsPrefix(string, start);
+
+  @override
+  String get pattern => _inner.pattern;
+
+  @override
+  bool get isCaseSensitive => _inner.isCaseSensitive;
+
+  @override
+  bool get isMultiLine => _inner.isMultiLine;
+
+  @override
+  bool get isUnicode => _inner.isUnicode;
+
+  @override
+  bool get isDotAll => _inner.isDotAll;
+}
+
+void main() {
+  const topUrl = 'https://top-of-history.example.com/discover-on-quiesce';
+
+  testWidgets(
+    'a pure viewport fling performs ZERO detection regex passes; anchors '
+    'survive; quiesce discovers newly-revealed scrollback (#1044)',
+    (tester) async {
+      final controller = TerminalController(
+        config: const TerminalConfig(cols: 62, rows: 36),
+      );
+      addTearDown(controller.dispose);
+
+      // The realistic multiplied pattern set: url + path + relpath-shaped +
+      // 2 custom patterns, all with counting regexes. (Shapes mirror the
+      // built-ins closely enough to measure scheduling; exact regex parity is
+      // not the point — pass COUNTS are.)
+      final counters = <CountingRegExp>[
+        CountingRegExp(r'(?:https?://|www\.)[^\s<>"' "'" r'`]+'),
+        CountingRegExp(r'(?<![\w.\-~@+:/])/(?:[\w.\-~@+]+/?)+'),
+        CountingRegExp(r'(?<![\w.\-~@+:/])[\w.\-@+]+(?:/[\w.\-~@+]+)+/?'),
+        CountingRegExp(r'ISSUE-\d+'),
+        CountingRegExp(r'\b[0-9a-f]{7,40}\b'),
+      ];
+      final ids = ['url', 'path', 'relpath', 'custom.issue', 'custom.sha'];
+      for (var i = 0; i < counters.length; i++) {
+        controller.registerTextPattern(
+          TextPattern(id: ids[i], regex: counters[i]),
+        );
+      }
+
+      final scrollController = TerminalScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 700,
+              height: 620,
+              child: TerminalView(
+                controller: controller,
+                scrollController: scrollController,
+                autofocus: false,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      void write(String s) {
+        controller.write(Uint8List.fromList(utf8.encode(s)));
+      }
+
+      // A seq-style flood with anchors sprinkled through it: the top URL
+      // (outside the initial bounded scan window once 800 lines land), then
+      // filler with a URL/path every 40 lines so anchors are on screen at
+      // every fling position.
+      write('$topUrl\r\n');
+      for (var i = 0; i < 800; i++) {
+        if (i % 40 == 0) {
+          write('line ${i.toString().padLeft(5, '0')} '
+              'https://example.com/page/$i and /etc/hosts too\r\n');
+        } else {
+          write('line ${i.toString().padLeft(5, '0')} '
+              'filler filler filler filler\r\n');
+        }
+      }
+      // Settle output, the detection debounce (~120ms), and the scroll-settle
+      // timer (~140ms).
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+
+      expect(
+        controller.anchors.any(
+          (a) => '${a.payload}'.contains('example.com/page/'),
+        ),
+        isTrue,
+        reason: 'precondition: anchors are live before the fling',
+      );
+      final anchorsBefore = controller.anchors.length;
+
+      // ---- the measured fling: 60 frames of pure viewport movement ----
+      for (final c in counters) {
+        c.passes = 0;
+      }
+      final position = scrollController.position;
+      final startPixels = position.pixels;
+      final wall = Stopwatch()..start();
+      for (var frame = 1; frame <= 60; frame++) {
+        position.jumpTo(startPixels - frame * 40.0);
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      wall.stop();
+      final flingPasses =
+          counters.fold<int>(0, (sum, c) => sum + c.passes);
+
+      // Numbers for the PR (before/after runs of this same file).
+      debugPrint('PERF#1044 fling: regexPasses=$flingPasses '
+          'wallMs=${wall.elapsedMilliseconds} anchorsLive=$anchorsBefore');
+
+      expect(
+        flingPasses,
+        0,
+        reason: 'a pure viewport fling must perform ZERO detection regex '
+            'passes — scan work is content-driven and quiesce-deferred, '
+            'never viewport-driven (#1044)',
+      );
+
+      // ---- quiesce: the settle pass reconciles, anchors survive ----
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+      expect(
+        controller.anchors.any(
+          (a) => '${a.payload}'.contains('example.com/page/'),
+        ),
+        isTrue,
+        reason: 'anchors must survive a pure viewport fling + quiesce',
+      );
+
+      // ---- discovery on quiesce: scroll to the very top; the settle pass
+      // scans the newly-revealed rows and the top URL anchors. ----
+      controller.scrollToTop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+      expect(
+        controller.anchors.any((a) => a.payload == topUrl),
+        isTrue,
+        reason: 'after quiesce over newly-revealed scrollback the top URL '
+            'must be discovered (#1044 settle reconcile)',
+      );
+    },
+  );
+
+  testWidgets(
+    'content churn that holds the scroll state open (a bottom-following '
+    'repaint) still anchors via the settle max-wait — never starved (#1044)',
+    (tester) async {
+      final controller = TerminalController(
+        config: const TerminalConfig(cols: 62, rows: 36),
+      );
+      addTearDown(controller.dispose);
+      controller.registerTextPattern(TextPattern.url());
+
+      final scrollController = TerminalScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 700,
+              height: 620,
+              child: TerminalView(
+                controller: controller,
+                scrollController: scrollController,
+                autofocus: false,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      void write(String s) {
+        controller.write(Uint8List.fromList(utf8.encode(s)));
+      }
+
+      // Build scrollback so there is pixel range to jitter within.
+      for (var i = 0; i < 400; i++) {
+        write('line ${i.toString().padLeft(5, '0')} filler filler filler\r\n');
+      }
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+
+      const churnUrl = 'https://churn.example.com/repaint-in-place';
+      final position = scrollController.position;
+      final base = position.pixels;
+
+      // Reproduce the emulator #1046/#1044 shape headlessly: an in-place
+      // repaint (cursor-home + clear-line, NO newline → the grid does not grow)
+      // rewrites the top grid row with the URL every frame, WHILE the painted
+      // offset jitters by a row every frame (a bottom-follow re-pins), so the
+      // scroll-settle timer (140ms) is re-armed on every frame and never fires
+      // — controller.isScrolling stays TRUE the whole time. Each frame is 60ms
+      // (< 140ms settle) and the burst runs well past the 300ms settle ceiling.
+      // Pre-fix: every rescan defers at the scroll gate and the URL NEVER
+      // anchors (the on-emulator "repainted line never anchored"). The settle
+      // max-wait must force a reconcile and surface it.
+      var anchoredDuringChurn = false;
+      var anchoredAtFrame = -1;
+      var sawScrolling = false;
+      for (var frame = 0; frame < 12; frame++) {
+        write('[H[2K// note $churnUrl steady');
+        position.jumpTo(base - (frame.isEven ? 20.0 : 60.0));
+        await tester.pump(const Duration(milliseconds: 60));
+        if (controller.isScrolling) sawScrolling = true;
+        if (controller.anchors.any((a) => '${a.payload}'.contains(churnUrl))) {
+          anchoredDuringChurn = true;
+          anchoredAtFrame = frame;
+          break;
+        }
+      }
+
+      // Stop jittering and drain the settle + max-wait timers so the scroll
+      // state comes to rest (no pending Timer at teardown).
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+
+      expect(sawScrolling, isTrue,
+          reason: 'precondition: the offset jitter must hold isScrolling true '
+              '(otherwise this exercises the debounce ceiling, not the settle '
+              'ceiling)');
+      expect(anchoredDuringChurn, isTrue,
+          reason: 'a repainting line that keeps the scroll state open must '
+              'still anchor via the settle max-wait — the scroll gate must not '
+              'starve discovery forever (#1044 emulator failure)');
+      // 60ms/frame, 300ms ceiling → the forced reconcile lands within ~6
+      // frames of continuous churn, well before the 12-frame burst ends.
+      expect(anchoredAtFrame, lessThan(10),
+          reason: 'the settle ceiling must bound the wait under continuous '
+              'churn (anchored at frame $anchoredAtFrame)');
+    },
+  );
+}


### PR DESCRIPTION
Re-implements the reverted #1056. Keeps everything that was right and adds the **max-wait fix** whose absence made a continuously-repainting line never anchor — the on-emulator acceptance failure that got #1056 reverted.

## What was kept from #1056 (profile-first, owner-directed)
- **Content-keyed scan cache** over the immutable-scrollback invariant: pure viewport movement over already-scanned rows = 0 cell reads, 0 regex passes.
- **Scroll drag-gate**: no prune/rescan during an active fling; defer to a settle reconcile.
- **#1046 chip steadiness**: identity-preserving reconcile + atomic relocate + bounded miss-grace (350ms span / 1500ms block).
- Zero new RenderState consumers; `DetectionScanStats` telemetry seam.

## The fix (why #1056 was reverted)
A region that repaints **in place** faster than the 120ms detection debounce re-arms the trailing debounce on every notify, so it fires **never** and the line is never scanned/anchored (the owner's Claude-Code TUI status line, a progress bar, a clock). Two max-wait ceilings force a periodic reconcile under continuous churn while leaving the drag-gate intact:

- **Detection-debounce ceiling** — forces a rescan after 300ms of continuous sub-debounce content churn even if it never settles.
- **Scroll-settle ceiling** — a bottom-following repaint re-arms the 140ms settle timer every frame, holding `isScrolling` true so every rescan defers at the scroll gate; the ceiling forces one quiesce reconcile after 300ms, **gated on `_contentDirty`** so a pure user fling (which never sets it) keeps "zero scans while flinging".

## Emulator acceptance (the reason for the revert — now green)
`scripts/native-connect-test.sh integration_test/scroll_scan_perf_1044_test.dart` on the dedicated AVD — **PASSED**:
- **Part 1 fling**: `dragScanDelta rescans=0` (drag-gate intact). Frame times detection ON avg 17.3ms / p95 21.7ms vs OFF avg 16.5ms / p95 19.5ms (~5%).
- **Part 2 10Hz in-place repaint**: the line anchors within ~1 sample (~300ms) via the ceiling (was: never); the chip never vanishes (`vanishes=0`, #1046).

Root cause the emulator telemetry surfaced beyond the debounce starvation: Part 1's fling leaves the viewport scrolled up in history and `clear` does not yank it down, so the repaint was off-screen and outside the scan window. Part 2 now scrolls to bottom first — the #1046 case is a status line the user is watching (i.e. at the bottom).

## Tests
- fork `detection_scan_cache_1044`: adds a debounce-ceiling starvation probe (verified red without the ceiling).
- fork `scroll_scan_perf_1044`: adds a settle-ceiling probe — content churn holding the scroll state open still anchors (verified red without the ceiling); pure-fling zero-passes invariant unchanged.
- integration `scroll_scan_perf_1044` Part 2: scrolls to bottom, asserts anchor appears + chip steady.

**Gates**: fork suite 881 tests pass; native fast gate analyzer clean + 2090 unit tests pass; emulator acceptance PASS.

Closes #1044
Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa