### PR TITLE
fix(native): quiesce-gate the detection wash — pause during content churn, not only scroll (#1064)

### DIFF
--- a/native/integration_test/wash_quiesce_gate_1064_shot_test.dart
+++ b/native/integration_test/wash_quiesce_gate_1064_shot_test.dart
@@ -1,0 +1,260 @@
+// On-emulator acceptance for #1064 (owner P0) — the detection WASH must be
+// QUIESCE-GATED: visible ONLY when the screen is settled. It PAUSES (hides)
+// while the screen is CHURNING — an active scroll OR content updating (a live
+// TUI repainting in place) — and repaints at the fresh positions after a
+// debounce once quiescent.
+//
+// This is the case +140 (#1062/#1063) MISSED: +140 paused the wash only on
+// SCROLL (isScrolling). A live-updating TUI churns content WITHOUT scrolling
+// (isScrolling=false, the grid rewritten in place), so +140 left the wash SHOWN
+// at stale spots there. THIS test drives exactly that shape over SSH: a loop
+// that repaints a fixed band of anchor lines IN PLACE (absolute cursor
+// addressing, NO newline growth → the viewport never scrolls) so the churn is
+// attributable to CONTENT, not scroll.
+//
+// Through the churn it asserts, against the REAL device paint stack:
+//   * isScrolling is FALSE (the churn does not scroll), yet
+//   * the render layer SUPPRESSES the wash (renderBox.debugWashSuppressed) — the
+//     CONTENT-settle gate fires (contentSettling), and
+//   * the washHiddenForContentChurn telemetry increments.
+// Then, once the TUI stops, it asserts the wash RE-SHOWS on its tokens
+// (not suppressed, on-glyph). It HOLDS for external screenshots at both phases:
+//   DURING-CHURN (wash hidden) and SETTLED (wash on its tokens).
+//
+// Bridge: scripts/native-connect-test.sh (127.0.0.1:2222 → socat → test-sshd).
+// Run: scripts/native-connect-test.sh integration_test/wash_quiesce_gate_1064_shot_test.dart
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' hide Key;
+import 'package:flutter/material.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:mobissh/main.dart' show MobisshApp;
+import 'package:mobissh/state/detection_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/ghostty_terminal_view.dart';
+
+import 'support/connect_helpers.dart';
+
+const _url = 'https://docs.brew.sh/Tap-Trust';
+
+/// Every ON-SCREEN capsule wash cell-run that sits over cells NOT holding (part
+/// of) its payload, mapped at [offset]. Empty == every visible wash is on its
+/// token's glyphs.
+List<String> _driftedWashes(TerminalController c, int offset) {
+  final visible = c.scrollbar.visible;
+  final out = <String>[];
+  for (final r in c.highlights) {
+    if (!r.capsule) continue;
+    final payload = '${r.payload}';
+    for (var absRow = r.topRow; absRow <= r.bottomRow; absRow++) {
+      final viewRow = absRow - offset;
+      if (viewRow < 0 || viewRow >= visible) continue;
+      final rowText = c.visibleRowsText(viewRow, viewRow);
+      final startCol = absRow == r.topRow ? r.topCol : 0;
+      final endCol = absRow == r.bottomRow ? r.bottomCol : rowText.length;
+      final s = startCol.clamp(0, rowText.length);
+      final e = endCol.clamp(0, rowText.length);
+      final slice = (e > s ? rowText.substring(s, e) : '').trim();
+      final onGlyph =
+          slice.isNotEmpty && (payload.contains(slice) || slice.contains(payload));
+      if (!onGlyph) out.add('view=$viewRow "$slice" payload=$payload');
+    }
+  }
+  return out;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'the detection wash HIDES during an in-place content churn (isScrolling '
+    'false) and re-shows on its tokens after settle (#1064 quiesce gate)',
+    (tester) async {
+      FlutterForegroundTask.initCommunicationPort();
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(detectionSettingsProvider.notifier).setEnabled(true);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MobisshApp(),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      await adhocPasswordConnect(
+        tester,
+        host: '127.0.0.1',
+        port: '2222',
+        user: 'testuser',
+        pass: 'testpass',
+      );
+
+      var connected = false;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        final accept = find.text('Trust + connect');
+        if (accept.evaluate().isNotEmpty) {
+          await tester.tap(accept.first);
+          await tester.pump(const Duration(milliseconds: 300));
+        }
+        if (find.byKey(const Key('session-menu-button')).evaluate().isNotEmpty) {
+          connected = true;
+          break;
+        }
+      }
+      expect(connected, isTrue, reason: 'never reached the terminal screen');
+
+      final entry = container.read(sessionsProvider).active;
+      expect(entry, isNotNull, reason: 'no active session after connect');
+      final sessionId = entry!.id;
+
+      TerminalController? controllerOf() =>
+          GhosttyTerminalView.debugControllers[sessionId];
+      for (var i = 0; i < 40 && controllerOf() == null; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final controller = controllerOf();
+      expect(controller, isNotNull, reason: 'no ghostty controller for session');
+
+      final termKey = find.byKey(Key('ghostty-terminal-$sessionId'));
+      expect(termKey, findsOneWidget, reason: 'no ghostty terminal view');
+      TerminalRenderBox renderBox() => tester.renderObject<TerminalRenderBox>(
+            find.descendant(of: termKey, matching: find.byType(TerminalRenderer)),
+          );
+
+      // Wait for a live shell prompt.
+      final out = <int>[];
+      final sub = entry.proxy.output.listen(out.addAll);
+      addTearDown(sub.cancel);
+      for (var i = 0; i < 40 && out.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(out.isNotEmpty, isTrue, reason: 'no shell prompt — dead PTY');
+
+      // A live-updating TUI that repaints a FIXED band of anchor lines IN PLACE
+      // via ABSOLUTE cursor addressing (\033[<row>;1H) with \033[K erases and NO
+      // trailing newline — so the viewport NEVER scrolls (isScrolling stays
+      // false). 500 iterations × 0.05s ≈ 25s of continuous churn, long enough to
+      // cover the sampling + during-churn screenshot windows below. When it stops
+      // it clears and reprints the anchors settled, for the settled screenshot.
+      const script = r'''
+u=https://docs.brew.sh/Tap-Trust
+p1=/Applications/Xcode.app/Contents/Developer
+clear
+i=0
+while [ $i -lt 500 ]; do
+  printf '\033[1;1H\033[Kbuild %d fetch %s' "$i" "$u"
+  printf '\033[2;1H\033[Ksdk %s' "$p1"
+  printf '\033[3;1H\033[Kstatus running task %d ...' "$i"
+  i=$((i + 1))
+  sleep 0.05
+done
+printf '\033[2J\033[H'
+printf 'churn done CHURN1064DONE settled anchor washes:\n'
+printf 'fetch %s\n' "$u"
+printf 'sdk %s\n' "$p1"
+printf 'prompt> \n'
+''';
+      entry.proxy.sendInput(Uint8List.fromList(utf8.encode('$script\n')));
+
+      // ---- SAMPLE PHASE: through the churn, the wash must be HIDDEN by the
+      // CONTENT gate (suppressed) while isScrolling stays FALSE.
+      var sawHiddenDuringChurn = false;
+      var sawScrollingDuringChurn = false;
+      var sawWashData = false;
+      var churnDone = false;
+      for (var frame = 0; frame < 90 && !churnDone; frame++) {
+        await tester.pump(const Duration(milliseconds: 100));
+        controller!.reportPaintedViewportOffset(controller.scrollbar.offset);
+        final scrolling = controller.isScrolling;
+        final suppressed = renderBox().debugWashSuppressed;
+        final hasWash = controller.highlights.any((r) => r.capsule);
+        if (scrolling) sawScrollingDuringChurn = true;
+        if (hasWash) sawWashData = true;
+        if (hasWash && suppressed && !scrolling) sawHiddenDuringChurn = true;
+        if (utf8.decode(out, allowMalformed: true).contains('CHURN1064DONE')) {
+          churnDone = true;
+        }
+      }
+
+      expect(sawWashData, isTrue,
+          reason: 'the TUI never surfaced a detected anchor — the ceiling '
+              'rescan must bake a wash even mid-churn (precondition)');
+      expect(sawScrollingDuringChurn, isFalse,
+          reason: 'the in-place churn must NOT scroll — the hide must be '
+              'attributable to the CONTENT gate, not scroll');
+      expect(sawHiddenDuringChurn, isTrue,
+          reason: 'the wash must HIDE during the content churn while '
+              'isScrolling=false — the +140 gap this issue closes (#1064)');
+      expect(controller!.detectionScanStats.washHiddenForContentChurn,
+          greaterThan(0),
+          reason: 'the washHiddenForContentChurn telemetry must show the '
+              'content-pause path fired over live detected content');
+
+      // ---- DURING-CHURN screenshot window: the churn is still running (well
+      // inside the 25s remote loop); the wash is HIDDEN. Hold for emu-shot.
+      debugPrint('WASH1064 churn sample OK: hidden=$sawHiddenDuringChurn '
+          'scrolled=$sawScrollingDuringChurn '
+          'washHiddenForContentChurn='
+          '${controller.detectionScanStats.washHiddenForContentChurn}');
+      if (!churnDone) {
+        debugPrint('WASH1064_DURING_CHURN_WINDOW_OPEN');
+        for (var i = 0; i < 12; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+          controller.reportPaintedViewportOffset(controller.scrollbar.offset);
+          expect(renderBox().debugWashSuppressed, isTrue,
+              reason: 'the wash must stay hidden for the whole during-churn '
+                  'screenshot window');
+        }
+        debugPrint('WASH1064_DURING_CHURN_WINDOW_CLOSED');
+      }
+
+      // ---- wait for the remote loop to finish (churn stops).
+      for (var i = 0; i < 200 && !churnDone; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+        if (utf8.decode(out, allowMalformed: true).contains('CHURN1064DONE')) {
+          churnDone = true;
+        }
+      }
+      expect(churnDone, isTrue, reason: 'the churn never stopped');
+
+      // ---- SETTLE: after the churn stops + the debounce, the wash RE-SHOWS on
+      // its tokens (the case that needs an explicit re-show: the churn ended on
+      // the same URL token, so the equality-gated rescan would not notify).
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      controller.reportPaintedViewportOffset(controller.scrollbar.offset);
+      expect(controller.isScrolling, isFalse, reason: 'not scrolling at settle');
+      expect(controller.contentSettling, isFalse,
+          reason: 'content must settle after the churn stops');
+      expect(renderBox().debugWashSuppressed, isFalse,
+          reason: 'the wash must be un-suppressed once content settles');
+      expect(controller.highlights.any((r) => r.capsule), isTrue,
+          reason: 'the wash must re-show after settle (not stranded hidden)');
+      expect(
+        _driftedWashes(controller, controller.paintedViewportOffset),
+        isEmpty,
+        reason: 'after settle every wash must sit on its token',
+      );
+      debugPrint('WASH1064 settle pass: contentSettling=${controller.contentSettling} '
+          'suppressed=${renderBox().debugWashSuppressed}');
+
+      // ---- SETTLED screenshot window: stationary, wash on its tokens.
+      debugPrint('WASH1064_SETTLED_WINDOW_OPEN');
+      for (var i = 0; i < 48; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      debugPrint('WASH1064_SETTLED_WINDOW_CLOSED');
+    },
+  );
+}

--- a/native/test/ui/detection_style_seam_test.dart
+++ b/native/test/ui/detection_style_seam_test.dart
@@ -49,6 +49,9 @@ class _FakeGutterController extends ChangeNotifier
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   Listenable get decorationListenable => this;
 
   @override

--- a/native/test/ui/ghostty_file_url_994_test.dart
+++ b/native/test/ui/ghostty_file_url_994_test.dart
@@ -70,6 +70,9 @@ class _FakeController extends ChangeNotifier implements TerminalController {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   Listenable get decorationListenable => this;
 
   @override

--- a/native/test/ui/ghostty_gutter_command_test.dart
+++ b/native/test/ui/ghostty_gutter_command_test.dart
@@ -79,6 +79,9 @@ class _FakeController extends ChangeNotifier implements TerminalController {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   Listenable get decorationListenable => this;
 
   @override

--- a/native/test/ui/ghostty_gutter_layer_test.dart
+++ b/native/test/ui/ghostty_gutter_layer_test.dart
@@ -95,6 +95,9 @@ class _FakeController extends ChangeNotifier implements TerminalController {
   bool get isScrolling => _scrolling;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   Listenable get decorationListenable => this;
 
   @override

--- a/native/third_party/flterm/lib/src/foundation/detection_scan_stats.dart
+++ b/native/third_party/flterm/lib/src/foundation/detection_scan_stats.dart
@@ -75,6 +75,15 @@ class DetectionScanStats {
   /// hides it and re-shows on settle at the correct offset (the #988 stance).
   int washHiddenForScroll = 0;
 
+  /// #1064: content-change notifies where the detection WASH was HIDDEN because
+  /// the grid is CHURNING (content updating — a live/streaming TUI repaint) and
+  /// a wash was live. The quiesce-gated wash rule pauses the wash during content
+  /// churn just as [washHiddenForScroll] pauses it during scroll: >0 while a
+  /// live-updating TUI rewrites detected content, 0 on a settled screen. This is
+  /// the case +140 missed — it paused only on scroll, not on content updates, so
+  /// a repainting TUI (isScrolling=false) left the wash shown at stale spots.
+  int washHiddenForContentChurn = 0;
+
   /// One flat map for telemetry / test assertions.
   Map<String, int> snapshot() => <String, int>{
         'rescans': rescans,
@@ -91,6 +100,7 @@ class DetectionScanStats {
         'notifiesSuppressed': notifiesSuppressed,
         'washSuppressedForGrace': washSuppressedForGrace,
         'washHiddenForScroll': washHiddenForScroll,
+        'washHiddenForContentChurn': washHiddenForContentChurn,
       };
 
   /// Zero every counter (tests bracket a measured phase with this).
@@ -109,5 +119,6 @@ class DetectionScanStats {
     notifiesSuppressed = 0;
     washSuppressedForGrace = 0;
     washHiddenForScroll = 0;
+    washHiddenForContentChurn = 0;
   }
 }

--- a/native/third_party/flterm/lib/src/foundation/terminal_render_observer.dart
+++ b/native/third_party/flterm/lib/src/foundation/terminal_render_observer.dart
@@ -51,6 +51,19 @@ abstract class TerminalRenderObserver implements Listenable {
   /// [reportPaintedViewportOffset]; a settle timer flips it back.
   bool get isScrolling;
 
+  /// #1064: whether the grid CONTENT is currently churning — a live/streaming
+  /// TUI is rewriting cells and the detection rescan has not yet SETTLED (the
+  /// trailing content-settle debounce is still pending). The render box ORs this
+  /// with [isScrolling] to set `TerminalPaintState.washSuppressed`, so the
+  /// [HighlightPainter] HIDES the detection wash during content churn exactly as
+  /// it hides during scroll. The owner's rule: the wash is visible ONLY when the
+  /// screen is quiescent (not scrolling AND content settled). +140 paused only on
+  /// scroll, so a repainting TUI (isScrolling=false, content churning) left the
+  /// wash shown at stale spots; this term fixes that. Flipped true on a content
+  /// notify, back to false when the rescan debounce fires after a quiet gap (a
+  /// genuine settle — NOT the mid-churn max-wait reconcile, which keeps churning).
+  bool get contentSettling;
+
   /// Report the viewport offset the render box JUST painted the text with
   /// (#803). The render box calls this at the end of each frame sync, handing
   /// back the SAME `viewportOffset` the [HighlightPainter] read from the frame

--- a/native/third_party/flterm/lib/src/rendering/paint_state.dart
+++ b/native/third_party/flterm/lib/src/rendering/paint_state.dart
@@ -45,16 +45,20 @@ class TerminalPaintState {
 
   var viewportOffset = 0;
 
-  /// #1062: while the painted viewport offset is actively CHANGING (a user
-  /// scroll / fling, or a streaming-output auto-scroll), the detection WASH
-  /// [highlights] is HIDDEN. The render box sets this each paint from the
-  /// controller's `isScrolling`. It exists because during a scroll the
-  /// rescan/relocate that keeps a wash's ABSOLUTE rows aligned to its token is
-  /// DEFERRED (#1044 scan-gating), so a mid-scroll wash can sit over the cells
-  /// where its token USED to be (the owner's "pinned wash"). Rather than chase
-  /// the offset per frame (float/pin, burned twice), the wash follows the #988
-  /// bubble stance: hidden while in flight, re-derived + re-shown on settle at
-  /// the correct offset. The [HighlightPainter] early-returns when this is set.
+  /// #1062/#1064: the detection WASH [highlights] is HIDDEN while the screen is
+  /// CHURNING and re-shown once it is QUIESCENT. The render box sets this each
+  /// paint to `isScrolling || contentSettling`:
+  ///   - `isScrolling` (#1062): the painted viewport offset is in flight (a user
+  ///     scroll / fling or streaming-output auto-scroll). A mid-scroll wash can
+  ///     sit over the cells where its token USED to be (the rescan/relocate that
+  ///     keeps a wash's ABSOLUTE rows aligned is DEFERRED, #1044 scan-gating).
+  ///   - `contentSettling` (#1064): a live/streaming TUI is rewriting cells and
+  ///     the content-settle rescan has not fired yet — the wash could sit at a
+  ///     stale spot (the case +140 missed by pausing only on scroll).
+  /// Rather than chase the offset per frame (float/pin, burned twice), the wash
+  /// follows the #988 bubble stance: hidden while churning, re-derived + re-shown
+  /// on settle at the correct positions. The owner's rule (#1064): the wash is
+  /// visible ONLY when quiescent. The [HighlightPainter] early-returns when set.
   var washSuppressed = false;
 
   var cursor = const Cursor();

--- a/native/third_party/flterm/lib/src/rendering/painters/highlight_painter.dart
+++ b/native/third_party/flterm/lib/src/rendering/painters/highlight_painter.dart
@@ -26,14 +26,16 @@ class HighlightPainter implements TerminalPainter {
 
   @override
   void paint(Canvas canvas) {
-    // #1062: HIDE the detection wash while the painted viewport offset is in
-    // flight. During a scroll the rescan/relocate that keeps each range's
-    // ABSOLUTE rows aligned to its token is deferred (#1044), so a wash painted
-    // this frame can sit over the cells its token just scrolled off of (the
-    // owner's "pinned wash"). The controller re-derives + re-shows the wash on
-    // scroll-settle at the correct offset (the #988 bubble stance ported to the
-    // behind-glyph fill). This is the ONLY detection-wash writer, so skipping
-    // the whole layer is exactly "hide the wash".
+    // #1062/#1064: HIDE the detection wash while the screen is CHURNING — an
+    // active scroll (painted offset in flight) OR content updating (a live TUI
+    // repaint). In either case the rescan/relocate that keeps each range's
+    // ABSOLUTE rows aligned to its token is deferred / not-yet-settled (#1044),
+    // so a wash painted this frame can sit over cells its token just left (the
+    // owner's "pinned"/"stale" wash). The controller re-derives + re-shows the
+    // wash on SETTLE at the correct positions (the #988 bubble stance ported to
+    // the behind-glyph fill). This is the ONLY detection-wash writer, so skipping
+    // the whole layer is exactly "hide the wash". The render box sets
+    // washSuppressed = isScrolling || contentSettling each paint.
     if (_state.washSuppressed) return;
 
     final highlights = _state.highlights;

--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -359,10 +359,12 @@ class TerminalRenderBox extends RenderBox {
   /// content ([_syncFrameState] with `_needsFrameSync` set). Monotonic.
   int get debugFrameSyncCount => _debugFrameSyncCount;
 
-  /// #1062 (test seam): whether the LAST paint hid the detection wash because
-  /// the controller was scrolling. Proves the render-layer hide-on-scroll wiring
-  /// (`_renderObserver.isScrolling` → `_paintState.washSuppressed` →
-  /// [HighlightPainter] early-return) without a pixel read.
+  /// #1062/#1064 (test seam): whether the LAST paint hid the detection wash
+  /// because the screen was CHURNING — scrolling OR content updating. Proves the
+  /// render-layer quiesce-gate wiring
+  /// (`_renderObserver.isScrolling || _renderObserver.contentSettling` →
+  /// `_paintState.washSuppressed` → [HighlightPainter] early-return) without a
+  /// pixel read.
   @visibleForTesting
   bool get debugWashSuppressed => _paintState.washSuppressed;
 
@@ -954,12 +956,19 @@ class TerminalRenderBox extends RenderBox {
   void _syncFrameState() {
     if (_paintState.rows == 0) return;
 
-    // #1062: read the controller's scroll state EACH paint (unconditional — not
-    // gated on terminalDirty) so the HighlightPainter hides the detection wash
-    // while the painted offset is in flight and re-shows it on settle. The
-    // re-show is driven by a controller notify on scroll-settle (which repaints
-    // this box with isScrolling now false).
-    _paintState.washSuppressed = _renderObserver.isScrolling;
+    // #1062/#1064: read the controller's QUIESCENCE state EACH paint
+    // (unconditional — not gated on terminalDirty) so the HighlightPainter hides
+    // the detection wash while the screen is CHURNING and re-shows it on settle.
+    // Churn = an active scroll (painted offset in flight, [isScrolling]) OR
+    // content updating (a live/streaming TUI repaint before the rescan debounce
+    // settles, [contentSettling]). The owner's rule (#1064): the wash is visible
+    // ONLY when quiescent. +140 gated on scroll alone, so a repainting TUI with
+    // isScrolling=false left the wash shown at stale spots; the content-settle
+    // term fixes that. The re-show is driven by a controller notify on settle
+    // (scroll-settle flips isScrolling false; the content-settle debounce flips
+    // contentSettling false), which repaints this box with the wash unsuppressed.
+    _paintState.washSuppressed =
+        _renderObserver.isScrolling || _renderObserver.contentSettling;
 
     final terminalDirty = _needsFrameSync;
     _needsFrameSync = false;

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
@@ -254,6 +254,16 @@ abstract class TerminalController extends ChangeNotifier
   @override
   bool get isScrolling;
 
+  /// #1064: whether the grid CONTENT is currently churning (a live/streaming TUI
+  /// repaint) and the detection rescan has not yet settled. The render box ORs
+  /// this with [isScrolling] to hide the detection wash, so the wash is visible
+  /// ONLY when the screen is QUIESCENT — not scrolling AND content settled. This
+  /// closes the +140 gap: pausing only on scroll left the wash shown at stale
+  /// spots on a repainting TUI (isScrolling=false). Set true on a content notify;
+  /// cleared when the rescan debounce fires after a quiet gap.
+  @override
+  bool get contentSettling;
+
   /// A [Listenable] that fires ONLY when the inputs a widget-layer decorator
   /// reads have changed (#805): the detected [anchors] set, or the
   /// [paintedViewportOffset] the decorator resolves [anchorRects] against.

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -297,6 +297,20 @@ class TerminalControllerImpl extends TerminalController
   /// settle edge instead of competing with fling frames for FFI/regex time.
   bool _rescanPendingSettle = false;
 
+  /// #1064: the CONTENT is churning — a content notify arrived and the trailing
+  /// content-settle rescan has not yet fired after a quiet gap. Exposed as
+  /// [contentSettling]; the render box ORs it with [isScrolling] to hide the
+  /// detection wash (paint_state `washSuppressed`), so the wash pauses during a
+  /// live/streaming TUI repaint exactly as it pauses during scroll (the case
+  /// +140 missed). Set true on a content notify ([_onTerminalChanged]); cleared
+  /// ONLY by [_onDetectionSettled] — the trailing debounce firing after
+  /// [_detectionDebounceMs] of QUIET (a genuine settle). Deliberately NOT cleared
+  /// by [_onDetectionMaxWait]: the max-wait ceiling reconciles mid-churn to keep
+  /// detections live, but the screen is still churning, so the wash stays hidden
+  /// until real quiescence — clearing it there would flash the wash every
+  /// [_detectionMaxWaitMs] during continuous churn. Reset on clear / dispose.
+  bool _washContentSettling = false;
+
   /// #1044: how many rows of scanned coverage to RETAIN around the viewport.
   /// Scrolling through a long buffer accumulates coverage (and its matches);
   /// beyond this the far end is trimmed and re-scanned on return. Generous —
@@ -572,8 +586,12 @@ class TerminalControllerImpl extends TerminalController
     if (_textPatterns.isEmpty && _detectionMatches.isEmpty) return;
     _textPatterns.clear();
     _detectionDebounce?.cancel();
+    _detectionDebounce = null;
     _detectionMaxWait?.cancel();
     _detectionMaxWait = null;
+    // #1064: no patterns → no wash; drop the content-churn pause so a stale flag
+    // never outlives the timers that would clear it.
+    _washContentSettling = false;
     _cancelAllMissGrace();
     _invalidateDetectionScanCache();
     _detectionMatches = const [];
@@ -638,6 +656,9 @@ class TerminalControllerImpl extends TerminalController
 
   @override
   bool get isScrolling => _isScrolling;
+
+  @override
+  bool get contentSettling => _washContentSettling;
 
   @override
   Listenable get decorationListenable => _decorationNotifier;
@@ -860,32 +881,68 @@ class TerminalControllerImpl extends TerminalController
     _detectionDebounce?.cancel();
     _detectionDebounce = Timer(
       const Duration(milliseconds: _detectionDebounceMs),
-      _fireDetectionRescan,
+      _onDetectionSettled,
     );
     // #1044: arm the max-wait ceiling at the START of a churn chain and do NOT
     // push it out on later notifies (`??=`). Continuous sub-debounce churn (a
     // repainting status line, progress bar, spinner) keeps cancelling the
     // trailing debounce above, so without this it would fire never and the
     // line would never anchor; this forces one reconcile after
-    // [_detectionMaxWaitMs] regardless. [_fireDetectionRescan] clears it so a
+    // [_detectionMaxWaitMs] regardless. [_onDetectionMaxWait] clears it so a
     // quiet gap starts a fresh chain.
     _detectionMaxWait ??= Timer(
       const Duration(milliseconds: _detectionMaxWaitMs),
-      _fireDetectionRescan,
+      _onDetectionMaxWait,
     );
   }
 
-  /// #1044: the debounce / max-wait timer target. Cancels BOTH timers (whichever
-  /// did not fire) and clears the ceiling so the next notify starts a fresh
-  /// churn chain, then runs the scan. Routing both timers through here keeps the
-  /// trailing edge and the ceiling from double-scanning and guarantees the
-  /// ceiling is re-armable.
-  void _fireDetectionRescan() {
-    _detectionDebounce?.cancel();
+  /// #1044/#1064: the TRAILING-edge target — the content held QUIET for
+  /// [_detectionDebounceMs] (a genuine SETTLE). Cancels the ceiling so it does
+  /// not double-scan, runs the reconcile scan, then RE-SHOWS the detection wash
+  /// (#1064): matching was paused while the grid churned, so now that it is
+  /// quiescent the wash must repaint at the fresh positions. [_rescanDetections]
+  /// only notifies when the styled list actually CHANGES (equality-gated), so a
+  /// churn that ended on the SAME matches (a clock tick beside an unchanged URL)
+  /// would otherwise leave the wash hidden — wake the render layer explicitly so
+  /// it repaints with `contentSettling` now false and the wash reappears.
+  void _onDetectionSettled() {
     _detectionDebounce = null;
     _detectionMaxWait?.cancel();
     _detectionMaxWait = null;
     _rescanDetections();
+    if (_washContentSettling) {
+      _washContentSettling = false;
+      // Re-show the wash only when a wash is live (anchors exist); a pattern-less
+      // / empty terminal has nothing to re-show (mirrors [_onScrollSettled]'s
+      // #805 battery guard). The render box reads `contentSettling` each paint.
+      if (_detectionMatches.isNotEmpty) notifyListeners();
+    }
+  }
+
+  /// #1044/#1064: the CEILING target — continuous sub-debounce churn starved the
+  /// trailing edge, so force ONE reconcile after [_detectionMaxWaitMs] to keep a
+  /// live-updating line anchoring. Unlike [_onDetectionSettled] this is NOT a
+  /// settle: the grid is still churning, so [_washContentSettling] stays TRUE and
+  /// the wash stays HIDDEN (re-showing it here would flash the wash every ceiling
+  /// window during continuous churn — the opposite of the owner's quiesce-gate).
+  ///
+  /// #1064: re-arm ONE trailing debounce so a genuine settle is still detected —
+  /// if the churn STOPS right after this ceiling fire (no further notify to
+  /// re-arm the trailing edge), this re-armed timer fires [_onDetectionSettled]
+  /// after a quiet gap, clearing the flag and re-showing the wash. Without it the
+  /// wash could stay stranded-hidden until the next unrelated content change.
+  /// Continuous churn simply cancels + re-arms this on the next notify (no-op).
+  /// The max-wait ceiling itself re-arms on the next notify (`??=` in
+  /// [_scheduleDetectionRescan]).
+  void _onDetectionMaxWait() {
+    _detectionMaxWait = null;
+    _rescanDetections();
+    if (_textPatterns.isEmpty) return;
+    _detectionDebounce?.cancel();
+    _detectionDebounce = Timer(
+      const Duration(milliseconds: _detectionDebounceMs),
+      _onDetectionSettled,
+    );
   }
 
   /// #873: SYNCHRONOUSLY re-validate the live detection anchors against the
@@ -2676,6 +2733,20 @@ class TerminalControllerImpl extends TerminalController
     // active grid in place — mark the mutable suffix dirty so the next rescan
     // re-reads it (and only it).
     _contentDirty = true;
+    // #1064: content is CHURNING — pause the detection wash (hide it) until the
+    // rescan SETTLES. Only when a pattern is registered (else there is no wash and
+    // no settle timer would ever fire to clear the flag). The flag ORs with
+    // isScrolling in the render box's `washSuppressed`, so a live/streaming TUI
+    // repaint (isScrolling=false) now hides the wash — the case +140 missed.
+    // Cleared by [_onDetectionSettled] after a quiet gap.
+    if (_textPatterns.isNotEmpty) {
+      _washContentSettling = true;
+      // Telemetry: prove the content-churn pause fired over LIVE detected content
+      // (>0 on a live-updating TUI with a wash, 0 on a settled screen).
+      if (_detectionMatches.isNotEmpty) {
+        _detectionStats.washHiddenForContentChurn++;
+      }
+    }
     _scheduleDetectionRescan();
 
     // #887: the remaining work emits notifications that REBUILD or read layout

--- a/native/third_party/flterm/test/rendering/cursor_layer_test.dart
+++ b/native/third_party/flterm/test/rendering/cursor_layer_test.dart
@@ -360,6 +360,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/emoji_golden_test.dart
+++ b/native/third_party/flterm/test/rendering/emoji_golden_test.dart
@@ -472,6 +472,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/force_repaint_robustness_918_test.dart
+++ b/native/third_party/flterm/test/rendering/force_repaint_robustness_918_test.dart
@@ -244,6 +244,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/frame_debug_telemetry_922_test.dart
+++ b/native/third_party/flterm/test/rendering/frame_debug_telemetry_922_test.dart
@@ -275,6 +275,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/paint_order_1045_test.dart
+++ b/native/third_party/flterm/test/rendering/paint_order_1045_test.dart
@@ -143,6 +143,9 @@ class _HighlightObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/resume_typing_repaint_931_test.dart
+++ b/native/third_party/flterm/test/rendering/resume_typing_repaint_931_test.dart
@@ -336,6 +336,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/sprites_golden_test.dart
+++ b/native/third_party/flterm/test/rendering/sprites_golden_test.dart
@@ -344,6 +344,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/terminal_renderer_golden_test.dart
+++ b/native/third_party/flterm/test/rendering/terminal_renderer_golden_test.dart
@@ -982,6 +982,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/terminal_renderer_test.dart
+++ b/native/third_party/flterm/test/rendering/terminal_renderer_test.dart
@@ -250,6 +250,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/rendering/transparent_background_golden_test.dart
+++ b/native/third_party/flterm/test/rendering/transparent_background_golden_test.dart
@@ -170,6 +170,9 @@ class _Observer implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/widgets/alt_screen_inplace_repaint_898_test.dart
+++ b/native/third_party/flterm/test/widgets/alt_screen_inplace_repaint_898_test.dart
@@ -269,6 +269,9 @@ class _TestRenderObserver implements TerminalRenderObserver {
   bool get isScrolling => false;
 
   @override
+  bool get contentSettling => false;
+
+  @override
   void addListener(VoidCallback listener) {}
 
   @override

--- a/native/third_party/flterm/test/widgets/detection_scan_cache_1044_test.dart
+++ b/native/third_party/flterm/test/widgets/detection_scan_cache_1044_test.dart
@@ -223,6 +223,10 @@ void main() {
         }
       }
 
+      // #1064: the ceiling keeps a trailing settle armed (so the wash re-shows
+      // if the churn stops); drain it so no Timer is pending at teardown.
+      await tester.pump(const Duration(milliseconds: 400));
+
       expect(anchoredDuringChurn, isTrue,
           reason: 'a line repainted faster than the debounce must still '
               'anchor via the max-wait ceiling; the trailing debounce alone '

--- a/native/third_party/flterm/test/widgets/wash_quiesce_gate_1064_test.dart
+++ b/native/third_party/flterm/test/widgets/wash_quiesce_gate_1064_test.dart
@@ -1,0 +1,224 @@
+@Tags(['ffi'])
+library;
+
+// #1064 (owner P0) — the detection WASH must be QUIESCE-GATED: visible ONLY when
+// the screen is settled. It PAUSES (hides) while the screen is CHURNING — an
+// active scroll OR content updating (a live/streaming TUI repaint) — and repaints
+// at the fresh positions after a debounce once quiescent.
+//
+// +140 (#1062/#1063) paused the wash only on SCROLL (isScrolling). The owner's
+// live-updating TUI churns content WITHOUT scrolling (isScrolling=false, the grid
+// rewritten in place), so +140 left the wash SHOWN at stale spots there — the gap
+// this issue closes. The fix ORs a CONTENT-settle term into the render box's
+// wash-suppression: washSuppressed = isScrolling || contentSettling, where
+// contentSettling is true from a content notify until the rescan debounce settles
+// after a quiet gap.
+//
+// This test drives a REAL TerminalView with an IN-PLACE content churn (no scroll)
+// and asserts:
+//   * quiescent precondition — a stable screen shows the wash on its token,
+//   * during churn — isScrolling is false yet the wash is HIDDEN (contentSettling
+//     drives washSuppressed), and the washHiddenForContentChurn telemetry fires,
+//   * after churn stops + the settle debounce — the wash RE-SHOWS on its token.
+// The settle re-show is the case that needs an explicit wake: the churn ends on
+// the SAME matches (the URL never moved), so the equality-gated rescan would not
+// notify — _onDetectionSettled must re-show the wash anyway.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _url = 'https://example.com/quiesce/gate';
+
+HighlightStyle? _washResolver(StructuredMatch m) {
+  if (m.patternId != 'url') return null;
+  return const HighlightStyle(background: Color(0x8800FF00), capsule: true);
+}
+
+/// True when a capsule wash currently sits ON its payload's glyph cells at
+/// [offset] (the wash is correctly placed and, by construction, would paint).
+bool _washOnToken(TerminalController c, int cols, int offset) {
+  final visible = c.scrollbar.visible;
+  for (final r in c.highlights) {
+    if (!r.capsule) continue;
+    final payload = '${r.payload}';
+    for (var absRow = r.topRow; absRow <= r.bottomRow; absRow++) {
+      final viewRow = absRow - offset;
+      if (viewRow < 0 || viewRow >= visible) continue;
+      final startCol = absRow == r.topRow ? r.topCol : 0;
+      final endCol = absRow == r.bottomRow ? r.bottomCol : cols;
+      final rowText = c.visibleRowsText(viewRow, viewRow);
+      final s = startCol.clamp(0, rowText.length);
+      final e = endCol.clamp(0, rowText.length);
+      final slice = (e > s ? rowText.substring(s, e) : '').trim();
+      if (slice.isNotEmpty &&
+          (payload.contains(slice) || slice.contains(payload))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void main() {
+  testWidgets(
+    'the detection wash HIDES during a content churn (isScrolling=false) and '
+    're-shows on its token after the settle debounce (#1064 quiesce gate)',
+    (tester) async {
+      const cols = 62;
+      final controller = TerminalController(
+        config: const TerminalConfig(cols: cols, rows: 24),
+      )
+        ..registerTextPattern(TextPattern.url())
+        ..detectionHighlightStyleOf = _washResolver;
+      addTearDown(controller.dispose);
+
+      final scrollController = TerminalScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 700,
+              height: 460,
+              child: TerminalView(
+                controller: controller,
+                scrollController: scrollController,
+                autofocus: false,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      void write(String s) =>
+          controller.write(Uint8List.fromList(utf8.encode(s)));
+
+      TerminalRenderBox renderBox() => tester.renderObject<TerminalRenderBox>(
+            find.byType(TerminalRenderer),
+          );
+
+      // A little scrollback, then a URL line the cursor stays on (NO newline) so
+      // the churn rewrites THIS line in place — the viewport is already at the
+      // bottom, so an in-place rewrite never moves the offset (isScrolling stays
+      // false: this exercises the CONTENT gate, not the scroll gate).
+      for (var i = 0; i < 10; i++) {
+        write('filler ${i.toString().padLeft(4, '0')}\r\n');
+      }
+      write('note $_url here');
+      // Settle output + the detection debounce so the wash appears on the URL.
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+
+      // ---- quiescent precondition: wash present, NOT suppressed, on its token.
+      expect(controller.isScrolling, isFalse, reason: 'must start at rest');
+      expect(controller.contentSettling, isFalse,
+          reason: 'content must be settled before the churn');
+      expect(renderBox().debugWashSuppressed, isFalse,
+          reason: 'a quiescent frame must NOT suppress the wash');
+      expect(controller.highlights.any((r) => r.capsule), isTrue,
+          reason: 'precondition: a capsule wash is live on the URL');
+      expect(_washOnToken(controller, cols, controller.paintedViewportOffset),
+          isTrue,
+          reason: 'precondition: the settled wash sits on its token');
+
+      // ---- the measured churn: rewrite the SAME line in place every frame, far
+      // faster than the ~120ms settle debounce, so the content never quiesces.
+      // A trailing counter changes the line (guaranteeing a content notify) while
+      // the URL token itself never moves.
+      controller.detectionScanStats.reset();
+      var sawHiddenDuringChurn = false;
+      var sawScrollingDuringChurn = false;
+      for (var frame = 1; frame <= 12; frame++) {
+        write('\rnote $_url here tick=$frame   ');
+        await tester.pump(const Duration(milliseconds: 40));
+        if (controller.isScrolling) sawScrollingDuringChurn = true;
+        if (renderBox().debugWashSuppressed) sawHiddenDuringChurn = true;
+      }
+
+      // The churn must NOT have scrolled — this proves the hide came from the
+      // CONTENT gate (contentSettling), the case +140 missed.
+      expect(sawScrollingDuringChurn, isFalse,
+          reason: 'the in-place churn must not scroll — the hide must be '
+              'attributable to content churn, not scroll');
+      expect(sawHiddenDuringChurn, isTrue,
+          reason: 'the wash must HIDE while content churns (the +140 gap: '
+              'isScrolling=false yet the screen is not quiescent)');
+      expect(controller.contentSettling, isTrue,
+          reason: 'contentSettling must hold true through continuous churn');
+      expect(controller.detectionScanStats.washHiddenForContentChurn,
+          greaterThan(0),
+          reason: 'the washHiddenForContentChurn telemetry must show the '
+              'content-pause path fired over live detected content');
+
+      // ---- settle: stop churning, drain the debounce; the wash RE-SHOWS.
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+      expect(controller.isScrolling, isFalse);
+      expect(controller.contentSettling, isFalse,
+          reason: 'content must settle once the churn stops');
+      expect(renderBox().debugWashSuppressed, isFalse,
+          reason: 'the wash must be un-suppressed once content settles — even '
+              'though the churn ended on the SAME matches (the equality-gated '
+              'rescan would not notify; _onDetectionSettled re-shows it)');
+      expect(controller.highlights.any((r) => r.capsule), isTrue,
+          reason: 'the wash must re-show after settle (churn must not strand it '
+              'hidden)');
+      expect(_washOnToken(controller, cols, controller.paintedViewportOffset),
+          isTrue,
+          reason: 'after settle the wash must sit back on its token');
+
+      debugPrint('WASH1064 churn OK: hiddenDuringChurn=$sawHiddenDuringChurn '
+          'washHiddenForContentChurn='
+          '${controller.detectionScanStats.washHiddenForContentChurn} '
+          'anchorsAfter=${controller.anchors.length}');
+    },
+  );
+
+  testWidgets(
+    'a quiescent screen with detected content keeps the wash VISIBLE — the gate '
+    'does not falsely hide when nothing is churning (#1064)',
+    (tester) async {
+      const cols = 50;
+      final controller = TerminalController(
+        config: const TerminalConfig(cols: cols, rows: 16),
+      )
+        ..registerTextPattern(TextPattern.url())
+        ..detectionHighlightStyleOf = _washResolver;
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 560,
+              height: 320,
+              child: TerminalView(controller: controller, autofocus: false),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      controller.write(
+        Uint8List.fromList(utf8.encode('visit $_url now\r\n')),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+
+      final renderBox = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+      expect(controller.contentSettling, isFalse);
+      expect(controller.isScrolling, isFalse);
+      expect(renderBox.debugWashSuppressed, isFalse,
+          reason: 'a settled screen must show the wash');
+      expect(_washOnToken(controller, cols, controller.paintedViewportOffset),
+          isTrue);
+    },
+  );
+}


### PR DESCRIPTION
Closes #1064

## Owner's authoritative spec (verbatim intent)
The behind-glyph detection wash is visible ONLY when the screen is quiescent. It PAUSES (hides) while the screen is CHURNING — an active scroll OR content updating (a live/streaming TUI repaint) — and repaints at fresh positions after a debounce once settled.

+140 (#1062/#1063) paused the wash only on scroll (`isScrolling`). A live-updating TUI churns content WITHOUT scrolling (`isScrolling=false`, grid rewritten in place), so +140 left the wash shown at stale spots there. This PR closes that gap by unifying the two quiescence notions.

## Change (unify existing machinery, no rebuild)
- Render box sets `washSuppressed = isScrolling || contentSettling` each paint; `HighlightPainter` early-returns on it. New `contentSettling` term added to `TerminalRenderObserver` / `TerminalController`.
- `contentSettling` reuses #1044's content-dirty + settle-debounce: set true on a content notify, cleared when the trailing rescan debounce fires after a quiet gap. The shared rescan callback is split:
  - `_onDetectionSettled` (trailing edge = genuine settle): clears the flag and re-shows the wash — even when the churn ended on the SAME matches, where the equality-gated rescan would not notify.
  - `_onDetectionMaxWait` (ceiling = still churning): keeps the wash hidden, but re-arms a trailing settle so a churn that stops right after the ceiling is never stranded-hidden.
- `washHiddenForContentChurn` telemetry counter proves the content-pause path.
- No new RenderState/damage consumer (`reference_paint_root_985`). #1044 scan-gating, #1060 no-float, #1044 perf invariants all intact.

## Acceptance

### Fork widget test — `wash_quiesce_gate_1064_test.dart`
Wash hidden during in-place content churn (`isScrolling=false`, driven by `contentSettling`), telemetry `washHiddenForContentChurn` > 0, wash visible + on-token after settle+debounce even when the matches were unchanged. Full flterm fork suite green (885 tests).

### Emulator, TWO cases (real SSH → shell → flterm, on-device paint stack)

**(b) LIVE-UPDATING TUI (the case +140 missed)** — `wash_quiesce_gate_1064_shot_test.dart` PASS.
An in-place repainting band (absolute cursor addressing, no scroll). On-device: `hidden=true scrolled=false washHiddenForContentChurn=305`; at settle `contentSettling=false suppressed=false`, wash on both tokens, no drift.
- During-churn shot (URL/path anchors visible, gutter chips tracking, behind-glyph wash HIDDEN): `test-results/emulator-shots/20260711T224837+0000-wash1064-during-churn_.png`
- Settled shot (wash re-shown ON `https://docs.brew.sh/Tap-Trust` and `/Applications/Xcode.app/Contents/Developer`): `test-results/emulator-shots/20260711T224859+0000-wash1064-settled_.png`

**(a) SCROLL (unchanged by this PR)** — `wash_hide_on_scroll_1062_shot_test.dart` PASS on-device: `sawHiddenMidScroll=true washHiddenForScroll=101`, no drift, settled un-suppressed.
- Mid-scroll shot (no pinned/stale wash band): `test-results/emulator-shots/20260711T225017+0000-wash1064-scroll-midscroll_.png`
- Settled shot: `test-results/emulator-shots/20260711T225043+0000-wash1064-scroll-settled_.png`

### Gates
- `scripts/native-fork-test.sh` — 885 pass (incl. #1060/#1044/#1062 fixtures + the new #1064 widget test).
- `scripts/native-fast-gate.sh` — analyzer clean, 2093 native unit/widget tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa