### PR TITLE
feat(native): additive DA-leak + wash-geometry telemetry (#1072)

### DIFF
--- a/native/lib/diagnostics/detection_geom.dart
+++ b/native/lib/diagnostics/detection_geom.dart
@@ -1,0 +1,65 @@
+// #1072: detection wash GEOMETRY snapshot (frozen-bubble diagnostics).
+//
+// The "frozen bubble" symptom is a detection wash/gutter chip that stops
+// tracking its token — it stays pinned to a viewport row while the content
+// scrolls, or never repaints at all. Diagnosing it from a screenshot is
+// guesswork: you can't see WHICH offset the painter used, whether the wash
+// layer repainted between two captures, or whether the anchor's absolute row
+// still maps to the row where the payload text actually is.
+//
+// This module captures, at bug-report time, a single `detectionGeom` object:
+// the controller's live viewport offsets (screenViewportTop / scrollbarOffset /
+// paintedViewportOffset), the render box's last-painted wash rows
+// (drawnWashViewRows) and a monotonic paintTick (so a SECOND capture reveals
+// whether the wash layer repaints at all), plus per-anchor rows — the absolute
+// top row, the resolved gutter row, the row the painter WOULD draw the wash on
+// (absTopRow - paintedViewportOffset), and the row where the payload text is
+// ACTUALLY visible right now. When those diverge, the freeze is localized to a
+// specific layer without another blind device build.
+//
+// ADDITIVE + read-only: the probe only reads accessors; it never mutates
+// terminal, controller, or render state. Mirrors the paint_stats.dart registry
+// pattern (session-keyed + an active pointer) so the above-the-Navigator
+// feedback overlay can snapshot the on-screen session with no Riverpod scope.
+
+/// Signature of the per-session geometry probe the terminal view installs. It
+/// reads the live controller + render box and returns the assembled
+/// `detectionGeom` map, or null when the view can't resolve them yet (before
+/// first layout / after unmount).
+typedef DetectionGeomProbe = Map<String, Object?>? Function();
+
+final Map<String, DetectionGeomProbe> _probes = <String, DetectionGeomProbe>{};
+String? _activeSessionId;
+
+/// Register (or replace) the geometry probe for [sessionId]. The terminal view
+/// wires this to a closure that reads its own controller + render box.
+void registerDetectionGeom(String sessionId, DetectionGeomProbe probe) {
+  _probes[sessionId] = probe;
+}
+
+/// Drop the geometry probe for [sessionId] (session teardown). Clears the active
+/// pointer if it referenced this session.
+void unregisterDetectionGeom(String sessionId) {
+  _probes.remove(sessionId);
+  if (_activeSessionId == sessionId) _activeSessionId = null;
+}
+
+/// Mark [sessionId] as the active (on-screen) session whose geometry the
+/// feedback overlay snapshots. Pass null when no terminal is foregrounded.
+void setActiveDetectionGeom(String? sessionId) {
+  _activeSessionId = sessionId;
+}
+
+/// Detection-geometry snapshot of the active session, or null when none is
+/// active or the probe can't resolve the controller/render box.
+Map<String, Object?>? activeDetectionGeomSnapshot() {
+  final id = _activeSessionId;
+  if (id == null) return null;
+  return _probes[id]?.call();
+}
+
+/// Clear the whole registry + active pointer (tests).
+void clearAllDetectionGeom() {
+  _probes.clear();
+  _activeSessionId = null;
+}

--- a/native/lib/diagnostics/session_byte_recorder.dart
+++ b/native/lib/diagnostics/session_byte_recorder.dart
@@ -35,17 +35,27 @@ import 'dart:typed_data';
 
 import 'feedback_bundle.dart' show scrubSecrets;
 
-/// Default byte-ring cap: ~256 KB of the most recent terminal output. Past this
+/// Default byte-ring cap: ~1 MB of the most recent terminal output. Past this
 /// the oldest chunks are evicted (backward-looking — newest always wins).
-const int kByteRecorderMaxBytes = 256 * 1024;
+///
+/// #1072: raised from 256 KB → 1 MB so a RESUME-SPANNING window survives. The
+/// DA-leak repro straddles suspend/resume; on a busy terminal 256 KB held only
+/// a few seconds, evicting the pre-resume bytes before the report was captured.
+/// 1 MB (with the 60 s age cap below) holds the full ~30 s+ window the byte
+/// stream needs to show what happened across the resume. Conservative: 4× the
+/// old cap, still bounded and backward-looking.
+const int kByteRecorderMaxBytes = 1024 * 1024;
 
 /// Default byte-ring event cap (defense against a flood of tiny chunks blowing
-/// the list length even under the byte cap).
-const int kByteRecorderMaxEvents = 4096;
+/// the list length even under the byte cap). #1072: raised in step with the
+/// 4× byte cap so the event cap is not the new binding limit.
+const int kByteRecorderMaxEvents = 16384;
 
-/// Default age cap for BOTH rings: ~30 s. Events older than this (relative to
-/// the newest event) are evicted.
-const Duration kByteRecorderMaxAge = Duration(seconds: 30);
+/// Default age cap for the byte/scroll/termReply rings: ~60 s. Events older than
+/// this (relative to the newest event) are evicted. #1072: raised from 30 s →
+/// 60 s so a suspend/resume-spanning window is retained (the byte cap above is
+/// still the usual binding limit on a busy terminal).
+const Duration kByteRecorderMaxAge = Duration(seconds: 60);
 
 /// Default scroll-ring event cap.
 const int kScrollRecorderMaxEvents = 2048;
@@ -53,6 +63,11 @@ const int kScrollRecorderMaxEvents = 2048;
 /// Default sent-SGR-ring event cap (#793). The synthesized mouse/wheel reports
 /// the app SENDS are short and infrequent; a modest cap holds a full swipe burst.
 const int kSentSgrRecorderMaxEvents = 1024;
+
+/// #1072: default terminal-auto-reply ring event cap. DA/DSR/CPR/XTVERSION/OSC
+/// replies are short and infrequent; a modest cap holds a full burst. Age
+/// eviction shares [kByteRecorderMaxAge].
+const int kTermReplyRecorderMaxEvents = 1024;
 
 class _ByteEvent {
   _ByteEvent(this.tMs, this.bytes);
@@ -91,6 +106,36 @@ bool isSentSgrMouseReport(Uint8List chunk) {
   return true;
 }
 
+/// #1072: coarse classification of a terminal AUTO-REPLY chunk by its leading
+/// bytes, for the term-reply diagnostics trace. Pure + allocation-free.
+///
+///   `DA1`      `ESC [ ?` (`\x1b[?…`)  — primary device attributes reply
+///   `DA2`      `ESC [ >` (`\x1b[>…`)  — secondary device attributes reply
+///   `DSR`/`CPR``ESC [` + digits + `R`/`n` — cursor position / device status
+///   `OSC`      `ESC ]`               — OSC query answer
+///   `other`    anything else (e.g. XTVERSION `ESC P … ST`)
+///
+/// Best-effort: it only inspects the shape, never decodes content, so it can't
+/// leak anything a scrub would catch.
+String termReplyKind(Uint8List chunk) {
+  if (chunk.length < 2) return 'other';
+  if (chunk[0] != 0x1b) return 'other';
+  // OSC: ESC ]
+  if (chunk[1] == 0x5d) return 'OSC';
+  // CSI replies: ESC [
+  if (chunk[1] == 0x5b) {
+    if (chunk.length >= 3) {
+      if (chunk[2] == 0x3f) return 'DA1'; // ESC [ ?
+      if (chunk[2] == 0x3e) return 'DA2'; // ESC [ >
+    }
+    // DSR/CPR: ESC [ <digits/;> terminated by 'R' (0x52) or 'n' (0x6e).
+    final last = chunk[chunk.length - 1];
+    if (last == 0x52 || last == 0x6e) return chunk[chunk.length - 1] == 0x52 ? 'CPR' : 'DSR';
+    return 'other';
+  }
+  return 'other';
+}
+
 /// A bounded, backward-looking recorder of the raw bytes written to ONE
 /// session's terminal plus its scroll-offset events. See the file header.
 class SessionByteRecorder {
@@ -100,6 +145,7 @@ class SessionByteRecorder {
     this.maxAge = kByteRecorderMaxAge,
     this.maxScrollEvents = kScrollRecorderMaxEvents,
     this.maxSentSgrEvents = kSentSgrRecorderMaxEvents,
+    this.maxTermReplyEvents = kTermReplyRecorderMaxEvents,
     int Function()? nowMs,
   }) : _nowMs = nowMs ?? _defaultNowMs;
 
@@ -108,6 +154,7 @@ class SessionByteRecorder {
   final Duration maxAge;
   final int maxScrollEvents;
   final int maxSentSgrEvents;
+  final int maxTermReplyEvents;
 
   /// Monotonic relative-ms clock. Injected in tests for determinism; production
   /// uses an epoch-anchored elapsed millis.
@@ -127,6 +174,11 @@ class SessionByteRecorder {
   // scroll never moves). NEVER carries keystrokes, so a typed password can never
   // be recorded — the filter is the security boundary.
   final ListQueue<_ByteEvent> _sentSgr = ListQueue<_ByteEvent>();
+  // #1072: terminal auto-reply ring — the DA/DSR/CPR/XTVERSION/OSC responses the
+  // terminal itself writes back (teed from flterm's `onWritePty`, never user
+  // keystrokes). Reveals a spurious/duplicated device-attributes reply (the
+  // #1072 DA-leak). Each event also carries a coarse `kind` computed at snapshot.
+  final ListQueue<_ByteEvent> _termReply = ListQueue<_ByteEvent>();
 
   int? _cols;
   int? _rows;
@@ -178,6 +230,25 @@ class SessionByteRecorder {
             _sentSgr.length > maxSentSgrEvents)) {
       if (_sentSgr.length == 1 && _sentSgr.first.tMs >= ageFloor) break;
       _sentSgr.removeFirst();
+    }
+  }
+
+  /// #1072: append a terminal AUTO-REPLY chunk (teed from flterm's
+  /// `onWritePty`). These are the terminal's own DA/DSR/CPR/XTVERSION/OSC
+  /// responses — NOT user keystrokes, which never reach `onWritePty` — so a
+  /// typed password can't enter this ring. Hot path: store the reference +
+  /// timestamp, then evict past the age/event caps. No copy/encode here (cold
+  /// path at snapshot). Same eviction discipline as the sent-SGR ring.
+  void recordTermReply(Uint8List chunk) {
+    if (chunk.isEmpty) return;
+    final t = _nowMs();
+    _termReply.add(_ByteEvent(t, chunk));
+    final ageFloor = t - maxAge.inMilliseconds;
+    while (_termReply.isNotEmpty &&
+        (_termReply.first.tMs < ageFloor ||
+            _termReply.length > maxTermReplyEvents)) {
+      if (_termReply.length == 1 && _termReply.first.tMs >= ageFloor) break;
+      _termReply.removeFirst();
     }
   }
 
@@ -235,6 +306,28 @@ class SessionByteRecorder {
     return out;
   }
 
+  /// #1072: snapshot the terminal-auto-reply ring as a list of
+  /// `{tMs, b64, kind}`, oldest first. SCRUBS each chunk (defense in depth —
+  /// device-attributes/cursor replies carry no credentials, but the ring uses
+  /// the same cold-path scrub as the output ring) and tags a coarse [kind].
+  /// Encode + scrub + classify happen here, not on the hot path.
+  List<Map<String, Object?>> snapshotTermReplyTrace() {
+    final out = <Map<String, Object?>>[];
+    for (final ev in _termReply) {
+      final text = utf8.decode(ev.bytes, allowMalformed: true);
+      final scrubbed = scrubSecrets(text);
+      final bytes = identical(scrubbed, text) || scrubbed == text
+          ? ev.bytes
+          : Uint8List.fromList(utf8.encode(scrubbed));
+      out.add(<String, Object?>{
+        'tMs': ev.tMs,
+        'b64': base64Encode(bytes),
+        'kind': termReplyKind(ev.bytes),
+      });
+    }
+    return out;
+  }
+
   /// #793 (test-only): the live total of bytes retained in the byte ring, so the
   /// O(1)-eviction tests can assert `_byteTotal` stays consistent with the
   /// surviving chunks after `ListQueue` eviction.
@@ -259,6 +352,7 @@ class SessionByteRecorder {
     _byteTotal = 0;
     _scroll.clear();
     _sentSgr.clear();
+    _termReply.clear();
     _cols = null;
     _rows = null;
   }
@@ -315,6 +409,11 @@ List<Map<String, Object?>> activeScrollTraceSnapshot() =>
 /// active session, or empty when none is active.
 List<Map<String, Object?>> activeSentSgrTraceSnapshot() =>
     _active?.snapshotSentSgrTrace() ?? const <Map<String, Object?>>[];
+
+/// #1072: terminal auto-reply trace (DA/DSR/CPR/XTVERSION/OSC responses the
+/// terminal generated) of the active session, or empty when none is active.
+List<Map<String, Object?>> activeTermReplyTraceSnapshot() =>
+    _active?.snapshotTermReplyTrace() ?? const <Map<String, Object?>>[];
 
 /// Grid `{cols, rows}` of the active session, or null when none is active.
 Map<String, Object?>? activeGridSnapshot() => _active?.grid();

--- a/native/lib/ui/feedback_overlay.dart
+++ b/native/lib/ui/feedback_overlay.dart
@@ -28,6 +28,8 @@ import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
 
 import 'package:mobissh/diagnostics/connect_trace.dart';
+import 'package:mobissh/diagnostics/detection_geom.dart'
+    show activeDetectionGeomSnapshot;
 import 'package:mobissh/diagnostics/feedback_bundle.dart' show scrubSecrets;
 import 'package:mobissh/diagnostics/paint_stats.dart'
     show activePaintStatsSnapshot;
@@ -91,7 +93,9 @@ Map<String, Object?> buildFeedbackPayload({
   List<Map<String, Object?>> byteTrace = const <Map<String, Object?>>[],
   List<Map<String, Object?>> scrollTrace = const <Map<String, Object?>>[],
   List<Map<String, Object?>> sentSgrTrace = const <Map<String, Object?>>[],
+  List<Map<String, Object?>> termReplyTrace = const <Map<String, Object?>>[],
   Map<String, Object?>? grid,
+  Map<String, Object?>? detectionGeom,
   // #967: the pre-send Review & Send sheet lets the user EXCLUDE categories.
   // These gate ASSEMBLY (not just display) so an excluded artifact is provably
   // absent from the uploaded body. Default true → report quality preserved; the
@@ -188,7 +192,23 @@ Map<String, Object?> buildFeedbackPayload({
     // Filtered at the send seam to SGR-mouse reports ONLY, so a typed password
     // is NEVER recorded. Omitted entirely when no session is active.
     if (includeTraces && sentSgrTrace.isNotEmpty) 'sentSgrTrace': sentSgrTrace,
+    // #1072: terminal AUTO-REPLY trace (DA/DSR/CPR/XTVERSION/OSC answers the
+    // terminal generated, teed from flterm's onWritePty — never keystrokes).
+    // Shape mirrors byteTrace ({tMs,b64}) plus a coarse `kind`. The server
+    // persists it as `${ts}-bug-report.term-reply-trace.json`; the COUNT rides
+    // in the bundle json so a DA-leak (#1072) shows the duplicated reply.
+    // Already scrubbed at snapshot time. Omitted when no session is active.
+    if (includeTraces && termReplyTrace.isNotEmpty) ...<String, Object?>{
+      'termReplyTrace': termReplyTrace,
+      'termReplyTraceEventCount': termReplyTrace.length,
+    },
     if (includeTraces && grid != null) 'grid': grid,
+    // #1072: detection-wash GEOMETRY at capture time (frozen-bubble diagnosis)
+    // — viewport offsets, last-painted wash rows, a monotonic paintTick, and
+    // per-anchor rows (absolute / gutter / wash-drawn / payload-actual). A
+    // second capture whose paintTick didn't advance proves the wash never
+    // repainted. Read-only telemetry; omitted when no session is active.
+    if (includeTraces && detectionGeom != null) 'detectionGeom': detectionGeom,
   };
 }
 
@@ -428,7 +448,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       byteTrace: activeByteTraceSnapshot(),
       scrollTrace: activeScrollTraceSnapshot(),
       sentSgrTrace: activeSentSgrTraceSnapshot(),
+      termReplyTrace: activeTermReplyTraceSnapshot(),
       grid: activeGridSnapshot(),
+      detectionGeom: activeDetectionGeomSnapshot(),
     );
   }
 
@@ -471,6 +493,11 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     final byteTrace = activeByteTraceSnapshot();
     final scrollTrace = activeScrollTraceSnapshot();
     final sentSgrTrace = activeSentSgrTraceSnapshot();
+    // #1072: snapshot the terminal auto-reply ring + the detection-wash geometry
+    // at the EXACT moment of tap — both backward/point-in-time, so the report
+    // reflects the state the owner is reporting.
+    final termReplyTrace = activeTermReplyTraceSnapshot();
+    final detectionGeom = activeDetectionGeomSnapshot();
     final grid = activeGridSnapshot();
     final dpr = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0;
     final bytes = await widget.screenshotCapturer(_captureKey, dpr);
@@ -490,7 +517,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       byteTrace: byteTrace,
       scrollTrace: scrollTrace,
       sentSgrTrace: sentSgrTrace,
+      termReplyTrace: termReplyTrace,
       grid: grid,
+      detectionGeom: detectionGeom,
     );
   }
 
@@ -505,7 +534,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     List<Map<String, Object?>> byteTrace = const <Map<String, Object?>>[],
     List<Map<String, Object?>> scrollTrace = const <Map<String, Object?>>[],
     List<Map<String, Object?>> sentSgrTrace = const <Map<String, Object?>>[],
+    List<Map<String, Object?>> termReplyTrace = const <Map<String, Object?>>[],
     Map<String, Object?>? grid,
+    Map<String, Object?>? detectionGeom,
   }) async {
     // Show the sheet from the Navigator's OVERLAY context — NOT this overlay's
     // own context, which sits above the Navigator (mounted via
@@ -533,7 +564,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
         byteTrace: byteTrace,
         scrollTrace: scrollTrace,
         sentSgrTrace: sentSgrTrace,
+        termReplyTrace: termReplyTrace,
         grid: grid,
+        detectionGeom: detectionGeom,
       ),
     );
     if (review == null) return; // cancelled / dismissed — nothing sent
@@ -550,7 +583,9 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       byteTrace: byteTrace,
       scrollTrace: scrollTrace,
       sentSgrTrace: sentSgrTrace,
+      termReplyTrace: termReplyTrace,
       grid: grid,
+      detectionGeom: detectionGeom,
       includeImages: review.includeImages,
       includeTraces: review.includeTraces,
     );
@@ -677,7 +712,9 @@ class _FeedbackReviewSheet extends StatefulWidget {
     required this.byteTrace,
     required this.scrollTrace,
     required this.sentSgrTrace,
+    required this.termReplyTrace,
     required this.grid,
+    required this.detectionGeom,
   });
 
   final String version;
@@ -690,7 +727,9 @@ class _FeedbackReviewSheet extends StatefulWidget {
   final List<Map<String, Object?>> byteTrace;
   final List<Map<String, Object?>> scrollTrace;
   final List<Map<String, Object?>> sentSgrTrace;
+  final List<Map<String, Object?>> termReplyTrace;
   final Map<String, Object?>? grid;
+  final Map<String, Object?>? detectionGeom;
 
   @override
   State<_FeedbackReviewSheet> createState() => _FeedbackReviewSheetState();
@@ -810,7 +849,9 @@ class _FeedbackReviewSheetState extends State<_FeedbackReviewSheet> {
               title: const Text('Include diagnostic traces'),
               subtitle: Text(
                 'Terminal I/O + logs ($_traceLineCount log lines'
-                '${widget.byteTrace.isNotEmpty ? ", terminal bytes" : ""}), '
+                '${widget.byteTrace.isNotEmpty ? ", terminal bytes" : ""}'
+                '${widget.termReplyTrace.isNotEmpty ? ", terminal replies" : ""}'
+                '${widget.detectionGeom != null ? ", wash geometry" : ""}), '
                 'device & app version.',
               ),
               value: _includeTraces,

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -173,6 +173,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart' as xterm;
 
 import '../diagnostics/connect_trace.dart' show clifecycle, ctrace;
+import '../diagnostics/detection_geom.dart';
+import '../diagnostics/feedback_bundle.dart' show scrubSecrets;
 import '../diagnostics/gesture_trace.dart';
 import '../diagnostics/paint_stats.dart';
 import '../diagnostics/session_byte_recorder.dart';
@@ -2712,6 +2714,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
         // damage/frame path dropped the redraw. Coalesced to once per frame.
         _forceTerminalRepaint();
       };
+      // #1072 (telemetry, additive): TEE the terminal's own AUTO-REPLIES
+      // (DA/DSR/CPR/XTVERSION/OSC answers flterm writes back through
+      // `onWritePty`) into the diagnostics ring. This is a PURE observer — the
+      // reply still forwards through the controller's onOutput seam above
+      // exactly as before — so it changes nothing that reaches the SSH stream;
+      // it only lets a bug report show a spurious/duplicated DA reply (#1072).
+      // User keystrokes never reach onTerminalReply (they bypass onWritePty), so
+      // no typed content can enter this ring.
+      controller.onTerminalReply = _byteRecorder.recordTermReply;
       // Grid resize. flterm reports (cols, rows) from its OWN layout; we RECORD
       // it for the replay harness but do NOT let it write _cols/_rows or the PTY.
       controller.onResize = (cols, rows) {
@@ -2821,6 +2832,10 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
       // Paint replay harness: let the stats snapshot probe the live render-box
       // boundary counters (notifies / paints / frame syncs) at read time.
       _paintStats.boxProbe = _probePaintBox;
+      // #1072 (telemetry, additive): install the detection-geometry probe so the
+      // bug report can snapshot this session's live wash offsets + per-anchor
+      // rows for the frozen-bubble diagnosis. Read-only.
+      registerDetectionGeom(widget.sessionId, _probeDetectionGeom);
       // #702: arm the first-connect resize re-sync on the proxy's shellReady
       // stream. The xterm #666 fit-burst is offstage for ghostty, so this is the
       // ghostty-LOCAL equivalent: once the task-side shell EXISTS, force-re-send
@@ -3600,6 +3615,86 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     return found;
   }
 
+  /// #1072 (telemetry, additive): assemble this session's detection-wash
+  /// GEOMETRY snapshot for the bug-report bundle (frozen-bubble diagnosis).
+  /// READ-ONLY — reads controller + render-box accessors, mutates nothing.
+  /// Null before first layout / when the controller or render box is gone.
+  ///
+  /// Per anchor (capped) it records the absolute top row, the resolved gutter
+  /// row, the row the wash painter WOULD draw on (`absTopRow -
+  /// paintedViewportOffset`), and the viewport row where the payload text is
+  /// ACTUALLY visible now — so a divergence localizes the freeze to a layer.
+  Map<String, Object?>? _probeDetectionGeom() {
+    if (!mounted) return null;
+    final controller = _controller;
+    if (controller == null) return null;
+    final box = _findTerminalRenderBox();
+
+    final paintedOffset = controller.paintedViewportOffset;
+    final gridRows = controller.scrollbar.visible;
+
+    // Cap the per-anchor detail so a screen full of matches can't bloat the
+    // bundle. The COUNT below always reports the full anchor set.
+    const maxAnchors = 12;
+    final anchors = controller.anchors;
+    final anchorGeom = <Map<String, Object?>>[];
+    for (final anchor in anchors.take(maxAnchors)) {
+      if (anchor.ranges.isEmpty) continue;
+      final topRange = anchor.ranges.first;
+      final absTopRow = topRange.topRow;
+      final payloadStr = anchor.payload.toString();
+      final prefix =
+          payloadStr.length > 24 ? payloadStr.substring(0, 24) : payloadStr;
+      anchorGeom.add(<String, Object?>{
+        // Scrubbed defensively — a URL/path payload is not a credential, but the
+        // same no-secrets contract as every other bundle string applies.
+        'payloadPrefix': scrubSecrets(prefix),
+        'patternId': anchor.patternId,
+        'absTopRow': absTopRow,
+        'gutterRow': controller.anchorGutterRow(topRange),
+        'washDrawnViewRow': absTopRow - paintedOffset,
+        'payloadActualViewRow':
+            _payloadActualViewRow(controller, payloadStr, gridRows),
+      });
+    }
+
+    return <String, Object?>{
+      'activeScreen': controller.activeScreen.name,
+      'screenViewportTop': controller.screenViewportTop,
+      'scrollbarOffset': controller.scrollbar.offset,
+      'paintedViewportOffset': paintedOffset,
+      'gridRows': gridRows,
+      // The viewport rows the HighlightPainter actually drew the wash on last
+      // paint (empty when nothing drew). `null` when the box isn't resolvable.
+      'drawnWashViewRows': box?.washViewRows,
+      // Monotonic paint counter: compare across two captures to see whether the
+      // wash layer repaints AT ALL (a frozen bubble that never advances = the
+      // paint was never scheduled). Reuses the existing render-box paint count.
+      'paintTick': box?.debugPaintCount,
+      'anchorCount': anchors.length,
+      'anchors': anchorGeom,
+    };
+  }
+
+  /// #1072: the viewport row whose visible text currently contains [payloadStr]
+  /// (matched on a bounded prefix so a long/wrapped payload still localizes), or
+  /// -1 when the payload isn't visible. Scans single rows — the head row of a
+  /// wrapped match carries the prefix. Cold path (bug-report time only).
+  int _payloadActualViewRow(
+    TerminalController controller,
+    String payloadStr,
+    int gridRows,
+  ) {
+    if (gridRows <= 0 || payloadStr.isEmpty) return -1;
+    final needle =
+        payloadStr.length > 16 ? payloadStr.substring(0, 16) : payloadStr;
+    for (var r = 0; r < gridRows; r++) {
+      final text = controller.visibleRowsText(r, r);
+      if (text.contains(needle)) return r;
+    }
+    return -1;
+  }
+
   /// #720: force flterm to repaint on resume even when focus was RETAINED.
   ///
   /// Gated by [ghosttyShouldCycleFocusForRepaint]: only the ACTIVE, connected
@@ -4289,6 +4384,8 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     _pathVerifier = null;
     _controller?.removeListener(_onControllerChanged);
     _controller?.onOutput = null;
+    // #1072: drop the auto-reply tee with the session.
+    _controller?.onTerminalReply = null;
     _controller?.onResize = null;
     _controller?.dispose();
     _scrollController.dispose();
@@ -4298,6 +4395,8 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // Paint replay harness: drop the paint-stack counters with the session.
     _paintStats.boxProbe = null;
     unregisterPaintStats(widget.sessionId);
+    // #1072: drop the detection-geometry probe with the session.
+    unregisterDetectionGeom(widget.sessionId);
     super.dispose();
   }
 

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -29,6 +29,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
 
 import '../diagnostics/connect_trace.dart';
+import '../diagnostics/detection_geom.dart';
 import '../diagnostics/paint_stats.dart';
 import '../diagnostics/session_byte_recorder.dart';
 import '../ssh/ssh_session.dart';
@@ -149,6 +150,9 @@ class TerminalScreen extends ConsumerWidget {
     // Paint replay harness: same single place for the paint-stack counters, so
     // the bug report snapshots the ON-SCREEN session's boundary counters.
     setActivePaintStats(activeEntry.id);
+    // #1072: same single place for the detection-geometry probe, so the bug
+    // report snapshots the ON-SCREEN session's wash geometry.
+    setActiveDetectionGeom(activeEntry.id);
 
     // #573: keybar visibility is PER-SESSION — read the ACTIVE session's flag.
     // Switching sessions re-watches the new active id, so each session shows

--- a/native/test/diagnostics/session_byte_recorder_test.dart
+++ b/native/test/diagnostics/session_byte_recorder_test.dart
@@ -319,4 +319,59 @@ void main() {
       expect(activeGridSnapshot(), isNull);
     });
   });
+
+  // #1072: terminal AUTO-REPLY ring — the DA/DSR/CPR/OSC responses the terminal
+  // itself generates (teed from flterm's onWritePty). Same eviction/scrub
+  // discipline as the byte ring, plus a coarse `kind` tag per event.
+  group('term-reply ring', () {
+    test('records {tMs, b64, kind} that round-trips the exact bytes', () {
+      final rec = SessionByteRecorder();
+      rec.recordTermReply(Uint8List.fromList(utf8.encode('\x1b[?62c')));
+      final snap = rec.snapshotTermReplyTrace();
+      expect(snap, hasLength(1));
+      final ev = snap.single;
+      expect(ev['tMs'], isA<int>());
+      expect(utf8.decode(base64Decode(ev['b64'] as String)), '\x1b[?62c');
+    });
+
+    test('classifies replies by leading bytes', () {
+      Uint8List b(String s) => Uint8List.fromList(utf8.encode(s));
+      expect(termReplyKind(b('\x1b[?62c')), 'DA1');
+      expect(termReplyKind(b('\x1b[>1;95;0c')), 'DA2');
+      expect(termReplyKind(b('\x1b[8;24;80R')), 'CPR');
+      expect(termReplyKind(b('\x1b[0n')), 'DSR');
+      expect(termReplyKind(b('\x1b]11;rgb:0000/0000/0000\x1b\\')), 'OSC');
+      expect(termReplyKind(b('plain')), 'other');
+    });
+
+    test('evicts oldest past the event cap', () {
+      final rec = SessionByteRecorder(maxTermReplyEvents: 3);
+      for (var i = 0; i < 6; i++) {
+        rec.recordTermReply(Uint8List.fromList([0x1b, 0x5b, 0x30 + i, 0x6e]));
+      }
+      final snap = rec.snapshotTermReplyTrace();
+      expect(snap, hasLength(3), reason: 'only the newest 3 survive the cap');
+    });
+
+    test('scrubs credential-looking bytes at snapshot', () {
+      final rec = SessionByteRecorder();
+      rec.recordTermReply(
+        Uint8List.fromList(utf8.encode('\x1b]0;token=SECRET123\x1b\\')),
+      );
+      final decoded =
+          utf8.decode(base64Decode(rec.snapshotTermReplyTrace().single['b64'] as String));
+      expect(decoded, isNot(contains('SECRET123')));
+      expect(decoded, contains('[REDACTED]'));
+    });
+
+    test('active registry routes the term-reply snapshot to the active session',
+        () {
+      final a = registerByteRecorder('s-a');
+      a.recordTermReply(Uint8List.fromList(utf8.encode('\x1b[?62c')));
+      setActiveByteRecorder('s-a');
+      expect(activeTermReplyTraceSnapshot(), hasLength(1));
+      setActiveByteRecorder(null);
+      expect(activeTermReplyTraceSnapshot(), isEmpty);
+    });
+  });
 }

--- a/native/test/ui/feedback_payload_test.dart
+++ b/native/test/ui/feedback_payload_test.dart
@@ -256,7 +256,9 @@ void main() {
           byteTrace: const [{'tMs': 1, 'b64': 'zz'}],
           scrollTrace: const [{'tMs': 1, 'offset': 3}],
           sentSgrTrace: const [{'tMs': 1, 'b64': 'yy'}],
+          termReplyTrace: const [{'tMs': 1, 'b64': 'xx', 'kind': 'DA1'}],
           grid: const {'cols': 80, 'rows': 24},
+          detectionGeom: const {'paintTick': 7, 'anchorCount': 0, 'anchors': []},
           includeImages: images,
           includeTraces: traces,
         );
@@ -266,9 +268,12 @@ void main() {
       for (final k in const [
         'screenshot', 'frames', 'connectLog', 'gestureLog', 'lifecycleLog',
         'byteTrace', 'scrollTrace', 'sentSgrTrace', 'grid',
+        'termReplyTrace', 'termReplyTraceEventCount', 'detectionGeom',
       ]) {
         expect(p.containsKey(k), isTrue, reason: '$k present by default');
       }
+      // #1072: the count mirrors the trace length.
+      expect(p['termReplyTraceEventCount'], 1);
     });
 
     test('excludeImages OMITS screenshot + frames, keeps traces + comment', () {
@@ -286,6 +291,7 @@ void main() {
       for (final k in const [
         'connectLog', 'gestureLog', 'lifecycleLog',
         'byteTrace', 'scrollTrace', 'sentSgrTrace', 'grid',
+        'termReplyTrace', 'termReplyTraceEventCount', 'detectionGeom',
       ]) {
         expect(p.containsKey(k), isFalse, reason: '$k must be omitted');
       }

--- a/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/native/third_party/flterm/lib/src/rendering/terminal_renderer.dart
@@ -367,6 +367,12 @@ class TerminalRenderBox extends RenderBox {
   @visibleForTesting
   List<int> get debugWashViewRows => _paintState.debugWashViewRows;
 
+  /// #1072 (telemetry): the VIEWPORT rows the [HighlightPainter] drew the
+  /// detection wash on in the LAST paint — the SAME data as [debugWashViewRows]
+  /// but readable from production diagnostics (the bug-report bundle) without
+  /// the test-only restriction. Read-only; the painter resets it every paint.
+  List<int> get washViewRows => _paintState.debugWashViewRows;
+
   /// #918 (test seam): inject the settle-timer factory so headless tests fire the
   /// output tick deterministically and assert the idle-no-fire perf guard.
   void debugSetOutputSettleTickFactory(

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller.dart
@@ -34,6 +34,18 @@ abstract class TerminalController extends ChangeNotifier
   /// [sendText], and [paste].
   ValueChanged<Uint8List>? onOutput;
 
+  /// #1072 (telemetry, additive): called with the bytes of a terminal
+  /// AUTO-REPLY — a response the terminal itself generates and writes back to
+  /// the backend (DA1/DA2 device attributes, DSR/CPR cursor reports, XTVERSION,
+  /// OSC query answers). These flow through libghostty's `onWritePty`, the SAME
+  /// channel [onOutput] emits on, but are NOT user keystrokes (keystrokes emit
+  /// via [sendKey]/[sendText]/[paste] directly, bypassing `onWritePty`). This is
+  /// a pure TEE: it fires with the exact bytes just before [onOutput] forwards
+  /// them, so a diagnostics ring can capture auto-replies (e.g. the #1072
+  /// DA-leak) without changing what reaches the backend. Never set in
+  /// production paths that only care about forwarding; leave null there.
+  ValueChanged<Uint8List>? onTerminalReply;
+
   /// Called when the terminal receives a BEL character (0x07).
   VoidCallback? onBell;
 

--- a/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/native/third_party/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -2018,7 +2018,17 @@ class TerminalControllerImpl extends TerminalController
   }
 
   void _wireTerminalCallbacks() {
-    terminal.onWritePty = _emitOutput;
+    // #1072 (telemetry, additive): `onWritePty` is EXCLUSIVELY terminal
+    // auto-replies (DA/DSR/CPR/XTVERSION/OSC answers) — user keystrokes emit via
+    // [sendKey]/[sendText]/[paste] straight through [_emitOutput], never here.
+    // TEE those replies to [onTerminalReply] (diagnostics ring) THEN forward via
+    // [_emitOutput] EXACTLY as before. Pure observer: the forwarded bytes are
+    // unchanged, so backend behavior is identical whether or not a reply
+    // listener is attached.
+    terminal.onWritePty = (bytes) {
+      onTerminalReply?.call(bytes);
+      _emitOutput(bytes);
+    };
     terminal.onBell = () => onBell?.call();
     terminal.onTitleChanged = () => onTitleChanged?.call();
     terminal.onColorScheme = () => _brightness == .light ? .light : .dark;

--- a/native/third_party/flterm/test/widgets/terminal_reply_tee_1072_test.dart
+++ b/native/third_party/flterm/test/widgets/terminal_reply_tee_1072_test.dart
@@ -1,0 +1,75 @@
+@Tags(['ffi'])
+library;
+
+import 'dart:convert';
+
+import 'package:flterm/src/widgets/terminal_controller_impl.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// #1072 (telemetry): the terminal auto-reply TEE.
+///
+/// The controller wraps libghostty's `onWritePty` — the channel the terminal
+/// writes its OWN generated replies back on (DA1/DA2 device attributes, DSR/CPR
+/// cursor reports, XTVERSION, OSC answers) — as a PURE TEE: it fires
+/// [onTerminalReply] with the reply bytes THEN forwards them via [onOutput]
+/// exactly as before. These tests prove both halves: the tee observes the reply
+/// AND the reply still reaches onOutput unchanged (backend behavior preserved).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('onTerminalReply tee (#1072)', () {
+    late TerminalControllerImpl controller;
+
+    setUp(() => controller = TerminalControllerImpl());
+    tearDown(() => controller.dispose());
+
+    void writeUtf8(String text) =>
+        controller.write(Uint8List.fromList(utf8.encode(text)));
+
+    test('DA1 request tees the reply to onTerminalReply AND onOutput', () {
+      final replies = <Uint8List>[];
+      final output = <Uint8List>[];
+      controller.onTerminalReply = replies.add;
+      controller.onOutput = output.add;
+
+      // CSI c = Primary Device Attributes request. libghostty answers via
+      // onWritePty with the default DA1 reply (CSI ? 62 c).
+      writeUtf8('\x1b[c');
+
+      // The tee fired with the DA reply bytes.
+      expect(replies, isNotEmpty, reason: 'onTerminalReply never fired');
+      final replyText = replies.map(utf8.decode).join();
+      expect(replyText, contains('\x1b[?62c'),
+          reason: 'expected the default DA1 reply CSI ? 62 c');
+
+      // And the SAME bytes still forwarded to onOutput (pure tee — backend
+      // behavior unchanged).
+      expect(output, isNotEmpty, reason: 'reply was not forwarded to onOutput');
+      expect(output.map(utf8.decode).join(), contains('\x1b[?62c'));
+    });
+
+    test('plain text output does NOT fire onTerminalReply', () {
+      final replies = <Uint8List>[];
+      controller.onTerminalReply = replies.add;
+
+      // Ordinary printable output is not a terminal auto-reply — it produces no
+      // onWritePty write, so the tee stays silent.
+      writeUtf8('hello world');
+
+      expect(replies, isEmpty);
+    });
+
+    test('reply still forwards when no onTerminalReply listener is attached',
+        () {
+      final output = <Uint8List>[];
+      controller.onOutput = output.add;
+      // onTerminalReply intentionally left null.
+
+      writeUtf8('\x1b[c');
+
+      expect(output.map(utf8.decode).join(), contains('\x1b[?62c'),
+          reason: 'the null tee must not swallow the forwarded reply');
+    });
+  });
+}


### PR DESCRIPTION
## Additive telemetry for #1072 (DA-leak + frozen-bubble)

Two read-only diagnostics probes added to the in-app bug-report bundle so two
device P0s become one-shot diagnosable. **Telemetry ONLY** — no runtime
behavior change, and this does **not** fix either underlying bug. References
#1072; does not close it.

### Probe 1 — terminal auto-reply capture (DA-leak)
- **flterm**: new `onTerminalReply` controller callback. `terminal.onWritePty`
  is now a **pure tee** — it calls `onTerminalReply?.call(bytes)` then forwards
  via `_emitOutput(bytes)` exactly as before. `onWritePty` carries *only*
  terminal auto-replies (DA1/DA2/DSR/CPR/XTVERSION/OSC), never keystrokes, so no
  typed content can enter the ring.
- **session_byte_recorder**: parallel `termReply` ring recording
  `{tMs, b64, kind}` (coarse `kind` by leading bytes: DA1/DA2/DSR/CPR/OSC/other),
  same scrub + eviction discipline as the existing rings.
- **Widened OUTPUT byteTrace retention** for a resume-spanning window:
  byte cap **256 KB → 1 MB**, event cap **4096 → 16384**, age **30 s → 60 s**.
- **Bundle**: `termReplyTrace` (server persists as `*.term-reply-trace.json`)
  plus `termReplyTraceEventCount`.

### Probe 2 — wash geometry snapshot (frozen-bubble)
- New `detection_geom` registry (mirrors `paint_stats`): a per-session probe
  reads the controller + render box and returns a `detectionGeom` object:
  `activeScreen`, `screenViewportTop`, `scrollbarOffset`,
  `paintedViewportOffset`, `gridRows`, `drawnWashViewRows`, `paintTick`
  (reuses the render box's monotonic paint count so a second capture reveals
  whether the wash layer repaints at all), and per-anchor (cap 12):
  `payloadPrefix` (24 chars, scrubbed), `patternId`, `absTopRow`, `gutterRow`,
  `washDrawnViewRow` (`absTopRow - paintedViewportOffset`), `payloadActualViewRow`.
- Added a non-test `washViewRows` getter on `TerminalRenderBox` (the existing
  `debugWashViewRows` is `@visibleForTesting`, unusable from production code).

### Tests
- **Fork tee test** (`terminal_reply_tee_1072_test.dart`): a `\x1b[c` (DA1)
  request fires `onTerminalReply` with the DA reply (`\x1b[?62c`) **and** still
  forwards to `onOutput` — tee proven; plain output does not fire it; a null tee
  does not swallow the forward.
- Term-reply ring unit tests: round-trip, classify, evict, scrub, active
  registry routing.
- Feedback payload: emits `termReplyTrace` + `termReplyTraceEventCount` +
  `detectionGeom`, gated by the #967 include/exclude toggle.

### Gate
- `scripts/native-fork-test.sh`: **882 passed**.
- `scripts/native-fast-gate.sh`: analyze clean, **2090 passed** (5 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa