### PR TITLE
feat(viewer): Copy all button in text/markdown file preview (#460)

### DIFF
--- a/native/lib/ui/markdown_file_viewer.dart
+++ b/native/lib/ui/markdown_file_viewer.dart
@@ -28,6 +28,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:url_launcher/url_launcher.dart';
 
+import '../services/clipboard.dart';
 import '../services/session_messages.dart';
 import '../services/text_file_fetcher.dart';
 import '../services/viewer_file_actions.dart';
@@ -35,6 +36,7 @@ import 'file_browser_screen.dart';
 import 'file_viewer_actions.dart';
 import 'mermaid_diagram_view.dart';
 import 'sftp_markdown_image.dart';
+import 'top_toast.dart';
 
 /// Opens a markdown link [href] in the system browser (externalApplication).
 /// Mirrors the terminal URL handler idiom. Injected as a typedef so widget
@@ -123,12 +125,30 @@ class _MarkdownFileViewerScreenState
     setState(() => _raw = !_raw);
   }
 
+  /// #460: copy the WHOLE raw markdown source to the clipboard in one tap
+  /// (independent of rendered/raw view mode). Routes through the hardened
+  /// labeled-clip helper (#845) and toasts on success.
+  Future<void> _copyAll() async {
+    final text = _content;
+    if (text == null || text.isEmpty) return;
+    final ok = await copyToClipboard(text);
+    if (ok && mounted) showTopToast(context, 'Copied');
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.entry.name, overflow: TextOverflow.ellipsis),
         actions: [
+          // #460: one-tap "Copy all" of the whole raw source (only once loaded).
+          if (_phase == _Phase.ready)
+            IconButton(
+              key: const Key('markdown-viewer-copy-all'),
+              tooltip: 'Copy all',
+              icon: const Icon(Icons.copy_all),
+              onPressed: () => unawaited(_copyAll()),
+            ),
           // #1038: Download + Share from any open preview.
           FileViewerActions(
             source: RemoteFileSource(

--- a/native/lib/ui/text_file_viewer.dart
+++ b/native/lib/ui/text_file_viewer.dart
@@ -15,11 +15,13 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../services/clipboard.dart';
 import '../services/session_messages.dart';
 import '../services/text_file_fetcher.dart';
 import '../services/viewer_file_actions.dart';
 import 'file_browser_screen.dart';
 import 'file_viewer_actions.dart';
+import 'top_toast.dart';
 
 /// Full-screen read-only preview route for a single remote text [entry] on
 /// [sessionId].
@@ -84,12 +86,29 @@ class _TextFileViewerScreenState extends ConsumerState<TextFileViewerScreen> {
     }
   }
 
+  /// #460: copy the WHOLE file to the clipboard in one tap. Routes through the
+  /// hardened labeled-clip helper (#845) and toasts on success.
+  Future<void> _copyAll() async {
+    final text = _content;
+    if (text == null || text.isEmpty) return;
+    final ok = await copyToClipboard(text);
+    if (ok && mounted) showTopToast(context, 'Copied');
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.entry.name, overflow: TextOverflow.ellipsis),
         actions: [
+          // #460: one-tap "Copy all" of the whole file (only once loaded).
+          if (_phase == _Phase.ready)
+            IconButton(
+              key: const Key('text-viewer-copy-all'),
+              tooltip: 'Copy all',
+              icon: const Icon(Icons.copy_all),
+              onPressed: () => unawaited(_copyAll()),
+            ),
           // #1038: Download + Share from any open preview.
           FileViewerActions(
             source: RemoteFileSource(

--- a/native/test/widget/viewer_copy_all_460_test.dart
+++ b/native/test/widget/viewer_copy_all_460_test.dart
@@ -1,0 +1,235 @@
+// Verify-first widget tests for the "Copy all" affordance in the text/code and
+// markdown file viewers (#460).
+//
+// Assert:
+//   - the text viewer's AppBar exposes a Copy-all action (keyed
+//     `text-viewer-copy-all`, aria/tooltip "Copy all") and tapping it writes the
+//     FULL file content to the clipboard,
+//   - the markdown viewer exposes the same action (keyed `markdown-viewer-copy-all`)
+//     and copies the full RAW source (regardless of rendered/raw view mode).
+//
+// Clipboard copy routes through the hardened `mobissh/clipboard` native channel
+// (#845); mock it (and the platform read-back) exactly like
+// file_browser_context_menu_test.dart — without the mock the custom channel call
+// has no responder and HANGS the test.
+
+import 'dart:async';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/services/text_file_fetcher.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+class _ScriptedSftpSession implements SftpSession {
+  _ScriptedSftpSession(this._byPath);
+  final Map<String, List<SftpEntry>> _byPath;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async => _byPath[path] ?? const [];
+  @override
+  Future<int?> sizeOf(String path) async => 0;
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async => 0;
+  @override
+  Future<int> upload(String path, Uint8List bytes) async => bytes.length;
+  @override
+  Future<int> uploadFile(
+    String localPath,
+    String remotePath, {
+    required void Function(int sent, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+/// Injectable text fetcher: returns canned content without touching SFTP.
+class _CannedTextFetcher implements TextFileFetcher {
+  _CannedTextFetcher(this.text);
+  final String text;
+
+  @override
+  Future<String> fetch(
+    String sessionId,
+    SftpEntry entry, {
+    int maxBytes = 2 * 1024 * 1024,
+    void Function(int received, int? total)? onProgress,
+  }) async => text;
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+({ProviderContainer container, SessionEntry session, SessionHost host}) _wire(
+  WidgetTester tester, {
+  required Map<String, List<SftpEntry>> byPath,
+  required String content,
+}) {
+  final pair = InMemoryGatewayPair();
+  addTearDown(pair.dispose);
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: _stubControllerFactory,
+    sftpOpener: (_) async => _ScriptedSftpSession(byPath),
+    snapshotInterval: const Duration(hours: 1),
+  );
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      textFileFetcherProvider.overrideWithValue(_CannedTextFetcher(content)),
+    ],
+  );
+  addTearDown(container.dispose);
+  const params = SshConnectParams(
+    host: 'h',
+    port: 22,
+    username: 'u',
+    auth: SshAuth.password('p'),
+  );
+  final session = container.read(sessionsProvider.notifier).addOrActivate(
+    params,
+  );
+  session.proxy.connect(params);
+  return (container: container, session: session, host: host);
+}
+
+Future<SessionHost> _open(
+  WidgetTester tester, {
+  required String name,
+  required String content,
+}) async {
+  final w = _wire(
+    tester,
+    byPath: {
+      '/': [
+        SftpEntry(name: name, path: '/$name', isDirectory: false, size: 20),
+      ],
+    },
+    content: content,
+  );
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: w.container,
+      child: MaterialApp(home: FileBrowserScreen(sessionId: w.session.id)),
+    ),
+  );
+  await _pump(tester);
+  await tester.tap(find.byKey(Key('file-entry-$name')));
+  await _pump(tester);
+  return w.host;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  String? lastClipboard;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    lastClipboard = null;
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('mobissh/clipboard'),
+      (call) async {
+        if (call.method == 'setText') {
+          lastClipboard = (call.arguments as Map)['text'] as String?;
+          return true;
+        }
+        return null;
+      },
+    );
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        lastClipboard = (call.arguments as Map)['text'] as String?;
+      }
+      if (call.method == 'Clipboard.getData') {
+        return <String, dynamic>{'text': lastClipboard};
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('mobissh/clipboard'),
+      null,
+    );
+    messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  testWidgets('text viewer exposes a Copy-all action that copies the full file', (
+    tester,
+  ) async {
+    const content = 'line one\nline two\nline three\n';
+    final host = await _open(tester, name: 'notes.txt', content: content);
+
+    final btn = find.byKey(const Key('text-viewer-copy-all'));
+    expect(btn, findsOneWidget);
+    // Discoverable affordance labelled "Copy all".
+    expect(
+      tester.widget<IconButton>(btn).tooltip,
+      'Copy all',
+    );
+
+    await tester.tap(btn);
+    await _pump(tester);
+
+    expect(lastClipboard, content);
+    host.disposeSyncForTest();
+  });
+
+  testWidgets(
+    'markdown viewer exposes a Copy-all action that copies the full raw source',
+    (tester) async {
+      const content = '# Title\n\nSome **bold** body.\n\n- a\n- b\n';
+      final host = await _open(tester, name: 'README.md', content: content);
+
+      final btn = find.byKey(const Key('markdown-viewer-copy-all'));
+      expect(btn, findsOneWidget);
+      expect(
+        tester.widget<IconButton>(btn).tooltip,
+        'Copy all',
+      );
+
+      await tester.tap(btn);
+      await _pump(tester);
+
+      // The FULL raw markdown source, not the rendered/flattened text.
+      expect(lastClipboard, content);
+      host.disposeSyncForTest();
+    },
+  );
+}


### PR DESCRIPTION
## What

Adds a top-right **Copy all** action to the in-app text/code viewer and the markdown viewer (#460). One tap copies the **full** file content to the clipboard and toasts "Copied".

## Native, not PWA

Issue #460 was worded against the PWA (`src/modules/sftp-preview.ts`). This implements the same affordance in the Flutter native app, which is the PWA UX duplicate. Targets:

- `native/lib/ui/text_file_viewer.dart`
- `native/lib/ui/markdown_file_viewer.dart`

## Details

- Reuses the hardened labeled-clip helper `copyToClipboard` (#845) + top toast — no new copy path.
- Markdown copies the **raw source** regardless of rendered/raw view mode.
- The button only appears once content has loaded (`_Phase.ready`), so there is never an empty copy before the fetch completes.
- Monochrome Material glyph (`Icons.copy_all`), standard 48dp IconButton, theme-aware — no inline styles, no emoji.

## Verify-first (TDD)

`native/test/widget/viewer_copy_all_460_test.dart` was written FIRST and confirmed RED (action absent), then GREEN after implementation:

- action present in each viewer's AppBar, tooltip "Copy all"
- tapping writes the exact full content to the clipboard (native `mobissh/clipboard` channel mocked)

## Gate

`scripts/native-fast-gate.sh` PASSED — analyze clean, 2143 tests pass.

Device validation of the on-device clipboard surface is owner-only (headless mocks the native channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa