### PR TITLE
fix(#493): collapse redundant path prefixes in favorites submenu

### DIFF
--- a/native/lib/ui/favorites_menu_sheet.dart
+++ b/native/lib/ui/favorites_menu_sheet.dart
@@ -18,6 +18,7 @@
 import 'package:flutter/material.dart';
 
 import '../storage/favorites_store.dart';
+import '../util/favorites_prefix.dart';
 
 /// Opens the favorites sheet for [profileKey]. Tapping a favorite pops the sheet
 /// then calls [onNavigate] with its path; long-press removes it; "Clear all"
@@ -36,6 +37,18 @@ Future<void> showFavoritesMenu(
     builder: (sheetContext) {
       return StatefulBuilder(
         builder: (ctx, setSheetState) {
+          // Collapse the shared path prefix of UNLABELED favorites (#493) so
+          // the divergent leaf is scannable. Labeled favorites keep their
+          // label (they fall through to f.display below).
+          final unlabeledPaths = [
+            for (final f in favs)
+              if (f.label == null || f.label!.isEmpty) f.path,
+          ];
+          final collapsed = collapsePrefix(unlabeledPaths);
+          final collapsedByPath = {
+            for (var i = 0; i < unlabeledPaths.length; i++)
+              unlabeledPaths[i]: collapsed[i],
+          };
           return SafeArea(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -74,7 +87,7 @@ Future<void> showFavoritesMenu(
                             key: Key('favorite-item-${f.path}'),
                             leading: const Icon(Icons.folder_outlined),
                             title: Text(
-                              f.display,
+                              collapsedByPath[f.path] ?? f.display,
                               overflow: TextOverflow.ellipsis,
                             ),
                             subtitle: (f.label != null && f.label!.isNotEmpty)

--- a/native/lib/util/favorites_prefix.dart
+++ b/native/lib/util/favorites_prefix.dart
@@ -1,0 +1,50 @@
+// #493 — favorites submenu shows full redundant path prefixes. When several
+// unlabeled bookmarks share a common parent (e.g. all under
+// `/home/dev/workspace/`), the divergent leaf — the part the user reads — gets
+// buried at the right edge. This pure display layer collapses the shared prefix
+// to `…/` so only the distinguishing suffix renders.
+//
+// Comparison is SEGMENT-WISE (split on `/`) so `/home/dev` is never treated as
+// a prefix of `/home/develop`. The collapse stops one segment short of the
+// shortest path so a single common-parent set still shows distinguishable
+// leaves.
+
+import 'dart:math';
+
+/// Segment-wise common leading segments across [paths] (each path split on
+/// `/`, empty segments — including the leading one for absolute paths — kept so
+/// comparison never splits mid-segment). Returns an empty list for fewer than
+/// two paths (nothing to collapse against).
+List<String> commonPathPrefix(List<String> paths) {
+  if (paths.length < 2) return const <String>[];
+  final segLists = paths.map((p) => p.split('/')).toList();
+  final minLen = segLists.map((s) => s.length).reduce(min);
+  final common = <String>[];
+  for (var i = 0; i < minLen; i++) {
+    final seg = segLists.first[i];
+    if (segLists.every((s) => s[i] == seg)) {
+      common.add(seg);
+    } else {
+      break;
+    }
+  }
+  return common;
+}
+
+/// Display strings for [paths], aligned by index, with the shared leading
+/// directory prefix replaced by `…/`. The cut stops one segment short of the
+/// shortest path. Paths are returned unchanged when there are fewer than two,
+/// or when the shared prefix hides no real (non-empty) segment — e.g. two
+/// unrelated absolute paths share only the empty root segment.
+List<String> collapsePrefix(List<String> paths) {
+  if (paths.length < 2) return List<String>.of(paths);
+  final segLists = paths.map((p) => p.split('/')).toList();
+  final shortest = segLists.map((s) => s.length).reduce(min);
+  var cut = commonPathPrefix(paths).length;
+  if (cut >= shortest) cut = shortest - 1; // stop one short of the shortest
+  // Only collapse when the hidden prefix contains at least one real segment —
+  // otherwise we'd replace nothing meaningful (or just the root) with `…`.
+  final hidesRealSegment = segLists.first.take(cut).any((s) => s.isNotEmpty);
+  if (!hidesRealSegment) return List<String>.of(paths);
+  return [for (final segs in segLists) '…/${segs.sublist(cut).join('/')}'];
+}

--- a/native/test/util/favorites_prefix_test.dart
+++ b/native/test/util/favorites_prefix_test.dart
@@ -1,0 +1,86 @@
+// #493 — favorites submenu shows full redundant path prefixes. Pure display
+// logic: when 2+ unlabeled favorites share a path-segment-wise common prefix,
+// collapse the prefix to `…/` so only the distinguishing suffix renders.
+//
+// commonPathPrefix: segment-wise common leading segments across paths.
+// collapsePrefix: aligned display strings with the shared prefix replaced by
+// `…/`, stopping one segment short of the shortest path.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/util/favorites_prefix.dart';
+
+void main() {
+  group('#493 commonPathPrefix', () {
+    test('shared leaf set — returns the common leading segments', () {
+      expect(
+        commonPathPrefix([
+          '/home/dev/workspace/mobissh',
+          '/home/dev/workspace/cuda',
+          '/home/dev/workspace/devloop',
+        ]),
+        ['', 'home', 'dev', 'workspace'],
+      );
+    });
+
+    test('single item — no common prefix (nothing to collapse against)', () {
+      expect(commonPathPrefix(['/home/dev/workspace/mobissh']), isEmpty);
+    });
+
+    test('no shared prefix beyond root', () {
+      expect(commonPathPrefix(['/var/log', '/etc/hosts']), ['']);
+    });
+
+    test('mid-segment safety — /home/dev is not a prefix of /home/develop', () {
+      expect(
+        commonPathPrefix(['/home/dev/x', '/home/develop/y']),
+        ['', 'home'],
+      );
+    });
+  });
+
+  group('#493 collapsePrefix', () {
+    test('shared leaf set collapses to the divergent leaf', () {
+      expect(
+        collapsePrefix([
+          '/home/dev/workspace/mobissh',
+          '/home/dev/workspace/cuda',
+          '/home/dev/workspace/devloop',
+        ]),
+        ['…/mobissh', '…/cuda', '…/devloop'],
+      );
+    });
+
+    test('stops one segment short of the shortest path', () {
+      // Common prefix equals the shortest path (/home/dev/workspace). Collapse
+      // must stop one short so the common-parent leaf still shows.
+      expect(
+        collapsePrefix([
+          '/home/dev/workspace',
+          '/home/dev/workspace/mobissh',
+        ]),
+        ['…/workspace', '…/workspace/mobissh'],
+      );
+    });
+
+    test('single item — unchanged', () {
+      expect(
+        collapsePrefix(['/home/dev/workspace/mobissh']),
+        ['/home/dev/workspace/mobissh'],
+      );
+    });
+
+    test('no shared prefix beyond root — unchanged', () {
+      expect(
+        collapsePrefix(['/var/log', '/etc/hosts']),
+        ['/var/log', '/etc/hosts'],
+      );
+    });
+
+    test('mid-segment safety — dev and develop are not merged', () {
+      expect(
+        collapsePrefix(['/home/dev/x', '/home/develop/y']),
+        ['…/dev/x', '…/develop/y'],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## #493 — collapse redundant path prefixes in favorites submenu

Unlabeled bookmarks that share a common parent (e.g. all under `/home/dev/workspace/`) rendered their **full path**, burying the divergent leaf — the part the user reads — at the right edge.

### Change
New pure display layer `native/lib/util/favorites_prefix.dart`:
- `commonPathPrefix(paths)` — segment-wise common leading segments (split on `/`, so `/home/dev` is never a prefix of `/home/develop` — no mid-segment split).
- `collapsePrefix(paths)` — aligned display strings with the shared prefix replaced by `…/`, stopping one segment short of the shortest path so a single common-parent set still shows distinguishable leaves. No-op for single / no-shared-prefix sets.

Wired into `favorites_menu_sheet.dart`: only **unlabeled** favorites participate; labeled favorites keep their `label` unchanged.

Example:
```
/home/dev/workspace/mobissh   ->  …/mobissh
/home/dev/workspace/cuda      ->  …/cuda
/home/dev/workspace/devloop   ->  …/devloop
```

### Acceptance coverage
`native/test/util/favorites_prefix_test.dart` (9 tests) — single-item, no-shared, shared-leaf, stops-one-short, mid-segment-safety for both functions. Written red-first (functions absent → compile fail), now green.

### Gate
`scripts/native-fast-gate.sh` — analyze clean, 2150 tests pass. Pure display logic; touches no state machine / connect / SFTP, so integration suite not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa