### PR TITLE
feat(sftp): streaming download plumbing — Slice A of #976

### DIFF
--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -383,6 +383,8 @@ class SessionHost {
         _handleSftpList(cmd);
       case SftpDownloadCommand():
         _handleSftpDownload(cmd);
+      case SftpDownloadFileCommand():
+        _handleSftpDownloadFile(cmd);
       case SftpUploadCommand():
         _handleSftpUpload(cmd);
       case SftpUploadFileCommand():
@@ -1727,6 +1729,49 @@ class SessionHost {
       );
     } catch (e) {
       ctrace('task.host', 'sftp download FAILED path=${cmd.path} — $e');
+      _emitSftpError(cmd.sessionId, cmd.requestId, 'Download failed: $e');
+    }
+  }
+
+  /// #976: STREAMING download — the mirror of [_handleSftpUploadFile]. The task
+  /// streams the remote file straight to the local staging path and emits ONLY
+  /// lightweight [SftpDownloadProgressEvent]s (received/total) + a terminal
+  /// [SftpDownloadDoneEvent]. The file bytes never cross the gateway (contrast
+  /// [_handleSftpDownload], which base64s every chunk across) — the fix for the
+  /// large-file force-quit. Leaves the chunk path untouched (Slice C retires it).
+  Future<void> _handleSftpDownloadFile(SftpDownloadFileCommand cmd) async {
+    try {
+      final sftp = await _ensureSftp(cmd.sessionId);
+      if (sftp == null) {
+        _emitSftpError(cmd.sessionId, cmd.requestId, 'Session not connected');
+        return;
+      }
+      final written = await sftp.downloadFile(
+        cmd.remotePath,
+        cmd.localPath,
+        onProgress: (done, total) {
+          if (_disposed) return;
+          _gateway.send(
+            SftpDownloadProgressEvent(
+              sessionId: cmd.sessionId,
+              requestId: cmd.requestId,
+              done: done,
+              totalBytes: total,
+            ).toJson(),
+          );
+        },
+      );
+      if (_disposed) return;
+      _gateway.send(
+        SftpDownloadDoneEvent(
+          sessionId: cmd.sessionId,
+          requestId: cmd.requestId,
+          totalBytes: written,
+        ).toJson(),
+      );
+    } catch (e) {
+      ctrace('task.host',
+          'sftp downloadFile FAILED remote=${cmd.remotePath} — $e');
       _emitSftpError(cmd.sessionId, cmd.requestId, 'Download failed: $e');
     }
   }

--- a/native/lib/services/session_messages.dart
+++ b/native/lib/services/session_messages.dart
@@ -62,6 +62,14 @@ enum SshTaskCommandKind {
   /// Download a single remote file; the task streams chunks back.
   sftpDownload,
 
+  /// STREAMING download of a remote file to a LOCAL staging path (#976). The
+  /// mirror of [sftpUploadFile]: the task reads the remote file itself and
+  /// writes it straight to the local staging file, emitting only
+  /// [SftpDownloadProgressEvent]s + a terminal [SftpDownloadDoneEvent]. Unlike
+  /// [sftpDownload] (every chunk's bytes cross the IPC as base64), the file
+  /// never crosses the isolate — the fix for the large-file force-quit.
+  sftpDownloadFile,
+
   /// Upload (whole-file write) a single remote file (#892). The bytes are
   /// carried inline; the task opens the resolved path write|create|truncate and
   /// writes them, then replies with a terminal [SftpUploadDoneEvent].
@@ -180,6 +188,12 @@ enum SshTaskEventKind {
   /// browser renders a determinate bar; resume reports its starting offset via
   /// the first event.
   sftpUploadProgress,
+
+  /// Progress for a streaming file download (#976): bytes received so far +
+  /// total. Mirrors [sftpUploadProgress] — the ONLY thing the streaming
+  /// download path sends across the isolate (the bytes stay task-side). The
+  /// terminal completion reuses [sftpDownloadDone].
+  sftpDownloadProgress,
 
   /// The reply to an [SshTaskCommandKind.sftpStat] probe (#990): whether the
   /// path exists on the connected host. Errors collapse to `exists=false`
@@ -346,6 +360,13 @@ sealed class SshTaskCommand {
           requestId: json['requestId'] as String,
           path: json['path'] as String,
         );
+      case SshTaskCommandKind.sftpDownloadFile:
+        return SftpDownloadFileCommand(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          remotePath: json['remotePath'] as String,
+          localPath: json['localPath'] as String,
+        );
       case SshTaskCommandKind.sftpUpload:
         return SftpUploadCommand(
           sessionId: sessionId,
@@ -457,6 +478,39 @@ class SftpDownloadCommand extends SshTaskCommand {
     'sessionId': sessionId,
     'requestId': requestId,
     'path': path,
+  };
+}
+
+/// UI → task: STREAMING download of the remote file at [remotePath] to the
+/// LOCAL staging file at [localPath] (#976). The task reads the remote file
+/// itself and writes it straight to disk (it shares the app process's
+/// filesystem), emitting [SftpDownloadProgressEvent]s and a terminal
+/// [SftpDownloadDoneEvent] (or [SftpErrorEvent]), all keyed by [requestId]. The
+/// whole file never crosses the isolate IPC — the mirror of [SftpUploadFileCommand]
+/// and the fix for the large-file force-quit (unlike [SftpDownloadCommand],
+/// which streams every chunk's bytes back to the UI).
+class SftpDownloadFileCommand extends SshTaskCommand {
+  const SftpDownloadFileCommand({
+    required String sessionId,
+    required this.requestId,
+    required this.remotePath,
+    required this.localPath,
+  }) : super(sessionId);
+
+  final String requestId;
+  final String remotePath;
+  final String localPath;
+
+  @override
+  SshTaskCommandKind get kind => SshTaskCommandKind.sftpDownloadFile;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'requestId': requestId,
+    'remotePath': remotePath,
+    'localPath': localPath,
   };
 }
 
@@ -1052,6 +1106,13 @@ sealed class SshTaskEvent {
           sent: json['sent'] as int,
           totalBytes: json['totalBytes'] as int,
         );
+      case SshTaskEventKind.sftpDownloadProgress:
+        return SftpDownloadProgressEvent(
+          sessionId: sessionId,
+          requestId: json['requestId'] as String,
+          done: json['done'] as int,
+          totalBytes: json['totalBytes'] as int,
+        );
       case SshTaskEventKind.sftpStatResult:
         return SftpStatResultEvent(
           sessionId: sessionId,
@@ -1557,6 +1618,37 @@ class SftpUploadProgressEvent extends SshTaskEvent {
     'sessionId': sessionId,
     'requestId': requestId,
     'sent': sent,
+    'totalBytes': totalBytes,
+  };
+}
+
+/// Task → UI: progress for a STREAMING file download (#976). [done] is the
+/// bytes received + written to the local staging file so far; [totalBytes] is
+/// the remote file size (0 when the server omitted it). Mirrors
+/// [SftpUploadProgressEvent] — the ONLY event the streaming download path emits
+/// while transferring (the bytes stay task-side); completion reuses
+/// [SftpDownloadDoneEvent].
+class SftpDownloadProgressEvent extends SshTaskEvent {
+  const SftpDownloadProgressEvent({
+    required String sessionId,
+    required this.requestId,
+    required this.done,
+    required this.totalBytes,
+  }) : super(sessionId);
+
+  final String requestId;
+  final int done;
+  final int totalBytes;
+
+  @override
+  SshTaskEventKind get kind => SshTaskEventKind.sftpDownloadProgress;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'kind': kind.name,
+    'sessionId': sessionId,
+    'requestId': requestId,
+    'done': done,
     'totalBytes': totalBytes,
   };
 }

--- a/native/lib/ssh/sftp_session.dart
+++ b/native/lib/ssh/sftp_session.dart
@@ -123,6 +123,21 @@ abstract class SftpSession {
     int chunkSize,
   });
 
+  /// STREAMING download of the remote file at [remotePath] to the LOCAL file at
+  /// [localPath] (#976). The mirror of [uploadFile]: the task reads the remote
+  /// file chunk-by-chunk and writes each straight to the local staging file
+  /// (never the whole file in memory), reporting only (done, total) via
+  /// [onProgress] — the bytes never cross the isolate IPC (unlike [download],
+  /// which hands every chunk back to the UI). [total] is resolved up front via
+  /// stat (0 when the server omits the size) so the UI can render a determinate
+  /// bar. Returns the total bytes written. Reuses `~`/relative resolution.
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize,
+  });
+
   /// Release the underlying SFTP channel.
   Future<void> close();
 }
@@ -292,6 +307,38 @@ class DartSshSftpSession implements SftpSession {
       await _client.rename(partPath, resolved);
     }
     return total;
+  }
+
+  @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    final resolved = await _resolve(remotePath);
+    // Resolve the size up front for a determinate bar; a null size (server
+    // omitted it) reports as 0 total — the UI falls back to an indeterminate
+    // spinner but progress still ticks by `done`.
+    final attr = await _client.stat(resolved);
+    final total = attr.size ?? 0;
+    final file = await _client.open(resolved);
+    // openWrite streams to disk incrementally — the whole file is never held in
+    // memory and never returned to the caller (bytes stay task-side).
+    final sink = File(localPath).openWrite();
+    var done = 0;
+    try {
+      onProgress(done, total);
+      await for (final chunk in file.read(chunkSize: chunkSize)) {
+        sink.add(chunk);
+        done += chunk.length;
+        onProgress(done, total);
+      }
+    } finally {
+      await file.close();
+      await sink.close();
+    }
+    return done;
   }
 
   @override

--- a/native/lib/ssh/ssh_session_proxy.dart
+++ b/native/lib/ssh/ssh_session_proxy.dart
@@ -364,6 +364,27 @@ class SshSessionProxy {
     );
   }
 
+  /// Request a STREAMING download over SFTP (#976) of the remote file at
+  /// [remotePath] to the LOCAL staging file at [localPath]. The task streams the
+  /// file straight to disk task-side; [SftpDownloadProgressEvent]s and the
+  /// terminal [SftpDownloadDoneEvent] (or [SftpErrorEvent]) arrive on
+  /// [sftpEvents] keyed by [requestId]. Large files never cross the IPC — the
+  /// mirror of [sftpUploadFile] and the fix for the large-file force-quit.
+  void sftpDownloadFile({
+    required String requestId,
+    required String remotePath,
+    required String localPath,
+  }) {
+    gateway.send(
+      SftpDownloadFileCommand(
+        sessionId: sessionId,
+        requestId: requestId,
+        remotePath: remotePath,
+        localPath: localPath,
+      ).toJson(),
+    );
+  }
+
   /// Request a WHOLE-FILE upload over SFTP (#892). [bytes] are written to the
   /// remote file at [path] (write|create|truncate). The terminal
   /// [SftpUploadDoneEvent] (or [SftpErrorEvent]) arrives on [sftpEvents] keyed
@@ -599,6 +620,7 @@ class SshSessionProxy {
       case SftpListingEvent():
       case SftpDownloadChunkEvent():
       case SftpDownloadDoneEvent():
+      case SftpDownloadProgressEvent():
       case SftpUploadDoneEvent():
       case SftpUploadProgressEvent():
       case SftpStatResultEvent():

--- a/native/test/services/sftp_host_test.dart
+++ b/native/test/services/sftp_host_test.dart
@@ -6,6 +6,7 @@
 // surface as SftpErrorEvent without tearing the session down.
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
@@ -52,6 +53,12 @@ class FakeSftpSession implements SftpSession {
   bool closed = false;
   String? lastListedPath;
   String? lastDownloadedPath;
+
+  /// Records the streaming file-download call (#976): the remote + local paths.
+  /// The fake writes [fileBytes] to the local staging path in TWO chunks — the
+  /// bytes are written to DISK task-side, never returned across the gateway.
+  String? lastDownloadFileRemote;
+  String? lastDownloadFileLocal;
 
   /// #990: when set, [sizeOf] (the stat seam the host's sftpStat handler uses)
   /// succeeds ONLY for paths in this set and throws for anything else —
@@ -105,6 +112,35 @@ class FakeSftpSession implements SftpSession {
       }
     }
     return all.length;
+  }
+
+  @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    lastDownloadFileRemote = remotePath;
+    lastDownloadFileLocal = localPath;
+    if (throwOnDownload) throw Exception('boom-download');
+    // Stream the bytes to the staging file in two chunks (task-side), emitting
+    // a monotonic 0 → mid → total progress sequence. Mirrors the real
+    // DartSshSftpSession.downloadFile: the file is written to DISK here and only
+    // (done, total) counters are handed back — the bytes never leave this side.
+    final all = Uint8List.fromList(fileBytes);
+    final total = all.length;
+    final sink = File(localPath).openWrite();
+    onProgress(0, total);
+    if (total > 0) {
+      final mid = (total / 2).ceil();
+      sink.add(Uint8List.sublistView(all, 0, mid));
+      onProgress(mid, total);
+      if (mid < total) sink.add(Uint8List.sublistView(all, mid));
+    }
+    onProgress(total, total);
+    await sink.close();
+    return total;
   }
 
   @override
@@ -219,6 +255,81 @@ void main() {
     expect(chunks.first.totalBytes, 10); // size resolved up front
     expect(fake.lastDownloadedPath, '/a.bin');
 
+    await sub.cancel();
+  });
+
+  test(
+      'sftpDownloadFile streams to a staging file + emits progress, ZERO file '
+      'bytes cross the gateway (#976 Slice A)', () async {
+    // A "large" file: big enough that had bytes crossed (base64) the total wire
+    // traffic would dwarf the handful of tiny progress envelopes.
+    final big = List<int>.generate(512 * 1024, (i) => i & 0xff);
+    final fake = FakeSftpSession(fileBytes: big);
+    final ctx = await setUpConnected('sid-dlf', fake);
+    addTearDown(ctx.pair.dispose);
+    addTearDown(ctx.host.dispose);
+    addTearDown(ctx.proxy.dispose);
+
+    final tmp = await Directory.systemTemp.createTemp('mobissh_dlf_');
+    addTearDown(() => tmp.delete(recursive: true));
+    final localPath = '${tmp.path}/staged.bin';
+
+    // Capture EVERY raw task→UI envelope so we can prove no file bytes crossed.
+    final rawFromTask = <Map<String, dynamic>>[];
+    final rawSub = ctx.pair.uiSide.incoming.listen(rawFromTask.add);
+
+    final progress = <SftpDownloadProgressEvent>[];
+    final chunks = <SftpDownloadChunkEvent>[];
+    SftpDownloadDoneEvent? done;
+    final sub = ctx.proxy.sftpEvents.listen((e) {
+      if (e is SftpDownloadProgressEvent) progress.add(e);
+      if (e is SftpDownloadChunkEvent) chunks.add(e);
+      if (e is SftpDownloadDoneEvent) done = e;
+    });
+
+    ctx.proxy.sftpDownloadFile(
+      requestId: 'sid-dlf#0',
+      remotePath: '~/videos/big.mp4',
+      localPath: localPath,
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    // Progress-only path: NO chunk events at all.
+    expect(chunks, isEmpty,
+        reason: 'the new path must never ship SftpDownloadChunkEvent');
+    // Monotonic progress, keyed by request id, ending exactly at total.
+    expect(progress, isNotEmpty);
+    expect(progress.every((p) => p.requestId == 'sid-dlf#0'), isTrue);
+    expect(progress.every((p) => p.totalBytes == big.length), isTrue);
+    final dones = progress.map((p) => p.done).toList();
+    for (var i = 1; i < dones.length; i++) {
+      expect(dones[i] >= dones[i - 1], isTrue, reason: 'progress must be monotonic');
+    }
+    expect(dones.last, big.length);
+    // Terminal done event, keyed by request id.
+    expect(done, isNotNull);
+    expect(done!.requestId, 'sid-dlf#0');
+    expect(done!.totalBytes, big.length);
+
+    // The staging file was written task-side with the FULL bytes.
+    final staged = await File(localPath).readAsBytes();
+    expect(staged.length, big.length);
+    expect(staged, big);
+    expect(fake.lastDownloadFileRemote, '~/videos/big.mp4');
+    expect(fake.lastDownloadFileLocal, localPath);
+
+    // KEY assertion: ZERO file bytes crossed the gateway. Every task→UI envelope
+    // is a tiny control message — none carries a 'bytes' field, and the TOTAL
+    // serialized size is a small constant, independent of the 512KB file. The
+    // retired chunk path would have base64'd ~700KB across here.
+    final totalWire =
+        rawFromTask.fold<int>(0, (a, m) => a + jsonEncode(m).length);
+    expect(rawFromTask.any((m) => m.containsKey('bytes')), isFalse,
+        reason: 'no task→UI envelope may carry file bytes');
+    expect(totalWire, lessThan(4096),
+        reason: 'progress-only wire traffic must stay tiny vs the 512KB file');
+
+    await rawSub.cancel();
     await sub.cancel();
   });
 

--- a/native/test/services/sftp_messages_test.dart
+++ b/native/test/services/sftp_messages_test.dart
@@ -95,6 +95,22 @@ void main() {
       expect(restored.path, '~/.ssh/config');
       expect(restored.bytes, bytes);
     });
+
+    test('SftpDownloadFileCommand preserves request id + remote/local paths',
+        () {
+      const cmd = SftpDownloadFileCommand(
+        sessionId: 'sid',
+        requestId: 'sid#dl0',
+        remotePath: '~/videos/big.mp4',
+        localPath: '/data/local/tmp/staged.mp4',
+      );
+      final restored =
+          SshTaskCommand.fromJson(cmd.toJson()) as SftpDownloadFileCommand;
+      expect(restored.sessionId, 'sid');
+      expect(restored.requestId, 'sid#dl0');
+      expect(restored.remotePath, '~/videos/big.mp4');
+      expect(restored.localPath, '/data/local/tmp/staged.mp4');
+    });
   });
 
   group('SFTP event round-trip', () {
@@ -142,6 +158,21 @@ void main() {
       final restored =
           SshTaskEvent.fromJson(ev.toJson()) as SftpDownloadDoneEvent;
       expect(restored.totalBytes, 123456);
+    });
+
+    test('SftpDownloadProgressEvent preserves done + totalBytes + request id',
+        () {
+      const ev = SftpDownloadProgressEvent(
+        sessionId: 'sid',
+        requestId: 'sid#dl0',
+        done: 65536,
+        totalBytes: 524288,
+      );
+      final restored =
+          SshTaskEvent.fromJson(ev.toJson()) as SftpDownloadProgressEvent;
+      expect(restored.requestId, 'sid#dl0');
+      expect(restored.done, 65536);
+      expect(restored.totalBytes, 524288);
     });
 
     test('SftpUploadDoneEvent preserves totalBytes + request id', () {

--- a/native/test/services/text_file_writer_test.dart
+++ b/native/test/services/text_file_writer_test.dart
@@ -80,6 +80,17 @@ class _RecordingSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/services/viewer_file_actions_test.dart
+++ b/native/test/services/viewer_file_actions_test.dart
@@ -102,6 +102,17 @@ class _ChunkedSftpSession implements SftpSession {
     int chunkSize = 64 * 1024,
   }) async => 0;
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/file_browser_context_menu_test.dart
+++ b/native/test/widget/file_browser_context_menu_test.dart
@@ -58,6 +58,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/file_browser_dismiss_test.dart
+++ b/native/test/widget/file_browser_dismiss_test.dart
@@ -70,6 +70,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/file_browser_favorites_test.dart
+++ b/native/test/widget/file_browser_favorites_test.dart
@@ -79,6 +79,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/file_browser_sort_test.dart
+++ b/native/test/widget/file_browser_sort_test.dart
@@ -59,6 +59,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/file_browser_upload_test.dart
+++ b/native/test/widget/file_browser_upload_test.dart
@@ -74,6 +74,17 @@ class _RecordingSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/file_browser_widget_test.dart
+++ b/native/test/widget/file_browser_widget_test.dart
@@ -73,6 +73,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 
@@ -394,6 +405,17 @@ class _ThrowingSftpSession implements SftpSession {
     String localPath,
     String remotePath, {
     required void Function(int sent, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
     int chunkSize = 64 * 1024,
   }) async {
     onProgress(0, 0);

--- a/native/test/widget/file_viewer_actions_test.dart
+++ b/native/test/widget/file_viewer_actions_test.dart
@@ -84,6 +84,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/html_file_viewer_widget_test.dart
+++ b/native/test/widget/html_file_viewer_widget_test.dart
@@ -71,6 +71,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/markdown_file_viewer_widget_test.dart
+++ b/native/test/widget/markdown_file_viewer_widget_test.dart
@@ -74,6 +74,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/pdf_viewer_widget_test.dart
+++ b/native/test/widget/pdf_viewer_widget_test.dart
@@ -79,6 +79,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 

--- a/native/test/widget/text_file_viewer_widget_test.dart
+++ b/native/test/widget/text_file_viewer_widget_test.dart
@@ -72,6 +72,17 @@ class _ScriptedSftpSession implements SftpSession {
   }
 
   @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
   Future<void> close() async {}
 }
 


### PR DESCRIPTION
Part of #976 (Slice A). Additive plumbing only — no UI change, no behavior change to the existing download path.

## What
Adds a progress-only streaming download that mirrors the #960 upload fix, so a large-file download never crosses file bytes over the client↔task gateway (the root cause of the large-file force-quit).

- `native/lib/ssh/sftp_session.dart` — `SftpSession.downloadFile(remote, local, {onProgress})` streams the remote file straight to the local staging path task-side (incremental `IOSink` write, no full-file buffer). Size resolved up front via stat for a determinate bar.
- `native/lib/services/session_messages.dart` — `SftpDownloadFileCommand` (remotePath/localPath) + `SftpDownloadProgressEvent` (done/total) with toJson/fromJson + dispatch, mirroring the upload messages. Terminal completion reuses the existing `SftpDownloadDoneEvent`.
- `native/lib/services/session_host.dart` — `_handleSftpDownloadFile` streams task-side and emits ONLY progress events (no bytes), registered in the command dispatch.
- `native/lib/ssh/ssh_session_proxy.dart` — `sftpDownloadFile(...)` sends the new command; the new progress event forwards on the shared `sftpEvents` stream.

## Not touched
The `SftpDownloadChunkEvent` chunk path and `_handleSftpDownload` are left intact — Slice C retires them once the consumer migrates. No consumer is wired to the new path yet (that's Slice B).

## Tests (TDD, verify-first)
- New host test (`sftp_host_test.dart`): downloads a 512KB fake file via the new path, asserts monotonic progress + a task-side staging-file write with the full bytes, and asserts **ZERO file bytes cross the gateway** — every task→UI envelope is captured; none carries a `bytes` field and the total serialized wire traffic is < 4KB (independent of the 512KB file). Contrast: the retired chunk path base64s ~700KB across. Confirmed red (compile failure, new symbols undefined) before implementing, then green.
- Round-trip tests added for `SftpDownloadFileCommand` + `SftpDownloadProgressEvent`.
- Every other `SftpSession` fake gets a `downloadFile` stub.
- `scripts/native-fast-gate.sh`: PASS (2144 tests).

## Note for integration
Per `.claude/rules/testing.md` #589, SFTP/IPC changes warrant the emulator integration suite before merge (`native-fast-gate.sh --with-integration`). This slice is additive with no live consumer, so the fast gate is the functional bar here; the device-visible migration lands in Slice B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa