### PR TITLE
feat(layout): large-landscape — keybar hidden + menus on top (#1086 B/C/D)

### DIFF
--- a/native/lib/main.dart
+++ b/native/lib/main.dart
@@ -23,6 +23,7 @@ import 'ui/connect_form.dart';
 import 'ui/feedback_overlay.dart';
 import 'ui/settings_screen.dart';
 import 'ui/terminal_screen.dart';
+import 'util/large_landscape.dart';
 
 void main() {
   // CrashReporter.runGuarded wraps the entire app in a zone that captures
@@ -413,39 +414,74 @@ class _ConnectHomePageState extends State<ConnectHomePage> {
             onPressed: () => Navigator.of(context).maybePop(),
           )
         : null;
+
+    // #643: NO SingleChildScrollView — the chooser fills the body so its profile
+    // list expands and scrolls internally. IndexedStack gives ConnectForm a
+    // bounded height (its Expanded needs that) and keeps each destination's
+    // state alive across tab switches. Shared by both layouts below.
+    final destinations = IndexedStack(
+      index: _index,
+      children: const [ConnectForm(), SettingsScreen()],
+    );
+
+    // #1086: large-landscape (tablet / desktop-mode / connected display) presents
+    // the two destinations as a regular top-of-side menu — here a Material
+    // NavigationRail down the leading edge — instead of the phone bottom nav, so
+    // the wide layout reads as desktop chrome. Phone/portrait keeps the bottom
+    // NavigationBar unchanged.
+    final largeLandscape = isLargeLandscape(MediaQuery.sizeOf(context));
+
     return Scaffold(
       appBar: AppBar(leading: leading, title: Text(_titles[_index])),
       body: SafeArea(
-        child: IndexedStack(
-          index: _index,
-          children: const [
-            // #643: NO SingleChildScrollView — the chooser fills the body so
-            // its profile list expands and scrolls internally. IndexedStack
-            // gives ConnectForm a bounded height (its Expanded needs that).
-            ConnectForm(),
-            SettingsScreen(),
-          ],
-        ),
+        child: largeLandscape
+            ? Row(
+                children: [
+                  NavigationRail(
+                    key: const Key('home-side-nav'),
+                    selectedIndex: _index,
+                    onDestinationSelected: (i) => setState(() => _index = i),
+                    labelType: NavigationRailLabelType.all,
+                    destinations: const [
+                      NavigationRailDestination(
+                        icon: Icon(Icons.dns_outlined),
+                        selectedIcon: Icon(Icons.dns),
+                        label: Text('Profiles'),
+                      ),
+                      NavigationRailDestination(
+                        icon: Icon(Icons.settings_outlined),
+                        selectedIcon: Icon(Icons.settings),
+                        label: Text('Settings'),
+                      ),
+                    ],
+                  ),
+                  const VerticalDivider(width: 1, thickness: 1),
+                  Expanded(child: destinations),
+                ],
+              )
+            : destinations,
       ),
-      bottomNavigationBar: NavigationBar(
-        key: const Key('home-bottom-nav'),
-        selectedIndex: _index,
-        onDestinationSelected: (i) => setState(() => _index = i),
-        destinations: const [
-          NavigationDestination(
-            key: Key('home-nav-profiles'),
-            icon: Icon(Icons.dns_outlined),
-            selectedIcon: Icon(Icons.dns),
-            label: 'Profiles',
-          ),
-          NavigationDestination(
-            key: Key('home-nav-settings'),
-            icon: Icon(Icons.settings_outlined),
-            selectedIcon: Icon(Icons.settings),
-            label: 'Settings',
-          ),
-        ],
-      ),
+      bottomNavigationBar: largeLandscape
+          ? null
+          : NavigationBar(
+              key: const Key('home-bottom-nav'),
+              selectedIndex: _index,
+              onDestinationSelected: (i) => setState(() => _index = i),
+              destinations: const [
+                NavigationDestination(
+                  key: Key('home-nav-profiles'),
+                  icon: Icon(Icons.dns_outlined),
+                  selectedIcon: Icon(Icons.dns),
+                  label: 'Profiles',
+                ),
+                NavigationDestination(
+                  key: Key('home-nav-settings'),
+                  icon: Icon(Icons.settings_outlined),
+                  selectedIcon: Icon(Icons.settings),
+                  label: 'Settings',
+                ),
+              ],
+            ),
     );
   }
 }

--- a/native/lib/state/ui_prefs_providers.dart
+++ b/native/lib/state/ui_prefs_providers.dart
@@ -855,6 +855,7 @@ class SessionAppearance {
     this.fontFamily = fontFamilyDefault,
     this.color,
     this.keybarVisible = keybarVisibleDefault,
+    this.keybarVisibleExplicit = false,
   });
 
   final int themeIndex;
@@ -877,7 +878,21 @@ class SessionAppearance {
   /// global: hiding it on one session leaves every sibling session's keybar
   /// untouched. Defaults to [keybarVisibleDefault] (true) so a fresh session
   /// shows the keybar (PWA parity — no behavior change for a new session).
+  ///
+  /// This is the STORED value. The value the UI actually renders is derived by
+  /// [resolveKeybarVisible], which — for a session the user has NOT explicitly
+  /// toggled ([keybarVisibleExplicit] false) — hides the keybar by default on a
+  /// large-landscape surface (#1086) while keeping it visible on a phone.
   final bool keybarVisible;
+
+  /// Whether the user has EXPLICITLY chosen this session's keybar visibility
+  /// (#1086). A fresh session is `false` (no choice made), so its rendered
+  /// keybar follows the layout default: shown on a phone, hidden in
+  /// large-landscape. Once the user flips the keybar toggle this becomes `true`
+  /// and [keybarVisible] is honoured verbatim regardless of layout — an explicit
+  /// choice wins. A separate flag (rather than a nullable [keybarVisible]) keeps
+  /// `copyWith` free of the null-means-"leave unchanged" ambiguity.
+  final bool keybarVisibleExplicit;
 
   SessionAppearance copyWith({
     int? themeIndex,
@@ -885,6 +900,7 @@ class SessionAppearance {
     String? fontFamily,
     Color? color,
     bool? keybarVisible,
+    bool? keybarVisibleExplicit,
   }) {
     return SessionAppearance(
       themeIndex: themeIndex ?? this.themeIndex,
@@ -892,6 +908,8 @@ class SessionAppearance {
       fontFamily: fontFamily ?? this.fontFamily,
       color: color ?? this.color,
       keybarVisible: keybarVisible ?? this.keybarVisible,
+      keybarVisibleExplicit:
+          keybarVisibleExplicit ?? this.keybarVisibleExplicit,
     );
   }
 
@@ -902,12 +920,38 @@ class SessionAppearance {
       other.fontSize == fontSize &&
       other.fontFamily == fontFamily &&
       other.color == color &&
-      other.keybarVisible == keybarVisible;
+      other.keybarVisible == keybarVisible &&
+      other.keybarVisibleExplicit == keybarVisibleExplicit;
 
   @override
-  int get hashCode =>
-      Object.hash(themeIndex, fontSize, fontFamily, color, keybarVisible);
+  int get hashCode => Object.hash(
+    themeIndex,
+    fontSize,
+    fontFamily,
+    color,
+    keybarVisible,
+    keybarVisibleExplicit,
+  );
 }
+
+/// Resolve the keybar visibility the UI should RENDER for a session (#1086),
+/// from its stored [visible] flag, whether the user made an [explicit] choice,
+/// and whether the surface is [largeLandscape].
+///
+/// - Explicit user choice always wins ([visible] verbatim) — a hardware-keyboard
+///   user who showed the keybar on a tablet keeps it; one who hid it on a phone
+///   keeps it hidden.
+/// - Otherwise the keybar is HIDDEN by default in large-landscape (a hardware
+///   keyboard is assumed on wide/desktop screens) and shown (per
+///   [keybarVisibleDefault]) on a phone.
+///
+/// Pure so it is unit-testable and callable at each layout site with a
+/// `largeLandscape` derived from `MediaQuery.sizeOf(context)`.
+bool resolveKeybarVisible({
+  required bool visible,
+  required bool explicit,
+  required bool largeLandscape,
+}) => explicit ? visible : (largeLandscape ? false : keybarVisibleDefault);
 
 /// Parse a PWA-style profile color hex (#653) into a [Color]. Accepts
 /// `#RRGGBB`, `#AARRGGBB`, or those forms without a leading `#`. Returns null
@@ -1005,8 +1049,19 @@ class SessionAppearanceNotifier
   /// Set [sessionId]'s keybar visibility (#573). Affects only this session —
   /// sibling sessions never change (the per-session isolation the issue is
   /// about). Mirrors [setTheme]/[setFontSize].
+  ///
+  /// #1086: this records an EXPLICIT user choice
+  /// ([SessionAppearance.keybarVisibleExplicit] → true), so the keybar is
+  /// henceforth honoured verbatim regardless of layout — the large-landscape
+  /// hide-by-default no longer applies to a session the user has toggled.
   void setKeybarVisible(String sessionId, bool visible) {
-    _put(sessionId, appearanceOf(sessionId).copyWith(keybarVisible: visible));
+    _put(
+      sessionId,
+      appearanceOf(sessionId).copyWith(
+        keybarVisible: visible,
+        keybarVisibleExplicit: true,
+      ),
+    );
   }
 
   /// Flip [sessionId]'s keybar visibility (#573). Reads the session's CURRENT
@@ -1105,6 +1160,22 @@ final sessionKeybarVisibleProvider = Provider.family<bool, String>((
       .keybarVisible;
 });
 
+/// Per-session "did the user EXPLICITLY choose the keybar visibility?" flag
+/// (#1086). Companion to [sessionKeybarVisibleProvider]: the layout site pairs
+/// the two through [resolveKeybarVisible] so a session the user has NOT toggled
+/// hides the keybar by default in large-landscape, while an explicit choice is
+/// honoured verbatim. Rebuilds when the session's appearance entry changes.
+final sessionKeybarVisibleExplicitProvider = Provider.family<bool, String>((
+  ref,
+  sessionId,
+) {
+  ref.watch(sessionAppearanceProvider);
+  return ref
+      .read(sessionAppearanceProvider.notifier)
+      .appearanceOf(sessionId)
+      .keybarVisibleExplicit;
+});
+
 /// The [NamedTerminalTheme] for a given session, guarding a stale index.
 final sessionTerminalThemeProvider =
     Provider.family<NamedTerminalTheme, String>((ref, sessionId) {
@@ -1139,6 +1210,16 @@ final activeSessionKeybarVisibleProvider = Provider<bool>((ref) {
   final activeId = ref.watch(activeSessionIdProvider);
   if (activeId == null) return keybarVisibleDefault;
   return ref.watch(sessionKeybarVisibleProvider(activeId));
+});
+
+/// The ACTIVE session's explicit-keybar-choice flag (#1086) — pairs with
+/// [activeSessionKeybarVisibleProvider] so the session menu can resolve the
+/// EFFECTIVE keybar state (via [resolveKeybarVisible]) for its toggle. Falls
+/// back to `false` (no explicit choice) when no session is active.
+final activeSessionKeybarVisibleExplicitProvider = Provider<bool>((ref) {
+  final activeId = ref.watch(activeSessionIdProvider);
+  if (activeId == null) return false;
+  return ref.watch(sessionKeybarVisibleExplicitProvider(activeId));
 });
 
 /// The ACTIVE session's terminal font family (#679) — what the session menu's

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -33,6 +33,7 @@ import '../state/profiles_providers.dart';
 import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart' show ProfilesStore;
+import '../util/large_landscape.dart';
 import 'detection_lab_screen.dart';
 import 'favorites_menu_sheet.dart';
 import 'file_browser_screen.dart';
@@ -289,7 +290,17 @@ class SessionMenu extends ConsumerWidget {
     // rows read and mutate the ACTIVE session only. With no active session
     // (empty list) these resolve to the default so the rows still render
     // sensibly.
-    final keybarVisible = ref.watch(activeSessionKeybarVisibleProvider);
+    //
+    // #1086: the keybar toggle reflects and flips the EFFECTIVE (rendered) state,
+    // not the raw stored flag — in large-landscape an un-toggled session's keybar
+    // is hidden by default, so the toggle must show "hidden" and flip to shown.
+    // Resolution happens here (the notifier has no BuildContext to read the
+    // layout from).
+    final keybarVisible = resolveKeybarVisible(
+      visible: ref.watch(activeSessionKeybarVisibleProvider),
+      explicit: ref.watch(activeSessionKeybarVisibleExplicitProvider),
+      largeLandscape: isLargeLandscape(MediaQuery.sizeOf(context)),
+    );
     final activeId = sessions.activeId;
     final palette = ref.watch(activeSessionThemeProvider);
     final fontFamily = ref.watch(activeSessionFontFamilyProvider);
@@ -606,9 +617,12 @@ class _SessionControlsRow extends ConsumerWidget {
             icon: keybarVisible ? Icons.keyboard : Icons.keyboard_outlined,
             selected: keybarVisible,
             enabled: hasActive,
+            // #1086: flip the EFFECTIVE (rendered) value. setKeybarVisible marks
+            // the choice explicit, so the large-landscape hide-by-default no
+            // longer applies to this session — the user's choice is honoured.
             onTap: () => ref
                 .read(sessionAppearanceProvider.notifier)
-                .toggleKeybarVisible(activeId!),
+                .setKeybarVisible(activeId!, !keybarVisible),
           ),
           // 5. Disconnect the ACTIVE session (#607). Fully closes (disconnect +
           // dispose + REMOVE the entry) so a re-connect restarts the service

--- a/native/lib/ui/terminal_screen.dart
+++ b/native/lib/ui/terminal_screen.dart
@@ -39,6 +39,7 @@ import '../state/terminal_backend.dart';
 import '../state/terminal_providers.dart';
 import '../state/ui_prefs_providers.dart';
 import '../terminal/url_hit_test.dart';
+import '../util/large_landscape.dart';
 import 'compose_bar.dart';
 import 'ghostty_terminal_view.dart';
 import 'keybar.dart';
@@ -158,8 +159,16 @@ class TerminalScreen extends ConsumerWidget {
     // Switching sessions re-watches the new active id, so each session shows
     // its own keybar state; toggling one never affects another. The compose
     // bar's bottomReserve (below) consumes the same active-session value.
-    final keybarVisible = ref.watch(
-      sessionKeybarVisibleProvider(activeEntry.id),
+    //
+    // #1086: the STORED flag + the explicit-choice flag resolve (via
+    // resolveKeybarVisible) to the value we actually render. On a large-landscape
+    // surface a hardware keyboard is assumed, so a session the user hasn't
+    // explicitly toggled hides the keybar by default; an explicit choice wins.
+    final largeLandscape = isLargeLandscape(MediaQuery.sizeOf(context));
+    final keybarVisible = resolveKeybarVisible(
+      visible: ref.watch(sessionKeybarVisibleProvider(activeEntry.id)),
+      explicit: ref.watch(sessionKeybarVisibleExplicitProvider(activeEntry.id)),
+      largeLandscape: largeLandscape,
     );
 
     // #653: resolve the active session's swatch color. Prefer the profile's
@@ -185,6 +194,34 @@ class TerminalScreen extends ConsumerWidget {
     // keyboard COVERING the session bar (P0). #610 made the compose bar dock to
     // FIXED margins (it no longer chases the keyboard inset), so that override
     // is unnecessary AND harmful — removed. The bar now floats over the keyboard.
+    // #566/#1086: the slim session bar — the thumb-reachable trigger for the
+    // session menu (tap the label area) + a compose toggle at the right edge,
+    // with a horizontal swipe across it switching sessions (#568). On a phone it
+    // sits at the BOTTOM (below the keybar) so the menu sheet rises from
+    // immediately above the affordance that summoned it. In large-landscape
+    // (#1086) it moves to the TOP as a regular top menu (a hardware keyboard +
+    // desktop-style chrome is assumed), and the terminal reclaims the bottom
+    // space. Built once here so the swipe/compose wiring is identical either way.
+    final sessionBar = _SessionBar(
+      label: activeEntry.label,
+      sessionCount: entries.length,
+      swatchColor: swatchColor,
+      // Swipe left → next session, swipe right → previous, wrapping
+      // around the session ring (#568). No-op with a single session.
+      onSwipe: (delta) {
+        if (entries.length < 2) return;
+        final from = activeIndex < 0 ? 0 : activeIndex;
+        final count = entries.length;
+        final target = (from + delta) % count;
+        final nextIndex = target < 0 ? target + count : target;
+        ref.read(sessionsProvider.notifier).setActive(entries[nextIndex].id);
+        HapticFeedback.lightImpact();
+      },
+      composeOn: composeBarVisible,
+      onToggleCompose: () =>
+          ref.read(composeBarVisibleProvider.notifier).toggle(),
+    );
+
     return Scaffold(
       body: SafeArea(
         child: Stack(
@@ -192,6 +229,8 @@ class TerminalScreen extends ConsumerWidget {
             // The terminal + chrome column.
             Column(
               children: [
+                // #1086: session controls at the TOP in large-landscape.
+                if (largeLandscape) sessionBar,
                 Expanded(
                   child: IndexedStack(
                     index: activeIndex < 0 ? 0 : activeIndex,
@@ -205,32 +244,9 @@ class TerminalScreen extends ConsumerWidget {
                   ),
                 ),
                 if (keybarVisible) Keybar(activeEntry: activeEntry),
-                // Bottom session bar (#566): the thumb-reachable trigger for the
-                // session menu (tap the label area) + a disconnect affordance at the
-                // right edge. Sits below the keybar so the menu sheet rises from
-                // immediately above the affordance that summoned it. The label tap
-                // target leaves a clean seam for swipe-to-switch (#568).
-                _SessionBar(
-                  label: activeEntry.label,
-                  sessionCount: entries.length,
-                  swatchColor: swatchColor,
-                  // Swipe left → next session, swipe right → previous, wrapping
-                  // around the session ring (#568). No-op with a single session.
-                  onSwipe: (delta) {
-                    if (entries.length < 2) return;
-                    final from = activeIndex < 0 ? 0 : activeIndex;
-                    final count = entries.length;
-                    final target = (from + delta) % count;
-                    final nextIndex = target < 0 ? target + count : target;
-                    ref
-                        .read(sessionsProvider.notifier)
-                        .setActive(entries[nextIndex].id);
-                    HapticFeedback.lightImpact();
-                  },
-                  composeOn: composeBarVisible,
-                  onToggleCompose: () =>
-                      ref.read(composeBarVisibleProvider.notifier).toggle(),
-                ),
+                // #1086: on a phone the session bar stays at the BOTTOM, below
+                // the keybar (unchanged phone layout).
+                if (!largeLandscape) sessionBar,
               ],
             ),
             // Floating compose bar (#604): overlays the terminal as a draggable
@@ -249,9 +265,12 @@ class TerminalScreen extends ConsumerWidget {
                 // the session bar (#610). Heights are centralized constants
                 // (#615): kSessionBarReserve (session bar) + kKeybarReserve
                 // (keybar, only when visible). Update those — not magic numbers
-                // here — when the chrome height changes.
+                // here — when the chrome height changes. #1086: in large-landscape
+                // the session bar moved to the TOP, so it no longer reserves any
+                // bottom space.
                 bottomReserve:
-                    kSessionBarReserve + (keybarVisible ? kKeybarReserve : 0),
+                    (largeLandscape ? 0 : kSessionBarReserve) +
+                    (keybarVisible ? kKeybarReserve : 0),
                 onClose: () =>
                     ref.read(composeBarVisibleProvider.notifier).set(false),
               ),

--- a/native/test/state/keybar_resolve_test.dart
+++ b/native/test/state/keybar_resolve_test.dart
@@ -1,0 +1,145 @@
+// #1086 — keybar visibility resolution + the explicit-choice flag.
+//
+// resolveKeybarVisible is the pure decision the layout sites use: hide the
+// keybar by default in large-landscape (hardware keyboard assumed) UNLESS the
+// user has explicitly toggled it, in which case the stored value wins verbatim.
+// setKeybarVisible must record that explicit choice so it survives the layout
+// default.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+ProviderContainer _makeContainer() {
+  final pair = InMemoryGatewayPair();
+  final container = ProviderContainer(
+    overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+  );
+  addTearDown(() async => pair.dispose());
+  addTearDown(container.dispose);
+  return container;
+}
+
+SessionEntry _add(ProviderContainer c, String host) {
+  return c.read(sessionsProvider.notifier).addOrActivate(
+        SshConnectParams(
+          host: host,
+          port: 22,
+          username: 'u',
+          auth: const SshAuth.password('p'),
+        ),
+      );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('resolveKeybarVisible (#1086)', () {
+    test('no explicit choice, phone → keybar shown (default)', () {
+      expect(
+        resolveKeybarVisible(
+          visible: keybarVisibleDefault,
+          explicit: false,
+          largeLandscape: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('no explicit choice, large-landscape → keybar hidden by default', () {
+      expect(
+        resolveKeybarVisible(
+          visible: keybarVisibleDefault,
+          explicit: false,
+          largeLandscape: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('explicit visible wins even in large-landscape', () {
+      expect(
+        resolveKeybarVisible(
+          visible: true,
+          explicit: true,
+          largeLandscape: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('explicit hidden wins even on a phone', () {
+      expect(
+        resolveKeybarVisible(
+          visible: false,
+          explicit: true,
+          largeLandscape: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('SessionAppearance keybar explicit flag (#1086)', () {
+    test('a fresh session has not made an explicit keybar choice', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      expect(c.read(sessionKeybarVisibleExplicitProvider(a.id)), isFalse);
+      expect(c.read(sessionKeybarVisibleProvider(a.id)), keybarVisibleDefault);
+    });
+
+    test('setKeybarVisible marks the choice explicit', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      c.read(sessionAppearanceProvider.notifier).setKeybarVisible(a.id, false);
+      expect(c.read(sessionKeybarVisibleProvider(a.id)), isFalse);
+      expect(c.read(sessionKeybarVisibleExplicitProvider(a.id)), isTrue);
+    });
+
+    test('the explicit flag is per-session (no leakage)', () {
+      final c = _makeContainer();
+      final a = _add(c, 'host-a');
+      final b = _add(c, 'host-b');
+      c.read(sessionAppearanceProvider.notifier).setKeybarVisible(a.id, true);
+      expect(c.read(sessionKeybarVisibleExplicitProvider(a.id)), isTrue);
+      expect(
+        c.read(sessionKeybarVisibleExplicitProvider(b.id)),
+        isFalse,
+        reason: 'B made no choice; A toggling must not mark B explicit',
+      );
+    });
+
+    test('copyWith preserves the explicit flag when not overridden', () {
+      const base = SessionAppearance(
+        themeIndex: 0,
+        fontSize: 13,
+        keybarVisibleExplicit: true,
+      );
+      expect(base.copyWith(fontSize: 20).keybarVisibleExplicit, isTrue);
+      expect(
+        base.copyWith(keybarVisibleExplicit: false).keybarVisibleExplicit,
+        isFalse,
+      );
+    });
+
+    test('equality + hashCode account for the explicit flag', () {
+      const a = SessionAppearance(themeIndex: 0, fontSize: 13);
+      const b = SessionAppearance(
+        themeIndex: 0,
+        fontSize: 13,
+        keybarVisibleExplicit: true,
+      );
+      expect(a == b, isFalse);
+      expect(a.hashCode == b.hashCode, isFalse);
+    });
+  });
+}

--- a/native/test/widget/large_landscape_layout_test.dart
+++ b/native/test/widget/large_landscape_layout_test.dart
@@ -1,0 +1,242 @@
+// #1086 — large-landscape layout (Slices B/C/D).
+//
+// Drives the breakpoint via `tester.view.physicalSize` and asserts the three
+// layout differences a wide/landscape surface adopts vs a phone:
+//   B. keybar hidden by DEFAULT in large-landscape (but an explicit toggle wins).
+//   C. the terminal session bar moves to the TOP (above the terminal) instead of
+//      the bottom.
+//   D. the home nav moves to a side NavigationRail instead of the bottom bar.
+//
+// Terminal harness mirrors keybar_per_session_test.dart: an InMemoryGatewayPair
+// + a real SshShell per session so TerminalScreen mounts its chrome. Home
+// harness mirrors home_bottom_nav_test.dart.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/main.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_shell.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/state/terminal_providers.dart';
+import 'package:mobissh/state/ui_prefs_providers.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/keybar.dart';
+import 'package:mobissh/ui/terminal_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../support/fake_ssh_shell_transport.dart';
+
+// Logical sizes at dpr 1.0.
+const Size _kPhone = Size(400, 820); // portrait phone
+const Size _kLargeLandscape = Size(1280, 800); // tablet / desktop-mode
+
+void _useSize(WidgetTester tester, Size logical) {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = logical;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+Future<({SessionEntry a, SessionEntry b, ProviderContainer container})>
+_mountTerminal(WidgetTester tester, Size size) async {
+  _useSize(tester, size);
+  final pair = InMemoryGatewayPair();
+  addTearDown(() async => pair.dispose());
+
+  final transports = <String, FakeSshShellTransport>{};
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      sshShellProvider.overrideWith((ref, sessionId) async {
+        final entry = ref
+            .read(sessionsProvider)
+            .entries
+            .firstWhere((e) => e.id == sessionId);
+        final transport = transports.putIfAbsent(
+          sessionId,
+          FakeSshShellTransport.new,
+        );
+        final shell = SshShell(transport);
+        shell.attach(entry.terminal);
+        ref.onDispose(shell.dispose);
+        return shell;
+      }),
+    ],
+  );
+  addTearDown(() {
+    for (final t in transports.values) {
+      t.close();
+    }
+    container.dispose();
+  });
+
+  final notifier = container.read(sessionsProvider.notifier);
+  final a = notifier.addOrActivate(
+    const SshConnectParams(
+      host: 'host-a',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    ),
+    title: 'Session A',
+  );
+  final b = notifier.addOrActivate(
+    const SshConnectParams(
+      host: 'host-b',
+      port: 22,
+      username: 'u',
+      auth: SshAuth.password('p'),
+    ),
+    title: 'Session B',
+  );
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: TerminalScreen()),
+    ),
+  );
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  return (a: a, b: b, container: container);
+}
+
+ProviderContainer _homeContainer(InMemoryGatewayPair pair) {
+  return ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      profilesStoreProvider.overrideWithValue(ProfilesStore()),
+      secretsStoreProvider.overrideWithValue(
+        SecretsStore(backend: InMemorySecretsBackend()),
+      ),
+    ],
+  );
+}
+
+Future<void> _mountHome(
+  WidgetTester tester,
+  Size size,
+  ProviderContainer container,
+) async {
+  _useSize(tester, size);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: ConnectHomePage()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('terminal chrome (Slices B + C)', () {
+    testWidgets('phone: keybar shown, session bar at the BOTTOM', (
+      tester,
+    ) async {
+      final m = await _mountTerminal(tester, _kPhone);
+
+      expect(find.byType(Keybar), findsOneWidget, reason: 'phone shows keybar');
+
+      final barTop = tester.getTopLeft(find.byKey(const Key('session-bar'))).dy;
+      final bodyTop = tester
+          .getTopLeft(find.byKey(ValueKey('terminal-body-${m.b.id}')))
+          .dy;
+      expect(
+        barTop,
+        greaterThan(bodyTop),
+        reason: 'phone: session bar sits below the terminal body',
+      );
+    });
+
+    testWidgets('large-landscape: keybar hidden, session bar at the TOP', (
+      tester,
+    ) async {
+      final m = await _mountTerminal(tester, _kLargeLandscape);
+
+      expect(
+        find.byType(Keybar),
+        findsNothing,
+        reason: 'large-landscape hides the keybar by default (#1086 B)',
+      );
+
+      final barTop = tester.getTopLeft(find.byKey(const Key('session-bar'))).dy;
+      final bodyTop = tester
+          .getTopLeft(find.byKey(ValueKey('terminal-body-${m.b.id}')))
+          .dy;
+      expect(
+        barTop,
+        lessThan(bodyTop),
+        reason: 'large-landscape: session bar sits above the terminal (#1086 C)',
+      );
+    });
+
+    testWidgets(
+      'large-landscape: an explicit keybar toggle SHOWS the keybar (explicit '
+      'wins)',
+      (tester) async {
+        final m = await _mountTerminal(tester, _kLargeLandscape);
+        expect(find.byType(Keybar), findsNothing);
+
+        // The user explicitly shows the keybar for the active session (b).
+        m.container
+            .read(sessionAppearanceProvider.notifier)
+            .setKeybarVisible(m.b.id, true);
+        await tester.pump();
+
+        expect(
+          find.byType(Keybar),
+          findsOneWidget,
+          reason: 'explicit show beats the large-landscape hide-by-default',
+        );
+      },
+    );
+  });
+
+  group('home navigation (Slice D)', () {
+    testWidgets('phone: bottom NavigationBar, no side rail', (tester) async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async => pair.dispose());
+      final container = _homeContainer(pair);
+      addTearDown(container.dispose);
+
+      await _mountHome(tester, _kPhone, container);
+
+      expect(find.byKey(const Key('home-bottom-nav')), findsOneWidget);
+      expect(find.byKey(const Key('home-side-nav')), findsNothing);
+    });
+
+    testWidgets('large-landscape: side NavigationRail, no bottom bar', (
+      tester,
+    ) async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(() async => pair.dispose());
+      final container = _homeContainer(pair);
+      addTearDown(container.dispose);
+
+      await _mountHome(tester, _kLargeLandscape, container);
+
+      expect(
+        find.byKey(const Key('home-side-nav')),
+        findsOneWidget,
+        reason: 'large-landscape moves the nav to a side rail (#1086 D)',
+      );
+      expect(
+        find.byKey(const Key('home-bottom-nav')),
+        findsNothing,
+        reason: 'the bottom nav is gone in large-landscape',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Part of #1086 — the large-landscape layout (Slices B, C, D on top of Slice A's `isLargeLandscape` signal).

## What changed
On a large-landscape surface (landscape AND width >= 840dp), the app adopts desktop-style chrome:

- **Slice B — keybar hidden by default, explicit toggle wins.** `SessionAppearance` gains a `keybarVisibleExplicit` flag (default false). A pure `resolveKeybarVisible({visible, explicit, largeLandscape})` decides what renders: no explicit choice + large-landscape → hidden; no explicit choice + phone → shown; explicit → the stored value verbatim. `setKeybarVisible` now records the choice as explicit, and the session-menu keybar toggle flips the EFFECTIVE (resolved) value.
- **Slice C — terminal session bar on top.** The `_SessionBar` moves above the terminal in large-landscape and the terminal reclaims the bottom space; the compose bar's `bottomReserve` drops the session-bar reserve accordingly. Phone layout (bar below the keybar) is byte-for-byte unchanged. Swipe-to-switch is preserved (same widget, just repositioned).
- **Slice D — home nav on top.** `ConnectHomePage`'s bottom `NavigationBar` becomes a side `NavigationRail` in large-landscape (`home-side-nav`); phone/portrait keeps the bottom `NavigationBar` (`home-bottom-nav`) unchanged.

All three layout sites read `isLargeLandscape(MediaQuery.sizeOf(context))` and gate on `!largeLandscape` to keep the phone path unchanged.

## Tests
- Pure `resolveKeybarVisible` truth table + `SessionAppearance` explicit-flag/copyWith/equality unit tests (`test/state/keybar_resolve_test.dart`).
- Widget tests driving `tester.view.physicalSize` across the breakpoint (`test/widget/large_landscape_layout_test.dart`): phone → keybar shown, session bar at bottom, bottom nav; large-landscape → keybar hidden, session bar on top, side rail; explicit keybar toggle in large-landscape → keybar shows (explicit wins).
- `scripts/native-fast-gate.sh` green: `flutter analyze` clean, all 2184 unit/widget tests pass.

## Device validation required
This is device-class UX (orientation/resize/hardware keyboard). The widget tests are the functional bar; final visual correctness needs owner validation on a real large-screen / desktop-mode device (the build-host emulator is unstable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa