### PR TITLE
feat(keys): key manager UI + attach in profile editor (#1088 Slice 1b/1c)

### DIFF
--- a/native/lib/ui/keys_screen.dart
+++ b/native/lib/ui/keys_screen.dart
@@ -1,0 +1,330 @@
+// SSH key library manager (#1088 Slice 1b). Its own route, reached from
+// Settings. Lists the named library keys ([savedKeysProvider]) — each row shows
+// ONLY non-secret metadata (name, algorithm, fingerprint); the private key
+// bytes live solely in the vault and are NEVER rendered or logged here.
+//
+// Add: paste a PEM/OpenSSH private key + a name (+ optional passphrase) →
+// [KeysManager.importFromPem]. Per row: Rename ([KeysManager.rename]) and Delete
+// ([KeysManager.delete], warning when profiles still reference the key by its
+// `keyVaultId`). Generation is Slice 2, out of scope here.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/keys_providers.dart';
+import '../state/profiles_providers.dart';
+import '../storage/keys_store.dart';
+import 'top_toast.dart';
+
+/// Push the key-library manager as a route.
+Future<void> showKeysScreen(BuildContext context) {
+  return Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(builder: (_) => const KeysScreen()),
+  );
+}
+
+class KeysScreen extends ConsumerWidget {
+  const KeysScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final keysAsync = ref.watch(savedKeysProvider);
+    return Scaffold(
+      key: const ValueKey('keys-screen'),
+      appBar: AppBar(title: const Text('SSH keys')),
+      floatingActionButton: FloatingActionButton.extended(
+        key: const ValueKey('keys-add-fab'),
+        onPressed: () => _addKey(context, ref),
+        icon: const Icon(Icons.add),
+        label: const Text('Add key'),
+      ),
+      body: SafeArea(
+        child: keysAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Center(
+            child: Text('Could not load keys: $e'),
+          ),
+          data: (keys) {
+            if (keys.isEmpty) {
+              return const Center(
+                key: ValueKey('keys-empty'),
+                child: Padding(
+                  padding: EdgeInsets.all(32),
+                  child: Text(
+                    'No SSH keys yet. Tap "Add key" to paste a private key '
+                    'you can then attach to one or more profiles.',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              );
+            }
+            return ListView.builder(
+              key: const ValueKey('keys-list'),
+              itemCount: keys.length,
+              itemBuilder: (context, i) => _KeyRow(
+                key: ValueKey('keys-row-${keys[i].id}'),
+                savedKey: keys[i],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<void> _addKey(BuildContext context, WidgetRef ref) async {
+    final input = await showDialog<_AddKeyInput>(
+      context: context,
+      builder: (_) => const _AddKeyDialog(),
+    );
+    if (input == null) return;
+    await ref.read(keysManagerProvider).importFromPem(
+          name: input.name,
+          pem: input.pem,
+          passphrase: input.passphrase,
+        );
+    if (context.mounted) showTopToast(context, 'Key added');
+  }
+}
+
+/// One library-key row: name + optional algorithm/fingerprint, plus a Rename /
+/// Delete overflow menu. Never shows private material.
+class _KeyRow extends ConsumerWidget {
+  const _KeyRow({super.key, required this.savedKey});
+
+  final SavedKey savedKey;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final subtitleParts = <String>[
+      if (savedKey.algorithm != null && savedKey.algorithm!.isNotEmpty)
+        savedKey.algorithm!,
+      if (savedKey.fingerprint != null && savedKey.fingerprint!.isNotEmpty)
+        savedKey.fingerprint!,
+    ];
+    return ListTile(
+      leading: const Icon(Icons.vpn_key_outlined),
+      title: Text(savedKey.name),
+      subtitle: subtitleParts.isEmpty ? null : Text(subtitleParts.join(' · ')),
+      trailing: PopupMenuButton<String>(
+        key: ValueKey('keys-row-menu-${savedKey.id}'),
+        onSelected: (v) {
+          if (v == 'rename') {
+            _rename(context, ref);
+          } else if (v == 'delete') {
+            _delete(context, ref);
+          }
+        },
+        itemBuilder: (_) => const [
+          PopupMenuItem<String>(value: 'rename', child: Text('Rename')),
+          PopupMenuItem<String>(value: 'delete', child: Text('Delete')),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _rename(BuildContext context, WidgetRef ref) async {
+    final name = await showDialog<String>(
+      context: context,
+      builder: (_) => _RenameDialog(initial: savedKey.name),
+    );
+    if (name == null) return;
+    await ref.read(keysManagerProvider).rename(savedKey.id, name);
+  }
+
+  Future<void> _delete(BuildContext context, WidgetRef ref) async {
+    // Warn when profiles still point their keyVaultId at this key — deleting
+    // leaves those profiles needing a new key (we still allow it).
+    final profiles =
+        await ref.read(savedProfilesProvider.future);
+    final usedBy =
+        profiles.where((p) => p.keyVaultId == savedKey.vaultId).length;
+    if (!context.mounted) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        key: const ValueKey('keys-delete-dialog'),
+        title: Text('Delete "${savedKey.name}"?'),
+        content: Text(
+          usedBy > 0
+              ? 'Used by $usedBy profile${usedBy == 1 ? '' : 's'}; '
+                  "they'll need a new key. This can't be undone."
+              : "This can't be undone.",
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const ValueKey('keys-delete-confirm'),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await ref.read(keysManagerProvider).delete(savedKey.id);
+  }
+}
+
+/// The values collected by [_AddKeyDialog].
+class _AddKeyInput {
+  const _AddKeyInput({required this.name, required this.pem, this.passphrase});
+  final String name;
+  final String pem;
+  final String? passphrase;
+}
+
+/// Add-key dialog: name + pasted PEM + optional passphrase. The PEM is a key
+/// blob so it is shown in a plain multiline field (not obscured), but it is
+/// NEVER logged — it goes straight to the vault via the manager.
+class _AddKeyDialog extends StatefulWidget {
+  const _AddKeyDialog();
+
+  @override
+  State<_AddKeyDialog> createState() => _AddKeyDialogState();
+}
+
+class _AddKeyDialogState extends State<_AddKeyDialog> {
+  final _nameCtrl = TextEditingController();
+  final _pemCtrl = TextEditingController();
+  final _passphraseCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _pemCtrl.dispose();
+    _passphraseCtrl.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final pem = _pemCtrl.text.trim();
+    if (pem.isEmpty) {
+      showTopToast(context, 'Paste a private key');
+      return;
+    }
+    final passphrase = _passphraseCtrl.text;
+    Navigator.of(context).pop(
+      _AddKeyInput(
+        name: _nameCtrl.text,
+        pem: pem,
+        passphrase: passphrase.isEmpty ? null : passphrase,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const ValueKey('keys-add-dialog'),
+      title: const Text('Add SSH key'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              key: const ValueKey('keys-add-name'),
+              controller: _nameCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Name',
+                hintText: 'e.g. work laptop',
+              ),
+              autocorrect: false,
+              enableSuggestions: false,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              key: const ValueKey('keys-add-pem'),
+              controller: _pemCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Private key (PEM / OpenSSH)',
+                hintText: '-----BEGIN OPENSSH PRIVATE KEY-----',
+                border: OutlineInputBorder(),
+                alignLabelWithHint: true,
+              ),
+              maxLines: 6,
+              minLines: 4,
+              autocorrect: false,
+              enableSuggestions: false,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              key: const ValueKey('keys-add-passphrase'),
+              controller: _passphraseCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Passphrase (optional)',
+              ),
+              obscureText: true,
+              autocorrect: false,
+              enableSuggestions: false,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const ValueKey('keys-add-save'),
+          onPressed: _submit,
+          child: const Text('Add'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Rename dialog: a single name field seeded with the current name.
+class _RenameDialog extends StatefulWidget {
+  const _RenameDialog({required this.initial});
+
+  final String initial;
+
+  @override
+  State<_RenameDialog> createState() => _RenameDialogState();
+}
+
+class _RenameDialogState extends State<_RenameDialog> {
+  late final TextEditingController _ctrl =
+      TextEditingController(text: widget.initial);
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const ValueKey('keys-rename-dialog'),
+      title: const Text('Rename key'),
+      content: TextField(
+        key: const ValueKey('keys-rename-field'),
+        controller: _ctrl,
+        autofocus: true,
+        decoration: const InputDecoration(labelText: 'Name'),
+        autocorrect: false,
+        enableSuggestions: false,
+        onSubmitted: (_) => Navigator.of(context).pop(_ctrl.text),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const ValueKey('keys-rename-save'),
+          onPressed: () => Navigator.of(context).pop(_ctrl.text),
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+}

--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -30,8 +30,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../diagnostics/connect_trace.dart';
 import '../ssh/ssh_config_parser.dart';
+import '../state/keys_providers.dart';
 import '../state/profiles_providers.dart';
 import '../state/ui_prefs_providers.dart';
+import '../storage/keys_store.dart';
 import '../storage/profiles_store.dart';
 import 'color_picker_sheet.dart';
 import 'top_toast.dart';
@@ -42,6 +44,14 @@ enum _AuthKind { password, key }
 /// or a [stored] key already in the vault (reused by its keyVaultId, no
 /// re-paste). Default [pasted] preserves the pre-import editor behavior.
 enum _KeySource { pasted, stored }
+
+/// One selectable entry in the "Key source" dropdown: the vault id to reuse and
+/// the display label (`Library: <name>` or `Stored: <profile title>`).
+class _KeyOption {
+  const _KeyOption({required this.vaultId, required this.label});
+  final String vaultId;
+  final String label;
+}
 
 /// Outcome of the profile editor (#583). The editor is now the SINGLE entry for
 /// both editing a saved profile AND creating a new / ad-hoc connection — the
@@ -553,10 +563,9 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor>
   /// key, an IdentityFile hint from an imported config, and either a
   /// stored-key note (reuse) or the PEM + passphrase paste fields.
   List<Widget> _buildKeyAuthFields(BuildContext context) {
-    final storedKeys =
-        ref.watch(storedKeysProvider).asData?.value ?? const <StoredKeyRef>[];
+    final keyOptions = _keySourceOptions();
     return [
-      if (storedKeys.isNotEmpty) ...[
+      if (keyOptions.isNotEmpty) ...[
         InputDecorator(
           decoration: const InputDecoration(
             labelText: 'Key source',
@@ -575,10 +584,10 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor>
                   value: _pasteKeySentinel,
                   child: Text('Paste a new key…'),
                 ),
-                for (final k in storedKeys)
+                for (final o in keyOptions)
                   DropdownMenuItem<String>(
-                    value: k.keyVaultId,
-                    child: Text('Stored: ${k.label}'),
+                    value: o.vaultId,
+                    child: Text(o.label),
                   ),
               ],
               onChanged: (v) => setState(() {
@@ -612,7 +621,7 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor>
           contentPadding: EdgeInsets.zero,
           leading: const Icon(Icons.vpn_key),
           title: const Text('Using a stored key'),
-          subtitle: Text(_storedKeyLabel(storedKeys, _selectedStoredKeyVaultId)),
+          subtitle: Text(_storedKeyLabel(keyOptions, _selectedStoredKeyVaultId)),
         )
       else ...[
         TextField(
@@ -641,9 +650,35 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor>
     ];
   }
 
-  String _storedKeyLabel(List<StoredKeyRef> keys, String? id) {
-    for (final k in keys) {
-      if (k.keyVaultId == id) return k.label;
+  /// The selectable "Key source" entries: the named library keys
+  /// ([savedKeysProvider], #1088) plus any keys already attached to other
+  /// profiles ([storedKeysProvider]). Deduped by vault id — a library key that a
+  /// profile already uses appears once (library label wins) — so picking one
+  /// points this profile's `keyVaultId` at that shared vault id, writing no new
+  /// secret. The `_persist` reuse path is unchanged.
+  List<_KeyOption> _keySourceOptions() {
+    final out = <_KeyOption>[];
+    final seen = <String>{};
+    final libraryKeys =
+        ref.watch(savedKeysProvider).asData?.value ?? const <SavedKey>[];
+    for (final k in libraryKeys) {
+      if (seen.add(k.vaultId)) {
+        out.add(_KeyOption(vaultId: k.vaultId, label: 'Library: ${k.name}'));
+      }
+    }
+    final storedKeys =
+        ref.watch(storedKeysProvider).asData?.value ?? const <StoredKeyRef>[];
+    for (final k in storedKeys) {
+      if (seen.add(k.keyVaultId)) {
+        out.add(_KeyOption(vaultId: k.keyVaultId, label: 'Stored: ${k.label}'));
+      }
+    }
+    return out;
+  }
+
+  String _storedKeyLabel(List<_KeyOption> options, String? id) {
+    for (final o in options) {
+      if (o.vaultId == id) return o.label;
     }
     return id ?? '';
   }

--- a/native/lib/ui/settings_panel.dart
+++ b/native/lib/ui/settings_panel.dart
@@ -29,6 +29,7 @@ import '../storage/detection_exceptions_store.dart';
 import '../util/relative_time.dart';
 import 'detection_lab_screen.dart';
 import 'feedback_overlay.dart' show VersionResolver, resolveBuildVersion;
+import 'keys_screen.dart';
 import 'settings_subheader.dart';
 import 'top_toast.dart';
 
@@ -83,6 +84,21 @@ class SettingsPanel extends ConsumerWidget {
                   : null,
             );
           },
+        ),
+        const SettingsSubheader('Keys'),
+        // #1088: the SSH key library — named, reusable keys managed independently
+        // of any profile. Import here, then attach to one or more profiles from
+        // the profile editor's key-source picker. Its own route (a manager, not a
+        // settings toggle). Monochrome outlined icon.
+        ListTile(
+          key: const ValueKey('ssh-keys-tile'),
+          leading: const Icon(Icons.vpn_key_outlined),
+          title: const Text('SSH keys'),
+          subtitle: const Text(
+            'Manage named private keys you can attach to profiles.',
+          ),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () => showKeysScreen(context),
         ),
         const SettingsSubheader('Background'),
         SwitchListTile(

--- a/native/test/widget/appearance_settings_widget_test.dart
+++ b/native/test/widget/appearance_settings_widget_test.dart
@@ -95,8 +95,11 @@ void main() {
 
       await _pumpFrames(tester, count: 12);
 
-      // Drag the slider thumb to the far right (max).
+      // Drag the slider thumb to the far right (max). Scroll it into view first
+      // — the panel grows as sections are added, so don't assume a fixed offset.
       final slider = find.byKey(const ValueKey('font-size-slider'));
+      await tester.ensureVisible(slider);
+      await _pumpFrames(tester);
       await tester.drag(slider, const Offset(500, 0));
       await _pumpFrames(tester);
 
@@ -146,6 +149,9 @@ void main() {
       );
       await _pumpFrames(tester, count: 12);
 
+      // Scroll the row into view first — the panel grows as sections are added.
+      await tester.ensureVisible(find.byKey(const ValueKey('default-font-tile')));
+      await _pumpFrames(tester);
       await tester.tap(find.byKey(const ValueKey('default-font-tile')));
       await _pumpFrames(tester, count: 8);
 

--- a/native/test/widget/keys_screen_test.dart
+++ b/native/test/widget/keys_screen_test.dart
@@ -1,0 +1,191 @@
+// Widget tests for the SSH key-library manager (#1088 Slice 1b): the screen
+// lists library keys, Add imports one, Rename and Delete work, and Delete warns
+// when a profile references the key. Private material is never rendered.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/keys_providers.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/storage/keys_store.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/keys_screen.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required KeysStore keysStore,
+  required SecretsStore secrets,
+  required ProfilesStore profilesStore,
+}) async {
+  tester.view.physicalSize = const Size(1000, 2000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        keysStoreProvider.overrideWithValue(keysStore),
+        secretsStoreProvider.overrideWithValue(secrets),
+        profilesStoreProvider.overrideWithValue(profilesStore),
+      ],
+      child: const MaterialApp(home: KeysScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  testWidgets('lists library keys by name; no private material shown', (
+    tester,
+  ) async {
+    final keysStore = KeysStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    const pem = '-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n-----END-----';
+    final key = const SavedKey(
+      id: 'k1',
+      name: 'work laptop',
+      algorithm: 'ed25519',
+      createdAtMs: 1,
+    );
+    await secrets.write(key.vaultId, <String, Object?>{'data': pem});
+    await keysStore.upsert(key);
+
+    await _pump(
+      tester,
+      keysStore: keysStore,
+      secrets: secrets,
+      profilesStore: ProfilesStore(),
+    );
+
+    expect(find.text('work laptop'), findsOneWidget);
+    expect(find.textContaining('ed25519'), findsOneWidget);
+    // SECURITY: the private key blob must never render.
+    expect(find.textContaining('OPENSSH'), findsNothing);
+    expect(find.textContaining('secret'), findsNothing);
+  });
+
+  testWidgets('Add imports a key into the store and the vault', (tester) async {
+    final keysStore = KeysStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    await _pump(
+      tester,
+      keysStore: keysStore,
+      secrets: secrets,
+      profilesStore: ProfilesStore(),
+    );
+
+    expect(find.byKey(const ValueKey('keys-empty')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('keys-add-fab')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('keys-add-name')),
+      'deploy key',
+    );
+    const pem = '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END-----';
+    await tester.enterText(find.byKey(const ValueKey('keys-add-pem')), pem);
+    await tester.tap(find.byKey(const ValueKey('keys-add-save')));
+    await tester.pumpAndSettle();
+
+    final keys = await keysStore.load();
+    expect(keys.map((k) => k.name), ['deploy key']);
+    // The PEM went to the vault, not the metadata store.
+    final stored = await secrets.read(keys.single.vaultId);
+    expect(stored?['data'], pem);
+    expect(keys.single.toJson().toString(), isNot(contains('OPENSSH')));
+    // The new key shows in the list.
+    expect(find.text('deploy key'), findsOneWidget);
+  });
+
+  testWidgets('Rename updates the key name', (tester) async {
+    final keysStore = KeysStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    final key = const SavedKey(id: 'k1', name: 'old', createdAtMs: 1);
+    await secrets.write(key.vaultId, <String, Object?>{'data': 'x'});
+    await keysStore.upsert(key);
+    await _pump(
+      tester,
+      keysStore: keysStore,
+      secrets: secrets,
+      profilesStore: ProfilesStore(),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('keys-row-menu-k1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rename'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('keys-rename-field')),
+      'new name',
+    );
+    await tester.tap(find.byKey(const ValueKey('keys-rename-save')));
+    await tester.pumpAndSettle();
+
+    expect((await keysStore.load()).single.name, 'new name');
+    expect(find.text('new name'), findsOneWidget);
+  });
+
+  testWidgets('Delete removes the key and its vault blob', (tester) async {
+    final keysStore = KeysStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    final key = const SavedKey(id: 'k1', name: 'gone', createdAtMs: 1);
+    await secrets.write(key.vaultId, <String, Object?>{'data': 'x'});
+    await keysStore.upsert(key);
+    await _pump(
+      tester,
+      keysStore: keysStore,
+      secrets: secrets,
+      profilesStore: ProfilesStore(),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('keys-row-menu-k1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+    // No profile references it → the warning names no profiles.
+    expect(find.textContaining('profile'), findsNothing);
+    await tester.tap(find.byKey(const ValueKey('keys-delete-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(await keysStore.load(), isEmpty);
+    expect(await secrets.read(key.vaultId), isNull);
+  });
+
+  testWidgets('Delete warns when a profile references the key', (tester) async {
+    final keysStore = KeysStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    final key = const SavedKey(id: 'k1', name: 'shared', createdAtMs: 1);
+    await secrets.write(key.vaultId, <String, Object?>{'data': 'x'});
+    await keysStore.upsert(key);
+    final profilesStore = ProfilesStore();
+    await profilesStore.save(<SavedProfile>[
+      SavedProfile(
+        title: 'deploy@prod',
+        host: 'prod',
+        port: 22,
+        username: 'deploy',
+        authType: 'key',
+        keyVaultId: key.vaultId,
+      ),
+    ]);
+    await _pump(
+      tester,
+      keysStore: keysStore,
+      secrets: secrets,
+      profilesStore: profilesStore,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('keys-row-menu-k1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Used by 1 profile'), findsOneWidget);
+  });
+}

--- a/native/test/widget/profile_editor_library_key_test.dart
+++ b/native/test/widget/profile_editor_library_key_test.dart
@@ -1,0 +1,96 @@
+// Widget test for #1088 Slice 1c: the profile-editor key-source dropdown lists
+// LIBRARY keys ([savedKeysProvider]); selecting one + Save points the profile's
+// keyVaultId at that library key's vault id and writes NO new secret (many
+// profiles can share one library key).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mobissh/state/keys_providers.dart';
+import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/storage/keys_store.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/storage/secrets_store.dart';
+import 'package:mobissh/ui/profile_editor.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'selecting a library key sets the profile keyVaultId, writes no new secret',
+    (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      tester.view.physicalSize = const Size(1000, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      // A library key already in the store + vault (created via the keys manager).
+      final keysStore = KeysStore();
+      final key = const SavedKey(id: 'k1', name: 'work', createdAtMs: 1);
+      await keysStore.upsert(key);
+      final backend = InMemorySecretsBackend();
+      final secrets = SecretsStore(backend: backend);
+      await secrets.write(key.vaultId, <String, Object?>{
+        'data': '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END-----',
+      });
+      final blobsBefore = (await backend.readAll()).length;
+
+      final store = ProfilesStore();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            profilesStoreProvider.overrideWithValue(store),
+            secretsStoreProvider.overrideWithValue(secrets),
+            keysStoreProvider.overrideWithValue(keysStore),
+          ],
+          child: MaterialApp(
+            home: ProfileEditor(profile: blankProfile(), isNew: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-host')),
+        'new.example',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-username')),
+        'me',
+      );
+      await tester.tap(find.text('Key'));
+      await tester.pumpAndSettle();
+
+      // The dropdown lists the library key labeled "Library: work"; pick it.
+      await tester.tap(find.byKey(const Key('profile-editor-key-source')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Library: work').last);
+      await tester.pumpAndSettle();
+
+      // Reuse note replaces the PEM field.
+      expect(
+        find.byKey(const Key('profile-editor-stored-key-note')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('profile-editor-key')), findsNothing);
+
+      await tester.tap(find.byKey(const Key('profile-editor-save')));
+      await tester.pumpAndSettle();
+
+      final saved = (await store.load()).firstWhere(
+        (p) => p.host == 'new.example',
+      );
+      expect(saved.authType, 'key');
+      expect(
+        saved.keyVaultId,
+        key.vaultId,
+        reason: 'the profile reuses the library key by its vault id',
+      );
+      // No NEW secret blob written — the vault still holds only the library key.
+      expect((await backend.readAll()).length, blobsBefore);
+    },
+  );
+}


### PR DESCRIPTION
Part of #1088 — the user-facing SSH key-management UI on the merged foundation (ed9c479). Slices 1b + 1c.

## Slice 1b — Keys manager screen
`native/lib/ui/keys_screen.dart` (new): its own route, reached from a new "SSH keys" row under a "Keys" subheader in Settings.
- Lists `savedKeysProvider` — each row shows name + algorithm/fingerprint only. Private key bytes are never rendered or logged.
- "Add key" FAB → dialog (name + pasted PEM/OpenSSH + optional passphrase) → `keysManagerProvider.importFromPem`.
- Per row: Rename (`.rename`) and Delete (`.delete`). Delete confirm counts profiles whose `keyVaultId == key.vaultId` and warns ("Used by N profile(s); they'll need a new key") — still allowed.

## Slice 1c — attach a library key in the profile editor
`native/lib/ui/profile_editor.dart`: the existing "Key source" dropdown now also lists library keys (`Library: <name>`) beside the profile-derived stored keys (`Stored: <title>`), deduped by vault id. Selecting one sets `_selectedStoredKeyVaultId` to the library key's vault id; the existing `_persist` reuse path is unchanged, so no new secret is written and one library key can attach to many profiles.

## Tests
- `keys_screen_test.dart`: list, add (store+vault, no secret in metadata), rename, delete (removes vault blob + metadata), delete-warns-when-referenced.
- `profile_editor_library_key_test.dart`: pick a library key + Save → profile `keyVaultId == key.vaultId`, no new secret blob.
- Two interaction tests in `appearance_settings_widget_test.dart` gained `tester.ensureVisible` — the new Keys section grew the panel past the 600px test fold; those tests had assumed a fixed layout offset.
- `scripts/native-fast-gate.sh` green (analyze + full test suite).

## Security
Private key material lives only in the encrypted vault (secrets_store); the UI handles metadata only. The Add dialog's PEM goes straight to the vault via the manager and is never logged.

## Device validation required (owner)
Create a key in the manager, attach it to a profile, connect. Not "Closes" — generation (Slice 2) and deploy (Slice 3) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa