### PR TITLE
feat(keys): unify library + profile keys; new-key-from-editor into library (#1088)

### DIFF
--- a/native/lib/storage/keys_store.dart
+++ b/native/lib/storage/keys_store.dart
@@ -25,7 +25,6 @@ const String keysPrefsKey = 'mobissh.keys.v1';
 /// key bytes live in the vault under [vaultId].
 @immutable
 class SavedKey {
-  // ignore: prefer_initializing_formals
   const SavedKey({
     required this.id,
     required this.name,
@@ -34,7 +33,9 @@ class SavedKey {
     this.publicKey,
     this.fingerprint,
     this.createdAtMs = 0,
-  }) : _vaultId = vaultId;
+    // Deliberately a plain param, not an initializing formal: the nullable
+    // `vaultId` feeds the getter's `key-<id>` default (see [vaultId]).
+  }) : _vaultId = vaultId; // ignore: prefer_initializing_formals
 
   /// Explicit vault id override. Null for a natively-created library key (whose
   /// material lives at `key-<id>`); SET when a pre-existing per-profile key was

--- a/native/lib/ui/keys_screen.dart
+++ b/native/lib/ui/keys_screen.dart
@@ -23,11 +23,26 @@ Future<void> showKeysScreen(BuildContext context) {
   );
 }
 
-class KeysScreen extends ConsumerWidget {
+class KeysScreen extends ConsumerStatefulWidget {
   const KeysScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<KeysScreen> createState() => _KeysScreenState();
+}
+
+class _KeysScreenState extends ConsumerState<KeysScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Unify the library with pre-existing per-profile keys (#1088): adopt any
+    // profile key not yet in the library so it shows here by name. Idempotent
+    // and a no-op when there's nothing to adopt; the savedKeysProvider watch
+    // below picks up the newly-adopted rows after it invalidates.
+    ref.read(keysManagerProvider).adoptFromProfiles();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final keysAsync = ref.watch(savedKeysProvider);
     return Scaffold(
       key: const ValueKey('keys-screen'),

--- a/native/lib/ui/profile_editor.dart
+++ b/native/lib/ui/profile_editor.dart
@@ -186,6 +186,11 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor>
     } else {
       _authKind = _AuthKind.password;
     }
+    // Unify the key picker with pre-existing per-profile keys (#1088): adopt any
+    // profile key not yet in the library so the Library/Stored sources converge
+    // (a given vault id appears once, library label). Idempotent; the
+    // savedKeysProvider watch in _keySourceOptions rebuilds after it invalidates.
+    ref.read(keysManagerProvider).adoptFromProfiles();
   }
 
   @override
@@ -279,12 +284,17 @@ class _ProfileEditorState extends ConsumerState<ProfileEditor>
           if (passphrase.isNotEmpty) 'passphrase': passphrase,
         });
       } else if (_authKind == _AuthKind.key && key.isNotEmpty) {
-        keyVaultId ??= 'profile-key-$newIdentity';
-        // PWA canonical key entry shape: {data: <PEM>, passphrase?}.
-        await secrets.write(keyVaultId, <String, Object?>{
-          'data': key,
-          if (passphrase.isNotEmpty) 'passphrase': passphrase,
-        });
+        // A freshly pasted key becomes a first-class LIBRARY key (#1088) so it's
+        // manageable from the Keys screen — not a one-off `profile-key-…` blob.
+        // The manager writes the PEM to the vault; we point this profile at the
+        // returned library vault id. Named from the profile so it reads well in
+        // the Keys screen.
+        final libraryKey = await ref.read(keysManagerProvider).importFromPem(
+              name: '${_emptyToNull(_titleCtrl.text) ?? host} key',
+              pem: key,
+              passphrase: passphrase.isEmpty ? null : passphrase,
+            );
+        keyVaultId = libraryKey.vaultId;
       } else if (_authKind == _AuthKind.key &&
           passphrase.isNotEmpty &&
           keyVaultId != null) {

--- a/native/test/widget/keys_screen_test.dart
+++ b/native/test/widget/keys_screen_test.dart
@@ -157,6 +157,44 @@ void main() {
     expect(await secrets.read(key.vaultId), isNull);
   });
 
+  testWidgets('opening the screen adopts a profile key into the library (#1088)',
+      (tester) async {
+    // A profile carries a per-profile key, but the library is EMPTY — the two
+    // aren't unified yet. Opening the Keys screen must adopt it so it lists.
+    final keysStore = KeysStore();
+    final secrets = SecretsStore(backend: InMemorySecretsBackend());
+    const vaultId = 'profile-key-fd:22:me';
+    await secrets.write(vaultId, <String, Object?>{'data': 'x'});
+    final profilesStore = ProfilesStore();
+    await profilesStore.save(<SavedProfile>[
+      SavedProfile(
+        title: 'fd-dev',
+        host: 'fd',
+        port: 22,
+        username: 'me',
+        authType: 'key',
+        keyVaultId: vaultId,
+      ),
+    ]);
+
+    // Before opening, the library holds nothing.
+    expect(await keysStore.load(), isEmpty);
+
+    await _pump(
+      tester,
+      keysStore: keysStore,
+      secrets: secrets,
+      profilesStore: profilesStore,
+    );
+
+    // The adopted key is listed by the profile's name.
+    expect(find.text('fd-dev'), findsOneWidget);
+    final lib = await keysStore.load();
+    expect(lib.map((k) => k.name), ['fd-dev']);
+    // Adopted IN PLACE — points at the original vault id, no re-keying.
+    expect(lib.single.vaultId, vaultId);
+  });
+
   testWidgets('Delete warns when a profile references the key', (tester) async {
     final keysStore = KeysStore();
     final secrets = SecretsStore(backend: InMemorySecretsBackend());

--- a/native/test/widget/profile_editor_library_key_test.dart
+++ b/native/test/widget/profile_editor_library_key_test.dart
@@ -93,4 +93,72 @@ void main() {
       expect((await backend.readAll()).length, blobsBefore);
     },
   );
+
+  testWidgets(
+    'pasting a NEW key + Save creates a library key; profile points at it (#1088)',
+    (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      tester.view.physicalSize = const Size(1000, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final keysStore = KeysStore();
+      final backend = InMemorySecretsBackend();
+      final secrets = SecretsStore(backend: backend);
+      final store = ProfilesStore();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            profilesStoreProvider.overrideWithValue(store),
+            secretsStoreProvider.overrideWithValue(secrets),
+            keysStoreProvider.overrideWithValue(keysStore),
+          ],
+          child: MaterialApp(
+            home: ProfileEditor(profile: blankProfile(), isNew: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-title')),
+        'prod box',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-host')),
+        'prod.example',
+      );
+      await tester.enterText(
+        find.byKey(const Key('profile-editor-username')),
+        'deploy',
+      );
+      await tester.tap(find.text('Key'));
+      await tester.pumpAndSettle();
+
+      // Paste a NEW key into the PEM field (default pasted source).
+      const pem = '-----BEGIN OPENSSH PRIVATE KEY-----\nnewkey\n-----END-----';
+      await tester.enterText(find.byKey(const Key('profile-editor-key')), pem);
+      await tester.tap(find.byKey(const Key('profile-editor-save')));
+      await tester.pumpAndSettle();
+
+      // A library key was created (manageable from the Keys screen).
+      final lib = await keysStore.load();
+      expect(lib.length, 1);
+      final libraryKey = lib.single;
+      expect(libraryKey.name, 'prod box key');
+
+      // The profile points at that library key's vault id.
+      final saved =
+          (await store.load()).firstWhere((p) => p.host == 'prod.example');
+      expect(saved.authType, 'key');
+      expect(saved.keyVaultId, libraryKey.vaultId);
+
+      // The PEM lives in the vault under that id — NOT a one-off profile-key blob.
+      final blob = await secrets.read(libraryKey.vaultId);
+      expect(blob?['data'], pem);
+      expect(saved.keyVaultId, isNot(startsWith('profile-key-')));
+    },
+  );
 }

--- a/native/test/widget/profile_editor_ssh_config_test.dart
+++ b/native/test/widget/profile_editor_ssh_config_test.dart
@@ -312,10 +312,13 @@ void main() {
         await tester.tap(find.text('Key'));
         await tester.pumpAndSettle();
 
-        // The key-source dropdown lists the stored key; pick it.
+        // The key-source dropdown lists the key; pick it. Opening the editor
+        // adopts the pre-existing per-profile key into the library (#1088), so
+        // it now shows under the unified "Library:" label — pointing at the SAME
+        // vault id in place (no re-keying, no new secret).
         await tester.tap(find.byKey(const Key('profile-editor-key-source')));
         await tester.pumpAndSettle();
-        await tester.tap(find.text('Stored: deploy@existing').last);
+        await tester.tap(find.text('Library: deploy@existing').last);
         await tester.pumpAndSettle();
 
         // The stored-key note replaces the PEM field.


### PR DESCRIPTION
Part of #1088.

Wires the already-landed key-library data core (@6aaf540) into both UIs so the Keys screen and the profile-editor picker share one library.

## Changes
1. Keys screen (`keys_screen.dart`): `ConsumerWidget` -> `ConsumerStatefulWidget`; runs `adoptFromProfiles()` once in `initState`. Pre-existing per-profile keys now surface by name (fd-dev, NV-dev) instead of an empty list. Idempotent no-op when nothing to adopt.
2. Profile editor (`profile_editor.dart`): `adoptFromProfiles()` once in `initState` so the picker's Library/Stored sources converge — a given vault id appears once, under the unified "Library:" label. Existing dedup kept; no entries dropped.
3. New-key-from-editor feeds the library: a freshly pasted PEM now goes through `keysManagerProvider.importFromPem` (a first-class library key, manageable from the Keys screen) instead of a one-off `profile-key-<id>` blob; the profile's `keyVaultId` points at the returned library `vaultId`. The reuse-a-stored-key path is unchanged (writes no new secret). "Leave blank to keep existing" preserved.

## Incidental
Fixes a pre-existing `prefer_initializing_formals` info-lint in `keys_store.dart` (misplaced `// ignore:` on the constructor header didn't cover the initializer at line 37) that was failing `flutter analyze`. Moved the ignore to the diagnostic line; no behavior change.

## Tests (RED -> GREEN confirmed)
- `keys_screen_test`: opening the screen adopts a profile key -> listed by name, points at the original vault id in place.
- `profile_editor_library_key_test`: paste a NEW key + Save -> a library key is created (`savedKeysProvider` gains it), the profile `keyVaultId` points at it, and the PEM is in the vault under that id (not a `profile-key-` blob).
- Updated `profile_editor_ssh_config_test` "reuse a stored key": the label is now "Library:" post-unification; `keyVaultId` + no-new-secret assertions unchanged.
- Full `scripts/native-fast-gate.sh` green (analyze + 2210 tests).

## Security
Private key bytes go only to the vault via `KeysManager`/`secrets_store` — never rendered or logged.

## Device validation (owner, required)
Open Keys screen -> see fd-dev / NV-dev; create a key in the profile editor -> it appears in the Keys screen; attach + connect.

Generate/deploy still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEsXH6yExwUeGuhhnHURa