### PR TITLE
test(native): regression coverage + root-cause analysis for favorites menu reopen (#948)

### DIFF
--- a/native/integration_test/sftp_favorites_test.dart
+++ b/native/integration_test/sftp_favorites_test.dart
@@ -214,13 +214,32 @@ void main() {
       );
       expect(navback, isTrue, reason: 'quick-nav did not return to the root dir');
 
-      // 3) LONG-PRESS the favorite → removed (gone from the list).
+      // 3) SECOND open — now standing ON the favorite (cwd == favorite after the
+      // quick-nav). Regression for #948: the menu must reopen NON-EMPTY here (it
+      // used to render `favorites-empty`, so long-press-remove found 0 widgets).
       await tester.longPress(find.byKey(const Key('file-browser-star')));
-      await _pumpUntil(
+      final reopened = await _pumpUntil(
         tester,
         () => find.byKey(const Key('favorites-list')).evaluate().isNotEmpty,
         maxSlices: 20,
       );
+      expect(
+        reopened,
+        isTrue,
+        reason: '#948: second open (cwd IS the favorite) showed favorites-empty',
+      );
+      expect(
+        find.byKey(const Key('favorites-empty')),
+        findsNothing,
+        reason: '#948: favorites-empty on reopen while standing on the favorite',
+      );
+      expect(
+        find.byKey(Key('favorite-item-$root')),
+        findsOneWidget,
+        reason: '#948: favorite missing from the reopened menu',
+      );
+
+      // LONG-PRESS the favorite → removed (gone from the list).
       await tester.longPress(find.byKey(Key('favorite-item-$root')));
       final removedFromList = await _pumpUntil(
         tester,

--- a/native/test/widget/file_browser_favorites_test.dart
+++ b/native/test/widget/file_browser_favorites_test.dart
@@ -262,6 +262,60 @@ void main() {
     h.dispose();
   });
 
+  // Regression for #948: reopening the favorites menu while the CURRENT dir is
+  // itself the favorite (right after a quick-nav to it) must still list it.
+  // Sequence mirrors the device repro: favorite `/`, descend into `/docs`,
+  // long-press star → menu → tap favorite `/` (quick-nav back), long-press star
+  // AGAIN (now standing on `/`) → the menu must be NON-EMPTY and removal works.
+  testWidgets('reopen menu while standing ON the favorite still lists it (#948)', (
+    tester,
+  ) async {
+    final h = await _mount(tester);
+
+    // 1) Descend into `/docs` and favorite it (the favorite is a subdir, as in
+    //    the device repro — the quick-nav lands the cwd ON the favorite).
+    await tester.tap(find.byKey(const Key('file-entry-docs')));
+    await _pump(tester);
+    expect(find.text('/docs'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('file-browser-star')));
+    await _pump(tester);
+    expect(_starIcon(Icons.star), findsOneWidget);
+    expect(await FavoritesStore().isFavorite(_profileKey, '/docs'), isTrue);
+
+    // 2) Navigate up to `/` so cwd differs from the favorite.
+    await tester.tap(find.byKey(const Key('file-browser-up')));
+    await _pump(tester);
+    expect(find.byKey(const Key('file-entry-a.bin')), findsOneWidget);
+
+    // 3) First open (cwd != favorite): menu lists `/docs`, tap it → quick-nav.
+    await tester.longPress(find.byKey(const Key('file-browser-star')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorite-item-/docs')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('favorite-item-/docs')));
+    await _pump(tester);
+    expect(find.byKey(const Key('file-entry-inner.bin')), findsOneWidget);
+    // Back at `/docs`, standing ON the favorite → filled star.
+    expect(_starIcon(Icons.star), findsOneWidget);
+
+    // 4) Second open (cwd IS the favorite): the menu must NOT be empty.
+    await tester.longPress(find.byKey(const Key('file-browser-star')));
+    await _pump(tester);
+    expect(
+      find.byKey(const Key('favorites-empty')),
+      findsNothing,
+      reason: 'second open showed favorites-empty while standing on the favorite',
+    );
+    expect(find.byKey(const Key('favorite-item-/docs')), findsOneWidget);
+
+    // 5) Removal now succeeds.
+    await tester.longPress(find.byKey(const Key('favorite-item-/docs')));
+    await _pump(tester);
+    expect(find.byKey(const Key('favorite-item-/docs')), findsNothing);
+    expect(await FavoritesStore().isFavorite(_profileKey, '/docs'), isFalse);
+
+    h.dispose();
+  });
+
   testWidgets('clear all empties the favorites set', (tester) async {
     await FavoritesStore().add(_profileKey, '/docs');
     await FavoritesStore().add(_profileKey, '/a');


### PR DESCRIPTION
## Summary
- Adds regression coverage for #948 (favorites menu empty on reopen while the current dir IS the favorite) at both the widget and integration-test level.
- **No app-code change.** Root-cause analysis shows the menu already reads the favorites set fresh on every open; the described "captured-empty list / second read empty" mechanism does not exist in the current tree and does not reproduce headlessly.

## Root-cause analysis
- `_openFavoritesMenu` (`native/lib/ui/file_browser_screen.dart`) delegates to `showFavoritesMenu` (`native/lib/ui/favorites_menu_sheet.dart`), which does `var favs = await store.favoritesFor(profileKey)` at the top of **every** call, before `showModalBottomSheet`, and builds the sheet from that fresh read. There is no captured/stale list — in either the file-browser app-bar star or the session-menu star path (`session_menu.dart`).
- The original #632 implementation already read fresh the same way; #950 only extracted it into the shared sheet. So the "second read comes back empty" mechanism the issue describes is not present.
- `_profileKey == entry.profileKey` (consistent). `FavoritesStore` is a Riverpod singleton; `load()` re-reads `prefs.getString` each call and SharedPreferences updates its in-memory cache synchronously on write, so a read after the toggle+navigation is consistent.

## Reproduction attempts (all PASS — menu NON-EMPTY on the second open)
1. Widget: favorite `/`, descend `/docs`, menu -> tap -> quick-nav back to `/`, reopen.
2. Widget: favorite `/docs` (subdir), up to `/`, menu -> tap -> quick-nav to `/docs`, reopen.
3. Widget PROBE: rapid reopen (30ms pump, first sheet still dismissing) -> empty=0, item=1.

The exact device sequence does not reproduce headlessly. Corroborated by the internal note that #948 was previously paused ("star gesture dead when favorited").

## TDD Analysis
- Type: bug fix (attempted)
- Behavior change: no
- TDD approach: full — but the tests PASS on unmodified code, so there is no fail->pass. They serve as a **regression guard**: they go red if the menu is ever refactored to build from a captured/stale list (the failure mode the issue describes).

## Test coverage
- **New/extended tests**:
  - `native/test/widget/file_browser_favorites_test.dart` — "reopen menu while standing ON the favorite still lists it (#948)": favorite a subdir, navigate away, quick-nav back onto it, reopen the menu, assert `favorites-empty` is absent + `favorite-item` present + removal succeeds.
  - `native/integration_test/sftp_favorites_test.dart` — explicit `favorites-empty` findsNothing + `favorite-item` findsOneWidget assertions on the second open (device repro lock).

## Test results
- flutter analyze: PASS
- widget favorites suite: PASS (8/8)
- native-fast-gate: PASS except one UNRELATED flaky test (`port_forwarder_test.dart` — socket/port timing under the full parallel run; passes in isolation).

## If the owner confirms on-device
The real symptom (star filled but menu empty) is the `rules/state-management.md` zombie-state pattern: two data structures disagree (`_favoritePaths` cache vs a fresh store read). The root-cause direction would be a single source of truth — have the menu read the same reactive `profileFavoritesProvider` the session-menu star already watches — rather than an independent one-shot async read. Deliberately NOT implemented here without an on-device repro (constitution Article 5 / no band-aid).

Device-validation-pending.

Refs #948