### PR TITLE
fix(sftp): repoint browser download onto the task-side stream — kill the large-file force-quit (#976)

### DIFF
--- a/native/lib/services/sftp_download.dart
+++ b/native/lib/services/sftp_download.dart
@@ -163,7 +163,7 @@ class AppDownloadsSink implements FileDownloadSink {
     String fileName, {
     DownloadsPublisher? publisher,
   }) async {
-    final dir = await _resolveStagingDir();
+    final dir = await resolveDownloadStagingDir();
     return createInDir(dir, fileName, publisher: publisher);
   }
 
@@ -174,7 +174,7 @@ class AppDownloadsSink implements FileDownloadSink {
     String fileName, {
     DownloadsPublisher? publisher,
   }) async {
-    final safeName = _sanitize(fileName);
+    final safeName = sanitizeDownloadName(fileName);
     if (!await dir.exists()) {
       await dir.create(recursive: true);
     }
@@ -185,29 +185,6 @@ class AppDownloadsSink implements FileDownloadSink {
       safeName,
       publisher ?? platformPublishToDownloads,
     );
-  }
-
-  /// App-private staging directory for in-flight downloads. Not user-visible;
-  /// the file is moved into public Downloads on [finish].
-  static Future<Directory> _resolveStagingDir() async {
-    Directory base;
-    try {
-      base =
-          await getApplicationSupportDirectory();
-    } catch (_) {
-      base = await getApplicationDocumentsDirectory();
-    }
-    final dir = Directory('${base.path}/mobissh_downloads');
-    if (!await dir.exists()) {
-      await dir.create(recursive: true);
-    }
-    return dir;
-  }
-
-  /// Strip path separators so a remote basename can't escape the target dir.
-  static String _sanitize(String name) {
-    final base = name.split('/').last.split('\\').last;
-    return base.isEmpty ? 'download' : base;
   }
 
   @override
@@ -283,4 +260,145 @@ class TempFileSink implements FileDownloadSink {
 
   @override
   Future<void> abort() => _inner.abort();
+}
+
+/// App-private staging directory for in-flight downloads. Not user-visible; the
+/// finished file is moved into public Downloads on publish. Shared by
+/// [AppDownloadsSink] (chunk assembly) and [AppDownloadTarget] (task-side
+/// stream, #976).
+Future<Directory> resolveDownloadStagingDir() async {
+  Directory base;
+  try {
+    base = await getApplicationSupportDirectory();
+  } catch (_) {
+    base = await getApplicationDocumentsDirectory();
+  }
+  final dir = Directory('${base.path}/mobissh_downloads');
+  if (!await dir.exists()) {
+    await dir.create(recursive: true);
+  }
+  return dir;
+}
+
+/// Strip path separators so a remote basename can't escape the target dir.
+String sanitizeDownloadName(String name) {
+  final base = name.split('/').last.split('\\').last;
+  return base.isEmpty ? 'download' : base;
+}
+
+/// A TASK-SIDE download destination (#976). The task streams the remote file
+/// straight to [localPath] on disk (the whole file NEVER crosses the isolate —
+/// the fix for the large-file force-quit); the UI resolves the path up front,
+/// and on the terminal done event calls [publish] to move the finished file
+/// into the user-visible Downloads collection. [abort] deletes the partial file
+/// on error/cancel. Contrast [FileDownloadSink], which assembles chunks that
+/// each cross the isolate on the UI isolate.
+abstract class FileDownloadTarget {
+  /// Local staging path the task writes the downloaded file to.
+  String get localPath;
+
+  /// Publish the finished staging file into public Downloads; returns a display
+  /// location. Falls back to the staging path if publishing is unavailable, so a
+  /// completed download is never lost.
+  Future<String> publish();
+
+  /// Delete the (partial) staging file after an error or user cancel.
+  Future<void> abort();
+}
+
+/// Resolves the [FileDownloadTarget] for a task-side download (#976). Injected
+/// into the browser so widget tests substitute a fake (no filesystem, no
+/// platform channel). Production stages into app-private storage, then
+/// publishes to Downloads.
+typedef DownloadTargetFactory =
+    Future<FileDownloadTarget> Function(String fileName);
+
+/// Production factory: an [AppDownloadTarget] staging into app-scoped storage.
+Future<FileDownloadTarget> defaultDownloadTargetFactory(
+  String fileName,
+) async {
+  return AppDownloadTarget.create(fileName);
+}
+
+/// Resolves the destination for task-side downloads. Overridden in widget/
+/// emulator tests to avoid the real filesystem + platform channel. Mirror of
+/// [downloadSinkFactoryProvider] for the streaming path.
+final downloadTargetFactoryProvider = Provider<DownloadTargetFactory>(
+  (ref) => defaultDownloadTargetFactory,
+);
+
+/// Production [FileDownloadTarget]: the task streams the remote file into an
+/// app-private staging file; [publish] hands it to [platformPublishToDownloads].
+/// Mirrors [AppDownloadsSink] minus the UI-side chunk assembly (that now happens
+/// task-side in `sftp.downloadFile`).
+class AppDownloadTarget implements FileDownloadTarget {
+  AppDownloadTarget._(this._file, this._fileName, this._publish);
+
+  final File _file;
+  final String _fileName;
+  final DownloadsPublisher _publish;
+
+  @override
+  String get localPath => _file.path;
+
+  static Future<AppDownloadTarget> create(
+    String fileName, {
+    DownloadsPublisher? publisher,
+  }) async {
+    final dir = await resolveDownloadStagingDir();
+    return createInDir(dir, fileName, publisher: publisher);
+  }
+
+  /// Test seam: stage into an explicit [dir] so the publish/cleanup/fallback
+  /// contract is verifiable without path_provider.
+  static Future<AppDownloadTarget> createInDir(
+    Directory dir,
+    String fileName, {
+    DownloadsPublisher? publisher,
+  }) async {
+    final safeName = sanitizeDownloadName(fileName);
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    final file = File('${dir.path}/$safeName');
+    // Clear any stale partial from a prior attempt so the task's openWrite
+    // starts on a clean file.
+    try {
+      if (await file.exists()) await file.delete();
+    } catch (_) {
+      /* best-effort */
+    }
+    return AppDownloadTarget._(
+      file,
+      safeName,
+      publisher ?? platformPublishToDownloads,
+    );
+  }
+
+  @override
+  Future<String> publish() async {
+    try {
+      final location = await _publish(_file.path, _fileName, null);
+      // Published into public Downloads — drop the staging copy.
+      try {
+        if (await _file.exists()) await _file.delete();
+      } catch (_) {
+        /* best-effort cleanup */
+      }
+      return location;
+    } catch (_) {
+      // Publishing unavailable/failed: keep the completed staging file so the
+      // download isn't lost, and report its path.
+      return _file.path;
+    }
+  }
+
+  @override
+  Future<void> abort() async {
+    try {
+      if (await _file.exists()) await _file.delete();
+    } catch (_) {
+      /* ignore */
+    }
+  }
 }

--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -40,6 +40,55 @@ import 'top_toast.dart';
 // (tests) keep working unchanged.
 export '../services/sftp_download.dart' show downloadSinkFactoryProvider;
 
+/// Files at or above this size (#976) prompt a confirm dialog before download —
+/// large transfers are the ones that saturated the UI isolate and force-quit
+/// the app. Discoverable/tunable in one place. Default 50 MB.
+const int kLargeDownloadThresholdBytes = 50 * 1024 * 1024;
+
+/// Coalesces the task's frequent download-progress events into bounded UI
+/// rebuilds (#976). The old chunk path did one `setState` per chunk; the
+/// streaming path can emit progress just as often, so throttle: emit at most
+/// once per [minInterval] OR when progress advances by [minFraction] of the
+/// total, and always the terminal 100%. Pure + deterministic (the caller passes
+/// elapsed time) so it's unit-testable without a clock.
+class DownloadProgressThrottle {
+  DownloadProgressThrottle({
+    this.minInterval = const Duration(milliseconds: 100),
+    this.minFraction = 0.01,
+  });
+
+  final Duration minInterval;
+  final double minFraction;
+
+  Duration? _lastAt;
+  int _lastDone = 0;
+
+  /// Whether a progress update of [done]/[total] bytes at elapsed [now] warrants
+  /// a rebuild. The first update and the terminal (done >= total) always emit.
+  bool shouldEmit(int done, int total, Duration now) {
+    if (total > 0 && done >= total) {
+      _lastAt = now;
+      _lastDone = done;
+      return true;
+    }
+    final last = _lastAt;
+    if (last == null) {
+      _lastAt = now;
+      _lastDone = done;
+      return true;
+    }
+    final byTime = now - last >= minInterval;
+    final byFraction =
+        total > 0 && (done - _lastDone) >= (total * minFraction);
+    if (byTime || byFraction) {
+      _lastAt = now;
+      _lastDone = done;
+      return true;
+    }
+    return false;
+  }
+}
+
 /// Picks a single LOCAL file to upload (#960). Returns its on-device path +
 /// display name, or null when the user cancels. The task isolate reads the path
 /// and streams it chunk-by-chunk, so we ask for the path only (withData:false) —
@@ -214,8 +263,13 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
   String? _downloadRequestId;
   int _downloadReceived = 0;
   int? _downloadTotal;
-  FileDownloadSink? _downloadSink;
+  FileDownloadTarget? _downloadTarget;
   String? _downloadName;
+
+  /// Coalesces the task's frequent progress events into bounded rebuilds (#976)
+  /// so we don't `setState` per event. Non-null only during a download.
+  DownloadProgressThrottle? _downloadThrottle;
+  Stopwatch? _downloadStopwatch;
 
   /// In-flight chunked upload (#960), null when idle. One at a time. The bytes
   /// are streamed task-side; the UI only tracks progress by request id.
@@ -223,12 +277,6 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
   String? _uploadName;
   int _uploadSent = 0;
   int _uploadTotal = 0;
-
-  /// Serializes sink writes so a `done` event flushes only after every chunk
-  /// write has completed. Chunks can arrive reordered over the gateway (#591);
-  /// the sink writes each at its byte offset so order doesn't affect the bytes,
-  /// but chaining keeps `finish` strictly after the last write.
-  Future<void> _downloadWrites = Future<void>.value();
 
   bool _attached = false;
 
@@ -280,8 +328,8 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
   @override
   void dispose() {
     _sub?.cancel();
-    // Abort any partial download so we don't leak a half-written file.
-    unawaited(_downloadSink?.abort());
+    // Abort any partial download so we don't leak a half-written staging file.
+    unawaited(_downloadTarget?.abort());
     super.dispose();
   }
 
@@ -310,9 +358,9 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
           _loading = false;
           _error = null;
         });
-      case SftpDownloadChunkEvent():
+      case SftpDownloadProgressEvent():
         if (event.requestId != _downloadRequestId) return;
-        _onChunk(event);
+        _onDownloadProgress(event);
       case SftpDownloadDoneEvent():
         if (event.requestId != _downloadRequestId) return;
         unawaited(_onDownloadDone(event));
@@ -349,40 +397,41 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     _list(_path);
   }
 
-  void _onChunk(SftpDownloadChunkEvent event) {
-    final sink = _downloadSink;
-    if (sink == null) return;
-    final bytes = event.bytes;
-    final offset = event.offset;
-    // Write at the chunk's byte offset (#591). Chain writes so `done` only
-    // flushes after they all complete.
-    _downloadWrites = _downloadWrites.then((_) => sink.addChunk(bytes, offset));
+  /// Progress for the task-side streaming download (#976). The bytes stayed
+  /// task-side; this only advances the bar. Throttled so a fast transfer's
+  /// stream of progress events doesn't `setState` per event (the UI-isolate
+  /// saturation that used to force-quit the app).
+  void _onDownloadProgress(SftpDownloadProgressEvent event) {
+    final throttle = _downloadThrottle;
+    final elapsed = _downloadStopwatch?.elapsed ?? Duration.zero;
+    if (throttle != null &&
+        !throttle.shouldEmit(event.done, event.totalBytes, elapsed)) {
+      return;
+    }
     if (!mounted) return;
     setState(() {
-      _downloadReceived += bytes.length;
-      _downloadTotal = event.totalBytes;
+      _downloadReceived = event.done;
+      if (event.totalBytes > 0) _downloadTotal = event.totalBytes;
     });
   }
 
   Future<void> _onDownloadDone(SftpDownloadDoneEvent event) async {
-    final sink = _downloadSink;
+    final target = _downloadTarget;
     final name = _downloadName ?? 'file';
-    _downloadSink = null;
+    _downloadTarget = null;
+    _downloadThrottle = null;
+    _downloadStopwatch?.stop();
+    _downloadStopwatch = null;
+    // The task already wrote the whole file to the staging path; publish it into
+    // the user-visible Downloads collection and report where it landed.
     String? location;
-    var failed = false;
-    if (sink != null) {
+    if (target != null) {
       try {
-        await _downloadWrites; // drain all chunk writes first
-        location = await sink.finish(expectedTotal: event.totalBytes);
-      } catch (e) {
-        // Length mismatch / write failure → the file is corrupt. Clean up and
-        // report failure rather than claiming a successful download (#591).
-        failed = true;
-        await sink.abort();
+        location = await target.publish();
+      } catch (_) {
         location = null;
       }
     }
-    _downloadWrites = Future<void>.value();
     if (!mounted) return;
     setState(() {
       _downloadRequestId = null;
@@ -390,14 +439,33 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
       _downloadTotal = null;
       _downloadName = null;
     });
-    if (failed) {
-      _snack('Download failed: $name was incomplete');
-      return;
-    }
     final msg = location != null
         ? 'Downloaded $name → $location'
         : 'Downloaded $name';
     _snack(msg);
+  }
+
+  /// Cancel an in-flight download (#976). Stops tracking the request (later
+  /// progress/done events no longer match the request id) and deletes the
+  /// partial staging file. There is no task-side mid-stream cancel command to
+  /// reuse today — the task keeps streaming to the staging file, which
+  /// [FileDownloadTarget.abort] removes; a task-side cancel is a follow-up.
+  Future<void> _cancelDownload() async {
+    final target = _downloadTarget;
+    _downloadTarget = null;
+    _downloadThrottle = null;
+    _downloadStopwatch?.stop();
+    _downloadStopwatch = null;
+    if (mounted) {
+      setState(() {
+        _downloadRequestId = null;
+        _downloadReceived = 0;
+        _downloadTotal = null;
+        _downloadName = null;
+      });
+    }
+    await target?.abort();
+    _snack('Download cancelled');
   }
 
   void _onSftpError(SftpErrorEvent event) {
@@ -412,8 +480,11 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
       return;
     }
     if (event.requestId == _downloadRequestId) {
-      unawaited(_downloadSink?.abort());
-      _downloadSink = null;
+      unawaited(_downloadTarget?.abort());
+      _downloadTarget = null;
+      _downloadThrottle = null;
+      _downloadStopwatch?.stop();
+      _downloadStopwatch = null;
       if (!mounted) return;
       setState(() {
         _downloadRequestId = null;
@@ -499,27 +570,70 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
       _snack('A download is already in progress');
       return;
     }
+    // Size gate (#976): large transfers are the ones that used to hang the app —
+    // confirm before starting.
+    final size = entry.size;
+    if (size != null && size >= kLargeDownloadThresholdBytes) {
+      final proceed = await _confirmLargeDownload(entry.name, size);
+      if (!proceed || !mounted) return;
+    }
     final reqId = _nextRequestId();
-    final factory = ref.read(downloadSinkFactoryProvider);
-    FileDownloadSink sink;
+    final factory = ref.read(downloadTargetFactoryProvider);
+    FileDownloadTarget target;
     try {
-      sink = await factory(entry.name);
+      target = await factory(entry.name);
     } catch (e) {
       _snack('Could not start download: $e');
       return;
     }
     if (!mounted) {
-      await sink.abort();
+      await target.abort();
       return;
     }
+    _downloadThrottle = DownloadProgressThrottle();
+    _downloadStopwatch = Stopwatch()..start();
     setState(() {
       _downloadRequestId = reqId;
-      _downloadSink = sink;
+      _downloadTarget = target;
       _downloadName = entry.name;
       _downloadReceived = 0;
       _downloadTotal = entry.size;
     });
-    proxy.sftpDownload(requestId: reqId, path: entry.path);
+    // Task-side streaming download (#976): the task reads the remote file and
+    // writes it straight to `target.localPath` on disk, emitting only
+    // lightweight progress events. The file bytes NEVER cross the isolate — the
+    // fix for the large-file force-quit (contrast the old sftpDownload chunk
+    // firehose).
+    proxy.sftpDownloadFile(
+      requestId: reqId,
+      remotePath: entry.path,
+      localPath: target.localPath,
+    );
+  }
+
+  /// Confirm before downloading a large file (#976). Returns true to proceed.
+  Future<bool> _confirmLargeDownload(String name, int size) async {
+    final proceed = await showDialog<bool>(
+      context: context,
+      builder: (dialogCtx) => AlertDialog(
+        key: const Key('large-download-confirm'),
+        title: const Text('Download large file?'),
+        content: Text('$name is ${formatSize(size)}. Download it?'),
+        actions: [
+          TextButton(
+            key: const Key('large-download-cancel'),
+            onPressed: () => Navigator.of(dialogCtx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            key: const Key('large-download-confirm-ok'),
+            onPressed: () => Navigator.of(dialogCtx).pop(true),
+            child: const Text('Download'),
+          ),
+        ],
+      ),
+    );
+    return proceed ?? false;
   }
 
   void _goUp() {
@@ -930,6 +1044,7 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
               name: _downloadName ?? '',
               received: _downloadReceived,
               total: _downloadTotal,
+              onCancel: _cancelDownload,
             ),
           if (_uploadRequestId != null)
             _UploadProgress(
@@ -1102,27 +1217,41 @@ class _DownloadProgress extends StatelessWidget {
     required this.name,
     required this.received,
     required this.total,
+    required this.onCancel,
   });
 
   final String name;
   final int received;
   final int? total;
+  final VoidCallback onCancel;
 
   @override
   Widget build(BuildContext context) {
     final t = total;
     final value = (t != null && t > 0) ? (received / t).clamp(0.0, 1.0) : null;
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      padding: const EdgeInsets.fromLTRB(16, 8, 4, 8),
+      child: Row(
         children: [
-          Text(
-            'Downloading $name…',
-            style: Theme.of(context).textTheme.bodySmall,
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Downloading $name…',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                const SizedBox(height: 4),
+                LinearProgressIndicator(value: value),
+              ],
+            ),
           ),
-          const SizedBox(height: 4),
-          LinearProgressIndicator(value: value),
+          IconButton(
+            key: const Key('file-browser-download-cancel'),
+            tooltip: 'Cancel download',
+            icon: const Icon(Icons.close),
+            onPressed: onCancel,
+          ),
         ],
       ),
     );

--- a/native/test/widget/file_browser_download_progress_test.dart
+++ b/native/test/widget/file_browser_download_progress_test.dart
@@ -1,0 +1,413 @@
+// File browser download: task-side streaming path (#976).
+//
+// Slice B repoints the browser's download-to-file path off the old
+// SftpDownloadChunkEvent firehose (raw bytes base64 across the isolate per
+// chunk → UI-isolate saturation → ANR/force-quit) onto the task-side
+// SftpDownloadFileCommand + SftpDownloadProgressEvent path landed in Slice A.
+//
+// These tests assert the STRUCTURAL root-cause fix (no chunk events for a
+// download), the progress-update throttle, and the size-gate + cancel affordances.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/sftp_download.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+/// Scripted SFTP session for the download path. [download] (chunk firehose) must
+/// never be called by the browser after Slice B; [downloadFile] (task-side
+/// stream) is the new path. [blockDownload] parks [downloadFile] after the first
+/// progress event so an in-flight cancel can be exercised.
+class _DlSftp implements SftpSession {
+  _DlSftp({
+    required this.entries,
+    required this.fileSize,
+    this.blockDownload = false,
+  });
+
+  final List<SftpEntry> entries;
+  final int fileSize;
+  final bool blockDownload;
+  final Completer<void> release = Completer<void>();
+
+  bool downloadCalled = false;
+  bool downloadFileCalled = false;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async =>
+      path == '/' ? entries : const [];
+
+  @override
+  Future<int?> sizeOf(String path) async => fileSize;
+
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async {
+    downloadCalled = true;
+    onChunk(Uint8List.fromList(List<int>.filled(fileSize, 1)), 0);
+    return fileSize;
+  }
+
+  @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    downloadFileCalled = true;
+    onProgress(0, fileSize);
+    if (blockDownload) await release.future;
+    onProgress(fileSize, fileSize);
+    return fileSize;
+  }
+
+  @override
+  Future<int> upload(String path, Uint8List bytes) async => bytes.length;
+
+  @override
+  Future<int> uploadFile(
+    String localPath,
+    String remotePath, {
+    required void Function(int sent, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+/// Fake task-side destination: no filesystem, no platform channel.
+class _FakeTarget implements FileDownloadTarget {
+  _FakeTarget(this.localPath);
+
+  @override
+  final String localPath;
+
+  bool published = false;
+  bool aborted = false;
+
+  @override
+  Future<String> publish() async {
+    published = true;
+    return '/test/Download/${localPath.split('/').last}';
+  }
+
+  @override
+  Future<void> abort() async {
+    aborted = true;
+  }
+}
+
+Future<void> _pump(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+/// Wires a browser over a real proxy → task-side host with [fake], overriding
+/// the download target factory with [target]. Returns the session entry.
+Future<SessionEntry> _mountBrowser(
+  WidgetTester tester, {
+  required InMemoryGatewayPair pair,
+  required _DlSftp fake,
+  required _FakeTarget target,
+  required void Function(SessionHost) captureHost,
+}) async {
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: _stubControllerFactory,
+    sftpOpener: (_) async => fake,
+    snapshotInterval: const Duration(hours: 1),
+  );
+  captureHost(host);
+
+  final container = ProviderContainer(
+    overrides: [
+      taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+      downloadTargetFactoryProvider.overrideWithValue((name) async => target),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  const params = SshConnectParams(
+    host: 'h',
+    port: 22,
+    username: 'u',
+    auth: SshAuth.password('p'),
+  );
+  final entry = container.read(sessionsProvider.notifier).addOrActivate(params);
+  entry.proxy.connect(params);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(home: FileBrowserScreen(sessionId: entry.id)),
+    ),
+  );
+  await _pump(tester);
+  return entry;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets(
+    'download uses the task-side path — progress events, NEVER chunk events',
+    (tester) async {
+      final pair = InMemoryGatewayPair();
+      addTearDown(pair.dispose);
+
+      final fake = _DlSftp(
+        entries: const [
+          SftpEntry(
+            name: 'a.bin',
+            path: '/a.bin',
+            isDirectory: false,
+            size: 12,
+          ),
+        ],
+        fileSize: 12,
+      );
+      final target = _FakeTarget('/tmp/mobissh_test/a.bin');
+      late SessionHost host;
+      final entry = await _mountBrowser(
+        tester,
+        pair: pair,
+        fake: fake,
+        target: target,
+        captureHost: (h) => host = h,
+      );
+
+      // Spy on the SFTP event stream (broadcast) alongside the browser.
+      final events = <SshTaskEvent>[];
+      final spy = entry.proxy.sftpEvents.listen(events.add);
+      addTearDown(spy.cancel);
+
+      await tester.tap(find.byKey(const Key('file-entry-a.bin')));
+      await _pump(tester);
+
+      // The structural root-cause fix: the download rode the streaming path.
+      expect(fake.downloadFileCalled, isTrue);
+      expect(fake.downloadCalled, isFalse,
+          reason: 'the chunk firehose must not be used for a download');
+      expect(events.whereType<SftpDownloadChunkEvent>(), isEmpty,
+          reason: 'no file bytes may cross the isolate');
+      expect(events.whereType<SftpDownloadProgressEvent>(), isNotEmpty);
+      expect(events.whereType<SftpDownloadDoneEvent>(), isNotEmpty);
+      expect(target.published, isTrue);
+      expect(find.textContaining('Downloaded a.bin'), findsOneWidget);
+
+      host.disposeSyncForTest();
+    },
+  );
+
+  testWidgets('a file at/above the threshold prompts a confirm; cancel aborts',
+      (tester) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+
+    final bigSize = kLargeDownloadThresholdBytes + 1;
+    final fake = _DlSftp(
+      entries: [
+        SftpEntry(
+          name: 'big.bin',
+          path: '/big.bin',
+          isDirectory: false,
+          size: bigSize,
+        ),
+      ],
+      fileSize: bigSize,
+    );
+    final target = _FakeTarget('/tmp/mobissh_test/big.bin');
+    late SessionHost host;
+    await _mountBrowser(
+      tester,
+      pair: pair,
+      fake: fake,
+      target: target,
+      captureHost: (h) => host = h,
+    );
+
+    await tester.tap(find.byKey(const Key('file-entry-big.bin')));
+    await _pump(tester);
+
+    // Confirm dialog gates the large transfer.
+    expect(find.byKey(const Key('large-download-confirm')), findsOneWidget);
+
+    // Cancelling the gate starts nothing.
+    await tester.tap(find.byKey(const Key('large-download-cancel')));
+    await _pump(tester);
+    expect(find.byKey(const Key('large-download-confirm')), findsNothing);
+    expect(fake.downloadFileCalled, isFalse);
+    expect(
+      find.byKey(const Key('file-browser-download-progress')),
+      findsNothing,
+    );
+
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('a small file downloads with no confirm dialog', (tester) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+
+    final fake = _DlSftp(
+      entries: const [
+        SftpEntry(name: 's.bin', path: '/s.bin', isDirectory: false, size: 12),
+      ],
+      fileSize: 12,
+    );
+    final target = _FakeTarget('/tmp/mobissh_test/s.bin');
+    late SessionHost host;
+    await _mountBrowser(
+      tester,
+      pair: pair,
+      fake: fake,
+      target: target,
+      captureHost: (h) => host = h,
+    );
+
+    await tester.tap(find.byKey(const Key('file-entry-s.bin')));
+    await _pump(tester);
+
+    expect(find.byKey(const Key('large-download-confirm')), findsNothing);
+    expect(fake.downloadFileCalled, isTrue);
+    expect(target.published, isTrue);
+
+    host.disposeSyncForTest();
+  });
+
+  testWidgets('cancel aborts an in-flight transfer', (tester) async {
+    final pair = InMemoryGatewayPair();
+    addTearDown(pair.dispose);
+
+    final fake = _DlSftp(
+      entries: const [
+        SftpEntry(name: 's.bin', path: '/s.bin', isDirectory: false, size: 12),
+      ],
+      fileSize: 12,
+      blockDownload: true,
+    );
+    addTearDown(() {
+      if (!fake.release.isCompleted) fake.release.complete();
+    });
+    final target = _FakeTarget('/tmp/mobissh_test/s.bin');
+    late SessionHost host;
+    await _mountBrowser(
+      tester,
+      pair: pair,
+      fake: fake,
+      target: target,
+      captureHost: (h) => host = h,
+    );
+
+    await tester.tap(find.byKey(const Key('file-entry-s.bin')));
+    await _pump(tester);
+    // The transfer is parked mid-stream; the progress bar (with cancel) shows.
+    expect(
+      find.byKey(const Key('file-browser-download-progress')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('file-browser-download-cancel')));
+    await _pump(tester);
+
+    expect(target.aborted, isTrue);
+    expect(
+      find.byKey(const Key('file-browser-download-progress')),
+      findsNothing,
+    );
+    expect(find.textContaining('cancelled'), findsOneWidget);
+
+    // Release the parked transfer so it finishes within the test; the terminal
+    // done event no longer matches the (cleared) request id and is ignored.
+    fake.release.complete();
+    await _pump(tester);
+
+    host.disposeSyncForTest();
+  });
+
+  group('DownloadProgressThrottle', () {
+    test('first event and terminal 100% always emit', () {
+      final t = DownloadProgressThrottle();
+      expect(t.shouldEmit(0, 1000, Duration.zero), isTrue);
+      // Well within the interval + fraction (1 byte of 1000) → suppressed.
+      expect(
+        t.shouldEmit(1, 1000, const Duration(milliseconds: 5)),
+        isFalse,
+      );
+      // Terminal always emits regardless of interval/fraction.
+      expect(
+        t.shouldEmit(1000, 1000, const Duration(milliseconds: 6)),
+        isTrue,
+      );
+    });
+
+    test('emits by time OR by fraction, otherwise suppresses', () {
+      final t = DownloadProgressThrottle(
+        minInterval: const Duration(milliseconds: 100),
+        minFraction: 0.1,
+      );
+      expect(t.shouldEmit(0, 1000, Duration.zero), isTrue);
+      // +5ms, +1% → below both thresholds → suppressed.
+      expect(
+        t.shouldEmit(10, 1000, const Duration(milliseconds: 5)),
+        isFalse,
+      );
+      // +120ms → time threshold crossed → emit.
+      expect(
+        t.shouldEmit(20, 1000, const Duration(milliseconds: 120)),
+        isTrue,
+      );
+      // +5ms but +15% since last emit → fraction threshold crossed → emit.
+      expect(
+        t.shouldEmit(170, 1000, const Duration(milliseconds: 125)),
+        isTrue,
+      );
+    });
+
+    test('a burst of tiny updates collapses to few emits', () {
+      final t = DownloadProgressThrottle(
+        minInterval: const Duration(milliseconds: 100),
+        minFraction: 0.5,
+      );
+      var emits = 0;
+      // 100 updates, 1ms apart, 1 byte each of a 1000-byte file: no interval and
+      // no fraction threshold crossed → only the first emits (terminal not hit).
+      for (var i = 0; i < 100; i++) {
+        if (t.shouldEmit(i, 1000, Duration(milliseconds: i))) emits++;
+      }
+      expect(emits, lessThan(5));
+    });
+  });
+}

--- a/native/test/widget/file_browser_widget_test.dart
+++ b/native/test/widget/file_browser_widget_test.dart
@@ -79,44 +79,39 @@ class _ScriptedSftpSession implements SftpSession {
     required void Function(int done, int total) onProgress,
     int chunkSize = 64 * 1024,
   }) async {
-    onProgress(0, 0);
-    return 0;
+    // Mirror the real task-side stream: report progress by byte count without
+    // ever handing the bytes back across the isolate.
+    final total = _fileBytes.length;
+    onProgress(0, total);
+    onProgress(total, total);
+    return total;
   }
 
   @override
   Future<void> close() async {}
 }
 
-/// In-memory sink so the download path runs without a real filesystem. Honors
-/// the chunk byte offset (#591) by writing into an offset-indexed buffer, so it
-/// faithfully mirrors the real [OffsetFileSink] semantics.
-class _MemSink implements FileDownloadSink {
-  final List<int> _buf = <int>[];
-  bool finished = false;
-  int? finishExpectedTotal;
+/// Fake task-side download destination: no filesystem, no platform channel.
+/// [publish] records that the finished staging file was handed off (#976).
+class _FakeTarget implements FileDownloadTarget {
+  _FakeTarget(this.localPath);
 
   @override
-  Future<void> addChunk(Uint8List bytes, int offset) async {
-    final end = offset + bytes.length;
-    while (_buf.length < end) {
-      _buf.add(0);
-    }
-    for (var i = 0; i < bytes.length; i++) {
-      _buf[offset + i] = bytes[i];
-    }
-  }
+  final String localPath;
 
-  Uint8List toBytes() => Uint8List.fromList(_buf);
+  bool published = false;
+  bool aborted = false;
 
   @override
-  Future<String> finish({int? expectedTotal}) async {
-    finished = true;
-    finishExpectedTotal = expectedTotal;
-    return '/test/Download/captured';
+  Future<String> publish() async {
+    published = true;
+    return '/test/Download/${localPath.split('/').last}';
   }
 
   @override
-  Future<void> abort() async {}
+  Future<void> abort() async {
+    aborted = true;
+  }
 }
 
 Future<void> _pump(WidgetTester tester, {int count = 10}) async {
@@ -163,11 +158,13 @@ void main() {
       snapshotInterval: const Duration(hours: 1),
     );
 
-    final memSink = _MemSink();
+    final target = _FakeTarget('/tmp/mobissh_test/a.bin');
     final container = ProviderContainer(
       overrides: [
         taskSshGatewayProvider.overrideWithValue(pair.uiSide),
-        downloadSinkFactoryProvider.overrideWithValue((name) async => memSink),
+        downloadTargetFactoryProvider.overrideWithValue(
+          (name) async => target,
+        ),
       ],
     );
     addTearDown(container.dispose);
@@ -210,12 +207,12 @@ void main() {
     await _pump(tester);
     expect(find.byKey(const Key('file-entry-a.bin')), findsOneWidget);
 
-    // Tap the file → download runs through the injected sink.
+    // Tap the file → download runs through the task-side streaming path (#976):
+    // the finished staging file is published, bytes never crossing the isolate.
     await tester.tap(find.byKey(const Key('file-entry-a.bin')));
     await _pump(tester);
 
-    expect(memSink.finished, isTrue);
-    expect(memSink.toBytes(), Uint8List.fromList(fileBytes));
+    expect(target.published, isTrue);
     // Success snackbar.
     expect(find.textContaining('Downloaded a.bin'), findsOneWidget);
 

--- a/native/test/widget/text_file_viewer_widget_test.dart
+++ b/native/test/widget/text_file_viewer_widget_test.dart
@@ -86,25 +86,20 @@ class _ScriptedSftpSession implements SftpSession {
   Future<void> close() async {}
 }
 
-class _MemSink implements FileDownloadSink {
-  final List<int> _buf = <int>[];
-  bool finished = false;
+/// Fake task-side download destination (#976): no filesystem, no platform
+/// channel. Records that the finished staging file was published.
+class _FakeTarget implements FileDownloadTarget {
+  _FakeTarget(this.localPath);
 
   @override
-  Future<void> addChunk(Uint8List bytes, int offset) async {
-    final end = offset + bytes.length;
-    while (_buf.length < end) {
-      _buf.add(0);
-    }
-    for (var i = 0; i < bytes.length; i++) {
-      _buf[offset + i] = bytes[i];
-    }
-  }
+  final String localPath;
+
+  bool published = false;
 
   @override
-  Future<String> finish({int? expectedTotal}) async {
-    finished = true;
-    return '/test/Download/captured';
+  Future<String> publish() async {
+    published = true;
+    return '/test/Download/${localPath.split('/').last}';
   }
 
   @override
@@ -325,7 +320,7 @@ void main() {
   testWidgets('tapping an unknown binary falls through to download', (
     tester,
   ) async {
-    final memSink = _MemSink();
+    final target = _FakeTarget('/tmp/mobissh_test/app.bin');
     final bytes = List<int>.generate(8, (i) => i + 1);
     final w = _wire(
       tester,
@@ -341,7 +336,9 @@ void main() {
       },
       fileBytes: bytes,
       overrides: [
-        downloadSinkFactoryProvider.overrideWithValue((name) async => memSink),
+        downloadTargetFactoryProvider.overrideWithValue(
+          (name) async => target,
+        ),
       ],
     );
 
@@ -359,7 +356,7 @@ void main() {
     // No viewer; download path ran.
     expect(find.byType(TextFileViewerScreen), findsNothing);
     expect(find.byType(PdfViewerScreen), findsNothing);
-    expect(memSink.finished, isTrue);
+    expect(target.published, isTrue);
     expect(find.textContaining('Downloaded app.bin'), findsOneWidget);
 
     w.host.disposeSyncForTest();


### PR DESCRIPTION
## Summary
- Repoints the file browser's download-to-file path off the `SftpDownloadChunkEvent` firehose (raw bytes base64 across the isolate per chunk + one `setState` per chunk → UI-isolate saturation → ANR/force-quit) onto the task-side streaming path landed in Slice A (#1084): `_startDownload` now sends `SftpDownloadFileCommand` (`proxy.sftpDownloadFile`) with a local staging path and consumes `SftpDownloadProgressEvent` + the terminal done/error events. **File bytes never cross the isolate.**
- New `FileDownloadTarget`/`AppDownloadTarget` seam (mirrors `AppDownloadsSink` minus the UI-side chunk assembly): resolves a staging path the task writes to, then `publish()`es the finished file into public Downloads on done.
- `DownloadProgressThrottle` coalesces progress into bounded rebuilds (>=100ms OR >=1% delta, always the terminal 100%) — no more one `setState` per event.
- Size gate: files >= `kLargeDownloadThresholdBytes` (50 MB) prompt a confirm dialog before starting; a cancel affordance on the progress bar aborts any in-flight transfer (UI-side: stop tracking the request + delete the partial staging file).

## TDD Analysis
- Type: bug fix (structural)
- Behavior change: no user-facing behavior change beyond the new size-gate/cancel affordances; downloads still land in Downloads with the same snackbar.
- TDD approach: full for the structural fix + throttle helper; smoketest-level for the size-gate/cancel widgets.

## Test coverage
- **Existing tests updated**: `file_browser_widget_test.dart` and `text_file_viewer_widget_test.dart` — the browser download now drives `downloadTargetFactoryProvider` + `sftp.downloadFile` instead of the chunk sink.
- **New tests (`file_browser_download_progress_test.dart`)**:
  - download issues the task-side path — asserts `SftpDownloadProgressEvent` + `SftpDownloadDoneEvent` fire and **zero `SftpDownloadChunkEvent`** cross the (broadcast) event stream, and the chunk `download()` is never called (the structural root-cause fix).
  - a file at/above the threshold prompts a confirm dialog; cancelling the gate starts nothing.
  - a small file downloads with no dialog.
  - cancel aborts an in-flight (parked) transfer — `target.abort()` runs, the progress bar disappears, "Download cancelled".
  - `DownloadProgressThrottle` unit tests: first + terminal always emit; emits by time OR fraction; a burst of tiny updates collapses to few emits.

## Test results
- flutter analyze: PASS
- flutter test (native fast gate, `--exclude-tags integration`): PASS (2240 passed, 5 skipped)

## Diff stats
- Files changed: 5 (2 lib, 3 test)
- Lines: +779 / -125 (the new test file is ~370 of the insertions; production churn is the `_DownloadProgress` Row/Column restructure + the new target seam mirroring `AppDownloadsSink`)

## Notes / follow-ups
- **Device-validation pending**: the real failure is device-class (ANR) which a widget test cannot reproduce — the tests assert the byte path is gone and progress is throttled. Needs an on-device/emulator large-file download to confirm the force-quit is fixed.
- **Cancel is UI-side**: there is no task-side download-cancel command to reuse today (only the UI-side sink abort). Cancel stops tracking the request and deletes the partial staging file; the task keeps streaming to that (now-deleted) file. A task-side mid-stream cancel command is a follow-up (would touch the already-landed Slice A plumbing = out of scope here).
- `SftpDownloadCommand`/`_handleSftpDownload` (the chunk path) are intentionally left in place — the in-app viewers/fetchers (PDF, image, text, viewer Share) still use them.

Closes #976

## Cycles used
1/3