### PR TITLE
fix: port-forward remote port auto-fills for real instead of showing a hint (#1094)

### DIFF
--- a/native/lib/ui/port_forwards_sheet.dart
+++ b/native/lib/ui/port_forwards_sheet.dart
@@ -10,6 +10,11 @@
 // Presented via showModalBottomSheet on the app Navigator (the session-menu
 // overlay closes FIRST — its barrier sits above pushed routes, #664 idiom).
 //
+// Add form (#1094): the remote port MIRRORS the local port as a real controller
+// value until the user types their own, so the common `8080 → 8080` case is
+// actually committed. Port fields carry no numeric hintText — a grey number
+// inside an empty field is indistinguishable from a filled-in one.
+//
 // Security (.claude/rules/security.md): forwards bind 127.0.0.1 ONLY; the
 // sheet states that so the surface is honest about scope. No -R in v1.
 
@@ -99,6 +104,17 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
   final _remotePortCtrl = TextEditingController();
   String? _formError;
 
+  /// True once the user has typed their own remote port. While false the remote
+  /// port MIRRORS the local port (#1094) — the common case `8080 → 8080` is then
+  /// genuinely committed, not a hint that merely looks committed. A deliberate
+  /// `8080 → 80` is never clobbered by a later local-port edit.
+  bool _remotePortEdited = false;
+
+  /// Reentrancy guard: the mirror writes `_remotePortCtrl`, which fires that
+  /// controller's own listener. Without this the mirror would read as a user
+  /// edit and pin the field after one keystroke.
+  bool _mirroringRemotePort = false;
+
   @override
   void initState() {
     super.initState();
@@ -109,9 +125,9 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
     });
     // Live effect preview (#1054): rebuild the `L → host:R` line as the user
     // types so the concrete mapping + direction stay in front of them.
-    _localPortCtrl.addListener(_onFieldChanged);
+    _localPortCtrl.addListener(_onLocalPortChanged);
     _remoteHostCtrl.addListener(_onFieldChanged);
-    _remotePortCtrl.addListener(_onFieldChanged);
+    _remotePortCtrl.addListener(_onRemotePortChanged);
     // Hydrate: the task replays the authoritative table.
     widget.entry.proxy.forwardList();
     unawaited(_loadDefaults());
@@ -120,6 +136,29 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
   void _onFieldChanged() {
     if (!mounted) return;
     setState(() {});
+  }
+
+  /// Mirror the local port into the remote port (#1094) unless the user has
+  /// pinned their own. Clearing the local port clears the mirror too, so no
+  /// stale value is stranded in a field the user can no longer see the origin of.
+  void _onLocalPortChanged() {
+    if (!_remotePortEdited && _remotePortCtrl.text != _localPortCtrl.text) {
+      _mirroringRemotePort = true;
+      _remotePortCtrl.text = _localPortCtrl.text;
+      _mirroringRemotePort = false;
+    }
+    _onFieldChanged();
+  }
+
+  /// A user edit pins the remote port; wiping it back to empty hands the field
+  /// to the mirror again. Deliberately does NOT refill on the spot — refilling
+  /// the instant the field empties corrupts backspace-then-retype on a soft
+  /// keyboard (`80` → `8` → `` → refilled `8080`, then the new digits append).
+  void _onRemotePortChanged() {
+    if (!_mirroringRemotePort) {
+      _remotePortEdited = _remotePortCtrl.text.trim().isNotEmpty;
+    }
+    _onFieldChanged();
   }
 
   @override
@@ -214,6 +253,9 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
       remoteHost: remoteHost,
       remotePort: remotePort,
     );
+    // Reset the pin FIRST so clearing the local port also clears the mirror and
+    // the next entry mirrors again.
+    _remotePortEdited = false;
     _localPortCtrl.clear();
     _remotePortCtrl.clear();
   }
@@ -408,8 +450,10 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   decoration: const InputDecoration(
+                    // No numeric hint (#1094): a grey `8888` sitting inside an
+                    // EMPTY field reads as a committed value. The label +
+                    // helper + live preview carry the meaning instead.
                     labelText: 'Local',
-                    hintText: '8888',
                     helperText: 'phone',
                     isDense: true,
                   ),
@@ -446,8 +490,9 @@ class _PortForwardsSheetState extends State<PortForwardsSheet> {
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   decoration: const InputDecoration(
+                    // The #1094 trap itself: this hint was read as an
+                    // auto-filled value while the controller was empty.
                     labelText: 'Remote',
-                    hintText: '8250',
                     helperText: 'on server',
                     isDense: true,
                   ),

--- a/native/test/ui/port_forwards_sheet_mirror_1094_test.dart
+++ b/native/test/ui/port_forwards_sheet_mirror_1094_test.dart
@@ -1,0 +1,230 @@
+// Port-forward add form: the remote port MIRRORS the local port (#1094).
+//
+// The reported bug: the remote-port field carried `hintText: '8250'`, which
+// Flutter paints INSIDE the empty field as grey placeholder text. Typing a
+// local port left the user looking at a number in the remote field that reads
+// as "auto-filled to match" — but the controller was still EMPTY, so Add threw
+// 'Remote port must be 1–65535' and the user had to retype the same number.
+//
+// The fix makes the common case (local == remote) genuinely true instead of
+// merely looking true: the local port is mirrored into the remote-port
+// controller as a REAL value until the user types their own remote port.
+//
+// Driven over the same in-memory gateway pair as the #1054 preview tests (no
+// live SSH); the assertion of record is the `forwardAdd` command that actually
+// reaches the task side.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xterm/xterm.dart';
+
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/ssh_session_proxy.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/profiles_store.dart';
+import 'package:mobissh/ui/port_forwards_sheet.dart';
+
+const _sessionId = 'ra-server:22:me:1';
+
+class _Harness {
+  _Harness()
+      : pair = InMemoryGatewayPair(),
+        store = ProfilesStore() {
+    proxy = SshSessionProxy(sessionId: _sessionId, gateway: pair.uiSide);
+    entry = SessionEntry(
+      id: _sessionId,
+      host: 'ra-server',
+      port: 22,
+      username: 'me',
+      proxy: proxy,
+      terminal: Terminal(maxLines: 200),
+    );
+    // Record every UI → task command so the test can assert what was COMMITTED,
+    // not merely what was rendered.
+    pair.taskSide.incoming.listen(sent.add);
+  }
+
+  final InMemoryGatewayPair pair;
+  final ProfilesStore store;
+  final List<Map<String, dynamic>> sent = <Map<String, dynamic>>[];
+  late final SshSessionProxy proxy;
+  late final SessionEntry entry;
+
+  Iterable<Map<String, dynamic>> get forwardAdds =>
+      sent.where((m) => m['kind'] == 'forwardAdd');
+}
+
+Future<void> _pumpSheet(WidgetTester tester, _Harness h) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(body: PortForwardsSheet(entry: h.entry, store: h.store)),
+    ),
+  );
+  await tester.pump();
+}
+
+String _fieldText(WidgetTester tester, String key) {
+  return tester.widget<TextField>(find.byKey(Key(key))).controller!.text;
+}
+
+String _preview(WidgetTester tester) {
+  return tester.widget<Text>(find.byKey(const Key('forward-preview'))).data!;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('local port alone commits a forward with remotePort == localPort',
+      (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    addTearDown(h.pair.dispose);
+    await _pumpSheet(tester, h);
+
+    // The ONLY thing the user types is the local port — the exact reported flow.
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '8888');
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('forward-add-submit')));
+    await tester.pump();
+
+    // No "retype the same number" error.
+    expect(find.byKey(const Key('forward-form-error')), findsNothing);
+    expect(find.text('Remote port must be 1–65535'), findsNothing);
+
+    // And the forward was ACTUALLY committed, mirrored end to end.
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(h.forwardAdds, hasLength(1));
+    final add = h.forwardAdds.single;
+    expect(add['localPort'], 8888);
+    expect(add['remotePort'], 8888);
+    expect(add['remoteHost'], '127.0.0.1');
+  });
+
+  testWidgets('the mirrored value is visible in the field and the preview',
+      (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    addTearDown(h.pair.dispose);
+    await _pumpSheet(tester, h);
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '8080');
+    await tester.pump();
+
+    // A real controller value, not a hint that merely looks like one.
+    expect(_fieldText(tester, 'forward-remote-port'), '8080');
+    expect(_preview(tester), '8080  →  127.0.0.1:8080');
+  });
+
+  testWidgets('a user-typed remote port is never clobbered by later local edits',
+      (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    addTearDown(h.pair.dispose);
+    await _pumpSheet(tester, h);
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '8080');
+    await tester.pump();
+    // The deliberate 8080 → 80 mapping.
+    await tester.enterText(find.byKey(const Key('forward-remote-port')), '80');
+    await tester.pump();
+    expect(_fieldText(tester, 'forward-remote-port'), '80');
+
+    // Changing the local port must NOT overwrite the explicit remote port.
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '9090');
+    await tester.pump();
+    expect(_fieldText(tester, 'forward-remote-port'), '80');
+    expect(_preview(tester), '9090  →  127.0.0.1:80');
+
+    await tester.tap(find.byKey(const Key('forward-add-submit')));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(h.forwardAdds, hasLength(1));
+    expect(h.forwardAdds.single['localPort'], 9090);
+    expect(h.forwardAdds.single['remotePort'], 80);
+  });
+
+  testWidgets('clearing the local port strands no stale mirrored value',
+      (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    addTearDown(h.pair.dispose);
+    await _pumpSheet(tester, h);
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '8080');
+    await tester.pump();
+    expect(_fieldText(tester, 'forward-remote-port'), '8080');
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '');
+    await tester.pump();
+    expect(_fieldText(tester, 'forward-remote-port'), '');
+    expect(_preview(tester), '·  →  127.0.0.1:·');
+  });
+
+  testWidgets('clearing the remote port re-arms the mirror', (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    addTearDown(h.pair.dispose);
+    await _pumpSheet(tester, h);
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '8080');
+    await tester.pump();
+    await tester.enterText(find.byKey(const Key('forward-remote-port')), '80');
+    await tester.pump();
+    // Wiping the explicit value hands the field back to the mirror; it does NOT
+    // refill on the spot (that would corrupt backspace-then-retype).
+    await tester.enterText(find.byKey(const Key('forward-remote-port')), '');
+    await tester.pump();
+    expect(_fieldText(tester, 'forward-remote-port'), '');
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '9090');
+    await tester.pump();
+    expect(_fieldText(tester, 'forward-remote-port'), '9090');
+  });
+
+  testWidgets('the add form resets to mirroring after a successful add',
+      (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    addTearDown(h.pair.dispose);
+    await _pumpSheet(tester, h);
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '8080');
+    await tester.pump();
+    await tester.enterText(find.byKey(const Key('forward-remote-port')), '80');
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('forward-add-submit')));
+    await tester.pump();
+
+    // Both port fields are emptied, and the next entry mirrors again.
+    expect(_fieldText(tester, 'forward-local-port'), '');
+    expect(_fieldText(tester, 'forward-remote-port'), '');
+
+    await tester.enterText(find.byKey(const Key('forward-local-port')), '5900');
+    await tester.pump();
+    expect(_fieldText(tester, 'forward-remote-port'), '5900');
+  });
+
+  testWidgets('no numeric hint can be mistaken for a committed port value',
+      (tester) async {
+    final h = _Harness();
+    addTearDown(h.proxy.dispose);
+    addTearDown(h.pair.dispose);
+    await _pumpSheet(tester, h);
+
+    for (final key in const ['forward-local-port', 'forward-remote-port']) {
+      final hint = tester
+          .widget<TextField>(find.byKey(Key(key)))
+          .decoration
+          ?.hintText;
+      expect(
+        hint,
+        anyOf(isNull, isNot(matches(RegExp(r'\d')))),
+        reason: '$key hint must not look like a real port value (#1094)',
+      );
+    }
+  });
+}

--- a/native/test/ui/port_forwards_sheet_preview_1054_test.dart
+++ b/native/test/ui/port_forwards_sheet_preview_1054_test.dart
@@ -104,10 +104,12 @@ void main() {
 
     await tester.enterText(find.byKey(const Key('forward-local-port')), '8888');
     await tester.pump();
-    // Blank remote host still resolves to the default in the live preview.
+    // Blank remote host still resolves to the default in the live preview, and
+    // the remote PORT now mirrors the local one (#1094) — the preview reports
+    // the mapping that would actually be committed.
     expect(
       _text(tester, const Key('forward-preview')),
-      '8888  →  127.0.0.1:·',
+      '8888  →  127.0.0.1:8888',
     );
 
     await tester.enterText(


### PR DESCRIPTION
## Summary

- The remote-port field carried `hintText: '8250'` — Flutter paints that INSIDE the empty field as grey placeholder text. The user reads "auto-filled to match", taps Add, and `_submitAdd` parses an EMPTY controller → `null` → `Remote port must be 1–65535`. Nothing was ever committed; the field only ever *looked* filled. Not Android autofill.
- The local port is now mirrored into the remote-port controller as a **real value** while the user has not typed their own, so the common `8080 → 8080` case commits on the first tap. A user edit pins the field (a deliberate `8080 → 80` is never clobbered by a later local-port edit); clearing it re-arms the mirror. Clearing the local port clears the mirror too, stranding no stale value; the pin resets after a successful add.
- Both numeric `hintText`s (`8888` / `8250`) are dropped — a hint shaped like a committed value is the whole trap. The label, `helperText` and the live `L → host:R` preview already carry the meaning. The non-numeric `hostname` hint on the remote-HOST field stays: it can't be mistaken for a port, and that field already holds a real `127.0.0.1` default.

### Design forks, both resolved against the more "helpful" option

- **REJECTED — refilling the remote port the instant it goes empty.** On a soft keyboard that corrupts backspace-then-retype: `80` → `8` → `` → refilled `8080` → the user's next digits append to it. Clearing instead re-arms the mirror silently, and the *next* local-port edit refills it.
- **REJECTED — a hidden `remotePort ??= localPort` fallback inside `_submitAdd`.** It fixes the symptom while leaving the preview line dishonest. The mirror lives in the controller, so `previewMapping` reports exactly what will be sent.

## Part 2 (persistence) — investigated, NOT implemented: this is an owner UX call

The issue's second half ("port forwarding should be persistent once created during a session") was stated as a bug but **is not one**. Forwards added mid-session ARE re-armed on an in-session reconnect:

- `session_host.dart:890-896` — `_dropForwards` closes the listeners and **retains** `forwardConfigs`
- `session_host.dart:903-911` — re-entering `connected` calls `_armForwards`, which iterates `forwardConfigs` (ad-hoc and profile-sourced alike)
- `_HostedSession.forwardConfigs` (`session_host.dart:2397`) owns the desired set; `PortForwardListener` holds only live sockets
- already covered by `native/test/services/forward_host_test.dart:245` — *"leaving connected drops the listener; reconnect RE-ARMS it"*

**The real boundary:** ad-hoc forwards are lost only when the `_HostedSession` itself dies — foreground-isolate teardown (last-session drop) or an explicit disconnect. After that, `state/sessions.dart:404-413` re-sends **only the saved profile's** forwards. So the star's "arm on connect" is about session **death**, not reconnect — and the star is an unlabeled icon in a list row, so a user who never found it would experience exactly the reported symptom after a disconnect.

Two ways to close that, and picking between them is a product-taste decision, not a bot's:

1. **Discoverability only** — make the star legible (a labelled "Keep for this profile" affordance / a first-run hint). Semantics unchanged.
2. **Create implies persist** — new forwards default to starred, with the star becoming an opt-*out*. This changes what a saved profile means and would need the `_remove` un-star path revisited.

No new persistence semantics were invented here. Part 1 alone is a complete, shippable fix for the reported "have to type the same port number again" bug.

## TDD Analysis

- Type: bug fix
- Behavior change: yes, deliberate (the remote port becomes a real mirrored value)
- TDD approach: full — tests written first over the existing `InMemoryGatewayPair` harness, confirmed red (6 fail / 1 pass), then green

## Test coverage

**New tests added (fail→pass)** — `native/test/ui/port_forwards_sheet_mirror_1094_test.dart` (7 tests). The assertion of record is the `forwardAdd` command that actually reaches the task side, not what was rendered:

| Test | Verifies |
|---|---|
| `local port alone commits a forward with remotePort == localPort` | **the exact reported bug** — type only `8888`, tap Add, assert a real `forwardAdd{localPort:8888, remotePort:8888}` reaches the task and no `Remote port must be 1–65535` appears |
| `the mirrored value is visible in the field and the preview` | the controller holds `8080` and the preview reads `8080  →  127.0.0.1:8080` |
| `a user-typed remote port is never clobbered by later local edits` | the dirty-flag guard: `8080→80`, then local→`9090`, commits `9090→80` |
| `clearing the local port strands no stale mirrored value` | remote empties with it; preview falls back to `·  →  127.0.0.1:·` |
| `clearing the remote port re-arms the mirror` | wiping the pin hands the field back — and does NOT refill on the spot |
| `the add form resets to mirroring after a successful add` | the pin resets so the next entry mirrors again |
| `no numeric hint can be mistaken for a committed port value` | regression guard on the root cause: neither port field may carry a digit-bearing `hintText` |

**Existing tests updated**: `native/test/ui/port_forwards_sheet_preview_1054_test.dart` — the local-only preview assertion becomes `'8888  →  127.0.0.1:8888'` (was `'8888  →  127.0.0.1:·'`). That change *is* the fix showing through: the preview now reports the mapping that would actually be committed.

**Emulator fixtures — read, unchanged, not run** (shared emulator unavailable, #1098). `port_forward_1047_test.dart` (18088 / 127.0.0.1 / 8088) and `port_forward_preview_1054_test.dart` (8888 / hostname / 8250) both enter all three fields explicitly, so the explicit remote edit pins over the mirror and their expectations still hold. Neither asserts on `hintText`, so removing the hints breaks nothing silently.

## Test results

- flutter analyze: PASS
- flutter test (`scripts/native-fast-gate.sh`, run relative from the worktree): PASS — full unit suite, 212+ tests, 7 new
- `port_forwarder_test.dart` (known flaky, #1097): passed, no re-run needed

## Diff stats

- Files changed: 3 (1 lib, 1 new test, 1 updated test)
- Lines: +283 / -6 (lib is +47 / -4; the rest is the new test file)

## Device validation

Outstanding: confirm the mirrored value behaves on a real soft keyboard (typing, backspacing and retyping the remote port). The widget tests drive `enterText`, which replaces the whole value at once rather than keystroke-by-keystroke.

Closes #1094

## Cycles used

1/3