### PR TITLE
fix(native): 'Reconnect all' isolates per-session failures and reports an honest outcome (#959)

### DIFF
--- a/native/lib/state/sessions.dart
+++ b/native/lib/state/sessions.dart
@@ -157,6 +157,25 @@ SshSessionController _defaultControllerFactory() => SshSessionController();
 final sshSessionControllerFactoryProvider =
     Provider<SshSessionControllerFactory>((ref) => _defaultControllerFactory);
 
+/// Outcome of one "Reconnect all" batch (#959).
+///
+/// Both lists hold session ids. Membership is decided by the session's own
+/// state TRANSITION after the reconnect was dispatched — not by whether the
+/// dispatch returned — so a session that started reconnecting and then died is
+/// correctly reported as failed. See [SessionsNotifier.reconnectAll].
+class ReconnectAllResult {
+  const ReconnectAllResult({required this.reconnected, required this.failed});
+
+  /// Sessions that reached `connected`.
+  final List<String> reconnected;
+
+  /// Sessions that ended in a terminal drop, never settled, or could not be
+  /// dispatched at all.
+  final List<String> failed;
+
+  int get total => reconnected.length + failed.length;
+}
+
 /// Owns the multi-session collection. Mutations are synchronous; SSH connect
 /// runs against the per-entry proxy after `addOrActivate` returns.
 class SessionsNotifier extends Notifier<SessionsState> {
@@ -311,8 +330,102 @@ class SessionsNotifier extends Notifier<SessionsState> {
     }
     final e = entry;
     if (e == null) return;
-    unawaited(ref.read(keepaliveServiceStarterProvider)());
+    // #959: the keepalive start is the one place `reconnect` could throw
+    // SYNCHRONOUSLY (a provider build / starter that blows up). Unguarded, that
+    // throw escaped this method AND the caller's "Reconnect all" for-loop, so
+    // every session after the failing one was silently skipped. It is a
+    // best-effort prelude — the revive below is what actually matters.
+    try {
+      unawaited(ref.read(keepaliveServiceStarterProvider)());
+    } catch (_) {
+      // Service start failed; the revive still runs (and reports its own state).
+    }
     unawaited(_reviveFromProfile(e));
+  }
+
+  /// Reconnect every session in [ids] INDEPENDENTLY and report what actually
+  /// happened (#959).
+  ///
+  /// The plain fire-and-forget loop the "Reconnect all" affordances used had two
+  /// defects: one session's throw aborted the rest, and nothing observed the
+  /// outcome, so a batch where one machine refused to come back looked exactly
+  /// like a batch where every machine came back.
+  ///
+  /// This is an ADDITIVE seam over [reconnect] — the single-session callers keep
+  /// the unchanged fire-and-forget `void` contract. Per session it:
+  ///   1. subscribes to the proxy's state stream BEFORE dispatching, so a fast
+  ///      settle can't be missed;
+  ///   2. dispatches through [reconnect] inside a try/catch (isolation);
+  ///   3. resolves on the next TERMINAL TRANSITION — `connected` is a success,
+  ///      `failed`/`disconnected` is a failure. A reconnect that merely STARTS
+  ///      is not a reconnect that succeeded, so the outcome is read off the
+  ///      state stream, never off the return of the call.
+  /// A session that never settles within [settleTimeout] counts as failed —
+  /// that is the "one machine hangs the whole set" case the owner reported.
+  /// Unknown ids count as failed (the session vanished mid-batch).
+  Future<ReconnectAllResult> reconnectAll(
+    Iterable<String> ids, {
+    Duration settleTimeout = const Duration(seconds: 45),
+  }) async {
+    // Dispatch every session first (each `_reconnectAndSettle` runs
+    // synchronously up to its first await), THEN await the outcomes — so the
+    // batch is genuinely concurrent, not a serial chain.
+    final pending = <String, Future<bool>>{
+      for (final id in ids) id: _reconnectAndSettle(id, settleTimeout),
+    };
+    final reconnected = <String>[];
+    final failed = <String>[];
+    for (final entry in pending.entries) {
+      if (await entry.value) {
+        reconnected.add(entry.key);
+      } else {
+        failed.add(entry.key);
+      }
+    }
+    return ReconnectAllResult(reconnected: reconnected, failed: failed);
+  }
+
+  /// Reconnect [id] and resolve true once it reaches `connected`, false on a
+  /// terminal drop or [timeout]. See [reconnectAll].
+  Future<bool> _reconnectAndSettle(String id, Duration timeout) async {
+    SessionEntry? entry;
+    for (final e in state.entries) {
+      if (e.id == id) {
+        entry = e;
+        break;
+      }
+    }
+    final target = entry;
+    if (target == null) return false;
+    final settled = Completer<bool>();
+    void resolve(bool ok) {
+      if (!settled.isCompleted) settled.complete(ok);
+    }
+
+    // Consumer before the signal: subscribe BEFORE dispatching so a session that
+    // settles immediately still reports its outcome.
+    final sub = target.proxy.stream.listen((data) {
+      if (data.state == SshSessionState.connected) {
+        resolve(true);
+      } else if (data.state == SshSessionState.failed ||
+          data.state == SshSessionState.disconnected) {
+        resolve(false);
+      }
+      // connecting / authenticating / awaitingHostKey / softDisconnected /
+      // reconnecting / idle are in-flight — keep waiting.
+    });
+    try {
+      reconnect(id);
+    } catch (_) {
+      // ISOLATION: one session's dispatch failure is that session's failure,
+      // never the batch's.
+      resolve(false);
+    }
+    try {
+      return await settled.future.timeout(timeout, onTimeout: () => false);
+    } finally {
+      await sub.cancel();
+    }
   }
 
   /// #916: reconnect every LIVE session so it re-enters with the current

--- a/native/lib/ui/profile_list.dart
+++ b/native/lib/ui/profile_list.dart
@@ -29,6 +29,7 @@ import '../state/sessions.dart';
 import '../state/ui_prefs_providers.dart';
 import '../storage/profiles_store.dart';
 import 'session_state_dot.dart';
+import 'top_toast.dart';
 
 typedef ProfileSelectCallback = void Function(SavedProfile profile);
 typedef RecentSelectCallback = void Function(RecentSessionEntry entry);
@@ -405,11 +406,18 @@ class _ActiveReconnectAllRowState
               ? 'Reconnect'
               : 'Reconnect all (${dropped.length})',
         ),
-        onPressed: () {
+        onPressed: () async {
+          // #959: same batch seam as the in-menu row — per-session isolation
+          // plus a summary so a set where ONE machine refuses to come back is
+          // distinguishable from a clean one. The root overlay is resolved
+          // BEFORE the await so the verdict survives a route change.
           final notifier = ref.read(sessionsProvider.notifier);
-          for (final e in dropped) {
-            notifier.reconnect(e.id);
-          }
+          final overlay = Overlay.maybeOf(context, rootOverlay: true);
+          final result = await notifier.reconnectAll(
+            [for (final e in dropped) e.id],
+          );
+          if (overlay == null || !overlay.mounted) return;
+          showTopToastInOverlay(overlay, reconnectAllSummary(result));
         },
       ),
     );

--- a/native/lib/ui/session_menu.dart
+++ b/native/lib/ui/session_menu.dart
@@ -39,6 +39,7 @@ import 'favorites_menu_sheet.dart';
 import 'file_browser_screen.dart';
 import 'port_forwards_sheet.dart';
 import 'session_state_dot.dart';
+import 'top_toast.dart';
 
 /// Opens the session menu as a NON-MODAL overlay anchored to the bottom, above
 /// the keyboard. Returns once dismissed (outside tap or an action closes it).
@@ -1263,16 +1264,20 @@ class _ReconnectAllRowState extends ConsumerState<_ReconnectAllRow> {
         label: Text(
           dropped.length == 1 ? 'Reconnect' : 'Reconnect all (${dropped.length})',
         ),
-        onPressed: () {
+        onPressed: () async {
           // Route through the notifier so the foreground task isolate is
           // (re)started before each reconnect command — see
-          // SessionsNotifier.reconnect (#817). Each reconnect is fire-and-forget
-          // (_reviveFromProfile), so one session that won't connect can't block
-          // the others.
+          // SessionsNotifier.reconnect (#817). #959: `reconnectAll` isolates
+          // each session (one that throws can no longer abort the loop and
+          // silently skip the rest) and reports the batch OUTCOME, observed
+          // from each session's state transitions.
           final notifier = ref.read(sessionsProvider.notifier);
-          for (final e in dropped) {
-            notifier.reconnect(e.id);
-          }
+          // Resolve the ROOT overlay before awaiting: the menu may be dismissed
+          // while the batch is in flight, and the verdict must still surface.
+          final overlay = Overlay.maybeOf(context, rootOverlay: true);
+          // Dispatch is synchronous up to reconnectAll's first await, so every
+          // reconnect is already in flight when setActive runs below.
+          final batch = notifier.reconnectAll([for (final e in dropped) e.id]);
           // Owner request: don't leave the user parked on a session that won't
           // connect ("reconnect many hangs when one doesn't connect — should
           // focus first session"). FOCUS the first session immediately so they
@@ -1280,6 +1285,9 @@ class _ReconnectAllRowState extends ConsumerState<_ReconnectAllRow> {
           if (widget.entries.isNotEmpty) {
             notifier.setActive(widget.entries.first.id);
           }
+          final result = await batch;
+          if (overlay == null || !overlay.mounted) return;
+          showTopToastInOverlay(overlay, reconnectAllSummary(result));
         },
       ),
     );

--- a/native/lib/ui/session_state_dot.dart
+++ b/native/lib/ui/session_state_dot.dart
@@ -11,6 +11,7 @@
 import 'package:flutter/material.dart';
 
 import '../ssh/ssh_session.dart';
+import '../state/sessions.dart';
 
 /// True when [state] is a drop the user can manually reconnect from (#817).
 /// A live/connecting session is excluded — it's already healthy or trying.
@@ -20,6 +21,26 @@ bool sessionCanReconnect(SshSessionState state) {
       state == SshSessionState.reconnecting ||
       state == SshSessionState.failed ||
       state == SshSessionState.disconnected;
+}
+
+/// One-line verdict for a "Reconnect all" batch (#959), shared by BOTH
+/// surfaces (the in-session menu row and the Connect-view Active Sessions row)
+/// so the wording can't drift between them. The per-row dot/subtitle says WHICH
+/// session failed; this says the batch is done and how it went — without it a
+/// batch where one machine refused to come back was indistinguishable from a
+/// clean one.
+String reconnectAllSummary(ReconnectAllResult result) {
+  final ok = result.reconnected.length;
+  final bad = result.failed.length;
+  if (bad == 0) {
+    return ok == 1 ? 'Reconnected 1 session' : 'Reconnected $ok sessions';
+  }
+  if (ok == 0) {
+    return bad == 1
+        ? 'Reconnect failed for 1 session'
+        : 'Reconnect failed for $bad sessions';
+  }
+  return 'Reconnected $ok, $bad failed';
 }
 
 /// State-driven status dot for a session (#817). The COLOR encodes the

--- a/native/test/widget/active_sessions_group_test.dart
+++ b/native/test/widget/active_sessions_group_test.dart
@@ -302,6 +302,20 @@ void main() {
       );
       await _pumpFrames(tester);
       expect(find.byKey(const Key('active-sessions-group')), findsOneWidget);
+
+      // #959: the batch settles on the per-session state TRANSITIONS and then
+      // shows a summary toast — land both so neither outlives the test. The
+      // batch resolves through the REAL event loop (the in-memory gateway
+      // escapes the fake-async clock), hence the runAsync tick.
+      for (final e in entries) {
+        _pushState(wired.pair, e, SshSessionState.connected);
+      }
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      });
+      await _pumpFrames(tester);
+      expect(find.text('Reconnected 2 sessions'), findsOneWidget);
+      await _pumpFrames(tester, count: 80);
     },
   );
 

--- a/native/test/widget/session_menu_active_state_test.dart
+++ b/native/test/widget/session_menu_active_state_test.dart
@@ -25,6 +25,7 @@ import 'package:mobissh/services/session_messages.dart';
 import 'package:mobissh/services/task_ssh_gateway.dart';
 import 'package:mobissh/ssh/ssh_connect_params.dart';
 import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/keepalive_providers.dart';
 import 'package:mobissh/state/session_host_providers.dart';
 import 'package:mobissh/state/sessions.dart';
 import 'package:mobissh/ui/session_menu.dart';
@@ -54,6 +55,21 @@ Future<void> _pumpFrames(WidgetTester tester, {int count = 8}) async {
     await tester.pump(const Duration(milliseconds: 50));
   }
 }
+
+/// Let a "Reconnect all" batch (#959) settle. The batch resolves through the
+/// REAL event loop (the in-memory gateway + SharedPreferences replies escape
+/// `testWidgets`' fake-async clock), so `pump` alone never drains it — give it
+/// one real tick, then pump the result into the tree.
+Future<void> _settleBatch(WidgetTester tester) async {
+  await tester.runAsync(() async {
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  });
+  await _pumpFrames(tester, count: 4);
+}
+
+/// Pump past the batch-summary toast's auto-dismiss (#959) so neither its
+/// 2s timer nor its exit animation outlives the test.
+Future<void> _drainToast(WidgetTester tester) => _pumpFrames(tester, count: 80);
 
 SessionEntry _add(ProviderContainer c, String host) {
   return c.read(sessionsProvider.notifier).addOrActivate(
@@ -102,10 +118,16 @@ void main() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
   });
 
-  ({ProviderContainer container, InMemoryGatewayPair pair}) make() {
+  ({ProviderContainer container, InMemoryGatewayPair pair}) make({
+    KeepaliveStarter? starter,
+  }) {
     final pair = InMemoryGatewayPair();
     final container = ProviderContainer(
-      overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+      overrides: [
+        taskSshGatewayProvider.overrideWithValue(pair.uiSide),
+        if (starter != null)
+          keepaliveServiceStarterProvider.overrideWithValue(starter),
+      ],
     );
     addTearDown(() async {
       await pair.dispose();
@@ -459,6 +481,13 @@ void main() {
           a.id,
           reason: 'reconnect-all focuses the first session',
         );
+
+        // #959: the batch settles on the per-session state TRANSITIONS, so let
+        // both land before the test ends (else the settle timeout outlives it).
+        _drive(w.pair, a, SshSessionState.connected);
+        _drive(w.pair, b, SshSessionState.connected);
+        await _settleBatch(tester);
+        await _drainToast(tester);
       },
     );
 
@@ -504,6 +533,170 @@ void main() {
           find.byKey(Key('session-menu-reconnect-${a.id}')),
           findsOneWidget,
         );
+
+        // #959: settle b so the batch's timeout doesn't outlive the test.
+        _drive(w.pair, b, SshSessionState.connected);
+        await _settleBatch(tester);
+        await _drainToast(tester);
+      },
+    );
+  });
+
+  // #959 — "Reconnect all" must not fail SILENTLY when one session in the set
+  // fails. Two distinct defects: (a) a synchronous throw from one session's
+  // reconnect aborted the plain `for` loop, silently SKIPPING every session
+  // after it; (b) the batch reported no outcome at all, so the user could not
+  // tell what succeeded. Outcomes are asserted from the per-session state
+  // TRANSITIONS (feedback_test_state_transitions_not_states), never from the
+  // return of the dispatch call.
+  group('Reconnect all — batch isolation + honest outcome (#959)', () {
+    testWidgets(
+      'one session throwing on reconnect does NOT skip the rest of the batch',
+      (tester) async {
+        // The keepalive starter is the one SYNCHRONOUS throw site inside
+        // SessionsNotifier.reconnect. Arm it to blow up on the 2nd session of
+        // the batch only: before the fix that throw escaped reconnect(), escaped
+        // the row's for-loop, and session C never dispatched at all.
+        var armed = false;
+        var armedCalls = 0;
+        final w = make(
+          starter: () {
+            if (armed) {
+              armedCalls += 1;
+              if (armedCalls == 2) {
+                throw StateError('keepalive start failed for this session');
+              }
+            }
+            return Future<void>.value();
+          },
+        );
+        final a = _add(w.container, 'host-a');
+        final b = _add(w.container, 'host-b');
+        final c = _add(w.container, 'host-c');
+
+        final commands = <Map<String, dynamic>>[];
+        final sub = w.pair.taskSide.incoming.listen(commands.add);
+        addTearDown(sub.cancel);
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        for (final e in [a, b, c]) {
+          _drive(w.pair, e, SshSessionState.disconnected);
+        }
+        await _pumpFrames(tester);
+
+        armed = true;
+        await tester.tap(find.byKey(const Key('session-menu-reconnect-all')));
+        await _pumpFrames(tester);
+
+        final reconnects = commands
+            .where((cmd) => cmd['kind'] == SshTaskCommandKind.reconnect.name)
+            .map((cmd) => cmd['sessionId'] as String)
+            .toSet();
+        expect(
+          reconnects,
+          {a.id, b.id, c.id},
+          reason:
+              'every session reconnects independently — one failure must not '
+              'abort or mask the others',
+        );
+
+        // Settle the batch (b genuinely fails) and let the toast expire.
+        _drive(w.pair, a, SshSessionState.connected);
+        _drive(w.pair, b, SshSessionState.failed, error: 'auth failed');
+        _drive(w.pair, c, SshSessionState.connected);
+        await _settleBatch(tester);
+        await _drainToast(tester);
+      },
+    );
+
+    testWidgets(
+      'batch summarises the outcome and the failed row keeps its reason',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+        final b = _add(w.container, 'host-b');
+        final c = _add(w.container, 'host-c');
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        for (final e in [a, b, c]) {
+          _drive(w.pair, e, SshSessionState.disconnected);
+        }
+        await _pumpFrames(tester);
+
+        await tester.tap(find.byKey(const Key('session-menu-reconnect-all')));
+        await _pumpFrames(tester);
+
+        // No verdict while the batch is still in flight.
+        expect(find.byKey(const Key('top-toast')), findsNothing);
+
+        // B fails, A and C come back.
+        _drive(w.pair, a, SshSessionState.connected);
+        _drive(w.pair, b, SshSessionState.failed, error: 'auth failed');
+        _drive(w.pair, c, SshSessionState.connected);
+        await _settleBatch(tester);
+
+        expect(
+          find.byKey(const Key('top-toast')),
+          findsOneWidget,
+          reason: 'the batch outcome must be surfaced, not silent',
+        );
+        expect(find.text('Reconnected 2, 1 failed'), findsOneWidget);
+
+        // And the per-row signal still carries WHICH one failed + why.
+        expect(_dotColor(tester, b), isNot(_dotColor(tester, a)));
+        expect(find.text('auth failed'), findsOneWidget);
+
+        await _drainToast(tester);
+      },
+    );
+
+    testWidgets(
+      'batch skips ⊗-excluded and connected sessions (#817 preserved)',
+      (tester) async {
+        final w = make();
+        final a = _add(w.container, 'host-a');
+        final b = _add(w.container, 'host-b');
+        final c = _add(w.container, 'host-c');
+
+        final commands = <Map<String, dynamic>>[];
+        final sub = w.pair.taskSide.incoming.listen(commands.add);
+        addTearDown(sub.cancel);
+
+        await tester.pumpWidget(_host(container: w.container));
+        await tester.tap(find.byKey(const Key('open-menu')));
+        await _pumpFrames(tester);
+
+        // a stays CONNECTED, b + c are dropped; c is ⊗-excluded.
+        _drive(w.pair, a, SshSessionState.connected);
+        _drive(w.pair, b, SshSessionState.disconnected);
+        _drive(w.pair, c, SshSessionState.disconnected);
+        await _pumpFrames(tester);
+        await tester.tap(
+          find.byKey(Key('session-menu-exclude-reconnect-${c.id}')),
+        );
+        await _pumpFrames(tester);
+
+        await tester.tap(find.byKey(const Key('session-menu-reconnect-all')));
+        await _pumpFrames(tester);
+
+        final reconnects = commands
+            .where((cmd) => cmd['kind'] == SshTaskCommandKind.reconnect.name)
+            .map((cmd) => cmd['sessionId'] as String)
+            .toSet();
+        expect(reconnects, {b.id});
+
+        _drive(w.pair, b, SshSessionState.connected);
+        await _settleBatch(tester);
+
+        // The summary counts only the sessions the batch actually touched.
+        expect(find.text('Reconnected 1 session'), findsOneWidget);
+        await _drainToast(tester);
       },
     );
   });


### PR DESCRIPTION
## Summary

- **Investigated first, as the issue asked.** The per-row failed state DOES render during a batch — `_SessionRow` is a `StreamBuilder` on `entry.proxy.stream` and derives the dot color + the failure-reason subtitle from live state. No redundant per-row UI was added. What is missing is a BATCH verdict: reconnect-all `setActive`s the first session, moving the user away from the very list that carries the per-row evidence.
- **Fixed a real isolation defect.** `SessionsNotifier.reconnect(id)` ran `unawaited(ref.read(keepaliveServiceStarterProvider)())` UNGUARDED — the one synchronous throw site in the method (`_reviveFromProfile` is `async` and internally try/caught). That throw escaped `reconnect()`, escaped the plain `for` loop in BOTH reconnect-all rows, and silently skipped every session after the failing one. This is the reported bug.
- **Added an ADDITIVE `reconnectAll(ids)` seam.** `void reconnect(String id)` keeps its fire-and-forget contract for all three single-session call sites (session_menu ~L1072, profile_list ~L294, `reconnectForControlModeChange`). Per session `reconnectAll` subscribes to the proxy stream BEFORE dispatching, dispatches inside a try/catch, and resolves on the next TERMINAL TRANSITION — `connected` = reconnected, `failed`/`disconnected`/settle-timeout = failed. A reconnect that STARTS is not a reconnect that SUCCEEDED, so the verdict is read off the state stream, never off the return of the call.
- Both rows surface a shared top toast ("Reconnected 3, 1 failed") via the existing #667 `showTopToast` idiom — top-anchored so it never covers the keybar. The root overlay is resolved BEFORE the await so the verdict survives the menu closing or a route change.
- `sessionCanReconnect` filtering and the ⊗ `reconnectExcludedProvider` opt-out are preserved unchanged (#817), plus the owner's "focus the first session immediately" behavior (dispatch is synchronous up to `reconnectAll`'s first await, so focus still lands before any settle).

## TDD Analysis
- Type: bug fix
- Behavior change: yes — adds a batch-outcome toast (the isolation half restores intended behavior)
- TDD approach: full

## Test coverage

**New tests added (fail→pass)** — `native/test/widget/session_menu_active_state_test.dart`:
- `one session throwing on reconnect does NOT skip the rest of the batch` — the keepalive starter is armed to throw on the 2nd session of a 3-session batch. Before the guard, B's throw meant B never revived AND C never dispatched; the test asserts reconnect commands for **all three**. This is the exact reported failure and it is load-bearing on the `reconnect()` guard specifically.
- `batch summarises the outcome and the failed row keeps its reason` — A/C reach `connected`, B goes `failed('auth failed')`. Asserts no verdict while in flight, then the toast reads `Reconnected 2, 1 failed`, AND B's row still shows a distinct (red) dot plus its reason. Covers both "not silent" and "per-row signal not regressed".
- `batch skips ⊗-excluded and connected sessions (#817 preserved)` — a connected session and a ⊗-excluded session are both untouched; the summary counts only the one session the batch actually ran.

**Existing tests updated**: the three pre-existing reconnect-all taps now drive terminal states so the batch settles inside the test (`session_menu_active_state_test.dart` ×2, `active_sessions_group_test.dart` ×1). The Connect-view test additionally asserts its summary (`Reconnected 2 sessions`), so both surfaces are covered.

**Harness note worth keeping**: a batch resolves through the REAL event loop (the in-memory gateway + SharedPreferences replies escape `testWidgets`' fake-async clock), so `tester.pump()` never drains it regardless of frame count. Tests use a `_settleBatch` helper that gives one `tester.runAsync` tick then pumps. Symptom when missed: the assertion fails while the debug print proving the batch settled correctly arrives *after* the failure.

## Test results
- flutter analyze: PASS (No issues found)
- flutter test: PASS (2237 passed, 5 skipped, 0 failed) via `scripts/native-fast-gate.sh` inside the worktree
- Integration/emulator: NOT RUN — shared emulator unavailable (#1098), per delegation instructions

## Diff stats
- Files changed: 6
- Lines: +371 / -14 (production code is ~120 lines including doc comments; the rest is tests)

## Device validation
Owner-pending per constitution article 6: the toast is a UI affordance and could not be
run on hardware this session. Worth confirming on-device that it clears the keybar and
that its timing reads well against a slow batch.

Closes #959

## Cycles used
1/3