### PR TITLE
file browser: back gesture navigates directory history (#1102)

### DIFF
--- a/native/lib/ui/file_browser_screen.dart
+++ b/native/lib/ui/file_browser_screen.dart
@@ -254,6 +254,14 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
   /// star's filled/outline state; refreshed after every favorites mutation.
   Set<String> _favoritePaths = const {};
 
+  /// Directories visited before [_path], most recent last (#1102). The back
+  /// gesture walks THIS, not the parent chain — "previous" is where you came
+  /// FROM (a favorite quick-nav returns you to where you were, not to the
+  /// favorite's parent). Per-browser-instance, so per-session isolation holds
+  /// without any global state. Empty ⇒ back leaves the browser (the old
+  /// behaviour: one route above the terminal, #740).
+  final List<String> _history = [];
+
   /// Monotonic counter → request id, so a late listing for a directory we've
   /// already navigated away from is dropped.
   int _seq = 0;
@@ -335,11 +343,26 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
 
   String _nextRequestId() => '${widget.sessionId}#${_seq++}';
 
-  void _list(String path) {
+  /// List [path]. EVERY directory change funnels through here (descend, up,
+  /// favorite quick-nav, post-upload refresh), so this is where the back
+  /// history (#1102) is recorded. [recordHistory] is false only for
+  /// history-driven navigation — re-pushing there would loop back and forth.
+  void _list(String path, {bool recordHistory = true}) {
     final proxy = _proxy;
     if (proxy == null) return;
     final reqId = _nextRequestId();
+    final from = _path;
     setState(() {
+      if (recordHistory && path != from) {
+        // Navigating back to the directory we just came from (the up-arrow
+        // after descending) CONSUMES that history entry instead of growing the
+        // stack — otherwise back would bounce forward into the dir we just left.
+        if (_history.isNotEmpty && _history.last == path) {
+          _history.removeLast();
+        } else {
+          _history.add(from);
+        }
+      }
       _path = path;
       _loading = true;
       _error = null;
@@ -645,6 +668,16 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     _list(parent);
   }
 
+  /// Back gesture (#1102): navigate to the PREVIOUSLY-VISITED directory. Only
+  /// fires while [_history] is non-empty (otherwise `canPop` lets the real pop
+  /// through and back leaves the browser, as before). Distinct from the
+  /// up-arrow, which goes to the PARENT.
+  void _backToPreviousDirectory() {
+    if (_history.isEmpty) return;
+    final previous = _history.removeLast();
+    _list(previous, recordHistory: false);
+  }
+
   /// #740: return to THIS session's terminal — make the browsed session active
   /// (so the terminal screen's IndexedStack shows the right one in a
   /// multi-session setup) and dismiss back to it. Browsing happens in-place
@@ -890,171 +923,185 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     final swatchColor =
         ref.watch(sessionColorProvider(widget.sessionId)) ??
         ref.watch(sessionTerminalThemeProvider(widget.sessionId)).theme.cursor;
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          key: const Key('file-browser-back-to-terminal'),
-          tooltip: 'Back to terminal',
-          icon: const Icon(Icons.terminal),
-          onPressed: _backToTerminal,
-        ),
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              key: const Key('file-browser-swatch'),
-              width: 12,
-              height: 12,
-              decoration: BoxDecoration(
-                color: swatchColor,
-                shape: BoxShape.circle,
+    // #1102: back walks the directory history. `canPop` mirrors the history so
+    // the platform (predictive back included) knows whether this route really
+    // pops; with history left, the pop is intercepted and consumed here. The
+    // explicit close affordances still collapse straight out — they go through
+    // Navigator.pop/popUntil, which bypasses PopScope by design.
+    return PopScope(
+      canPop: _history.isEmpty,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        _backToPreviousDirectory();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            key: const Key('file-browser-back-to-terminal'),
+            tooltip: 'Back to terminal',
+            icon: const Icon(Icons.terminal),
+            onPressed: _backToTerminal,
+          ),
+          title: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                key: const Key('file-browser-swatch'),
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: swatchColor,
+                  shape: BoxShape.circle,
+                ),
               ),
-            ),
-            const SizedBox(width: 8),
-            Flexible(
-              child: Text(
-                label,
-                key: const Key('file-browser-title'),
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          // Sort menu (#951): radio-style key (Name/Modified/Size/Type) + a
-          // direction toggle. Per-profile, persisted. Disabled (no profile) for
-          // an ad-hoc session. Monochrome glyph.
-          PopupMenuButton<String>(
-            key: const Key('file-browser-sort-button'),
-            icon: const Icon(Icons.sort),
-            tooltip: 'Sort',
-            enabled: profileKey != null,
-            onSelected: (value) {
-              if (profileKey == null) return;
-              final notifier = ref.read(filesSortProvider(profileKey).notifier);
-              switch (value) {
-                case 'name':
-                  notifier.setKey(FilesSortKey.name);
-                case 'modified':
-                  notifier.setKey(FilesSortKey.modified);
-                case 'size':
-                  notifier.setKey(FilesSortKey.size);
-                case 'type':
-                  notifier.setKey(FilesSortKey.type);
-                case 'dir':
-                  notifier.toggleDirection();
-              }
-            },
-            itemBuilder: (context) => [
-              CheckedPopupMenuItem<String>(
-                key: const Key('sort-key-name'),
-                value: 'name',
-                checked: sortPref.key == FilesSortKey.name,
-                child: const Text('Name'),
-              ),
-              CheckedPopupMenuItem<String>(
-                key: const Key('sort-key-modified'),
-                value: 'modified',
-                checked: sortPref.key == FilesSortKey.modified,
-                child: const Text('Modified'),
-              ),
-              CheckedPopupMenuItem<String>(
-                key: const Key('sort-key-size'),
-                value: 'size',
-                checked: sortPref.key == FilesSortKey.size,
-                child: const Text('Size'),
-              ),
-              CheckedPopupMenuItem<String>(
-                key: const Key('sort-key-type'),
-                value: 'type',
-                checked: sortPref.key == FilesSortKey.type,
-                child: const Text('Type'),
-              ),
-              const PopupMenuDivider(),
-              PopupMenuItem<String>(
-                key: const Key('sort-dir-toggle'),
-                value: 'dir',
-                child: Row(
-                  children: [
-                    Icon(
-                      sortPref.ascending
-                          ? Icons.arrow_upward
-                          : Icons.arrow_downward,
-                    ),
-                    const SizedBox(width: 8),
-                    Text(sortPref.ascending ? 'Ascending' : 'Descending'),
-                  ],
+              const SizedBox(width: 8),
+              Flexible(
+                child: Text(
+                  label,
+                  key: const Key('file-browser-title'),
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
             ],
           ),
-          // Upload a local file INTO the current directory (#960). Disabled
-          // while an upload is in flight (one at a time). Monochrome glyph.
-          IconButton(
-            key: const Key('file-browser-upload'),
-            tooltip: 'Upload a file here',
-            icon: const Icon(Icons.upload_file),
-            onPressed: _uploadRequestId != null ? null : _pickAndUpload,
-          ),
-          // Favorites star (#632): TAP toggles favoriting the current path for
-          // this profile; LONG-PRESS opens the unified favorites menu. Built on
-          // a single InkResponse so both gestures are owned by ONE recognizer
-          // set — an IconButton's `tooltip` wraps it in a Tooltip that would eat
-          // the long-press, so we don't use IconButton here. Accessibility is
-          // preserved via the Semantics label.
-          Semantics(
-            button: true,
-            label: _currentFavorited
-                ? 'Unfavorite this folder'
-                : 'Favorite this folder',
-            child: InkResponse(
-              key: const Key('file-browser-star'),
-              radius: 24,
-              onTap: _toggleStar,
-              onLongPress: _openFavoritesMenu,
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Icon(
-                  _currentFavorited ? Icons.star : Icons.star_border,
+          actions: [
+            // Sort menu (#951): radio-style key (Name/Modified/Size/Type) + a
+            // direction toggle. Per-profile, persisted. Disabled (no profile) for
+            // an ad-hoc session. Monochrome glyph.
+            PopupMenuButton<String>(
+              key: const Key('file-browser-sort-button'),
+              icon: const Icon(Icons.sort),
+              tooltip: 'Sort',
+              enabled: profileKey != null,
+              onSelected: (value) {
+                if (profileKey == null) return;
+                final notifier = ref.read(
+                  filesSortProvider(profileKey).notifier,
+                );
+                switch (value) {
+                  case 'name':
+                    notifier.setKey(FilesSortKey.name);
+                  case 'modified':
+                    notifier.setKey(FilesSortKey.modified);
+                  case 'size':
+                    notifier.setKey(FilesSortKey.size);
+                  case 'type':
+                    notifier.setKey(FilesSortKey.type);
+                  case 'dir':
+                    notifier.toggleDirection();
+                }
+              },
+              itemBuilder: (context) => [
+                CheckedPopupMenuItem<String>(
+                  key: const Key('sort-key-name'),
+                  value: 'name',
+                  checked: sortPref.key == FilesSortKey.name,
+                  child: const Text('Name'),
+                ),
+                CheckedPopupMenuItem<String>(
+                  key: const Key('sort-key-modified'),
+                  value: 'modified',
+                  checked: sortPref.key == FilesSortKey.modified,
+                  child: const Text('Modified'),
+                ),
+                CheckedPopupMenuItem<String>(
+                  key: const Key('sort-key-size'),
+                  value: 'size',
+                  checked: sortPref.key == FilesSortKey.size,
+                  child: const Text('Size'),
+                ),
+                CheckedPopupMenuItem<String>(
+                  key: const Key('sort-key-type'),
+                  value: 'type',
+                  checked: sortPref.key == FilesSortKey.type,
+                  child: const Text('Type'),
+                ),
+                const PopupMenuDivider(),
+                PopupMenuItem<String>(
+                  key: const Key('sort-dir-toggle'),
+                  value: 'dir',
+                  child: Row(
+                    children: [
+                      Icon(
+                        sortPref.ascending
+                            ? Icons.arrow_upward
+                            : Icons.arrow_downward,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(sortPref.ascending ? 'Ascending' : 'Descending'),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            // Upload a local file INTO the current directory (#960). Disabled
+            // while an upload is in flight (one at a time). Monochrome glyph.
+            IconButton(
+              key: const Key('file-browser-upload'),
+              tooltip: 'Upload a file here',
+              icon: const Icon(Icons.upload_file),
+              onPressed: _uploadRequestId != null ? null : _pickAndUpload,
+            ),
+            // Favorites star (#632): TAP toggles favoriting the current path for
+            // this profile; LONG-PRESS opens the unified favorites menu. Built on
+            // a single InkResponse so both gestures are owned by ONE recognizer
+            // set — an IconButton's `tooltip` wraps it in a Tooltip that would eat
+            // the long-press, so we don't use IconButton here. Accessibility is
+            // preserved via the Semantics label.
+            Semantics(
+              button: true,
+              label: _currentFavorited
+                  ? 'Unfavorite this folder'
+                  : 'Favorite this folder',
+              child: InkResponse(
+                key: const Key('file-browser-star'),
+                radius: 24,
+                onTap: _toggleStar,
+                onLongPress: _openFavoritesMenu,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Icon(
+                    _currentFavorited ? Icons.star : Icons.star_border,
+                  ),
                 ),
               ),
             ),
-          ),
-          IconButton(
-            key: const Key('file-browser-close-to-terminal'),
-            tooltip: 'Close — back to terminal',
-            icon: const Icon(Icons.close),
-            onPressed: _backToTerminal,
-          ),
-        ],
-        bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(48),
-          child: _PathBar(
-            path: _path,
-            canGoUp: _path != '/' && _path.isNotEmpty,
-            onUp: _goUp,
+            IconButton(
+              key: const Key('file-browser-close-to-terminal'),
+              tooltip: 'Close — back to terminal',
+              icon: const Icon(Icons.close),
+              onPressed: _backToTerminal,
+            ),
+          ],
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(48),
+            child: _PathBar(
+              path: _path,
+              canGoUp: _path != '/' && _path.isNotEmpty,
+              onUp: _goUp,
+            ),
           ),
         ),
-      ),
-      body: Column(
-        children: [
-          if (downloading)
-            _DownloadProgress(
-              key: const Key('file-browser-download-progress'),
-              name: _downloadName ?? '',
-              received: _downloadReceived,
-              total: _downloadTotal,
-              onCancel: _cancelDownload,
-            ),
-          if (_uploadRequestId != null)
-            _UploadProgress(
-              key: const Key('file-browser-upload-progress'),
-              name: _uploadName ?? '',
-              sent: _uploadSent,
-              total: _uploadTotal,
-            ),
-          Expanded(child: _buildBody(sortEntries(_entries, sortPref))),
-        ],
+        body: Column(
+          children: [
+            if (downloading)
+              _DownloadProgress(
+                key: const Key('file-browser-download-progress'),
+                name: _downloadName ?? '',
+                received: _downloadReceived,
+                total: _downloadTotal,
+                onCancel: _cancelDownload,
+              ),
+            if (_uploadRequestId != null)
+              _UploadProgress(
+                key: const Key('file-browser-upload-progress'),
+                name: _uploadName ?? '',
+                sent: _uploadSent,
+                total: _uploadTotal,
+              ),
+            Expanded(child: _buildBody(sortEntries(_entries, sortPref))),
+          ],
+        ),
       ),
     );
   }

--- a/native/test/widget/file_browser_back_history_test.dart
+++ b/native/test/widget/file_browser_back_history_test.dart
@@ -1,0 +1,292 @@
+// File browser back-gesture history tests (#1102).
+//
+// The browser navigates by STATE (one route above the terminal, #740), so the
+// system back gesture used to pop the WHOLE browser and lose the browsing
+// position. Back must now walk the directory HISTORY — the directory you came
+// FROM, not the parent — and only leave the browser when the history is empty.
+//
+// These drive the route's pop path (`handlePopRoute`, i.e. the system back)
+// rather than tapping a widget, so the PopScope is what's exercised.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobissh/services/session_host.dart';
+import 'package:mobissh/services/session_messages.dart';
+import 'package:mobissh/services/task_ssh_gateway.dart';
+import 'package:mobissh/ssh/sftp_session.dart';
+import 'package:mobissh/ssh/ssh_connect_params.dart';
+import 'package:mobissh/ssh/ssh_session.dart';
+import 'package:mobissh/state/session_host_providers.dart';
+import 'package:mobissh/state/sessions.dart';
+import 'package:mobissh/storage/favorites_store.dart';
+import 'package:mobissh/ui/file_browser_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+SshSessionController _stubControllerFactory() {
+  return SshSessionController(
+    socketOpener: (host, port, {timeout}) => Completer<SSHSocket>().future,
+  );
+}
+
+class _ScriptedSftpSession implements SftpSession {
+  _ScriptedSftpSession(this._byPath);
+  final Map<String, List<SftpEntry>> _byPath;
+
+  @override
+  Future<List<SftpEntry>> list(String path) async => _byPath[path] ?? const [];
+  @override
+  Future<int?> sizeOf(String path) async => 0;
+  @override
+  Future<int> download(
+    String path, {
+    required void Function(Uint8List chunk, int offset) onChunk,
+    int chunkSize = 64 * 1024,
+  }) async => 0;
+  @override
+  Future<int> upload(String path, Uint8List bytes) async => bytes.length;
+  @override
+  Future<int> uploadFile(
+    String localPath,
+    String remotePath, {
+    required void Function(int sent, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
+  Future<int> downloadFile(
+    String remotePath,
+    String localPath, {
+    required void Function(int done, int total) onProgress,
+    int chunkSize = 64 * 1024,
+  }) async {
+    onProgress(0, 0);
+    return 0;
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+/// `host:port:username` of [_params] — the favorites identity key.
+const String _profileKey = 'h:22:u';
+
+const SshConnectParams _params = SshConnectParams(
+  host: 'h',
+  port: 22,
+  username: 'u',
+  auth: SshAuth.password('p'),
+);
+
+/// `/` → `a/` → `a/b/`, plus an unrelated `x/y/` branch for the favorite jump.
+const Map<String, List<SftpEntry>> _tree = {
+  '/': [
+    SftpEntry(name: 'a', path: '/a', isDirectory: true),
+    SftpEntry(name: 'x', path: '/x', isDirectory: true),
+  ],
+  '/a': [SftpEntry(name: 'b', path: '/a/b', isDirectory: true)],
+  '/a/b': [SftpEntry(name: 'deep', path: '/a/b/deep', isDirectory: true)],
+  '/x': [SftpEntry(name: 'y', path: '/x/y', isDirectory: true)],
+  '/x/y': [],
+};
+
+Future<void> _pump(WidgetTester tester, {int count = 12}) async {
+  for (var i = 0; i < count; i++) {
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 30));
+  }
+}
+
+Future<void> _settleRoutes(WidgetTester tester) async {
+  for (var i = 0; i < 20; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+/// The system back gesture: drive the route pop path so the browser's PopScope
+/// is what decides, not a tapped affordance.
+Future<void> _systemBack(WidgetTester tester) async {
+  await tester.binding.handlePopRoute();
+  await _pump(tester);
+  await _settleRoutes(tester);
+}
+
+String _currentPath(WidgetTester tester) =>
+    tester.widget<Text>(find.byKey(const Key('file-browser-path'))).data ?? '';
+
+/// Mounts a "terminal" base route and pushes the browser on top via the real
+/// entry point, so "back leaves the browser" is observable.
+Future<({ProviderContainer container, SessionHost host})>
+_mountBrowserOverTerminal(WidgetTester tester) async {
+  final pair = InMemoryGatewayPair();
+  addTearDown(pair.dispose);
+  final host = SessionHost(
+    gateway: pair.taskSide,
+    controllerFactory: _stubControllerFactory,
+    sftpOpener: (_) async => _ScriptedSftpSession(_tree),
+    snapshotInterval: const Duration(hours: 1),
+  );
+  final container = ProviderContainer(
+    overrides: [taskSshGatewayProvider.overrideWithValue(pair.uiSide)],
+  );
+  addTearDown(container.dispose);
+  final session = container
+      .read(sessionsProvider.notifier)
+      .addOrActivate(_params);
+  session.proxy.connect(_params);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                key: const Key('open-browser'),
+                onPressed: () => openFileBrowser(context, session.id),
+                child: const Text('terminal', key: Key('terminal-marker')),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await _pump(tester);
+  await tester.tap(find.byKey(const Key('open-browser')));
+  await _pump(tester);
+  expect(find.byType(FileBrowserScreen), findsOneWidget);
+  return (container: container, host: host);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('back walks the directory history instead of leaving (#1102)', (
+    tester,
+  ) async {
+    final w = await _mountBrowserOverTerminal(tester);
+
+    await tester.tap(find.byKey(const Key('file-entry-a')));
+    await _pump(tester);
+    await tester.tap(find.byKey(const Key('file-entry-b')));
+    await _pump(tester);
+    expect(_currentPath(tester), '/a/b');
+
+    // Back → the directory we came from, browser still on screen.
+    await _systemBack(tester);
+    expect(find.byType(FileBrowserScreen), findsOneWidget);
+    expect(_currentPath(tester), '/a');
+
+    // Again → root, still in the browser.
+    await _systemBack(tester);
+    expect(find.byType(FileBrowserScreen), findsOneWidget);
+    expect(_currentPath(tester), '/');
+
+    // History exhausted → back finally leaves the browser.
+    await _systemBack(tester);
+    expect(find.byType(FileBrowserScreen), findsNothing);
+    expect(find.byKey(const Key('terminal-marker')), findsOneWidget);
+
+    w.host.disposeSyncForTest();
+  });
+
+  testWidgets('back at the opening directory leaves the browser (#1102)', (
+    tester,
+  ) async {
+    final w = await _mountBrowserOverTerminal(tester);
+    expect(_currentPath(tester), '/');
+
+    await _systemBack(tester);
+
+    expect(find.byType(FileBrowserScreen), findsNothing);
+    expect(find.byKey(const Key('terminal-marker')), findsOneWidget);
+
+    w.host.disposeSyncForTest();
+  });
+
+  testWidgets(
+    'back after a favorite jump returns to where we were, not the parent (#1102)',
+    (tester) async {
+      await FavoritesStore().add(_profileKey, '/x/y');
+      final w = await _mountBrowserOverTerminal(tester);
+
+      await tester.tap(find.byKey(const Key('file-entry-a')));
+      await _pump(tester);
+      await tester.tap(find.byKey(const Key('file-entry-b')));
+      await _pump(tester);
+      expect(_currentPath(tester), '/a/b');
+
+      // Quick-nav to a favorite deep in an unrelated branch.
+      await tester.longPress(find.byKey(const Key('file-browser-star')));
+      await _pump(tester);
+      await tester.tap(find.byKey(const Key('favorite-item-/x/y')));
+      await _pump(tester);
+      expect(_currentPath(tester), '/x/y');
+
+      // Back = where we CAME FROM (/a/b), not the favorite's parent (/x).
+      await _systemBack(tester);
+      expect(find.byType(FileBrowserScreen), findsOneWidget);
+      expect(_currentPath(tester), '/a/b');
+
+      w.host.disposeSyncForTest();
+    },
+  );
+
+  testWidgets('up-arrow goes to the parent and back does not bounce (#1102)', (
+    tester,
+  ) async {
+    final w = await _mountBrowserOverTerminal(tester);
+
+    await tester.tap(find.byKey(const Key('file-entry-a')));
+    await _pump(tester);
+    await tester.tap(find.byKey(const Key('file-entry-b')));
+    await _pump(tester);
+    expect(_currentPath(tester), '/a/b');
+
+    // Up = PARENT (a distinct affordance from back).
+    await tester.tap(find.byKey(const Key('file-browser-up')));
+    await _pump(tester);
+    expect(_currentPath(tester), '/a');
+
+    // Back must NOT bounce forward into /a/b — it continues outward to root.
+    await _systemBack(tester);
+    expect(find.byType(FileBrowserScreen), findsOneWidget);
+    expect(_currentPath(tester), '/');
+
+    w.host.disposeSyncForTest();
+  });
+
+  testWidgets('the close affordance still collapses out of the browser (#855)', (
+    tester,
+  ) async {
+    final w = await _mountBrowserOverTerminal(tester);
+
+    await tester.tap(find.byKey(const Key('file-entry-a')));
+    await _pump(tester);
+    await tester.tap(find.byKey(const Key('file-entry-b')));
+    await _pump(tester);
+    expect(_currentPath(tester), '/a/b');
+
+    // Deep history, but the X is the EXPLICIT close: straight out, one action.
+    await tester.tap(find.byKey(const Key('file-browser-close-to-terminal')));
+    await _settleRoutes(tester);
+
+    expect(find.byType(FileBrowserScreen), findsNothing);
+    expect(find.byKey(const Key('terminal-marker')), findsOneWidget);
+
+    w.host.disposeSyncForTest();
+  });
+}


### PR DESCRIPTION
## Summary
- Back gesture in the file browser now navigates to the PREVIOUSLY-VISITED directory instead of popping the whole browser back to the terminal.
- "Previous" is history, not parent-walk: a favorite quick-nav returns you to where you were, not to the favorite's parent; the up-arrow after a descend does not bounce forward.
- Back leaves the browser only when the history is empty (today's behaviour). The up-arrow (parent) and the close X (#855, straight out) are unchanged.

## Design
`_list()` is the single funnel for every directory change (descend, `_goUp`, `_navigateToFavorite`, deep-link, post-upload refresh), so the history is recorded there:
- push the directory we're leaving, unless `recordHistory: false` (history-driven navigation, which would otherwise loop);
- navigating to the directory we just came from CONSUMES that entry instead of pushing (this is what keeps the up-arrow from creating a forward bounce);
- same-path refreshes never record.

`PopScope(canPop: _history.isEmpty, onPopInvokedWithResult: ...)` wraps the scaffold. `canPop` mirrors the history so the platform (predictive back included) knows whether the route really pops; with history left, the pop is intercepted and consumed. `_backToTerminal()` is untouched — `Navigator.pop`/`popUntil` bypass PopScope by design, so the X still collapses the browser+viewer stack in one action.

History lives in the browser state, so per-session isolation holds with no global/provider state.

## TDD Analysis
- Type: feature (behavior change)
- Behavior change: yes — back inside the browser
- TDD approach: full (tests written first, confirmed red, then implemented)

## Test coverage
- **New tests (fail→pass)** — `native/test/widget/file_browser_back_history_test.dart`, driving the real route pop path (`handlePopRoute`) so the PopScope is what's exercised, not a button:
  - descend two levels → back → previous directory, browser still on screen; back again → root; back again → leaves the browser (was red)
  - favorite quick-nav from `/a/b` to `/x/y` → back returns to `/a/b`, not `/x` (was red)
  - up-arrow goes to the parent, and back afterwards continues outward instead of bouncing into the directory just left (was red)
  - back at the opening directory (empty history) leaves the browser (guard against over-capture — green before and after)
  - the close X still collapses out of a deep directory (#855 regression guard — green before and after)
- **Existing tests updated**: none needed. `file_browser_dismiss_test.dart`, `file_browser_widget_test.dart`, `viewer_actions_1038_test.dart` and `sftp_browse_smoke_test.dart` drive the up-arrow / close X, never the system back — all unchanged and green.

## Test results
- `scripts/native-fast-gate.sh` (run inside the worktree): analyze PASS, flutter test PASS — 2256 passed, 5 skipped.
- Integration/emulator suite NOT run (shared fleet emulator has known pre-existing failures on main, #1101).
- **Device validation is owner-pending** — this is a gesture/navigation change, so it should be confirmed on hardware (real Android back gesture + predictive back) before it is considered done.

## Diff stats
- Files changed: 2 (1 source, 1 new test)
- Source change: +50 / -3 ignoring whitespace (the rest of the line count is the mechanical re-indent from wrapping the scaffold in `PopScope` — `git diff -w` shows the real change)

Closes #1102

## Cycles used
1/3