### PR TITLE
fix: deleting an adopted SSH key removes the wrong vault entry (#1109 part C)

### DIFF
--- a/native/lib/state/keys_providers.dart
+++ b/native/lib/state/keys_providers.dart
@@ -105,9 +105,24 @@ class KeysManager {
   /// Delete a library key — removes BOTH the vault blob and the metadata. The
   /// caller is responsible for warning when profiles still reference it (their
   /// `keyVaultId` will dangle until re-attached).
+  ///
+  /// Resolves the vault id the same way the write path does (`key.vaultId`,
+  /// #1109c): an ADOPTED key's material lives at the profile's original
+  /// `keyVaultId`, NOT the `key-<id>` default — deleting the default would be a
+  /// silent no-op that leaks the private key and leaves the profile still
+  /// authenticating. Falls back to `keyVaultIdFor(id)` for a metadata-only stray
+  /// with no matching [SavedKey].
   Future<void> delete(String id) async {
-    await _ref.read(secretsStoreProvider).delete(keyVaultIdFor(id));
-    await _ref.read(keysStoreProvider).remove(id);
+    final store = _ref.read(keysStoreProvider);
+    String vaultId = keyVaultIdFor(id);
+    for (final k in await store.load()) {
+      if (k.id == id) {
+        vaultId = k.vaultId;
+        break;
+      }
+    }
+    await _ref.read(secretsStoreProvider).delete(vaultId);
+    await store.remove(id);
     _ref.invalidate(savedKeysProvider);
   }
 }

--- a/native/test/state/keys_providers_test.dart
+++ b/native/test/state/keys_providers_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobissh/state/keys_providers.dart';
 import 'package:mobissh/state/profiles_providers.dart';
+import 'package:mobissh/storage/keys_store.dart';
 import 'package:mobissh/storage/profiles_store.dart';
 import 'package:mobissh/storage/secrets_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -156,6 +157,73 @@ void main() {
         ),
       ]);
       expect(await c.read(keysManagerProvider).adoptFromProfiles(), 1);
+    });
+  });
+
+  group('delete resolves the override-aware vaultId (#1109c)', () {
+    test(
+        'deleting an ADOPTED key removes its ORIGINAL vault entry, and the '
+        'referencing profile can no longer resolve a credential', () async {
+      const profileKeyVaultId = 'profile-key-fd:22:me';
+      final store = ProfilesStore();
+      final profile = SavedProfile(
+        title: 'fd-dev',
+        host: 'fd',
+        port: 22,
+        username: 'me',
+        authType: 'key',
+        keyVaultId: profileKeyVaultId,
+      );
+      await store.save([profile]);
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      // The private material lives at the profile's ORIGINAL vault id, NOT
+      // `key-<id>`. This is what the adopted key points at.
+      await secrets.write(profileKeyVaultId, <String, Object?>{
+        'data': '-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n-----END-----',
+      });
+      final c = ProviderContainer(overrides: [
+        secretsStoreProvider.overrideWithValue(secrets),
+        profilesStoreProvider.overrideWithValue(store),
+      ]);
+      addTearDown(c.dispose);
+
+      final mgr = c.read(keysManagerProvider);
+      expect(await mgr.adoptFromProfiles(), 1);
+      final adopted = (await c.read(keysStoreProvider).load()).single;
+      expect(adopted.vaultId, profileKeyVaultId);
+
+      await mgr.delete(adopted.id);
+
+      // The ORIGINAL vault entry is actually gone (not a silent no-op on a
+      // never-written `key-<id>`).
+      expect(await secrets.read(profileKeyVaultId), isNull);
+      // The metadata is gone too.
+      expect(await c.read(keysStoreProvider).load(), isEmpty);
+      // The profile that referenced it can no longer authenticate.
+      expect((await loadProfileCredentials(secrets, profile)).isEmpty, isTrue);
+    });
+
+    test('deleting a natively-imported key still removes its key-<id> entry',
+        () async {
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final c = makeContainer(secrets);
+      final mgr = c.read(keysManagerProvider);
+      final key = await mgr.importFromPem(name: 'k', pem: 'x');
+      // A native key's material lives at `key-<id>` (no override).
+      expect(key.vaultId, keyVaultIdFor(key.id));
+      expect(await secrets.read(keyVaultIdFor(key.id)), isNotNull);
+
+      await mgr.delete(key.id);
+
+      expect(await secrets.read(keyVaultIdFor(key.id)), isNull);
+      expect(await c.read(keysStoreProvider).load(), isEmpty);
+    });
+
+    test('deleting a non-existent id is a safe no-op', () async {
+      final secrets = SecretsStore(backend: InMemorySecretsBackend());
+      final c = makeContainer(secrets);
+      await c.read(keysManagerProvider).delete('does-not-exist');
+      expect(await c.read(keysStoreProvider).load(), isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Fix `KeysManager.delete(id)` deleting the WRONG vault entry for an ADOPTED key (part C of #1109). It hard-coded `keyVaultIdFor(id)` (`key-<id>`) instead of the override-aware `SavedKey.vaultId` the write path uses. For an adopted per-profile key (whose material lives at the profile's original `keyVaultId`), the delete hit a never-written `key-<id>` → silent no-op: the private PEM+passphrase stayed orphaned in the vault forever, and the referencing profile KEPT authenticating despite the UI saying "This can't be undone".
- `delete(id)` now resolves the `SavedKey` from `keysStoreProvider` and deletes `key.vaultId` (mirroring the write at `keys_providers.dart:48`), then removes the metadata. Falls back to `keyVaultIdFor(id)` when no `SavedKey` matches, so a metadata-only stray still cleans up.

## TDD Analysis
- Type: bug fix (security + correctness)
- Behavior change: no (restores intended delete semantics)
- TDD approach: full — regression tests written first, watched the adopted-key case fail (original vault entry survived), then fixed to green.

## Test coverage
- **Existing tests updated**: none needed (native-key delete + import/rename/adopt tests unchanged and still green).
- **New tests added (fail→pass)** in `native/test/state/keys_providers_test.dart`, group `delete resolves the override-aware vaultId (#1109c)`:
  - deleting an ADOPTED key removes its ORIGINAL vault entry AND the referencing profile can no longer resolve a credential (`loadProfileCredentials` returns empty). This was the failing case pre-fix.
  - regression: deleting a natively-imported key still removes its `key-<id>` entry.
  - deleting a non-existent id is a safe no-op.

## Test results
- flutter analyze: PASS
- flutter test (fast gate, `--exclude-tags integration`): PASS — all unit tests green (2261 passed, 5 integration-tagged skipped)
- Did NOT run `--with-integration` / boot an emulator: the fleet integration suite is RED on main (#1101) and burns an exclusive device lease.

## Diff stats
- Files changed: 2
- Lines: +85 / -2

## Device-validation
Device-validation-pending. This is a logic/storage fix fully covered by widget-free unit tests against an in-memory vault fake; no device-class (layout/keyboard/gesture) surface. Owner may confirm on hardware.

## Follow-ups (OUT of scope, not built here)
- (a) A one-time reconciliation/cleanup flow for keys ALREADY orphaned by the old bug (needs `secrets_store.dart` `listVaultIds` + a review UI to identify and purge unreachable blobs).
- (b) The fix does NOT revoke a PEM already materialized into a LIVE session's reconnect params — a delete takes effect on the next COLD connect, not mid-session.

Refs #1109 (part C)

## Cycles used
1/3