### PR TITLE
Compile raw terminal content out of public bug reports (#1109-A)

### DIFF
--- a/native/lib/diagnostics/diagnostics_config.dart
+++ b/native/lib/diagnostics/diagnostics_config.dart
@@ -1,0 +1,23 @@
+// Centralized compile-time gate for RAW terminal-derived diagnostics (#1109-A).
+//
+// Raw terminal OUTPUT (the byte-trace), remote OSC/hook message text, and
+// verbatim selection text are DEVELOPMENT-TIME diagnostics only: they can carry
+// secrets a runtime scrubber cannot reliably catch (a token echoed on screen, a
+// password in scrollback). Per the owner decision (#1109), that content is
+// COMPILED OUT of public release builds rather than scrubbed at runtime.
+//
+// This single const is the gate. Raw terminal-derived content is captured and
+// uploaded ONLY when it is true. Public release builds pass nothing, so it
+// resolves to its `defaultValue: false`; every `if (kRawContentDiagnosticsEnabled)`
+// block then becomes dead code the AOT (`--release`) compiler tree-shakes out —
+// verified by codex to survive `--split-per-abi` / `--obfuscate` /
+// `--split-debug-info`, and to FAIL CLOSED (an unset define → false → no raw
+// content). A tracing-enabled internal build passes
+// `--dart-define=MOBISSH_RAW_DIAGNOSTICS=true`.
+//
+// Mirrors the existing `String.fromEnvironment` idiom in
+// `ui/feedback_overlay.dart` (`MOBISSH_FEEDBACK_ENDPOINT` / `MOBISSH_FEEDBACK_KEY`).
+const bool kRawContentDiagnosticsEnabled = bool.fromEnvironment(
+  'MOBISSH_RAW_DIAGNOSTICS',
+  defaultValue: false,
+);

--- a/native/lib/diagnostics/session_byte_recorder.dart
+++ b/native/lib/diagnostics/session_byte_recorder.dart
@@ -23,11 +23,16 @@
 //   - The scroll ring stores `{tMs, offset}` bounded by event count + age. Grid
 //     `{cols, rows}` tracks the latest viewport (updated on resize).
 //
-// SECURITY (rules/security.md / #553 contract): the byte stream is terminal
-// OUTPUT and MAY contain secrets (an echoed token, a sudo prompt echo). The
-// snapshot decodes each chunk, runs it through [scrubSecrets] (shared with the
-// feedback bundle), and re-encodes — so credential-looking lines NEVER leave the
-// device. Scrubbing at snapshot (cold path) keeps the hot path allocation-light.
+// SECURITY (rules/security.md / #553 / #1109-A): the byte ring is terminal
+// OUTPUT and MAY contain secrets (an echoed token, a sudo prompt echo). A
+// best-effort [scrubSecrets] pass at snapshot time is defense-in-depth ONLY — it
+// is NOT relied on as the security boundary. The real boundary is the
+// [kRawContentDiagnosticsEnabled] gate at the call sites (#1109-A): in public
+// release builds `recordBytes` is never called and `byteTrace` is never
+// assembled, so the raw ring stays empty and is tree-shaken out. The term-reply
+// ring is additionally constrained to a strict DA/DSR/CPR/XTVERSION allowlist
+// ([isAllowedTermReply]) so it never records arbitrary OSC / other payloads.
+// Scrubbing at snapshot (cold path) keeps the hot path allocation-light.
 
 import 'dart:collection';
 import 'dart:convert';
@@ -136,6 +141,28 @@ String termReplyKind(Uint8List chunk) {
   return 'other';
 }
 
+/// #1109-A: true iff [chunk] is a terminal AUTO-REPLY the term-reply ring is
+/// ALLOWED to record — a strict allowlist so it never captures arbitrary OSC /
+/// hook / other payloads verbatim (which could embed remote-supplied content).
+/// Only the shape of a genuine device reply passes:
+///   - DA1  `ESC [ ?` …            (primary device attributes)
+///   - DA2  `ESC [ >` …            (secondary device attributes)
+///   - CPR/DSR `ESC [` … `R` / `n` (cursor position / device status)
+///   - XTVERSION `ESC P` …         (DCS version reply)
+/// A generic OSC (`ESC ]`) or anything else is rejected. Pure + allocation-free.
+bool isAllowedTermReply(Uint8List chunk) {
+  if (chunk.length < 2 || chunk[0] != 0x1b) return false;
+  // XTVERSION / other DCS reply: ESC P.
+  if (chunk[1] == 0x50) return true;
+  // CSI replies only: ESC [ … (excludes OSC `ESC ]` and everything else).
+  if (chunk[1] != 0x5b) return false;
+  if (chunk.length >= 3 && (chunk[2] == 0x3f || chunk[2] == 0x3e)) {
+    return true; // DA1 (ESC [ ?) / DA2 (ESC [ >)
+  }
+  final last = chunk[chunk.length - 1];
+  return last == 0x52 || last == 0x6e; // CPR (R) / DSR (n)
+}
+
 /// A bounded, backward-looking recorder of the raw bytes written to ONE
 /// session's terminal plus its scroll-offset events. See the file header.
 class SessionByteRecorder {
@@ -241,6 +268,10 @@ class SessionByteRecorder {
   /// path at snapshot). Same eviction discipline as the sent-SGR ring.
   void recordTermReply(Uint8List chunk) {
     if (chunk.isEmpty) return;
+    // #1109-A: only record genuine device replies (DA/DSR/CPR/XTVERSION). A
+    // generic OSC / hook / other chunk — which could carry remote-supplied
+    // content — is dropped here so it never enters the ring verbatim.
+    if (!isAllowedTermReply(chunk)) return;
     final t = _nowMs();
     _termReply.add(_ByteEvent(t, chunk));
     final ageFloor = t - maxAge.inMilliseconds;

--- a/native/lib/services/session_host.dart
+++ b/native/lib/services/session_host.dart
@@ -24,6 +24,8 @@ import 'package:flutter/foundation.dart';
 import 'package:dartssh2/dartssh2.dart';
 
 import '../diagnostics/connect_trace.dart';
+import '../diagnostics/diagnostics_config.dart'
+    show kRawContentDiagnosticsEnabled;
 import '../terminal/tmux_control_channel.dart';
 import '../terminal/tmux_control_mode_flag.dart';
 import '../ssh/da2_responder.dart';
@@ -2045,12 +2047,17 @@ class SessionHost {
     try {
       final signals = hosted.attentionScanner.feed(bytes);
       for (final sig in signals) {
-        // Slice 1: durable lifecycle log (kept).
-        clifecycle(
-          'attention',
-          '${sig.kind.name} ${sig.text == null ? '(no text)' : '"${sig.text}"'} '
-              '(session $sessionId)',
-        );
+        // Slice 1: durable lifecycle log (kept). #1109-A: `sig.text` is the
+        // arbitrary OSC 9/777 / hook-line message text extracted from REMOTE
+        // output — raw content that can carry secrets. Keep the structural
+        // signal KIND (and text length) in every build, but gate the verbatim
+        // text out of public release builds (fail-closed).
+        final textPart = sig.text == null
+            ? '(no text)'
+            : (kRawContentDiagnosticsEnabled
+                  ? '"${sig.text}"'
+                  : '(text len=${sig.text!.length})');
+        clifecycle('attention', '${sig.kind.name} $textPart (session $sessionId)');
         // Slice 2: post an attention notification, unless suppressed because
         // the user is already looking at this session (#847) or the signal
         // arrived inside the (re)connect replay window (#851).

--- a/native/lib/ui/feedback_overlay.dart
+++ b/native/lib/ui/feedback_overlay.dart
@@ -30,6 +30,8 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:mobissh/diagnostics/connect_trace.dart';
 import 'package:mobissh/diagnostics/detection_geom.dart'
     show activeDetectionGeomSnapshot;
+import 'package:mobissh/diagnostics/diagnostics_config.dart'
+    show kRawContentDiagnosticsEnabled;
 import 'package:mobissh/diagnostics/feedback_bundle.dart' show scrubSecrets;
 import 'package:mobissh/diagnostics/paint_stats.dart'
     show activePaintStatsSnapshot;
@@ -179,11 +181,16 @@ Map<String, Object?> buildFeedbackPayload({
     // Terminal ({tMs,b64}); scrollTrace = scroll-offset events ({tMs,offset});
     // grid = the active session's viewport {cols,rows}. The server (#790)
     // persists these as `${ts}-bug-report.byte-trace.json` so the captured trace
-    // can be replayed (#791) to reproduce a scrollback-render bug. The byte
-    // stream is ALREADY scrubbed by SessionByteRecorder.snapshotByteTrace() at
-    // snapshot time (rules/security.md). Omitted entirely when no session is
-    // active (no empty-array / null noise).
-    if (includeTraces && byteTrace.isNotEmpty) 'byteTrace': byteTrace,
+    // can be replayed (#791) to reproduce a scrollback-render bug.
+    //
+    // #1109-A: byteTrace is RAW terminal output — it can carry displayed secrets
+    // the snapshot-time scrubber cannot reliably catch. It is therefore gated
+    // behind [kRawContentDiagnosticsEnabled] (compile-time false in public
+    // release builds → this field, and the capture that feeds it, are tree-shaken
+    // out; nothing raw leaves the device). scrollTrace/grid below are structural
+    // (offsets / dimensions) and ride in every build. Omitted when empty.
+    if (kRawContentDiagnosticsEnabled && includeTraces && byteTrace.isNotEmpty)
+      'byteTrace': byteTrace,
     if (includeTraces && scrollTrace.isNotEmpty) 'scrollTrace': scrollTrace,
     // #793: the synthesized mouse/wheel SGR reports the app SENT
     // (sentSgrTrace: [{tMs,b64}]). In tmux mouse mode the scroll is wheel-SGR
@@ -444,8 +451,11 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
       lifecycleLog: lifecycleLog,
       controlModeTrace: controlModeTrace,
       // #790: backward-looking — snapshot NOW so the trace covers the bug just
-      // reproduced during the burst.
-      byteTrace: activeByteTraceSnapshot(),
+      // reproduced during the burst. #1109-A: raw output — only fetched when raw
+      // diagnostics are compiled in (else the snapshot call is tree-shaken out).
+      byteTrace: kRawContentDiagnosticsEnabled
+          ? activeByteTraceSnapshot()
+          : const <Map<String, Object?>>[],
       scrollTrace: activeScrollTraceSnapshot(),
       sentSgrTrace: activeSentSgrTraceSnapshot(),
       termReplyTrace: activeTermReplyTraceSnapshot(),
@@ -489,8 +499,11 @@ class _FeedbackOverlayState extends State<FeedbackOverlay> {
     final controlModeTrace = controlModeLogSnapshot();
     // #790: snapshot the byte/scroll recorder at the EXACT moment of tap — it's
     // backward-looking, so the rings hold the input + scroll that produced the
-    // current (buggy) frame the owner is reporting.
-    final byteTrace = activeByteTraceSnapshot();
+    // current (buggy) frame the owner is reporting. #1109-A: byteTrace is raw
+    // output — only fetched when raw diagnostics are compiled in.
+    final byteTrace = kRawContentDiagnosticsEnabled
+        ? activeByteTraceSnapshot()
+        : const <Map<String, Object?>>[];
     final scrollTrace = activeScrollTraceSnapshot();
     final sentSgrTrace = activeSentSgrTraceSnapshot();
     // #1072: snapshot the terminal auto-reply ring + the detection-wash geometry

--- a/native/lib/ui/ghostty_terminal_view.dart
+++ b/native/lib/ui/ghostty_terminal_view.dart
@@ -174,6 +174,8 @@ import 'package:xterm/xterm.dart' as xterm;
 
 import '../diagnostics/connect_trace.dart' show clifecycle, ctrace;
 import '../diagnostics/detection_geom.dart';
+import '../diagnostics/diagnostics_config.dart'
+    show kRawContentDiagnosticsEnabled;
 import '../diagnostics/feedback_bundle.dart' show scrubSecrets;
 import '../diagnostics/gesture_trace.dart';
 import '../diagnostics/paint_stats.dart';
@@ -2802,7 +2804,10 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
           // Terminal, so the recorder captures EXACTLY the input that produced
           // the rendered (possibly buggy) state. Allocation-light: the recorder
           // keeps the reference + a timestamp; no copy/encode here.
-          _byteRecorder.recordBytes(bytes);
+          // #1109-A: raw terminal output can carry displayed secrets, so the
+          // capture is compiled out of public release builds (fail-closed). The
+          // paint-stats counters below are structural and always run.
+          if (kRawContentDiagnosticsEnabled) _byteRecorder.recordBytes(bytes);
           // Paint replay harness: count the chunk at the write seam BEFORE the
           // write, so bytesIn reflects what was DELIVERED even if write throws.
           _paintStats.bytesInChunks++;
@@ -4061,15 +4066,19 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     final controller = _controller;
     if (controller == null) return;
     final text = controller.visibleRowsText(topViewRow, bottomViewRow);
-    final firstLine = text.split('\n').firstWhere(
-      (l) => l.trim().isNotEmpty,
-      orElse: () => '',
-    );
-    ctrace(
-      'gutter-copy',
-      'view=[$topViewRow..$bottomViewRow] rows=${controller.scrollbar.visible} '
-      'first="${firstLine.length > 40 ? firstLine.substring(0, 40) : firstLine}"',
-    );
+    // #1109-A: this logs a slice of the user's on-screen selection (raw content).
+    // Gate it out of public release builds — it can carry displayed secrets.
+    if (kRawContentDiagnosticsEnabled) {
+      final firstLine = text.split('\n').firstWhere(
+        (l) => l.trim().isNotEmpty,
+        orElse: () => '',
+      );
+      ctrace(
+        'gutter-copy',
+        'view=[$topViewRow..$bottomViewRow] rows=${controller.scrollbar.visible} '
+        'first="${firstLine.length > 40 ? firstLine.substring(0, 40) : firstLine}"',
+      );
+    }
     if (text.trim().isEmpty) {
       if (mounted) showTopToast(context, 'Nothing to copy on those lines');
       return;
@@ -4080,11 +4089,15 @@ class _GhosttyTerminalViewState extends ConsumerState<GhosttyTerminalView> {
     // smart-copy massager. The rendered layout — TUI forced-whitespace margins,
     // bullets, box-drawing, alignment padding — CANNOT be recovered from the raw
     // byte-trace (pre-render bytes + escapes), so this is the only faithful
-    // source. Newlines/backslashes escaped to keep it one trace line; the
-    // feedback bundle scrubs secrets before anything leaves the device. The
+    // source. Newlines/backslashes escaped to keep it one trace line. The
     // connect-log ring IS the "recent stack" of the last selections.
-    final escaped = text.replaceAll(r'\', r'\\').replaceAll('\n', r'\n');
-    ctrace('grossselect', 'rows=$rowCount cols=$_cols text="$escaped"');
+    // #1109-A: this is the user's VERBATIM on-screen selection — the best-effort
+    // scrubber cannot be trusted with it, so it is compiled out of public
+    // release builds (fail-closed) rather than relied on to redact.
+    if (kRawContentDiagnosticsEnabled) {
+      final escaped = text.replaceAll(r'\', r'\\').replaceAll('\n', r'\n');
+      ctrace('grossselect', 'rows=$rowCount cols=$_cols text="$escaped"');
+    }
     final ok = await copyToClipboard(text);
     if (!mounted) return;
     showTopToast(

--- a/native/test/diagnostics/raw_diagnostics_enabled_test.dart
+++ b/native/test/diagnostics/raw_diagnostics_enabled_test.dart
@@ -1,0 +1,36 @@
+// #1109-A: the ENABLED path of the raw-content diagnostics gate.
+//
+// The gate [kRawContentDiagnosticsEnabled] is a COMPILE-TIME const, so the plain
+// fast gate (`flutter test`, no --dart-define) runs it as false — the assertions
+// below then SKIP. To exercise the tracing-enabled internal build, run:
+//
+//   flutter test --dart-define=MOBISSH_RAW_DIAGNOSTICS=true \
+//     test/diagnostics/raw_diagnostics_enabled_test.dart
+//
+// With the flag on, the raw byteTrace flows into the payload (developers still
+// get full replay traces). This locks that the gate is a switch, not a deletion.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobissh/diagnostics/diagnostics_config.dart';
+import 'package:mobissh/ui/feedback_overlay.dart';
+
+void main() {
+  test('byteTrace flows when raw diagnostics are compiled in', () {
+    if (!kRawContentDiagnosticsEnabled) {
+      markTestSkipped(
+        'run with --dart-define=MOBISSH_RAW_DIAGNOSTICS=true to exercise this',
+      );
+      return;
+    }
+    final payload = buildFeedbackPayload(
+      comment: 'scroll stuck',
+      version: '[v]',
+      byteTrace: const [
+        {'tMs': 0, 'b64': 'aGVsbG8='}, // "hello"
+      ],
+    );
+    expect(payload.containsKey('byteTrace'), isTrue);
+    expect((payload['byteTrace'] as List), hasLength(1));
+  });
+}

--- a/native/test/diagnostics/session_byte_recorder_test.dart
+++ b/native/test/diagnostics/session_byte_recorder_test.dart
@@ -353,15 +353,39 @@ void main() {
       expect(snap, hasLength(3), reason: 'only the newest 3 survive the cap');
     });
 
-    test('scrubs credential-looking bytes at snapshot', () {
+    // #1109-A: the ring is constrained to a strict DA/DSR/CPR/XTVERSION
+    // allowlist. A generic OSC / hook / other reply — which could carry
+    // remote-supplied content verbatim — is DROPPED, never recorded.
+    test('drops non-allowlisted replies (generic OSC / other)', () {
       final rec = SessionByteRecorder();
+      // OSC carrying a secret-looking title — must NOT be recorded at all.
       rec.recordTermReply(
         Uint8List.fromList(utf8.encode('\x1b]0;token=SECRET123\x1b\\')),
       );
-      final decoded =
-          utf8.decode(base64Decode(rec.snapshotTermReplyTrace().single['b64'] as String));
-      expect(decoded, isNot(contains('SECRET123')));
-      expect(decoded, contains('[REDACTED]'));
+      // Arbitrary non-escape bytes — dropped.
+      rec.recordTermReply(Uint8List.fromList(utf8.encode('plain output')));
+      expect(rec.snapshotTermReplyTrace(), isEmpty);
+    });
+
+    test('records the allowlisted device replies (DA/CPR/DSR/XTVERSION)', () {
+      final rec = SessionByteRecorder();
+      rec.recordTermReply(Uint8List.fromList(utf8.encode('\x1b[?62c'))); // DA1
+      rec.recordTermReply(Uint8List.fromList(utf8.encode('\x1b[>1;95;0c'))); // DA2
+      rec.recordTermReply(Uint8List.fromList(utf8.encode('\x1b[8;24;80R'))); // CPR
+      rec.recordTermReply(Uint8List.fromList(utf8.encode('\x1b[0n'))); // DSR
+      rec.recordTermReply(Uint8List.fromList(utf8.encode('\x1bP>|xterm\x1b\\'))); // XTVERSION
+      expect(rec.snapshotTermReplyTrace(), hasLength(5));
+    });
+
+    test('isAllowedTermReply accepts device replies, rejects OSC/other', () {
+      Uint8List b(String s) => Uint8List.fromList(utf8.encode(s));
+      expect(isAllowedTermReply(b('\x1b[?62c')), isTrue); // DA1
+      expect(isAllowedTermReply(b('\x1b[>1;95;0c')), isTrue); // DA2
+      expect(isAllowedTermReply(b('\x1b[8;24;80R')), isTrue); // CPR
+      expect(isAllowedTermReply(b('\x1b[0n')), isTrue); // DSR
+      expect(isAllowedTermReply(b('\x1bP>|xterm\x1b\\')), isTrue); // XTVERSION
+      expect(isAllowedTermReply(b('\x1b]0;title\x1b\\')), isFalse); // OSC
+      expect(isAllowedTermReply(b('plain')), isFalse); // other
     });
 
     test('active registry routes the term-reply snapshot to the active session',

--- a/native/test/ui/feedback_payload_test.dart
+++ b/native/test/ui/feedback_payload_test.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:mobissh/diagnostics/diagnostics_config.dart';
 import 'package:mobissh/ui/feedback_overlay.dart';
 
 void main() {
@@ -210,8 +211,8 @@ void main() {
     );
 
     test(
-      'attaches byteTrace / scrollTrace / grid when present, omits when empty '
-      '(#790)',
+      'attaches scrollTrace / grid when present, omits when empty (#790); '
+      'byteTrace is gated off by default (#1109-A)',
       () {
         final withTrace = buildFeedbackPayload(
           comment: 'scroll stuck',
@@ -226,15 +227,17 @@ void main() {
           ],
           grid: const {'cols': 80, 'rows': 24},
         );
-        final bytes = withTrace['byteTrace'] as List;
-        expect(bytes, hasLength(2));
-        expect((bytes.first as Map)['b64'], 'aGVsbG8=');
+        // #1109-A: byteTrace is RAW terminal output — gated behind the
+        // compile-time kRawContentDiagnosticsEnabled (false under `flutter
+        // test`), so it is OMITTED even though a non-empty value was supplied.
+        expect(withTrace.containsKey('byteTrace'), isFalse);
+        // scrollTrace / grid are STRUCTURAL — they still flow in every build.
         final scroll = withTrace['scrollTrace'] as List;
         expect(scroll, hasLength(2));
         expect((scroll.last as Map)['offset'], 120);
         expect(withTrace['grid'], {'cols': 80, 'rows': 24});
 
-        // No trace → all three fields omitted (no empty-array / null noise).
+        // No trace → the structural fields are omitted (no empty-array noise).
         final without = buildFeedbackPayload(comment: 'x', version: '[v]');
         expect(without.containsKey('byteTrace'), isFalse);
         expect(without.containsKey('scrollTrace'), isFalse);
@@ -263,15 +266,18 @@ void main() {
           includeTraces: traces,
         );
 
-    test('defaults include everything (report quality preserved)', () {
+    test('defaults include everything EXCEPT the raw byteTrace (#1109-A)', () {
       final p = full();
       for (final k in const [
         'screenshot', 'frames', 'connectLog', 'gestureLog', 'lifecycleLog',
-        'byteTrace', 'scrollTrace', 'sentSgrTrace', 'grid',
+        'scrollTrace', 'sentSgrTrace', 'grid',
         'termReplyTrace', 'termReplyTraceEventCount', 'detectionGeom',
       ]) {
         expect(p.containsKey(k), isTrue, reason: '$k present by default');
       }
+      // #1109-A: byteTrace is raw output — gated off by default (compile-time
+      // false under `flutter test`) even with the include-traces toggle on.
+      expect(p.containsKey('byteTrace'), isFalse);
       // #1072: the count mirrors the trace length.
       expect(p['termReplyTraceEventCount'], 1);
     });
@@ -280,8 +286,8 @@ void main() {
       final p = full(images: false);
       expect(p.containsKey('screenshot'), isFalse);
       expect(p.containsKey('frames'), isFalse);
-      // Traces + the note remain.
-      expect(p.containsKey('byteTrace'), isTrue);
+      // Structural traces + the note remain.
+      expect(p.containsKey('scrollTrace'), isTrue);
       expect(p.containsKey('connectLog'), isTrue);
       expect(p['comment'], 'note');
     });
@@ -309,6 +315,49 @@ void main() {
       expect(p.containsKey('connectLog'), isFalse);
       expect(p['comment'], 'note');
       expect(p['version'], '[v]');
+    });
+  });
+
+  // #1109-A: the raw-content gate. Under `flutter test` (no --dart-define)
+  // kRawContentDiagnosticsEnabled is compile-time false, so a public release
+  // build's payload NEVER carries the raw byteTrace even when a non-empty value
+  // is supplied — proving raw terminal output is dropped by the gate, not merely
+  // scrubbed. Structural traces are unaffected.
+  group('raw-content gate (#1109-A)', () {
+    test('drops byteTrace even when a non-empty value is injected', () {
+      final p = buildFeedbackPayload(
+        comment: 'x',
+        version: '[v]',
+        byteTrace: const [
+          {'tMs': 0, 'b64': 'c2VjcmV0'}, // "secret"
+        ],
+      );
+      expect(p.containsKey('byteTrace'), isFalse);
+    });
+
+    test('the flag defaults to false (fail-closed for release builds)', () {
+      expect(kRawContentDiagnosticsEnabled, isFalse);
+    });
+
+    test('structural traces still flow while byteTrace is gated off', () {
+      final p = buildFeedbackPayload(
+        comment: 'x',
+        version: '[v]',
+        byteTrace: const [
+          {'tMs': 0, 'b64': 'c2VjcmV0'},
+        ],
+        scrollTrace: const [
+          {'tMs': 0, 'offset': 0},
+        ],
+        sentSgrTrace: const [
+          {'tMs': 0, 'b64': 'zzz'},
+        ],
+        grid: const {'cols': 80, 'rows': 24},
+      );
+      expect(p.containsKey('byteTrace'), isFalse);
+      expect(p.containsKey('scrollTrace'), isTrue);
+      expect(p.containsKey('sentSgrTrace'), isTrue);
+      expect(p.containsKey('grid'), isTrue);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds one centralized, fail-closed compile-time gate `kRawContentDiagnosticsEnabled` (`const bool.fromEnvironment('MOBISSH_RAW_DIAGNOSTICS', defaultValue: false)`) in new `native/lib/diagnostics/diagnostics_config.dart`. Public release builds pass nothing → false → the gated code is tree-shaken out (survives `--split-per-abi`/`--obfuscate`/`--split-debug-info`, fails closed).
- Routes every raw-terminal-derived capture + upload through the gate; constrains `termReply` to a strict device-reply allowlist.

## What is gated (compiled out of public release)
- **byteTrace** (raw terminal output): the `recordBytes` capture (`ghostty_terminal_view.dart`), the `activeByteTraceSnapshot()` fetches, and the `'byteTrace'` payload field (`feedback_overlay.dart`).
- **Selection text**: the gutter-copy first-40-chars log and the full verbatim `grossselect` log.
- **Remote OSC/hook text**: the attention `sig.text` in the lifecycle ring — the signal KIND and text length are kept in every build; only the verbatim text is gated.

## What is constrained (all builds)
- `recordTermReply` now drops any reply that is not DA1/DA2/CPR/DSR/XTVERSION (`isAllowedTermReply`); generic OSC / other payloads are no longer recorded verbatim.

## What is untouched (structural, all builds)
- `scrollTrace` (offsets), `grid` (dims), `sentSgrTrace` (already hard-filtered to SGR-mouse), connect/gesture/lifecycle/paint measurements.
- Also fixed stale comments claiming scrubbing means secrets "never leave the device".

## TDD Analysis
- Type: security hardening (feature-flag gate)
- Behavior change: yes (release builds omit raw content)
- TDD approach: full (pure payload builder + recorder are unit-testable)

## Test coverage
- **Existing tests updated**: `feedback_payload_test.dart` (byteTrace now omitted by default), `session_byte_recorder_test.dart` (OSC term-reply now dropped by the allowlist).
- **New tests (fail→pass)**: `feedback_payload_test.dart` `raw-content gate (#1109-A)` group — asserts a non-empty injected `byteTrace` is OMITTED (flag off), flag defaults false, structural traces still flow; `session_byte_recorder_test.dart` allowlist tests (`isAllowedTermReply`, OSC/other dropped, device replies kept).
- **Enabled-path test**: new `raw_diagnostics_enabled_test.dart` self-skips under the fast gate and asserts byteTrace flows when run with `flutter test --dart-define=MOBISSH_RAW_DIAGNOSTICS=true`.

## Test results
- flutter analyze: PASS (No issues found)
- flutter test (fast gate): PASS (2263 tests)

## Diff stats
- Files changed: 8 (1 new config, 4 gated lib sites, 3 test files)
- Lines: +245 / -49

## Design note
Gated at the CALL SITES rather than mutilating `SessionByteRecorder` — smallest diff that both blocks raw capture in release and keeps the recorder's existing unit-test contract green (the ring becomes unreferenced in release → tree-shaken anyway).

## Follow-ups (OUT of scope — not built here)
- Internal build FLAVOR / application ID that passes `--dart-define=MOBISSH_RAW_DIAGNOSTICS=true` so a tracing-enabled binary can never be submitted as the store app (gradle/ship-script change).
- #484 (the upload sink).

## Device validation
Device-validation-pending — this is a compile-time gate + pure-logic change; no device-class UI behavior. Verify a `--release` build's bug report omits `byteTrace`.

Closes #1109

## Cycles used
1/3