### PR TITLE
fix(security): close remote-content beacon in markdown-image + mermaid viewers (#1107 sibling)

### DIFF
--- a/native/assets/mermaid/mermaid_boot.js
+++ b/native/assets/mermaid/mermaid_boot.js
@@ -1,0 +1,57 @@
+// Boot script for the offline mermaid render host (mermaid_host.html).
+//
+// Externalized from an inline <script> block so the host can enforce a strict
+// Content-Security-Policy with `script-src 'self'` (no 'unsafe-inline'). The CSP
+// blocks ALL network egress (connect-src 'none', img-src data:, default-src
+// 'none') so untrusted diagram data can never beacon out (#1107 sibling). This
+// file is a bundled Flutter asset loaded via <script src>, so 'self' covers it.
+
+function post(payload) {
+  try {
+    if (window.MermaidChannel && window.MermaidChannel.postMessage) {
+      window.MermaidChannel.postMessage(JSON.stringify(payload));
+    }
+  } catch (e) {
+    /* channel not attached (e.g. preview) — ignore */
+  }
+}
+
+var mermaidReady = false;
+try {
+  if (window.mermaid) {
+    window.mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });
+    mermaidReady = true;
+  }
+} catch (e) {
+  post({ type: 'error', message: 'mermaid init failed: ' + e });
+}
+
+function reportSize() {
+  var el = document.getElementById('diagram');
+  var h = Math.ceil(el.getBoundingClientRect().height);
+  if (h > 0) post({ type: 'size', height: h });
+}
+
+// Called from Dart with the raw fenced-block source.
+window.renderMermaid = function (source) {
+  var target = document.getElementById('diagram');
+  if (!mermaidReady || !window.mermaid) {
+    post({ type: 'error', message: 'mermaid unavailable' });
+    return;
+  }
+  try {
+    window.mermaid
+      .render('mermaidGraph', source)
+      .then(function (result) {
+        target.innerHTML = result.svg;
+        reportSize();
+        // Re-measure after layout settles (fonts/labels).
+        setTimeout(reportSize, 60);
+      })
+      .catch(function (err) {
+        post({ type: 'error', message: String(err && err.message ? err.message : err) });
+      });
+  } catch (err) {
+    post({ type: 'error', message: String(err && err.message ? err.message : err) });
+  }
+};

--- a/native/assets/mermaid/mermaid_host.html
+++ b/native/assets/mermaid/mermaid_host.html
@@ -14,6 +14,21 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <!--
+      Strict CSP is the egress block (#1107 sibling). Diagram source can come
+      from untrusted content; mermaid's own securityLevel:'strict' sanitizes
+      labels but enforces NO network policy on its own. default-src/connect-src
+      'none' + img/font restricted to data:/self mean a mermaid-label injection
+      can never beacon out. script-src 'self' runs our BUNDLED mermaid.min.js +
+      mermaid_boot.js (both local assets) — the inline boot block was moved to
+      mermaid_boot.js so no 'unsafe-inline' is needed for scripts. style-src
+      keeps 'unsafe-inline' for the inline <style> and mermaid's generated SVG
+      styling.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self'; style-src 'unsafe-inline' 'self'; img-src data:; font-src data: 'self'; connect-src 'none'; base-uri 'none'; form-action 'none'"
+    />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, minimum-scale=0.5, maximum-scale=8.0, user-scalable=yes"
@@ -53,56 +68,8 @@
   </head>
   <body>
     <div id="diagram"></div>
-    <script>
-      function post(payload) {
-        try {
-          if (window.MermaidChannel && window.MermaidChannel.postMessage) {
-            window.MermaidChannel.postMessage(JSON.stringify(payload));
-          }
-        } catch (e) {
-          /* channel not attached (e.g. preview) — ignore */
-        }
-      }
-
-      var mermaidReady = false;
-      try {
-        if (window.mermaid) {
-          window.mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });
-          mermaidReady = true;
-        }
-      } catch (e) {
-        post({ type: 'error', message: 'mermaid init failed: ' + e });
-      }
-
-      function reportSize() {
-        var el = document.getElementById('diagram');
-        var h = Math.ceil(el.getBoundingClientRect().height);
-        if (h > 0) post({ type: 'size', height: h });
-      }
-
-      // Called from Dart with the raw fenced-block source.
-      window.renderMermaid = function (source) {
-        var target = document.getElementById('diagram');
-        if (!mermaidReady || !window.mermaid) {
-          post({ type: 'error', message: 'mermaid unavailable' });
-          return;
-        }
-        try {
-          window.mermaid
-            .render('mermaidGraph', source)
-            .then(function (result) {
-              target.innerHTML = result.svg;
-              reportSize();
-              // Re-measure after layout settles (fonts/labels).
-              setTimeout(reportSize, 60);
-            })
-            .catch(function (err) {
-              post({ type: 'error', message: String(err && err.message ? err.message : err) });
-            });
-        } catch (err) {
-          post({ type: 'error', message: String(err && err.message ? err.message : err) });
-        }
-      };
-    </script>
+    <!-- Boot logic externalized so a strict `script-src 'self'` (no
+         'unsafe-inline') still runs it. -->
+    <script src="mermaid_boot.js"></script>
   </body>
 </html>

--- a/native/lib/ui/sftp_markdown_image.dart
+++ b/native/lib/ui/sftp_markdown_image.dart
@@ -8,8 +8,11 @@
 //   - relative / absolute SFTP path → fetched as BYTES over the SAME SFTP
 //     session that fetched the .md (via [sftpImageFetcherProvider]); relative
 //     paths resolve against the .md's directory ([resolveSftpImagePath]),
-//   - explicit `http(s)://` URL → `Image.network` (the only allowed network
-//     fetch),
+//   - explicit `http(s)://` URL → NEVER fetched. An untrusted remote `.md`
+//     that references an attacker-chosen image URL would otherwise beacon out
+//     (revealing the viewer's IP + a "document opened" event) the moment the
+//     document is viewed (#1107 sibling). We render an inert "external image
+//     (not loaded)" affordance instead — no network request is ever made.
 //   - anything else / broken / missing / oversized → a graceful placeholder,
 //     never a crash.
 //
@@ -54,13 +57,11 @@ class SftpMarkdownImage extends ConsumerStatefulWidget {
   ConsumerState<SftpMarkdownImage> createState() => _SftpMarkdownImageState();
 }
 
-enum _ImgPhase { loading, ready, broken }
+enum _ImgPhase { loading, ready, broken, external }
 
 class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
   _ImgPhase _phase = _ImgPhase.loading;
   Uint8List? _bytes;
-  bool _isNetwork = false;
-  String? _networkUrl;
   bool _started = false;
 
   /// Basename of the resolved remote image path — names the Download/Share
@@ -82,12 +83,10 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
     final raw = widget.uri.toString();
     final lower = raw.toLowerCase();
     if (lower.startsWith('http://') || lower.startsWith('https://')) {
-      // Explicit absolute network URL — the only allowed network fetch.
-      setState(() {
-        _isNetwork = true;
-        _networkUrl = raw;
-        _phase = _ImgPhase.ready;
-      });
+      // Explicit absolute network URL — NEVER fetched. Loading it would beacon
+      // out to an attacker-chosen origin on view (#1107 sibling). Show an inert
+      // "external image (not loaded)" affordance; make no request.
+      setState(() => _phase = _ImgPhase.external);
       return;
     }
     final path = resolveSftpImagePath(widget.mdPath, raw);
@@ -121,16 +120,7 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
     // via the InteractiveViewer (#949).
     final Widget full;
     ViewerFileSource? source;
-    if (_isNetwork && _networkUrl != null) {
-      // Network-URL image: a web resource, not a file we hold — no
-      // Download/Share source (#1038 caveat).
-      full = Image.network(
-        _networkUrl!,
-        fit: BoxFit.contain,
-        filterQuality: FilterQuality.medium,
-        errorBuilder: (_, _, _) => _fillBroken(),
-      );
-    } else if (_bytes != null) {
+    if (_bytes != null) {
       full = Image.memory(
         _bytes!,
         fit: BoxFit.contain,
@@ -176,26 +166,19 @@ class _SftpMarkdownImageState extends ConsumerState<SftpMarkdownImage> {
         );
       case _ImgPhase.broken:
         return _Placeholder(alt: widget.alt);
+      case _ImgPhase.external:
+        return _ExternalPlaceholder(alt: widget.alt);
       case _ImgPhase.ready:
         return _buildInline(context);
     }
   }
 
   Widget _buildInline(BuildContext context) {
-    final Widget image;
-    if (_isNetwork && _networkUrl != null) {
-      image = Image.network(
-        _networkUrl!,
-        fit: BoxFit.contain,
-        errorBuilder: (_, _, _) => _Placeholder(alt: widget.alt),
-      );
-    } else {
-      image = Image.memory(
-        _bytes!,
-        fit: BoxFit.contain,
-        errorBuilder: (_, _, _) => _Placeholder(alt: widget.alt),
-      );
-    }
+    final Widget image = Image.memory(
+      _bytes!,
+      fit: BoxFit.contain,
+      errorBuilder: (_, _, _) => _Placeholder(alt: widget.alt),
+    );
     // A raw [Listener] — NOT a GestureDetector — drives tap-to-fill. The viewer
     // renders the markdown with `selectable: true`, so this inline image is a
     // WidgetSpan child inside a SelectableText.rich. A child tap GestureDetector
@@ -267,6 +250,47 @@ class _Placeholder extends StatelessWidget {
           Flexible(
             child: Text(
               caption,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Inert affordance for an `http(s)://` image reference in an untrusted remote
+/// `.md`. We deliberately do NOT fetch it — a remote fetch would beacon the
+/// viewer's IP + a view event to an attacker-chosen origin (#1107 sibling). The
+/// caption names the external source without loading it.
+class _ExternalPlaceholder extends StatelessWidget {
+  const _ExternalPlaceholder({this.alt});
+
+  final String? alt;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final label = (alt != null && alt!.trim().isNotEmpty)
+        ? '${alt!.trim()} — external image (not loaded)'
+        : 'External image (not loaded)';
+    return Container(
+      key: const Key('markdown-image-external'),
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.cloud_off_outlined, size: 18, color: scheme.outline),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label,
               overflow: TextOverflow.ellipsis,
               style: Theme.of(context).textTheme.bodySmall,
             ),

--- a/native/pubspec.yaml
+++ b/native/pubspec.yaml
@@ -236,6 +236,7 @@ flutter:
   # scripts/vendor-mermaid.sh — NO network is touched at build or runtime.
   assets:
     - assets/mermaid/mermaid_host.html
+    - assets/mermaid/mermaid_boot.js
     - assets/mermaid/mermaid.min.js
 
   # To add assets to your application, add an assets section, like this:

--- a/native/test/assets/mermaid_csp_test.dart
+++ b/native/test/assets/mermaid_csp_test.dart
@@ -1,0 +1,77 @@
+// Asset-content test for the offline mermaid render host's egress block
+// (#1107 sibling).
+//
+// The mermaid host runs our BUNDLED mermaid.js over diagram DATA that can come
+// from untrusted content. mermaid's own `securityLevel: 'strict'` sanitizes
+// labels but enforces NO network policy — a mermaid-label injection could still
+// beacon out. The host page must carry a strict Content-Security-Policy whose
+// `default-src 'none'` + `connect-src 'none'` (plus data:-only img/font) block
+// ALL network egress while still running the local bundled scripts.
+//
+// Whether the WebView engine actually enforces the <meta> CSP is engine
+// behavior — that is device-validation-pending. This test pins the policy in
+// the shipped asset so it can never silently regress.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final host = File('assets/mermaid/mermaid_host.html').readAsStringSync();
+  final boot = File('assets/mermaid/mermaid_boot.js').readAsStringSync();
+
+  test('host declares a Content-Security-Policy meta', () {
+    expect(
+      host.contains('http-equiv="Content-Security-Policy"'),
+      isTrue,
+      reason: 'mermaid host must carry a CSP meta as the egress block',
+    );
+  });
+
+  test('CSP blocks all network egress', () {
+    // The two load-bearing egress directives.
+    expect(host.contains("default-src 'none'"), isTrue);
+    expect(host.contains("connect-src 'none'"), isTrue);
+    // img/font restricted to inline data: (no remote fetch beacon).
+    expect(host.contains('img-src data:'), isTrue);
+    expect(host.contains("font-src data: 'self'"), isTrue);
+    // Lock down the remaining escape hatches.
+    expect(host.contains("base-uri 'none'"), isTrue);
+    expect(host.contains("form-action 'none'"), isTrue);
+  });
+
+  test('scripts stay local: script-src is self, no unsafe-inline', () {
+    expect(host.contains("script-src 'self'"), isTrue);
+    // A strict script-src must not open an inline-script hole.
+    expect(
+      host.contains("script-src 'self' 'unsafe-inline'") ||
+          host.contains("script-src 'unsafe-inline'"),
+      isFalse,
+      reason: 'inline scripts were externalized so unsafe-inline is not needed',
+    );
+  });
+
+  test('bundled + externalized scripts are referenced, no inline boot block', () {
+    // Bundled engine still loads locally.
+    expect(host.contains('src="mermaid.min.js"'), isTrue);
+    // Boot logic was externalized so `script-src 'self'` can run it.
+    expect(host.contains('src="mermaid_boot.js"'), isTrue);
+    // Every <script> tag must be a `src=` include — no inline script body, or
+    // the strict `script-src 'self'` (no 'unsafe-inline') would block it. Strip
+    // HTML comments first so prose mentioning `<script src>` isn't counted.
+    final markup = host.replaceAll(RegExp(r'<!--.*?-->', dotAll: true), '');
+    final scriptTags = RegExp(r'<script\b[^>]*>').allMatches(markup).toList();
+    expect(scriptTags.length, 2);
+    for (final m in scriptTags) {
+      expect(
+        m.group(0)!.contains('src='),
+        isTrue,
+        reason: 'inline <script> would be blocked by script-src \'self\'',
+      );
+    }
+    // The externalized boot file still defines the render entrypoint + strict
+    // mermaid init, so the diagram pipeline is intact under the policy.
+    expect(boot.contains('window.renderMermaid'), isTrue);
+    expect(boot.contains("securityLevel: 'strict'"), isTrue);
+  });
+}

--- a/native/test/widget/markdown_media_fill_test.dart
+++ b/native/test/widget/markdown_media_fill_test.dart
@@ -198,6 +198,36 @@ void main() {
     host.disposeSyncForTest();
   });
 
+  testWidgets(
+    'http(s) image is never fetched and renders an inert placeholder (#1107 sibling)',
+    (tester) async {
+      // An untrusted remote .md that references an attacker-chosen absolute URL
+      // must NOT trigger any outbound request on view (no beacon). We render an
+      // inert "external image (not loaded)" affordance and make no fetch.
+      final fetcher = _FakeImageFetcher(bytes: _png);
+      final host = await _open(
+        tester,
+        markdown: '![tracker](http://attacker.example/x.png)\n',
+        imageFetcher: fetcher,
+      );
+
+      // The inert affordance is shown...
+      expect(find.byKey(const Key('markdown-image-external')), findsOneWidget);
+      // ...and NO inline image / fill-viewer image was created.
+      expect(find.byKey(const Key('markdown-inline-image')), findsNothing);
+      // No Image widget backed by a NetworkImage (the beacon vector) exists.
+      expect(
+        find.byWidgetPredicate((w) => w is Image && w.image is NetworkImage),
+        findsNothing,
+      );
+      // The SFTP fetcher was never asked to fetch the remote URL either.
+      expect(fetcher.requestedPath, isNull);
+      expect(tester.takeException(), isNull);
+
+      host.disposeSyncForTest();
+    },
+  );
+
   testWidgets('broken image falls back to a placeholder without throwing', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
Closes the same "untrusted remote content can beacon out on view" class that #1107 hardened in the HTML viewer, in its two sibling viewers:

- **Markdown remote-image beacon (active leak)** — `native/lib/ui/sftp_markdown_image.dart` loaded an `http(s)://` image src from an untrusted remote `.md` via `Image.network` the moment the doc was viewed, sending an outbound request to an attacker-chosen origin (reveals viewer IP + a "document opened" event). Now http(s) srcs are **never fetched** — an inert "external image (not loaded)" affordance is rendered instead. Local/relative images still resolve **only** over the user's SFTP session (unchanged).
- **Mermaid CSP** — `native/assets/mermaid/mermaid_host.html` runs our bundled mermaid.js over diagram data that can be untrusted; mermaid's `securityLevel:'strict'` enforces no network policy. Added a strict CSP `<meta>` (`default-src 'none'; connect-src 'none'; img-src data:; font-src data: 'self'; base-uri 'none'; form-action 'none'`) as the egress block. The inline boot `<script>` was extracted to `mermaid_boot.js` so `script-src 'self'` (no `'unsafe-inline'`) still runs it; the bundled script stays ON.

## TDD Analysis
- Type: bug fix (security)
- Behavior change: yes (http(s) markdown image path becomes inert; mermaid host gains CSP)
- TDD approach: full (markdown widget test) + asset-content test (mermaid CSP; WebView enforcement is engine behavior)

## Test coverage
- **Existing tests updated**: none needed — the local/SFTP image path is unchanged and its existing tests stay green.
- **New tests added (fail→pass)**:
  - `markdown_media_fill_test.dart`: an `http://attacker.example/x.png` src renders the inert `markdown-image-external` placeholder, produces **no** `Image` backed by `NetworkImage`, and **never** calls the SFTP fetcher.
  - `test/assets/mermaid_csp_test.dart`: pins the CSP meta with `default-src 'none'` + `connect-src 'none'` (+ img/font/base-uri/form-action), asserts `script-src 'self'` with no inline-script hole, and that boot logic is externalized (`mermaid_boot.js`) with the bundled `mermaid.min.js` still referenced.

## Test results
- flutter analyze: PASS
- flutter test (fast gate, 2263 tests): PASS

## Diff stats
- Files changed: 6 (+242 / -86)

## Device-validation-pending
Whether the WebView engine enforces the `<meta>` CSP is engine behavior and should be confirmed on-device. The markdown fix is pure Dart and fully covered headless.

## Out of scope (follow-up, not built)
Extracting a shared `SafeRemoteHtmlWebView` harness adopted by the image/html/mermaid viewers — a consolidation; #1107 already hardened the HTML one.

Sibling of #1107.

## Cycles used
1/3