### PR TITLE
Harden feedback upload endpoints: auth + rate-limit + body caps (#484)

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -46,6 +46,10 @@ module.exports = defineConfig({
     timeout: 15_000,
     env: {
       PORT: '8081',
+      // #484: the feedback routes now require the X-MobiSSH-Key shared secret.
+      // Give the headless server a known key so the bug-report contract test can
+      // authenticate (see tests/bug-report-comment.spec.js).
+      MOBISSH_FEEDBACK_KEY: 'headless-feedback-key',
     },
   },
 

--- a/server-feedback/index.js
+++ b/server-feedback/index.js
@@ -29,6 +29,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const store = require('../server/feedback-store');
+const guard = require('../server/feedback-guard');
 
 const PORT = process.env.PORT || 8082;
 const HOST = process.env.HOST || '0.0.0.0';
@@ -57,14 +58,24 @@ const server = http.createServer(async (req, res) => {
 
   if (req.method === 'POST' && store.FEEDBACK_ROUTES.includes(req.url)) {
     const route = req.url;
-    const maxBytes = route === '/api/native-crash' ? store.MAX_CRASH_BYTES : 0;
+    // #484: same shared guard as the prod front door — auth + per-IP rate limit
+    // BEFORE buffering so neither door is an unauthenticated/unbounded bypass.
+    const rej = guard.preflight(req);
+    if (rej) {
+      res.writeHead(rej.status, { 'Content-Type': 'application/json' });
+      res.end(rej.body);
+      return;
+    }
+    const maxBytes = route === '/api/native-crash' ? store.MAX_CRASH_BYTES : guard.maxFeedbackBytes();
     let body;
     try {
       body = await store.readBody(req, maxBytes);
     } catch (err) {
       if (err.code === 'TOO_LARGE') {
-        res.writeHead(413, { 'Content-Type': 'application/json' });
-        res.end('{"error":"crash report exceeds 1MB"}');
+        // Connection: close so the unread oversized body is discarded and the
+        // 413 reaches the client cleanly (no socket-hang-up race) (#484).
+        res.writeHead(413, { 'Content-Type': 'application/json', 'Connection': 'close' });
+        res.end('{"error":"request body too large"}');
       }
       return;
     }

--- a/server/feedback-guard.js
+++ b/server/feedback-guard.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * server/feedback-guard.js — shared hardening for the feedback ingestion routes (#484).
+ *
+ * The four feedback routes (/api/bug-report, /api/drop-telemetry,
+ * /api/gesture-telemetry, /api/native-crash) accept attacker-sized JSON with
+ * base64 screenshots/logs and write them to disk. Before this guard they were
+ * unauthenticated, unbounded, and un-rate-limited on BOTH front doors
+ * (server/index.js AND server-feedback/index.js) — a Tailnet-wide disk-fill /
+ * DoS of the SSH bridge. This is the ONE place both doors import so neither is
+ * a bypass (the duplication that let the second uncapped door exist).
+ *
+ * Three gates, all applied BEFORE the request body is buffered:
+ *   1. AUTH (mandatory) — X-MobiSSH-Key must equal MOBISSH_FEEDBACK_KEY.
+ *      Key UNSET => 503 (block, don't degrade — constitution art.2); missing or
+ *      mismatched header => 401. Matches the existing idiom: the native app
+ *      (native/lib/ui/feedback_overlay.dart) and the Cloudflare worker
+ *      (infra/bug-report-worker/worker.js) already use X-MobiSSH-Key.
+ *   2. RATE LIMIT — per-IP sliding window (in-memory, no dependency) => 429.
+ *   3. BYTE CAP — maxFeedbackBytes() bounds the ENCODED body so an oversized
+ *      request is rejected at the buffering stage, never fully buffered/decoded.
+ *
+ * All env is read per-call (not at module load) so tests can toggle it and a
+ * deploy activates a value by an explicit container recreate, never a silent flip.
+ */
+
+const { timingSafeEqual } = require('crypto');
+
+/** Encoded-body cap for the non-crash routes (native-crash keeps its own 1MB
+ *  cap in feedback-store). Default 16MB accommodates a 120-frame repro burst. */
+function maxFeedbackBytes() {
+  return parseInt(process.env.MOBISSH_FEEDBACK_MAX_BYTES || '', 10) || 16 * 1024 * 1024;
+}
+
+function rateMax() {
+  return parseInt(process.env.MOBISSH_FEEDBACK_RATE_MAX || '', 10) || 30;
+}
+
+function rateWindowMs() {
+  return parseInt(process.env.MOBISSH_FEEDBACK_RATE_WINDOW_MS || '', 10) || 60_000;
+}
+
+/** Client IP, honoring a single X-Forwarded-For hop (mirrors server/index.js). */
+function getIP(req) {
+  return req.headers['x-forwarded-for']?.split(',')[0]?.trim()
+    || req.socket?.remoteAddress
+    || 'unknown';
+}
+
+function rejection(status, error) {
+  return { status, body: JSON.stringify({ error }) };
+}
+
+/**
+ * Constant-time equality that does not leak whether the length matched.
+ * Returns false for any non-string or empty input.
+ */
+function secretsEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length === 0 || b.length === 0) return false;
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+/** Enforce the shared secret. Returns null when authorized, else a rejection. */
+function checkAuth(req) {
+  const key = process.env.MOBISSH_FEEDBACK_KEY || '';
+  if (!key) return rejection(503, 'feedback auth not configured');
+  const provided = req.headers['x-mobissh-key'] || '';
+  if (!secretsEqual(provided, key)) return rejection(401, 'unauthorized');
+  return null;
+}
+
+// ip -> array of request timestamps within the current window.
+const rateHits = new Map();
+
+/** Per-IP sliding-window rate limit. Returns null when allowed, else a rejection. */
+function checkRateLimit(ip) {
+  const now = Date.now();
+  const windowMs = rateWindowMs();
+  const cutoff = now - windowMs;
+  const hits = (rateHits.get(ip) || []).filter((t) => t > cutoff);
+  if (hits.length >= rateMax()) {
+    rateHits.set(ip, hits);
+    return rejection(429, 'rate limit exceeded');
+  }
+  hits.push(now);
+  rateHits.set(ip, hits);
+  // Opportunistic prune so the map can't grow unbounded across many IPs.
+  if (rateHits.size > 4096) {
+    for (const [k, v] of rateHits) {
+      const kept = v.filter((t) => t > cutoff);
+      if (kept.length === 0) rateHits.delete(k); else rateHits.set(k, kept);
+    }
+  }
+  return null;
+}
+
+/** Auth first (cheap, header-only), then rate limit. Returns null when the
+ *  request may proceed to buffering, else the rejection to send. */
+function preflight(req) {
+  const authRej = checkAuth(req);
+  if (authRej) return authRej;
+  return checkRateLimit(getIP(req));
+}
+
+/** Test helper — clear the rate-limit state between cases. */
+function resetRateLimit() {
+  rateHits.clear();
+}
+
+module.exports = {
+  maxFeedbackBytes,
+  getIP,
+  checkAuth,
+  checkRateLimit,
+  preflight,
+  resetRateLimit,
+};

--- a/server/feedback-store.js
+++ b/server/feedback-store.js
@@ -31,6 +31,12 @@ const MAX_CRASH_BYTES = 1024 * 1024;
 const MAX_GESTURE_LOG_BYTES = 1024 * 1024;
 // Frame-burst guard for bug-report repro recordings.
 const MAX_FRAMES = 120;
+// Per-decoded-image cap (#484): a screenshot/frame whose DECODED bytes exceed
+// this is skipped, bounding per-file disk even when the encoded request body
+// slipped under the front-door byte cap. Read per-call so tests can toggle it.
+function maxImageDecodedBytes() {
+  return parseInt(process.env.MOBISSH_FEEDBACK_IMAGE_MAX_BYTES || '', 10) || 4 * 1024 * 1024;
+}
 // Server-side backstop caps for replay traces (client already bounds the rings).
 const MAX_BYTE_EVENTS = 8192;
 const MAX_SCROLL_EVENTS = 8192;
@@ -51,11 +57,25 @@ function stampNow() {
 
 /**
  * Buffer a request body, optionally enforcing a byte cap. Resolves with the
- * body as a utf8 string. Rejects with err.code === 'TOO_LARGE' (after
- * destroying the request) when the cap is exceeded — the caller answers 413.
+ * body as a utf8 string. Rejects with err.code === 'TOO_LARGE' when the cap is
+ * exceeded — the caller answers 413 (with Connection: close). readBody does NOT
+ * destroy the socket itself: destroying it before the caller writes the 413
+ * truncates the response into a client-side "socket hang up" (#484).
+ *
+ * A declared Content-Length over the cap is rejected up front, so an oversized
+ * request is refused WITHOUT buffering (or later base64-decoding) the body.
  */
 function readBody(req, maxBytes) {
   return new Promise((resolve, reject) => {
+    const tooLarge = () => {
+      const err = new Error(`body exceeds ${maxBytes} bytes`);
+      err.code = 'TOO_LARGE';
+      return err;
+    };
+    if (maxBytes) {
+      const declared = parseInt(req.headers['content-length'] || '', 10);
+      if (Number.isFinite(declared) && declared > maxBytes) { reject(tooLarge()); return; }
+    }
     const chunks = [];
     let total = 0;
     let aborted = false;
@@ -65,10 +85,7 @@ function readBody(req, maxBytes) {
       total += buf.length;
       if (maxBytes && total > maxBytes) {
         aborted = true;
-        try { req.destroy(); } catch (_) {}
-        const err = new Error(`body exceeds ${maxBytes} bytes`);
-        err.code = 'TOO_LARGE';
-        reject(err);
+        reject(tooLarge());
         return;
       }
       chunks.push(buf);
@@ -196,12 +213,18 @@ function saveBugReport(data, reportDir) {
   fs.mkdirSync(reportDir, { recursive: true });
 
   // Save screenshot
+  const imageCap = maxImageDecodedBytes();
   let screenshotFile = '';
   if (screenshot) {
     const imgData = screenshot.replace(/^data:image\/\w+;base64,/, '');
-    screenshotFile = `${ts}-bug-report.png`;
-    fs.writeFileSync(path.join(reportDir, screenshotFile), Buffer.from(imgData, 'base64'));
-    console.log(`[bug-report] screenshot: ${screenshotFile}`);
+    const buf = Buffer.from(imgData, 'base64');
+    if (buf.length > imageCap) {
+      console.warn(`[bug-report] screenshot skipped: decoded ${buf.length}B exceeds ${imageCap}B cap`);
+    } else {
+      screenshotFile = `${ts}-bug-report.png`;
+      fs.writeFileSync(path.join(reportDir, screenshotFile), buf);
+      console.log(`[bug-report] screenshot: ${screenshotFile}`);
+    }
   }
 
   // #repro: a recorded burst of frames (in-app 10s "video"). Save each as a
@@ -215,8 +238,10 @@ function saveBugReport(data, reportDir) {
       const f = frames[i];
       if (typeof f !== 'string' || !f) continue;
       const fData = f.replace(/^data:image\/\w+;base64,/, '');
+      const fbuf = Buffer.from(fData, 'base64');
+      if (fbuf.length > imageCap) continue; // #484: skip an oversized frame
       const name = `${ts}-bug-report.frame-${String(i + 1).padStart(3, '0')}.png`;
-      fs.writeFileSync(path.join(reportDir, name), Buffer.from(fData, 'base64'));
+      fs.writeFileSync(path.join(reportDir, name), fbuf);
       frameCount++;
     }
     framesPattern = `${ts}-bug-report.frame-%03d.png`;

--- a/server/index.js
+++ b/server/index.js
@@ -64,6 +64,7 @@ const { isOriginAllowed } = require('./origin');
 const TRACE_TRANSFER = process.env.MOBISSH_TRACE_TRANSFER === '1' || true; // default on for data gathering
 const { rewriteManifest } = require('./manifest');
 const feedbackStore = require('./feedback-store');
+const feedbackGuard = require('./feedback-guard');
 
 const PORT = process.env.PORT || 8081;
 const HOST = process.env.HOST || '0.0.0.0';
@@ -235,15 +236,21 @@ const FEEDBACK_PROXY_TIMEOUT_MS = parseInt(process.env.FEEDBACK_PROXY_TIMEOUT_MS
  * rather than piped so a transport failure can still fall back to local
  * handling with the full body. Service HTTP responses (4xx/5xx included) are
  * relayed verbatim; only transport errors (DNS/connect/timeout) reject.
+ *
+ * #484: forward the X-MobiSSH-Key the client already authenticated with, so the
+ * downstream feedback service (which runs the SAME shared guard) accepts the
+ * relayed request. Prod and the service share MOBISSH_FEEDBACK_KEY in the deploy.
  */
-function proxyFeedbackBody(serviceUrl, route, body, contentType) {
+function proxyFeedbackBody(serviceUrl, route, body, contentType, authKey) {
   return new Promise((resolve, reject) => {
+    const headers = {
+      'Content-Type': contentType || 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+    };
+    if (authKey) headers['X-MobiSSH-Key'] = authKey;
     const proxyReq = http.request(new URL(serviceUrl + route), {
       method: 'POST',
-      headers: {
-        'Content-Type': contentType || 'application/json',
-        'Content-Length': Buffer.byteLength(body),
-      },
+      headers,
       timeout: FEEDBACK_PROXY_TIMEOUT_MS,
     }, (proxyRes) => {
       let out = '';
@@ -258,14 +265,26 @@ function proxyFeedbackBody(serviceUrl, route, body, contentType) {
 
 async function handleFeedbackUpload(req, res) {
   const route = req.url;
-  const maxBytes = route === '/api/native-crash' ? feedbackStore.MAX_CRASH_BYTES : 0;
+  // #484: auth + per-IP rate limit BEFORE buffering, so an unauthenticated or
+  // over-quota caller can never buffer/decode an attacker-sized body.
+  const rej = feedbackGuard.preflight(req);
+  if (rej) {
+    res.writeHead(rej.status, { 'Content-Type': 'application/json' });
+    res.end(rej.body);
+    return;
+  }
+  const maxBytes = route === '/api/native-crash'
+    ? feedbackStore.MAX_CRASH_BYTES
+    : feedbackGuard.maxFeedbackBytes();
   let body;
   try {
     body = await feedbackStore.readBody(req, maxBytes);
   } catch (err) {
     if (err.code === 'TOO_LARGE') {
-      res.writeHead(413, { 'Content-Type': 'application/json' });
-      res.end('{"error":"crash report exceeds 1MB"}');
+      // Connection: close so the unread oversized body is discarded and the
+      // 413 reaches the client cleanly (no socket-hang-up race) (#484).
+      res.writeHead(413, { 'Content-Type': 'application/json', 'Connection': 'close' });
+      res.end('{"error":"request body too large"}');
     }
     return;
   }
@@ -275,7 +294,7 @@ async function handleFeedbackUpload(req, res) {
   const serviceUrl = (process.env.FEEDBACK_SERVICE_URL || '').replace(/\/+$/, '');
   if (serviceUrl) {
     try {
-      const relayed = await proxyFeedbackBody(serviceUrl, route, body, req.headers['content-type']);
+      const relayed = await proxyFeedbackBody(serviceUrl, route, body, req.headers['content-type'], req.headers['x-mobissh-key']);
       console.log(`[feedback-proxy] ${route} -> ${serviceUrl} (${relayed.status})`);
       res.writeHead(relayed.status, { 'Content-Type': 'application/json' });
       res.end(relayed.body);

--- a/src/modules/__tests__/feedback-guard.test.ts
+++ b/src/modules/__tests__/feedback-guard.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit + integration tests for feedback upload hardening (#484).
+ *
+ * The four feedback ingestion routes (/api/bug-report, /api/drop-telemetry,
+ * /api/gesture-telemetry, /api/native-crash) were unauthenticated and unbounded
+ * on BOTH front doors (server/index.js + server-feedback/index.js), sharing
+ * server/feedback-store.js. This asserts the shared guard (server/feedback-guard.js):
+ *   - encoded body cap (413) BEFORE buffering/decoding the whole thing
+ *   - decoded per-image cap (oversized artifact skipped, no giant file written)
+ *   - mandatory auth (401 missing/wrong header; 503 when key unconfigured)
+ *   - per-IP rate limit (429)
+ *   - a valid, in-cap, authenticated request still succeeds and writes (no regression)
+ * and that BOTH doors enforce it (server-feedback e2e + server/index.js wiring).
+ */
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { createRequire } from 'node:module';
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const req = createRequire(import.meta.url);
+
+// UPLOADS_DIR + key are read at module-load by server-feedback/index.js and
+// per-request by the guard, so set them BEFORE requiring the door.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'fb484-'));
+process.env.UPLOADS_DIR = TMP;
+process.env.MOBISSH_FEEDBACK_KEY = 'test-key-484';
+process.env.MOBISSH_FEEDBACK_RATE_MAX = '10000'; // generous default; the rate test lowers it
+
+const guard = req('../../../server/feedback-guard.js') as {
+  maxFeedbackBytes: () => number;
+  checkAuth: (r: unknown) => null | { status: number; body: string };
+  checkRateLimit: (ip: string) => null | { status: number; body: string };
+  preflight: (r: unknown) => null | { status: number; body: string };
+  getIP: (r: unknown) => string;
+  resetRateLimit: () => void;
+};
+const service = req('../../../server-feedback/index.js') as { server: http.Server };
+
+const KEY = 'test-key-484';
+
+function uploadFiles(): string[] {
+  try { return fs.readdirSync(TMP); } catch { return []; }
+}
+
+let port = 0;
+beforeEach(async () => {
+  guard.resetRateLimit();
+  process.env.MOBISSH_FEEDBACK_KEY = KEY;
+  delete process.env.MOBISSH_FEEDBACK_MAX_BYTES;
+  delete process.env.MOBISSH_FEEDBACK_IMAGE_MAX_BYTES;
+  process.env.MOBISSH_FEEDBACK_RATE_MAX = '10000';
+  // clear the uploads dir between tests
+  for (const f of uploadFiles()) { try { fs.unlinkSync(path.join(TMP, f)); } catch { /* ignore */ } }
+  if (!port) {
+    await new Promise<void>((resolve) => service.server.listen(0, '127.0.0.1', resolve));
+    port = (service.server.address() as { port: number }).port;
+  }
+});
+
+afterAll(() => {
+  try { service.server.close(); } catch { /* ignore */ }
+});
+
+interface Resp { status: number; body: string }
+function post(urlPath: string, body: string, headers: Record<string, string> = {}): Promise<Resp> {
+  return new Promise((resolve, reject) => {
+    const r = http.request(
+      { host: '127.0.0.1', port, path: urlPath, method: 'POST', headers: { 'Content-Type': 'application/json', ...headers } },
+      (res) => {
+        let out = '';
+        res.on('data', (c) => { out += c; });
+        res.on('end', () => resolve({ status: res.statusCode || 0, body: out }));
+      },
+    );
+    r.on('error', reject);
+    r.end(body);
+  });
+}
+
+const authHdr = { 'X-MobiSSH-Key': KEY };
+
+describe('feedback-guard #484 — shared guard', () => {
+  it('rejects an over-cap ENCODED body with 413 and writes nothing', async () => {
+    process.env.MOBISSH_FEEDBACK_MAX_BYTES = '1024'; // 1KB cap for the test
+    const big = JSON.stringify({ title: 'x', logs: 'A'.repeat(4096) }); // > 1KB
+    const res = await post('/api/bug-report', big, authHdr);
+    expect(res.status).toBe(413);
+    expect(uploadFiles().length).toBe(0);
+  });
+
+  it('rejects an oversized DECODED image artifact (small-ish encoded) without writing a giant file', async () => {
+    process.env.MOBISSH_FEEDBACK_IMAGE_MAX_BYTES = '64'; // 64-byte per-image decoded cap
+    // decoded screenshot is ~300 bytes (> 64) but the encoded body stays under the byte cap
+    const shot = 'data:image/png;base64,' + Buffer.alloc(300, 7).toString('base64');
+    const res = await post('/api/bug-report', JSON.stringify({ title: 'shot', screenshot: shot }), authHdr);
+    expect(res.status).toBe(200);
+    // the oversized screenshot must NOT be written; only the meta .json is
+    expect(uploadFiles().some((f) => f.endsWith('-bug-report.png'))).toBe(false);
+    expect(uploadFiles().some((f) => f.endsWith('-bug-report.json'))).toBe(true);
+  });
+
+  it('rejects a request with no auth header (401) and writes nothing', async () => {
+    const res = await post('/api/bug-report', JSON.stringify({ title: 'x' }), {});
+    expect(res.status).toBe(401);
+    expect(uploadFiles().length).toBe(0);
+  });
+
+  it('rejects a request with a WRONG auth header (401) and writes nothing', async () => {
+    const res = await post('/api/bug-report', JSON.stringify({ title: 'x' }), { 'X-MobiSSH-Key': 'nope' });
+    expect(res.status).toBe(401);
+    expect(uploadFiles().length).toBe(0);
+  });
+
+  it('rejects with 503 when the feedback key is not configured (block, do not degrade)', async () => {
+    delete process.env.MOBISSH_FEEDBACK_KEY;
+    const res = await post('/api/bug-report', JSON.stringify({ title: 'x' }), authHdr);
+    expect(res.status).toBe(503);
+    expect(uploadFiles().length).toBe(0);
+  });
+
+  it('rejects once the per-IP rate limit is exceeded (429)', async () => {
+    process.env.MOBISSH_FEEDBACK_RATE_MAX = '2';
+    guard.resetRateLimit();
+    const a = await post('/api/gesture-telemetry', JSON.stringify({ reason: 'r' }), authHdr);
+    const b = await post('/api/gesture-telemetry', JSON.stringify({ reason: 'r' }), authHdr);
+    const c = await post('/api/gesture-telemetry', JSON.stringify({ reason: 'r' }), authHdr);
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(c.status).toBe(429);
+  });
+
+  it('accepts a valid, in-cap, authenticated bug report and writes it (no regression)', async () => {
+    const shot = 'data:image/png;base64,' + Buffer.alloc(32, 1).toString('base64');
+    const res = await post('/api/bug-report', JSON.stringify({ title: 'real bug', comment: 'it broke', screenshot: shot }), authHdr);
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('"ok":true');
+    expect(uploadFiles().some((f) => f.endsWith('-bug-report.json'))).toBe(true);
+    expect(uploadFiles().some((f) => f.endsWith('-bug-report.png'))).toBe(true);
+  });
+});
+
+describe('feedback-guard #484 — guard unit surface', () => {
+  const fakeReq = (headers: Record<string, string>, ip = '9.9.9.9') => ({ headers, socket: { remoteAddress: ip } });
+
+  it('checkAuth returns null for a matching key, 401 for mismatch, 503 when unset', () => {
+    process.env.MOBISSH_FEEDBACK_KEY = KEY;
+    expect(guard.checkAuth(fakeReq({ 'x-mobissh-key': KEY }))).toBeNull();
+    expect(guard.checkAuth(fakeReq({ 'x-mobissh-key': 'bad' }))?.status).toBe(401);
+    expect(guard.checkAuth(fakeReq({}))?.status).toBe(401);
+    delete process.env.MOBISSH_FEEDBACK_KEY;
+    expect(guard.checkAuth(fakeReq({ 'x-mobissh-key': KEY }))?.status).toBe(503);
+  });
+
+  it('preflight enforces auth before rate limiting', () => {
+    process.env.MOBISSH_FEEDBACK_KEY = KEY;
+    guard.resetRateLimit();
+    expect(guard.preflight(fakeReq({ 'x-mobissh-key': KEY }))).toBeNull();
+    expect(guard.preflight(fakeReq({ 'x-mobissh-key': 'bad' }))?.status).toBe(401);
+  });
+});
+
+describe('feedback-guard #484 — both front doors wire the guard', () => {
+  it('server/index.js requires and calls the shared guard preflight', () => {
+    const src = fs.readFileSync(path.join(__dirname, '../../../server/index.js'), 'utf8');
+    expect(src).toContain("require('./feedback-guard')");
+    expect(src).toMatch(/feedbackGuard\.preflight\(/);
+  });
+
+  it('server-feedback/index.js requires and calls the shared guard preflight', () => {
+    const src = fs.readFileSync(path.join(__dirname, '../../../server-feedback/index.js'), 'utf8');
+    expect(src).toMatch(/require\('\.\.\/server\/feedback-guard'\)/);
+    expect(src).toMatch(/guard\.preflight\(/);
+  });
+
+  it('server/index.js forwards the auth key when relaying to the feedback service', () => {
+    // Otherwise the downstream service (same shared guard) 401s the relayed,
+    // already-authenticated request. Prod + service share MOBISSH_FEEDBACK_KEY.
+    const src = fs.readFileSync(path.join(__dirname, '../../../server/index.js'), 'utf8');
+    expect(src).toMatch(/proxyFeedbackBody\([^)]*x-mobissh-key/);
+    expect(src).toMatch(/headers\['X-MobiSSH-Key'\] = authKey/);
+  });
+});

--- a/tests/bug-report-comment.spec.js
+++ b/tests/bug-report-comment.spec.js
@@ -22,6 +22,11 @@ const { test, expect } = require('./fixtures.js');
 const BASE_URL = (process.env.BASE_URL || 'http://localhost:8081').replace(/\/?$/, '/');
 const UPLOADS_DIR = path.join(__dirname, '..', 'test-results', 'uploads');
 
+// #484: the feedback routes now require the X-MobiSSH-Key shared secret. Must
+// match playwright.config.js webServer env (or the external server's key).
+const FEEDBACK_KEY = process.env.MOBISSH_FEEDBACK_KEY || 'headless-feedback-key';
+const AUTH_HEADERS = { 'X-MobiSSH-Key': FEEDBACK_KEY };
+
 // A multi-line note whose later lines the old web form would have lost when it
 // sliced the first line to ~80 chars for the title.
 function bigNote(marker) {
@@ -50,6 +55,7 @@ test.describe('POST /api/bug-report — full comment persistence (#661)', () => 
     const comment = bigNote(marker);
 
     const res = await request.post(BASE_URL + 'api/bug-report', {
+      headers: AUTH_HEADERS,
       data: {
         title: `[1.0.0+9 deadbee] First line ${marker}`,
         comment,
@@ -75,6 +81,7 @@ test.describe('POST /api/bug-report — full comment persistence (#661)', () => 
     const truncatedTitle = `[1.0.0] ${fullText.split('\n')[0].slice(0, 80)}`;
 
     const res = await request.post(BASE_URL + 'api/bug-report', {
+      headers: AUTH_HEADERS,
       data: {
         title: truncatedTitle,
         logs: fullText,
@@ -91,5 +98,29 @@ test.describe('POST /api/bug-report — full comment persistence (#661)', () => 
     expect(meta.comment).toContain(`${marker}-END`);
     // The title is still the (truncated) web-form title — back-compatible.
     expect(meta.title).toBe(truncatedTitle);
+  });
+});
+
+test.describe('POST /api/bug-report — auth is mandatory (#484)', () => {
+  test('a request WITHOUT the X-MobiSSH-Key header is rejected and writes nothing', async ({ request }) => {
+    const marker = `m484noauth-${Date.now()}`;
+    const res = await request.post(BASE_URL + 'api/bug-report', {
+      data: { title: `unauth ${marker}`, comment: `should not persist ${marker}`, logs: marker },
+    });
+    // 401 (key configured, header missing) or 503 (key not configured) — never accepted.
+    expect(res.ok()).toBe(false);
+    expect([401, 403, 503]).toContain(res.status());
+    // Nothing carrying the marker was written to disk.
+    expect(findReportContaining(marker)).toBeNull();
+  });
+
+  test('a request with a WRONG X-MobiSSH-Key is rejected', async ({ request }) => {
+    const marker = `m484badauth-${Date.now()}`;
+    const res = await request.post(BASE_URL + 'api/bug-report', {
+      headers: { 'X-MobiSSH-Key': 'not-the-key' },
+      data: { title: `bad ${marker}`, comment: marker, logs: marker },
+    });
+    expect(res.status()).toBe(401);
+    expect(findReportContaining(marker)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- New shared guard `server/feedback-guard.js`, imported by BOTH front doors (`server/index.js` + `server-feedback/index.js`) so neither is an unauthenticated/unbounded bypass. Enforces, before buffering: mandatory `X-MobiSSH-Key` auth, per-IP sliding-window rate limit, and an encoded-body cap.
- `server/feedback-store.js`: `readBody` rejects on a `Content-Length` over the cap up front (refuse without buffering/decoding) + a streaming backstop; `saveBugReport` skips oversized decoded screenshot/frame artifacts (defense-in-depth on top of the existing 120-frame count cap).
- Prod relay (`proxyFeedbackBody`) now forwards the client's `X-MobiSSH-Key` so the downstream feedback service (same guard) accepts the already-authenticated request.

## Fix vs. issue #484
1. Encoded body capped BEFORE decode (413) — `MAX_FEEDBACK_BYTES`, default 16MB (env `MOBISSH_FEEDBACK_MAX_BYTES`), sized for the 120-frame repro burst; native-crash keeps its 1MB cap.
2. Decoded per-image cap (env `MOBISSH_FEEDBACK_IMAGE_MAX_BYTES`, default 4MB) + existing artifact-count cap (`MAX_FRAMES=120`).
3. Per-IP rate limit (env `MOBISSH_FEEDBACK_RATE_MAX`/`_WINDOW_MS`, default 30/60s) => 429. In-memory, no new dependency.
4. Auth mandatory, not optional: `X-MobiSSH-Key` must equal `MOBISSH_FEEDBACK_KEY` (timing-safe). Missing/wrong => 401; key UNSET => 503 (block, don't degrade — constitution art.2). Matches the existing idiom (`feedback_overlay.dart:54`, `infra/bug-report-worker/worker.js`).
5. Applied to the shared store + BOTH doors via one imported helper (no duplication).

## TDD Analysis
- Type: bug fix (security hardening) — Behavior change: YES (auth now required) — TDD: full.

## Test coverage
- **New** `src/modules/__tests__/feedback-guard.test.ts` (12): over-cap 413 (nothing written), oversized-decoded-image skipped, 401 (missing/wrong header), 503 (key unset), 429 (rate limit), happy-path write (no regression), guard unit surface, and BOTH doors wired (server-feedback e2e through a real HTTP door + structural checks incl. relay key-forwarding).
- **Updated** `tests/bug-report-comment.spec.js`: authenticates the #661 contract requests + adds keyless/wrong-key reject assertions. `playwright.config.js` webServer sets a headless key.

## Test results
- tsc: PASS
- eslint: PASS (changed files 0 problems; the fast-gate lint step aborts only because this worktree lives under a `.claude/` dot-path that ESLint 8 default-ignores — an environment artifact, not a code issue)
- vitest: PASS (1033 suite + 12 new)
- headless Playwright (`bug-report-comment.spec.js`): PASS (4/4)

## Diff stats
- Files changed: 7 (+417 / -22). Core logic in 4 (guard + store + 2 doors); 3 are the mandatory test/config updates for the behavior change.

## DEPLOY NOTE (owner action required — flagged)
Auth is fail-closed. To keep feedback working, `mobissh-prod` AND the feedback service must set `MOBISSH_FEEDBACK_KEY` (same value) in `docker-compose.prod.yml`, and clients must send `X-MobiSSH-Key`. The native app already sends it when built with `--dart-define=MOBISSH_FEEDBACK_KEY`. The **web form** (`public/native-feedback.js`) sends no key and cannot safely embed a secret, so it is **blocked** until the owner injects a key or retires that path — a deliberate security/product fork surfaced here rather than silently degrading.

Closes #484

## Cycles used
1/3